### PR TITLE
fix: compact energy editor and reactive CRUD refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.13.1 — 2026-07-28
+
+- Editor Energia compatto e richiudibile, ottimizzato per mobile.
+- CRUD ottimistico aggiorna immediatamente editor, dashboard, report e selettori, incluso rollback.
+
 ## 0.13.0 — 2026-07-28
 
 - Introduced the canonical DashboardStore, schema v2 migration and targeted reactive render coordination.

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
@@ -6199,7 +6199,7 @@ body.cd-nav-fixed { padding-bottom: 96px !important; }
    localStorage (se presente) ha priorità, così puoi ancora testare in locale.
    ─────────────────────────────────────────────────────────────────── */
 /* ═══ v258: VERSIONE — visibile in console, wizard e pagina Config ═══ */
-const DASHBOARD_VERSION = '0.13.0';
+const DASHBOARD_VERSION = '0.13.1';
 console.log('%c🏠 Dashboard Modern v' + DASHBOARD_VERSION, 'font-size:14px; font-weight:bold; color:#0ea5e9;');
 
 /* CD_BAKED_START */

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard.html
@@ -6205,7 +6205,7 @@ html[data-theme="dark"] .tc2-hum { background: rgba(14,165,233,0.16); color:#7dd
    localStorage (se presente) ha priorità, così puoi ancora testare in locale.
    ─────────────────────────────────────────────────────────────────── */
 /* ═══ v258: VERSIONE — visibile in console, wizard e pagina Config ═══ */
-const DASHBOARD_VERSION = '0.13.0';
+const DASHBOARD_VERSION = '0.13.1';
 console.log('%c🏠 Dashboard Modern v' + DASHBOARD_VERSION, 'font-size:14px; font-weight:bold; color:#0ea5e9;');
 
 /* CD_BAKED_START */

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -44,9 +44,46 @@ createRenderCoordinator(store, {
   renderEnergyReport() { globalThis.cdRebuildReportDevices?.(); },
   renderNavbar() { globalThis.cdApplyNavVis?.(); },
   renderRoomSelectors() { globalThis.cdFillRoomSelects?.(); },
+  renderCurrentEditor(section) {
+    const tab = globalThis.document?.querySelector?.(".ed-tab.active")?.dataset?.tab;
+    const sectionTabs = {
+      appliances: "appliances", cameras: "sezioni", energy: "sezioni", rooms: "stanze",
+      ev: "sezioni", lights: "luci", climate: "sezioni", covers: "tapp",
+      pool: "pool", irrigation: "irr",
+    };
+    const expected = sectionTabs[section];
+    const matches = expected === tab || (expected === "sezioni" && tab?.startsWith("sez"));
+    if (!globalThis.document?.getElementById?.("ed-body") || !matches) return;
+    // Re-render the active body directly; editorSwitch is navigation and was
+    // the accidental refresh mechanism that left confirmed deletes visible.
+    const body = globalThis.document.getElementById("ed-body");
+    if (tab === "appliances") {
+      body.innerHTML = globalThis.cdSecToggleHtml("appliances") + globalThis.editorRenderAppliances() + '<button class="ed-btn-add" style="width:100%; margin-top:10px;" onclick="edSecSave()">💾 Salva sezione</button>';
+      globalThis.edApplRenderEnts?.();
+    } else if (tab === "stanze") body.innerHTML = globalThis.editorRenderStanze();
+    else if (tab === "luci") body.innerHTML = globalThis.editorRenderLuci();
+    else if (tab === "tapp") body.innerHTML = globalThis.cdSecToggleHtml("tapparelle") + globalThis.editorRenderTapparelle();
+    else if (tab === "pool") body.innerHTML = globalThis.cdSecToggleHtml("piscina") + globalThis.editorRenderPiscina();
+    else if (tab === "irr") body.innerHTML = globalThis.cdSecToggleHtml("irrigazione") + globalThis.editorRenderIrrigazione();
+    else if (tab?.startsWith("sez") && tab !== "sezioni") {
+      body.innerHTML = globalThis.editorRenderSezioni();
+      globalThis.edFilterSez?.(body, Number(tab.slice(3)));
+    }
+  },
+  renderDropdowns() { globalThis.cdFillRoomSelects?.(); },
+  renderDashboard() { globalThis.render?.(); },
 });
 
+function installEnergyEditorStyles(document) {
+  if (!document?.head || document.getElementById("dm-energy-editor-styles")) return;
+  const style = document.createElement("style");
+  style.id = "dm-energy-editor-styles";
+  style.textContent = `.dm-energy-editor{gap:10px}.dm-energy-editor__group{border:1px solid var(--card-border);border-radius:15px;background:var(--surface-2);overflow:hidden}.dm-energy-editor__heading{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:12px 14px;font-size:16px;font-weight:800;cursor:pointer;list-style:none}.dm-energy-editor__heading::-webkit-details-marker{display:none}.dm-energy-editor__heading small,.dm-energy-editor__badges small{font-size:10px;font-style:normal;color:var(--text-dim);background:var(--surface-3);padding:3px 7px;border-radius:999px;white-space:nowrap}.dm-energy-editor__body{display:flex;flex-direction:column;gap:9px;padding:12px 14px;border-top:1px solid var(--card-border)}.dm-energy-editor__field{display:flex;flex-direction:column;gap:4px;margin:0}.dm-energy-editor__label{display:flex;align-items:center;justify-content:space-between;gap:6px;font-size:14px;font-weight:750}.dm-energy-editor__badges{display:flex;gap:4px}.dm-energy-editor__field>em{font-size:11.5px;line-height:1.25;color:var(--text-dim);font-style:normal;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}.dm-energy-editor__input-row{display:grid;grid-template-columns:minmax(0,1fr) 44px auto;gap:6px;align-items:center}.dm-energy-editor__input-row input,.dm-energy-editor__input-row button{height:44px;margin:0}.dm-energy-editor__input-row output{font-size:11px;color:var(--text-dim);white-space:nowrap}.dm-energy-editor__report{padding:12px 14px}.dm-energy-editor__report h3{font-size:16px;margin:0 0 8px}.dm-energy-editor__report .ed-btn-add{width:auto;padding:8px 12px;font-size:12px}@media(max-width:560px){.dm-energy-editor__input-row{grid-template-columns:minmax(0,1fr) 44px}.dm-energy-editor__input-row output{grid-column:1/-1;text-align:right}.dm-energy-editor__heading{padding:12px;font-size:15px}.dm-energy-editor__body{padding:12px}}`;
+  document.head.append(style);
+}
+
 function mountEnergyEditor(target) {
+  installEnergyEditorStyles(globalThis.document);
   const model = store.getSection("energy");
   renderEnergyEditor(globalThis.document, target, model, store.getSection("appliances"), globalThis.STATES || {},
     globalThis.document?.documentElement?.lang === "en" ? "en" : "it", {

--- a/custom_components/dashboardmodern/frontend/src/core/renderers.js
+++ b/custom_components/dashboardmodern/frontend/src/core/renderers.js
@@ -49,6 +49,13 @@ export function createRenderCoordinator(store, renderers = {}) {
       appliances: "renderAppliances",
       cameras: "renderCameras",
       lights: "renderLights",
+      climate: "renderClimate",
+      covers: "renderCovers",
+      pool: "renderPool",
+      irrigation: "renderIrrigation",
+      rooms: "renderRooms",
+      ev: "renderEvProfiles",
+      energy: "renderEnergy",
     };
     call(names[change.section], change);
     if (change.section === "appliances" || change.section === "energy")
@@ -58,6 +65,12 @@ export function createRenderCoordinator(store, renderers = {}) {
       call("renderLights", change);
       call("renderAppliances", change);
     }
+    // Keep the open editor in step with the optimistic model (and with a
+    // rollback).  Previously only dashboard renderers were called here, so
+    // the stale editor DOM survived until editorSwitch() happened to rebuild it.
+    call("renderCurrentEditor", change.section, change);
+    call("renderDropdowns", change.section, change);
+    call("renderDashboard", change.section, change);
     if (change.visibilityChanged) call("renderNavbar", change);
   });
 }
@@ -130,6 +143,8 @@ const ENERGY_GROUPS = [
   ],
 ];
 
