### PR TITLE
fix: merge Loads into Energy and stabilize editor pickers

### DIFF
--- a/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
@@ -6199,7 +6199,7 @@ body.cd-nav-fixed { padding-bottom: 96px !important; }
    localStorage (se presente) ha priorità, così puoi ancora testare in locale.
    ─────────────────────────────────────────────────────────────────── */
 /* ═══ v258: VERSIONE — visibile in console, wizard e pagina Config ═══ */
-const DASHBOARD_VERSION = '0.13.2';
+const DASHBOARD_VERSION = '0.13.3';
 console.log('%c🏠 Dashboard Modern v' + DASHBOARD_VERSION, 'font-size:14px; font-weight:bold; color:#0ea5e9;');
 
 /* CD_BAKED_START */
@@ -7297,11 +7297,9 @@ function apriConfigEntita() {
           <button class="ed-tab" data-tab="sost"  onclick="editorSwitch('sost')">🔁 Overrides</button>
           <button class="ed-tab" data-tab="sez0" onclick="editorSwitch('sez0')">🏠 Home</button>
           <button class="ed-tab" data-tab="sez1" onclick="editorSwitch('sez1')">⚡ Energy</button>
-          <button class="ed-tab" data-tab="load"  onclick="editorSwitch('load')">🔌 Loads</button>
           <button class="ed-tab" data-tab="sez2" onclick="editorSwitch('sez2')">🚗 EV</button>
           <button class="ed-tab" data-tab="sez3" onclick="editorSwitch('sez3')">🌞 Solare</button>
           <button class="ed-tab" data-tab="sez4" onclick="editorSwitch('sez4')">🛡️ Sicurezza</button>
-          <button class="ed-tab" data-tab="sez5" onclick="editorSwitch('sez5')">🧺 Lavatrice</button>
           <button class="ed-tab" data-tab="sez6" onclick="editorSwitch('sez6')">🖥️ MiniPC</button>
           <button class="ed-tab" data-tab="sez7" onclick="editorSwitch('sez7')">🌡️ Temperatura</button>
           <button class="ed-tab" data-tab="sez8" onclick="editorSwitch('sez8')">⚡ Azioni</button>
@@ -7344,6 +7342,7 @@ function editorSwitch(tab) {
     if (tab === 'testi')  body.innerHTML = editorRenderTesti();
     if (tab === 'hide')   body.innerHTML = editorRenderHide();
     if (tab === 'export') body.innerHTML = editorRenderExport();
+    try { var dmMount=globalThis.DashboardModernModules; if(dmMount&&dmMount.render) dmMount.render.mountCurrentEditor(tab, body); } catch(e){}
 }
 
 /* ─────────── TAB 1: SOSTITUZIONI (override entity) ─────────── */
@@ -7785,6 +7784,7 @@ function cdDbgStatus(){ try { return '<div class="ed-intro mono" style="font-siz
     }
 
     html += `<button class="ed-save-btn" onclick="edToast('💾 Lights layout saved — reload to apply'); cdSyncPush && cdSyncPush();">💾 Save lights layout</button>`;
+    html += `<div class="ed-form dm-light-add-form"><div class="ed-sec-title">＋ ADD LIGHT</div><div class="ed-form-row"><input id="luce-add-ent" class="ed-input mono" placeholder="light.living_room"><button type="button" class="dm-entity-picker" data-entity-target="luce-add-ent">🔍</button></div><input id="luce-add-name" class="ed-input" placeholder="Light name (optional)"><button class="ed-btn-add" onclick="cdLuceAdd()">＋ Add light</button></div>`;
     return html;
 }
 

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard.html
@@ -6205,7 +6205,7 @@ html[data-theme="dark"] .tc2-hum { background: rgba(14,165,233,0.16); color:#7dd
    localStorage (se presente) ha priorità, così puoi ancora testare in locale.
    ─────────────────────────────────────────────────────────────────── */
 /* ═══ v258: VERSIONE — visibile in console, wizard e pagina Config ═══ */
-const DASHBOARD_VERSION = '0.13.2';
+const DASHBOARD_VERSION = '0.13.3';
 console.log('%c🏠 Dashboard Modern v' + DASHBOARD_VERSION, 'font-size:14px; font-weight:bold; color:#0ea5e9;');
 
 /* CD_BAKED_START */
@@ -7306,11 +7306,9 @@ function apriConfigEntita() {
           <button class="ed-tab" data-tab="visib" onclick="editorSwitch('visib')">⚙️ Impostazioni</button>
           <button class="ed-tab" data-tab="sez0" onclick="editorSwitch('sez0')">🏠 Home</button>
           <button class="ed-tab" data-tab="sez1" onclick="editorSwitch('sez1')">⚡ Energia</button>
-          <button class="ed-tab" data-tab="load"  onclick="editorSwitch('load')">🔌 Carichi</button>
           <button class="ed-tab" data-tab="sez2" onclick="editorSwitch('sez2')">🚗 EV</button>
           <button class="ed-tab" data-tab="sez3" onclick="editorSwitch('sez3')">🌞 Solare</button>
           <button class="ed-tab" data-tab="sez4" onclick="editorSwitch('sez4')">🛡️ Sicurezza</button>
-          <button class="ed-tab" data-tab="sez5" onclick="editorSwitch('sez5')">🧺 Lavatrice</button>
           <button class="ed-tab" data-tab="sez6" onclick="editorSwitch('sez6')">🖥️ MiniPC</button>
           <button class="ed-tab" data-tab="sez7" onclick="editorSwitch('sez7')">🌡️ Temperatura</button>
           <button class="ed-tab" data-tab="sez8" onclick="editorSwitch('sez8')">⚡ Azioni</button>
@@ -7351,6 +7349,7 @@ function editorSwitch(tab) {
     if (tab === 'testi')  body.innerHTML = editorRenderTesti();
     if (tab === 'hide')   body.innerHTML = editorRenderHide();
     if (tab === 'export') body.innerHTML = editorRenderExport();
+    try { var dmMount=globalThis.DashboardModernModules; if(dmMount&&dmMount.render) dmMount.render.mountCurrentEditor(tab, body); } catch(e){}
 }
 
 /* ─────────── TAB 1: SOSTITUZIONI (override entity) ─────────── */
@@ -7800,6 +7799,7 @@ function cdDbgStatus(){ try { return '<div class="ed-intro mono" style="font-siz
     }
 
     html += `<button class="ed-save-btn" onclick="edToast('💾 Organizzazione luci salvata — ricarica per applicare'); cdSyncPush && cdSyncPush();">💾 Salva organizzazione luci</button>`;
+    html += `<div class="ed-form dm-light-add-form"><div class="ed-sec-title">＋ ${document.documentElement.lang === 'en' ? 'ADD LIGHT' : 'AGGIUNGI LUCE'}</div><div class="ed-form-row"><input id="luce-add-ent" class="ed-input mono" placeholder="light.salone"><button type="button" class="dm-entity-picker" data-entity-target="luce-add-ent">🔍</button></div><input id="luce-add-name" class="ed-input" placeholder="Nome luce (facoltativo)"><button class="ed-btn-add" onclick="cdLuceAdd()">＋ ${document.documentElement.lang === 'en' ? 'Add light' : 'Aggiungi luce'}</button></div>`;
     return html;
 }
 

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -70,6 +70,7 @@ createRenderCoordinator(store, {
       body.innerHTML = globalThis.editorRenderSezioni();
       globalThis.edFilterSez?.(body, Number(tab.slice(3)));
     }
+    mountCurrentEditor(tab, body);
   },
   renderDropdowns() { globalThis.cdFillRoomSelects?.(); },
   renderDashboard() { globalThis.render?.(); },
@@ -80,6 +81,7 @@ function mountEnergyEditor(target) {
   renderEnergyEditor(globalThis.document, target, model, store.getSection("appliances"), globalThis.STATES || {},
     globalThis.document?.documentElement?.lang === "en" ? "en" : "it", {
       onPick: (input) => globalThis.wzPickEntity?.(input),
+      renderLoads: (loads) => mountLoadsEditor(loads),
       renderSettings: (settings) => {
         settings.innerHTML = `${globalThis.cdEnViewsHtml?.() || ""}
           <div class="ed-sec-title">💶 Costo energia</div>
@@ -93,11 +95,31 @@ function mountEnergyEditor(target) {
         store.replaceSection("energy", next).catch((error) => globalThis.alert?.(`Energy save failed: ${error.message}`));
       },
     });
+  mountCurrentEditor("energy", target);
 }
 
 const esc = (value) => String(value ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/"/g, "&quot;");
 function entityField(id, label, value = "", placeholder = "sensor.entity") {
-  return `<label class="ed-slot"><span class="ed-slot-lbl">${label} <span class="ed-acc-n">Facoltativo</span></span><span class="ed-form-row"><input id="${id}" class="ed-input ed-slot-in mono" value="${esc(value)}" placeholder="${placeholder}"><button type="button" class="dm-entity-picker" onclick="wzPickEntity('#${id}')" aria-label="Seleziona ${label}">🔍</button></span></label>`;
+  return `<label class="ed-slot"><span class="ed-slot-lbl">${label} <span class="ed-acc-n">Facoltativo</span></span><span class="ed-form-row"><input id="${id}" class="ed-input ed-slot-in mono" value="${esc(value)}" placeholder="${placeholder}"><button type="button" class="dm-entity-picker" data-entity-target="${id}" aria-label="Seleziona ${label}">🔍</button></span></label>`;
+}
+
+export function mountEntityPickers(target) {
+  target?.querySelectorAll?.(".dm-entity-picker[data-entity-target]").forEach((button) => {
+    if (button.dataset.pickerMounted === "true") return;
+    button.dataset.pickerMounted = "true";
+    button.addEventListener("click", () => {
+      const input = target.querySelector?.(`#${button.dataset.entityTarget}`);
+      if (input) globalThis.wzPickEntity?.(input);
+    });
+  });
+}
+
+export function mountCurrentEditor(section, target = globalThis.document?.getElementById?.("ed-body")) {
+  if (!target) return;
+  mountEntityPickers(target);
+  globalThis.cdFillRoomSelects?.();
+  target.querySelectorAll?.("details.ed-acc").forEach((details) => details.dataset.editorMounted = "true");
+  target.dataset.mountedSection = section || "";
 }
 function mountLoadsEditor(target, editId = "") {
   const loads = store.getSection("loads");
@@ -116,6 +138,7 @@ function mountLoadsEditor(target, editId = "") {
     if (!item.name) return globalThis.alert?.("Inserisci il nome del carico");
     (editId ? store.updateItem("loads", editId, item) : store.addItem("loads", item)).catch((error) => globalThis.alert?.(error.message));
   });
+  mountCurrentEditor("energy-loads", target);
 }
 
 const DashboardModernModules = Object.freeze({
@@ -139,7 +162,7 @@ const DashboardModernModules = Object.freeze({
     removeCamera,
   }),
   store,
-  render: Object.freeze({ createEnergyReportRows, createRenderCoordinator, loadPopupMetrics, mountEnergyEditor, mountLoadsEditor, renderDeviceCard, renderEnergyEditor }),
+  render: Object.freeze({ createEnergyReportRows, createRenderCoordinator, loadPopupMetrics, mountCurrentEditor, mountEnergyEditor, mountEntityPickers, mountLoadsEditor, renderDeviceCard, renderEnergyEditor }),
 });
 
 globalThis.DashboardModernModules = DashboardModernModules;

--- a/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
+++ b/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
@@ -14,6 +14,31 @@ export const VISIBILITY_SECTION = Object.freeze({
   irrigation: "irrigazione",
 });
 
+const configured = (value) =>
+  typeof value === "string" ? value.trim().includes(".") : Boolean(value);
+export function hasConfiguredData(section, value) {
+  if (Array.isArray(value))
+    return value.some(
+      (item) =>
+        item?.enabled !== false &&
+        (Boolean(String(item?.name || "").trim()) ||
+          Object.entries(item || {}).some(
+            ([key, entry]) =>
+              /entit|entity|entities|profile/.test(key) &&
+              (Array.isArray(entry) ? entry.some(configured) : configured(entry)),
+          )),
+    );
+  if (!value || typeof value !== "object") return false;
+  if (section === "irrigation") return (value.zones || []).length > 0;
+  return Object.entries(value).some(
+    ([key, entry]) =>
+      key !== "metadata" &&
+      (typeof entry === "object"
+        ? hasConfiguredData(section, entry)
+        : /ent|power|energy|soc|camera|alarm/i.test(key) && configured(entry)),
+  );
+}
+
 export class DashboardStore {
   constructor({
     storage = globalThis.localStorage,
@@ -103,14 +128,7 @@ export class DashboardStore {
   ensureSectionVisibleForData(section) {
     const key = VISIBILITY_SECTION[section] || section;
     const value = this.state.sections[section];
-    const hasData = Array.isArray(value)
-      ? value.some((item) => item?.enabled !== false)
-      : Boolean(
-          value &&
-          Object.keys(value).some(
-            (name) => name !== "metadata" && Object.keys(value[name] || {}).length,
-          ),
-        );
+    const hasData = hasConfiguredData(section, value);
     if (hasData && this.state.visibility[key] === false) {
       this.state.visibility[key] = true;
       return true;

--- a/custom_components/dashboardmodern/frontend/src/core/migrations.js
+++ b/custom_components/dashboardmodern/frontend/src/core/migrations.js
@@ -133,6 +133,32 @@ export function readLegacyState(storage) {
       key,
       ["pool", "irrigation", "energy"].includes(section) ? {} : section === "lights" ? {} : [],
     );
+  // The historical washer was a standalone editor section backed by entity
+  // overrides. Promote it to the canonical appliance model without removing
+  // those overrides, so existing popup/control mappings keep working.
+  const overrides = parse("cd_entity_overrides", {});
+  const washerEntities = Object.entries(overrides).filter(
+    ([key, value]) => key.startsWith("dm.lavatrice_") && value,
+  );
+  if (
+    washerEntities.length &&
+    !sections.appliances.some((item) => item?.device_type === "lavatrice")
+  ) {
+    const get = (suffix) => washerEntities.find(([key]) => key.includes(suffix))?.[1] || "";
+    sections.appliances.push({
+      id: "appliance-lavatrice",
+      name: "Lavatrice",
+      icon: "mdi:washing-machine",
+      device_type: "lavatrice",
+      entities: washerEntities.map(([, entity]) => entity),
+      state_entity: get("fase_corrente"),
+      power_entity: get("potenza_presa"),
+      history_entity: get("tempo_rimanente"),
+      control_entity: get("presa_avvio") || get("avvio_ciclo"),
+      order: sections.appliances.length,
+      metadata: { migrated_from: "lavatrice" },
+    });
+  }
   // Consolidate the two historical secondary-consumption stores once.  The
   // canonical load id is generated independently from its mutable name and
   // report rows that point at an existing load are deliberately not copied.

--- a/custom_components/dashboardmodern/frontend/src/core/renderers.js
+++ b/custom_components/dashboardmodern/frontend/src/core/renderers.js
@@ -152,6 +152,36 @@ const ENERGY_GROUPS = [
 
 const ENERGY_ICONS = { house: "🏠", grid: "🔌", solar: "☀️", battery: "🔋" };
 
+export function createEntityPickerField(
+  document,
+  { value = "", placeholder = "", label = "Entità", state, unit = "", onPick, onChange } = {},
+) {
+  const field = document.createElement("span");
+  field.className = "dm-entity-field";
+  const row = document.createElement("span");
+  row.className = "ed-form-row";
+  const input = document.createElement("input");
+  input.className = "ed-input ed-slot-in mono";
+  input.value = value;
+  input.placeholder = placeholder;
+  const picker = document.createElement("button");
+  picker.type = "button";
+  picker.className = "dm-entity-picker";
+  picker.textContent = "🔍";
+  picker.setAttribute("aria-label", `Seleziona ${label}`);
+  picker.addEventListener("click", () => onPick?.(input));
+  input.addEventListener("change", () => onChange?.(input.value, input));
+  row.append(input, picker);
+  field.append(row);
+  if (value && state != null) {
+    const preview = document.createElement("output");
+    preview.className = "ed-row-old dm-entity-preview";
+    preview.textContent = `${state}${unit ? ` ${unit}` : ""}`;
+    field.append(preview);
+  }
+  return { field, input, picker };
+}
+
 export function renderEnergyEditor(
   document,
   target,
@@ -176,22 +206,32 @@ export function renderEnergyEditor(
   settingsButton.className = "ed-inner-tab";
   settingsButton.type = "button";
   settingsButton.textContent = locale === "it" ? "IMPOSTAZIONI" : "SETTINGS";
+  const loadsButton = document.createElement("button");
+  loadsButton.className = "ed-inner-tab";
+  loadsButton.type = "button";
+  loadsButton.textContent = locale === "it" ? "CARICHI" : "LOADS";
   const flows = document.createElement("section");
   flows.dataset.energyPanel = "flows";
   const settings = document.createElement("section");
   settings.dataset.energyPanel = "settings";
   settings.hidden = true;
+  const loads = document.createElement("section");
+  loads.dataset.energyPanel = "loads";
+  loads.hidden = true;
   const selectTab = (name) => {
     flows.hidden = name !== "flows";
     settings.hidden = name !== "settings";
+    loads.hidden = name !== "loads";
     flowsButton.classList.toggle("active", name === "flows");
     settingsButton.classList.toggle("active", name === "settings");
+    loadsButton.classList.toggle("active", name === "loads");
     handlers.onTabChange?.(name);
   };
   flowsButton.addEventListener("click", () => selectTab("flows"));
   settingsButton.addEventListener("click", () => selectTab("settings"));
-  tabs.append(flowsButton, settingsButton);
-  root.append(tabs, flows, settings);
+  loadsButton.addEventListener("click", () => selectTab("loads"));
+  tabs.append(flowsButton, loadsButton, settingsButton);
+  root.append(tabs, flows, loads, settings);
   ENERGY_GROUPS.forEach(([group, title, fields], groupIndex) => {
     const block = document.createElement("details");
     block.className = "ed-acc";
@@ -207,31 +247,24 @@ export function renderEnergyEditor(
       const field = document.createElement("label");
       field.className = "ed-slot";
       field.innerHTML = `<span class="ed-slot-lbl">${label} <span class="ed-acc-n">${unit}</span> <span class="ed-acc-n">Facoltativo</span></span><span class="ed-hint">Entità Home Assistant, es. ${example}</span>`;
-      const row = document.createElement("span");
-      row.className = "ed-form-row";
-      const input = document.createElement("input");
-      input.className = "ed-input ed-slot-in mono";
+      const { field: entity, input } = createEntityPickerField(document, {
+        value: model[group]?.[key] || "",
+        placeholder: example,
+        label,
+        state: states[model[group]?.[key] || ""]?.state,
+        unit,
+        onPick: handlers.onPick,
+        onChange: (value) => handlers.onChange?.(group, key, value),
+      });
       input.name = `${group}.${key}`;
-      input.value = model[group]?.[key] || "";
-      input.placeholder = example;
       input.dataset.validation = !input.value || states[input.value] ? "valid" : "invalid";
-      const preview = document.createElement("output");
-      preview.className = "ed-row-old";
-      preview.textContent = `${locale === "it" ? "Valore" : "Value"}: ${states[input.value]?.state ?? "—"}${states[input.value]?.state != null ? ` ${unit}` : ""}`;
-      const pick = document.createElement("button");
-      pick.type = "button";
-      pick.className = "dm-entity-picker";
-      pick.textContent = "🔍";
-      pick.setAttribute("aria-label", `Seleziona ${label}`);
-      input.addEventListener("change", () => handlers.onChange?.(group, key, input.value));
-      pick.addEventListener("click", () => handlers.onPick?.(input));
-      row.append(input, pick, preview);
-      field.append(row);
+      field.append(entity);
       body.append(field);
     }
     block.append(body);
     flows.append(block);
   });
+  handlers.renderLoads?.(loads);
   handlers.renderSettings?.(settings);
 }
 

--- a/custom_components/dashboardmodern/frontend/tests/energy-loads-editor.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energy-loads-editor.test.js
@@ -89,14 +89,58 @@ test("Energy real DOM opens Flussi by default, switches settings and reuses the 
   assert.equal(panels.find((node) => node.dataset.energyPanel === "flows").hidden, false);
   assert.equal(panels.find((node) => node.dataset.energyPanel === "settings").hidden, true);
   const tabs = root.queryAll((node) => node.classList.contains("ed-inner-tab"));
-  tabs[1].click();
-  assert.equal(panels[0].hidden, true);
-  assert.equal(panels[1].hidden, false);
+  assert.deepEqual(
+    tabs.map((tab) => tab.textContent),
+    ["FLUSSI ED ENTITÀ", "CARICHI", "IMPOSTAZIONI"],
+  );
+  tabs[2].click();
+  assert.equal(panels.find((node) => node.dataset.energyPanel === "flows").hidden, true);
+  assert.equal(panels.find((node) => node.dataset.energyPanel === "settings").hidden, false);
   const picker = root.queryAll((node) => node.classList.contains("dm-entity-picker"))[0];
   assert.ok(picker);
   picker.click();
   assert.equal(picked.value, "sensor.house");
   assert.match(root.queryAll((node) => node.tagName === "OUTPUT")[0].textContent, /432 W/);
+});
+
+test("empty Energy fields have no fixed Value placeholder and pickers survive 20 rerenders", () => {
+  const root = new Element("div");
+  let picks = 0;
+  for (let pass = 0; pass < 20; pass++) {
+    renderEnergyEditor(document, root, {}, [], {}, "it", { onPick: () => picks++ });
+    const pickers = root.queryAll((node) => node.classList.contains("dm-entity-picker"));
+    assert.ok(pickers.length > 0);
+    assert.equal(root.queryAll((node) => node.tagName === "OUTPUT").length, 0);
+    pickers.forEach((picker) => picker.click());
+  }
+  assert.ok(picks > 20);
+  assert.doesNotMatch(root.innerHTML, /Valore:/);
+});
+
+test("editor navbar exposes Loads only inside Energy and has no standalone washer", async () => {
+  for (const file of ["dashboard.html", "dashboard-en.html"]) {
+    const source = await readFile(new URL(`../legacy/${file}`, import.meta.url), "utf8");
+    const editor = source.slice(
+      source.indexOf('<div class="ed-tabs">'),
+      source.indexOf('<div class="ed-body"'),
+    );
+    assert.doesNotMatch(editor, /data-tab="load"/);
+    assert.doesNotMatch(editor, /data-tab="sez5"/);
+  }
+});
+
+test("legacy washer mappings migrate into the canonical appliance list", () => {
+  const state = readLegacyState(
+    storage({
+      cd_entity_overrides: {
+        "dm.lavatrice_presa_avvio_lavatrice": "switch.washer",
+        "dm.lavatrice_potenza_presa_lavatrice_per_lavatrici_no": "sensor.washer_power",
+      },
+    }),
+  );
+  const washer = state.sections.appliances.find((item) => item.id === "appliance-lavatrice");
+  assert.equal(washer.control_entity, "switch.washer");
+  assert.equal(washer.power_entity, "sensor.washer_power");
 });
 
 test("legacy secondary loads and manual report rows migrate once without duplicates", () => {

--- a/custom_components/dashboardmodern/frontend/tests/legacy-functional.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/legacy-functional.test.js
@@ -74,7 +74,7 @@ for (const [file, labels] of [
         Math.max(0, match.index - 250),
         match.index + match[0].length + 700,
       );
-      assert.match(around, /wzPickEntity/, match[0]);
+      assert.match(around, /wzPickEntity|data-entity-target/, match[0]);
     }
   });
 

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "0.13.2"
+  "version": "0.13.3"
 }

--- a/scripts/vendor_features.py
+++ b/scripts/vendor_features.py
@@ -170,7 +170,7 @@ WIZARD_STEP_REPLACEMENT = "WIZ = { step: (window.__DASHBOARDMODERN_HOSTED__ ? 2 
 
 # ── Visible build marker: prove the served HTML actually updated ───────────
 VERSION_ANCHOR = "const DASHBOARD_VERSION = '0.11.1';"
-VERSION_REPLACEMENT = "const DASHBOARD_VERSION = '0.13.2';"
+VERSION_REPLACEMENT = "const DASHBOARD_VERSION = '0.13.3';"
 
 # ── Temperature section: the Piano (floor) fields are hidden via CSS below ─
 

--- a/tests/test_vendor_features.py
+++ b/tests/test_vendor_features.py
@@ -56,7 +56,7 @@ def test_the_room_field_is_present_in_every_section_and_language() -> None:
         assert "!window.__DASHBOARDMODERN_HOSTED__" in html, name
         assert "step: (window.__DASHBOARDMODERN_HOSTED__ ? 2 : 1)" in html, name
         # The build marker proves the served HTML updated.
-        assert "0.13.2" in html, name
+        assert "0.13.3" in html, name
         # The repository logo is used, not the inline SVG mark.
         assert 'src="./logo.png"' in html, name
         # The Piano field is hidden in the temperature section.
@@ -157,7 +157,7 @@ def test_rooms_management_is_separated_from_temperatures() -> None:
         assert "Rilevamento e manutenzione" in html, name
         # Bugfix guards: sync loop-guard, hosted update-check, version bump.
         assert "cd_sync_rl2" in html, name
-        assert "0.13.2" in html and "0.11.1-int" not in html, name
+        assert "0.13.3" in html and "0.11.1-int" not in html, name
         # Tapparelle: open/close-all buttons and open-shutter alerts.
         assert "Apri tutte" in html and "Chiudi tutte" in html, name
         assert "tapp-avvisi" in html, name


### PR DESCRIPTION
### Motivation

- Consolidare la gestione dei Carichi dentro la sezione Energia per evitare accessi duplicati e ridondanze nella UI dell’Editor Dashboard.
- Eliminare il placeholder fisso "Valore: —" e stabilizzare i picker entità che scompaiono in seguito a rerender/operazioni CRUD.
- Rendere la visibilità delle sezioni reattiva ai dati effettivamente configurati e migrare la configurazione Lavatrice nel modello canonico senza perdere mapping legacy.

### Description

- Spostato il tab `Carichi` come tab interno di `Energia` e aggiunta la struttura interna obbligatoria con ordine `FLUSSI ED ENTITÀ`, `CARICHI`, `IMPOSTAZIONI` nel renderer `renderEnergyEditor` e relativo mount tramite `mountEnergyEditor`/`mountCurrentEditor`.
- Rimossi i tab principali `Carichi` e `Lavatrice` dall’editor principale; la configurazione Lavatrice viene migrata in `appliances` tramite `readLegacyState`/migrations preservando entità e mapping legacy (creato `appliance-lavatrice`).
- Introdotto componente canonico `createEntityPickerField(...)` e funzioni di mounting `mountEntityPickers(target)` e `mountCurrentEditor(section,target)` per collegare listener e picker ogni volta che l’editor viene renderizzato, eliminando l’uso distruttivo di `innerHTML` senza fase di mount.
- Rimosso il testo fisso `Valore: —` dall’input; la preview discreta viene mostrata solo quando esiste un’entità configurata con stato reale (preview sotto l’input, non occupa spazio fisso).
- Stabilizzato il flusso Luci mantenendo disponibile il form di aggiunta luce e montando i picker correttamente dopo salvataggi e rerender.
- Implementata la funzione `hasConfiguredData(section, value)` usata in `ensureSectionVisibleForData` per rendere visibili automaticamente le sezioni quando contengono configurazioni valide (appliance, EV, energy entities, irrigation zones ecc.) senza nasconderle automaticamente alla cancellazione.
- Aggiornata la versione dell’integrazione e del marker HTML a `0.13.3`.
- Aggiunte API/utility nel bridge vendored: `mountEntityPickers`, `mountCurrentEditor` e integrazione di `mountLoadsEditor` come renderer richiamabile da `renderEnergyEditor`.
- Aggiunti e aggiornati test automatici JS nella suite frontend per verificare: ordine tab Energia, assenza dei tab principali rimossi, assenza della stringa `Valore:` su campi vuoti, resistenza delle lenti dopo 20 rerender, migrazione Lavatrice.

### Testing

- Eseguiti i test frontend con `npm run test:frontend`: 99 test superati (tutti verdi).
- Eseguito il controllo inline-syntax con `npm run check:inline-syntax`: compilati correttamente tutti gli script inline delle dashboard vendute.
- Eseguiti i test vendor Python mirati con `python -m pytest -q tests/test_vendor_features.py`: 4 test superati.
- Eseguito `git diff --check` e `npm` checks: nessun warning bloccante residuo rilevato dai processi di integrazione automatica eseguiti.

Note/limitazioni automatiche: la suite Python completa che richiede il pacchetto `homeassistant` non è stata eseguita in questo ambiente containerizzato (mancanza del runtime HA), e non è stato possibile acquisire screenshot desktop/mobile perché non è disponibile un browser runtime nel container; tutti i test automatici locali pertinenti al frontend e alle migration/features sono stati eseguiti e passati con successo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68ae1ca7dc832ea8403d4b8caa29ed)