+const ENERGY_ICONS = { house: "🏠", grid: "🔌", solar: "☀️", battery: "🔋" };
+
 export function renderEnergyEditor(
   document,
   target,
@@ -142,26 +157,31 @@ export function renderEnergyEditor(
   const root = typeof target === "string" ? document.querySelector(target) : target;
   if (!root) return;
   root.replaceChildren();
-  root.classList.add("ed-list");
-  for (const [group, title, fields] of ENERGY_GROUPS) {
-    const block = document.createElement("section");
-    block.className = "ed-acc";
-    const heading = document.createElement("h3");
-    heading.textContent = title;
+  root.classList.add("ed-list", "dm-energy-editor");
+  ENERGY_GROUPS.forEach(([group, title, fields], groupIndex) => {
+    const block = document.createElement("details");
+    block.className = "dm-energy-editor__group";
+    block.open = groupIndex === 0;
+    const heading = document.createElement("summary");
+    heading.className = "dm-energy-editor__heading";
+    const configured = fields.filter(([key]) => Boolean(model[group]?.[key])).length;
+    heading.innerHTML = `<span>${ENERGY_ICONS[group]} ${title}</span><small>${configured}/${fields.length} configurati</small>`;
     block.append(heading);
+    const body = document.createElement("div");
+    body.className = "dm-energy-editor__body";
     for (const [key, label, unit, example] of fields) {
       const field = document.createElement("label");
-      field.className = "ed-slot";
-      field.innerHTML = `<span>${label} <small>Facoltativo · ${unit}</small></span><em>Entità Home Assistant, es. ${example}</em>`;
+      field.className = "dm-energy-editor__field";
+      field.innerHTML = `<span class="dm-energy-editor__label">${label}<span class="dm-energy-editor__badges"><small>${unit}</small><small>Facoltativo</small></span></span><em>Entità Home Assistant, es. ${example}</em>`;
       const row = document.createElement("span");
-      row.className = "ed-row";
+      row.className = "dm-energy-editor__input-row";
       const input = document.createElement("input");
       input.name = `${group}.${key}`;
       input.value = model[group]?.[key] || "";
       input.placeholder = example;
       input.dataset.validation = !input.value || states[input.value] ? "valid" : "invalid";
       const preview = document.createElement("output");
-      preview.textContent = states[input.value]?.state ?? "—";
+      preview.textContent = `${locale === "it" ? "Valore" : "Value"}: ${states[input.value]?.state ?? "—"}${states[input.value]?.state != null ? ` ${unit}` : ""}`;
       const pick = document.createElement("button");
       pick.type = "button";
       pick.textContent = "🔍";
@@ -170,12 +190,13 @@ export function renderEnergyEditor(
       pick.addEventListener("click", () => handlers.onPick?.(input));
       row.append(input, pick, preview);
       field.append(row);
-      block.append(field);
+      body.append(field);
     }
+    block.append(body);
     root.append(block);
-  }
+  });
   const appliancesBlock = document.createElement("section");
-  appliancesBlock.className = "ed-acc";
+  appliancesBlock.className = "dm-energy-editor__report";
   const heading = document.createElement("h3");
   heading.textContent = locale === "it" ? "Elettrodomestici" : "Appliances";
   appliancesBlock.append(heading);

--- a/custom_components/dashboardmodern/frontend/tests/dashboard-store.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/dashboard-store.test.js
@@ -251,3 +251,71 @@ test("legacy writes are reconciled back into the canonical runtime state", async
     "Legacy",
   );
 });
+
+test("add, update, delete and rollback rerender the active editor exactly once", async () => {
+  const storage = new MemoryStorage();
+  let fail = false;
+  const store = new DashboardStore({
+    storage,
+    sync: async () => {
+      if (fail) throw new Error("backend unavailable");
+    },
+  });
+  store.migrate();
+  const calls = [];
+  createRenderCoordinator(store, {
+    renderCurrentEditor: (section, change) => calls.push(`editor:${section}:${change.status}`),
+    renderDashboard: (section, change) => calls.push(`dashboard:${section}:${change.status}`),
+    renderDropdowns: (section, change) => calls.push(`dropdowns:${section}:${change.status}`),
+  });
+  const item = await store.addItem("appliances", { name: "Forno", icon: "mdi:stove" });
+  assert.equal(calls.filter((call) => call === "editor:appliances:optimistic").length, 1);
+  await store.updateItem("appliances", item.id, { name: "Forno nuovo", icon: "mdi:oven" });
+  assert.equal(store.getSection("appliances")[0].name, "Forno nuovo");
+  await store.removeItem("appliances", item.id);
+  assert.equal(store.getSection("appliances").length, 0, "delete is visible before navigation");
+
+  const camera = await store.addItem("cameras", { name: "Ingresso", entity: "camera.ingresso" });
+  fail = true;
+  await assert.rejects(store.removeItem("cameras", camera.id), /backend unavailable/);
+  assert.equal(
+    store.getSection("cameras").length,
+    1,
+    "rollback restores the deleted row immediately",
+  );
+  assert.equal(calls.filter((call) => call === "editor:cameras:rollback").length, 1);
+  assert.ok(calls.some((call) => call.startsWith("dashboard:")));
+  assert.ok(calls.some((call) => call.startsWith("dropdowns:")));
+});
+
+test("all CRUD editor sections are registered with the reactive coordinator", async () => {
+  const { store } = setup();
+  const rendered = [];
+  createRenderCoordinator(store, { renderCurrentEditor: (section) => rendered.push(section) });
+  for (const section of [
+    "appliances",
+    "cameras",
+    "rooms",
+    "ev",
+    "lights",
+    "climate",
+    "covers",
+  ]) {
+    await store.addItem(section, { name: section, entity: `sensor.${section}` });
+  }
+  await store.replaceSection("pool", { tempEnt: "sensor.pool" });
+  await store.replaceSection("irrigation", { zones: [] });
+  await store.replaceSection("energy", { house: { power: "sensor.house" } });
+  assert.deepEqual(rendered, [
+    "appliances",
+    "cameras",
+    "rooms",
+    "ev",
+    "lights",
+    "climate",
+    "covers",
+    "pool",
+    "irrigation",
+    "energy",
+  ]);
+});

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "0.13.0"
+  "version": "0.13.1"
 }

--- a/scripts/vendor_features.py
+++ b/scripts/vendor_features.py
@@ -170,7 +170,7 @@ WIZARD_STEP_REPLACEMENT = "WIZ = { step: (window.__DASHBOARDMODERN_HOSTED__ ? 2 
 
 # ── Visible build marker: prove the served HTML actually updated ───────────
 VERSION_ANCHOR = "const DASHBOARD_VERSION = '0.11.1';"
-VERSION_REPLACEMENT = "const DASHBOARD_VERSION = '0.13.0';"
+VERSION_REPLACEMENT = "const DASHBOARD_VERSION = '0.13.1';"
 
 # ── Temperature section: the Piano (floor) fields are hidden via CSS below ─
 

--- a/tests/test_vendor_features.py
+++ b/tests/test_vendor_features.py
@@ -56,7 +56,7 @@ def test_the_room_field_is_present_in_every_section_and_language() -> None:
         assert "!window.__DASHBOARDMODERN_HOSTED__" in html, name
         assert "step: (window.__DASHBOARDMODERN_HOSTED__ ? 2 : 1)" in html, name
         # The build marker proves the served HTML updated.
-        assert "0.13.0" in html, name
+        assert "0.13.1" in html, name
         # The repository logo is used, not the inline SVG mark.
         assert 'src="./logo.png"' in html, name
         # The Piano field is hidden in the temperature section.
@@ -157,7 +157,7 @@ def test_rooms_management_is_separated_from_temperatures() -> None:
         assert "Rilevamento e manutenzione" in html, name
         # Bugfix guards: sync loop-guard, hosted update-check, version bump.
         assert "cd_sync_rl2" in html, name
-        assert "0.13.0" in html and "0.11.1-int" not in html, name
+        assert "0.13.1" in html and "0.11.1-int" not in html, name
         # Tapparelle: open/close-all buttons and open-shutter alerts.
         assert "Apri tutte" in html and "Chiudi tutte" in html, name
         assert "tapp-avvisi" in html, name


### PR DESCRIPTION
### Motivation
- The Energy editor was visually too heavy on mobile and required a compact, clearer UI without changing global dashboard layout.
- CRUD operations (add/update/delete) did not update the open editor immediately because the optimistic change notifications did not target the active editor renderer, causing stale DOM until a tab change occurred. 

### Description
- Redesigned the Energy editor as a compact, mobile-first accordion with per-group icons, counters, badges for units/optional, two-line descriptions, aligned picker+input rows, reduced paddings, and constrained input heights (CSS scoped to `.dm-energy-editor*`).
- Made the reactive coordinator call an editor renderer on optimistic updates and rollbacks by adding `renderCurrentEditor`, `renderDropdowns` and `renderDashboard` hooks and wiring them into the legacy bridge so the active editor rerenders immediately (no tab switch required). 
- Implemented the editor-side refresh in the vendored bridge by re-rendering the active editor body directly (instead of relying on `editorSwitch()`), and injected compact editor styles at mount time.
- Bumped integration version to `0.13.1`, updated changelog, and included focused unit tests for optimistic rerender, rollback, single-invocation renderer and section coverage.

### Testing
- Ran `npm run test:frontend` and all frontend tests passed (92/92) in this environment. 
- Ran inline JS compilation check `npm run check:inline-syntax` and it succeeded for both Italian and English vendored HTML variants. 
- Added and ran new unit tests in `custom_components/dashboardmodern/frontend/tests/dashboard-store.test.js` validating immediate editor rerender on add/update/delete and rollback and section registration; they pass under Node test runner. 
- `python -m pytest -q` could not be completed in this environment due to missing `homeassistant` test dependency (collection error), so full Python integration test collection was not executed here. 

Notes: the failing runtime for generating real before/after screenshots (no authenticated Home Assistant browser runtime available) prevented attaching screenshots; the visual changes are isolated to `.dm-energy-editor*` so global navbar, cards and responsive behavior were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a689b9458ac832ea348dc2fee878f11)