### PR TITLE
fix: rifinitura finale Editor Dashboard 0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.13.4 — 2026-07-28
+
+- Rifinitura finale dell'Editor: Salva Telecamere, Report Energia canonico e card Costi uniforme.
+- Corretti picker entità persistenti, ricerca icone Stanze, visibilità immediata e migrazione Lavatrice.
+- Rimossi dalla pagina Elettrodomestici i richiami ridondanti alla configurazione.
+
 ## 0.13.2 — 2026-07-28
 
 - Unificato l'editor Energia con tab Flussi e Impostazioni e con il picker entità condiviso.

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
@@ -4791,7 +4791,7 @@ body.cd-nav-fixed { padding-bottom: 96px !important; }
   </div>
   <div class="appl-main-hero">
     <div><div class="appl-main-title">🧺 Appliances</div><div class="appl-main-sub" id="appl-main-sub">Configure cd_appliances in config.js or in the integrated editor.</div></div>
-    <button class="ed-btn-add appl-main-config" onclick="apriConfigEntita(); setTimeout(()=>editorSwitch('appliances'),250)">⚙️ Configure</button>
+
   </div>
   <div class="glance-grid appl-kpi-grid" id="appl-kpi-grid"></div>
   <div class="appl-main-view active" id="appl-view-overview"><h3 class="section-title">Overview</h3><div class="appl-page-grid" id="appl-grid-overview"></div></div>
@@ -6333,7 +6333,7 @@ function dmIconFilter(q) {
     const grid = document.getElementById('dm-icon-grid');
     if (!grid) return;
     const rows = q ? DM_ICONS.filter(x => x.k.includes(q) || x.e === q) : DM_ICONS;
-    if(!visible.length){ grid.innerHTML='<div style="text-align:center; padding:30px; color:var(--text-dim); font-weight:700;">No room con sensore — aggiungila nel tab Temperatura dell&#39;editor</div>'; return; } grid.innerHTML = rows.map(x => `<button type="button" onclick="dmIconChoose('${x.e}')" style="font-size:24px; padding:8px 0; border:1px solid var(--card-border,#e2e8f0); border-radius:12px; background:rgba(148,163,184,0.08); cursor:pointer;">${x.e}</button>`).join('') || '<div style="grid-column:1/-1; text-align:center; padding:16px; color:var(--text-dim); font-weight:700;">No icon</div>';
+    grid.innerHTML = rows.map(x => `<button type="button" onclick="dmIconChoose('${x.e}')" style="font-size:24px; padding:8px 0; border:1px solid var(--card-border,#e2e8f0); border-radius:12px; background:rgba(148,163,184,0.08); cursor:pointer;">${x.e}</button>`).join('') || '<div style="grid-column:1/-1; text-align:center; padding:16px; color:var(--text-dim); font-weight:700;">No icon</div>';
 }
 function dmIconChoose(e) {
     const sel = window._dmIconTarget;
@@ -6507,7 +6507,7 @@ function renderApplianceSection(force) {
   const day = list.reduce((t, a) => t + cdApplNum(cdApplEntity(a, ['energy_today','daily_energy'])), 0);
   const alerts = list.filter(a => !cdApplConfiguredEntities(a).length).length;
   setHtml('appl-kpi-grid', [[labs[0], on, '🟢'], [labs[1], Math.round(watts) + ' W', '⚡'], [labs[2], (day ? day.toFixed(1) : '—') + ' kWh', '📅'], [labs[3], alerts, '⚠️']].map(x => `<div class="glance-card" style="--g-rgb:14,165,233;display:flex;"><div class="g-info"><span class="g-name">${x[0]}</span><span class="g-val">${x[1]}</span></div><div class="g-icon-wrap">${x[2]}</div></div>`).join(''));
-  setTxt('appl-main-sub', list.length ? 'Configure entity_ids in cd_appliances: name, icon, category, power, energy, duration, switch, history.' : 'No appliance configured — Configure entity_ids in cd_appliances: name, icon, category, power, energy, duration, switch, history.');
+  setTxt('appl-main-sub', list.length ? '' : 'No appliances configured.');
   const cats = {
     overview: roomList,
     kitchen: list.filter(a => cdApplCategory(a) === 'kitchen'),
@@ -9825,7 +9825,7 @@ function editorRenderSezioni() {
             <input id="ed-cam-name" class="ed-input" placeholder="Name (e.g. Garden)">
             <div style="display:flex; gap:8px; margin-bottom:6px;"><input id="ed-cam-ent" style="flex:1;" class="ed-input mono" placeholder="camera.giardino"><button type="button" onclick="wzPickEntity('#ed-cam-ent')" style="flex:0 0 38px; height:38px; border:none; border-radius:10px; background:linear-gradient(135deg,#0ea5e9,#0369a1); color:#fff; font-size:14px; cursor:pointer;">🔍</button></div>
             <input id="ed-cam-stream" class="ed-input mono" placeholder="go2rtc stream name (optional, for WebRTC)">
-            <select id="ed-cam-room" class="ed-input" style="margin-bottom:6px;width:100%;"></select><button class="ed-btn-add" onclick="edAddCamera()">＋ Add camera</button>
+            <select id="ed-cam-room" class="ed-input" style="margin-bottom:6px;width:100%;"></select><button class="ed-btn-add" onclick="edAddCamera()">＋ Add camera</button><button type="button" class="ed-save-btn" onclick="edSaveSezione(this)">💾 Save section</button>
           </div>
         </div>
       </details>

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard-runtime.css
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard-runtime.css
@@ -13,3 +13,6 @@
 .dm-appliance-power { margin-top:auto;display:flex;flex-direction:column }.dm-appliance-power small{color:var(--text-dim)}.dm-appliance-power strong{font-size:22px;color:#f8fafc}
 .dm-appliance-history { grid-column:1/3;border:0;background:transparent;padding:0;cursor:pointer }.dm-appliance-history svg{width:100%;height:38px}.dm-appliance-history path{fill:none;stroke:#38bdf8;stroke-width:2;vector-effect:non-scaling-stroke}.dm-appliance-history.disabled{opacity:.3;cursor:default}
 @media(max-width:640px){.dm-appliance-card{grid-template-columns:82px 1fr;min-height:180px;padding:13px}.dm-entity-field{gap:6px}}
+.dm-energy-cost-card { margin-top:12px; padding:16px; border:1px solid var(--card-border,#e2e8f0); border-radius:14px; background:var(--card-bg,#fff) }
+.dm-light-add-form .ed-input { margin:0 }
+@media (max-width:700px) { .dm-energy-cost-card .ed-form-row { grid-template-columns:1fr; display:grid } }

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard.html
@@ -4796,8 +4796,7 @@ html[data-theme="dark"] .tc2-hum { background: rgba(14,165,233,0.16); color:#7dd
     </div>
   </div>
   <div class="appl-main-hero">
-    <div><div class="appl-main-title">🧺 Elettrodomestici</div><div class="appl-main-sub" id="appl-main-sub">Configura cd_appliances in config.js o dall'editor integrato.</div></div>
-    <button class="ed-btn-add appl-main-config" onclick="apriConfigEntita(); setTimeout(()=>editorSwitch('appliances'),250)">⚙️ Configura</button>
+    <div><div class="appl-main-title">🧺 Elettrodomestici</div><div class="appl-main-sub" id="appl-main-sub"></div></div>
   </div>
   <div class="glance-grid appl-kpi-grid" id="appl-kpi-grid"></div>
   <div class="appl-main-view active" id="appl-view-overview"><h3 class="section-title">Panoramica</h3><div class="appl-page-grid" id="appl-grid-overview"></div></div>
@@ -6339,7 +6338,7 @@ function dmIconFilter(q) {
     const grid = document.getElementById('dm-icon-grid');
     if (!grid) return;
     const rows = q ? DM_ICONS.filter(x => x.k.includes(q) || x.e === q) : DM_ICONS;
-    if(!visible.length){ grid.innerHTML='<div style="text-align:center; padding:30px; color:var(--text-dim); font-weight:700;">Nessuna stanza con sensore — aggiungila nel tab Temperatura dell&#39;editor</div>'; return; } grid.innerHTML = rows.map(x => `<button type="button" onclick="dmIconChoose('${x.e}')" style="font-size:24px; padding:8px 0; border:1px solid var(--card-border,#e2e8f0); border-radius:12px; background:rgba(148,163,184,0.08); cursor:pointer;">${x.e}</button>`).join('') || '<div style="grid-column:1/-1; text-align:center; padding:16px; color:var(--text-dim); font-weight:700;">Nessuna icona</div>';
+    grid.innerHTML = rows.map(x => `<button type="button" onclick="dmIconChoose('${x.e}')" style="font-size:24px; padding:8px 0; border:1px solid var(--card-border,#e2e8f0); border-radius:12px; background:rgba(148,163,184,0.08); cursor:pointer;">${x.e}</button>`).join('') || '<div style="grid-column:1/-1; text-align:center; padding:16px; color:var(--text-dim); font-weight:700;">Nessuna icona</div>';
 }
 function dmIconChoose(e) {
     const sel = window._dmIconTarget;
@@ -6513,7 +6512,7 @@ function renderApplianceSection(force) {
   const day = list.reduce((t, a) => t + cdApplNum(cdApplEntity(a, ['energy_today','daily_energy'])), 0);
   const alerts = list.filter(a => !cdApplConfiguredEntities(a).length).length;
   setHtml('appl-kpi-grid', [[labs[0], on, '🟢'], [labs[1], Math.round(watts) + ' W', '⚡'], [labs[2], (day ? day.toFixed(1) : '—') + ' kWh', '📅'], [labs[3], alerts, '⚠️']].map(x => `<div class="glance-card" style="--g-rgb:14,165,233;display:flex;"><div class="g-info"><span class="g-name">${x[0]}</span><span class="g-val">${x[1]}</span></div><div class="g-icon-wrap">${x[2]}</div></div>`).join(''));
-  setTxt('appl-main-sub', list.length ? 'Configura gli entity_id in cd_appliances: name, icon, category, power, energy, duration, switch, history.' : 'Nessun elettrodomestico configurato — Configura gli entity_id in cd_appliances: name, icon, category, power, energy, duration, switch, history.');
+  setTxt('appl-main-sub', list.length ? '' : 'Nessun elettrodomestico configurato.');
   const cats = {
     overview: roomList,
     kitchen: list.filter(a => cdApplCategory(a) === 'kitchen'),
@@ -9862,7 +9861,7 @@ function editorRenderSezioni() {
             <input id="ed-cam-name" class="ed-input" placeholder="Nome (es. Giardino)">
             <div style="display:flex; gap:8px; margin-bottom:6px;"><input id="ed-cam-ent" style="flex:1;" class="ed-input mono" placeholder="camera.giardino"><button type="button" onclick="wzPickEntity('#ed-cam-ent')" style="flex:0 0 38px; height:38px; border:none; border-radius:10px; background:linear-gradient(135deg,#0ea5e9,#0369a1); color:#fff; font-size:14px; cursor:pointer;">🔍</button></div>
             <input id="ed-cam-stream" class="ed-input mono" placeholder="Nome stream go2rtc (facoltativo, per WebRTC)">
-            <select id="ed-cam-room" class="ed-input" style="margin-bottom:6px;width:100%;"></select><button class="ed-btn-add" onclick="edAddCamera()">＋ Aggiungi telecamera</button>
+            <select id="ed-cam-room" class="ed-input" style="margin-bottom:6px;width:100%;"></select><button class="ed-btn-add" onclick="edAddCamera()">＋ Aggiungi telecamera</button><button type="button" class="ed-save-btn" onclick="edSaveSezione(this)">💾 Salva sezione</button>
           </div>
         </div>
       </details>

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -82,13 +82,13 @@ function mountEnergyEditor(target) {
     globalThis.document?.documentElement?.lang === "en" ? "en" : "it", {
       onPick: (input) => globalThis.wzPickEntity?.(input),
       renderLoads: (loads) => mountLoadsEditor(loads),
+      renderReport: (report) => mountLoadsEditor(report, "", "report"),
       renderSettings: (settings) => {
         settings.innerHTML = `${globalThis.cdEnViewsHtml?.() || ""}
-          <div class="ed-sec-title">💶 Costo energia</div>
+          <div class="ed-form dm-energy-cost-card"><div class="ed-sec-title">💶 Costo energia</div>
           <div class="ed-hint">Tariffe usate dal Report Energia.</div>
           <div class="ed-form-row"><input id="ed-costo-kwh" class="ed-input" type="number" step="0.001" min="0" placeholder="€/kWh prelevato" value="${globalThis.cdCfg?.("cd_costo_kwh") || ""}"><input id="ed-prezzo-imm" class="ed-input" type="number" step="0.001" min="0" placeholder="€/kWh immesso" value="${globalThis.cdCfg?.("cd_prezzo_immissione") || ""}"></div>
-          <button class="ed-save-btn" onclick="edSaveCosti()">💾 Salva costi</button>
-          <div class="ed-sec-title">📊 Report</div><div class="ed-intro">Il report usa Elettrodomestici, Carichi secondari e voci manuali configurati nella sezione Carichi.</div>`;
+          <button class="ed-save-btn" onclick="edSaveCosti()">💾 Salva costi</button></div>`;
       },
       onChange: (group, key, value) => {
         const next = store.getSection("energy"); next[group] ||= {}; next[group][key] = value;
@@ -104,6 +104,19 @@ function entityField(id, label, value = "", placeholder = "sensor.entity") {
 }
 
 export function mountEntityPickers(target) {
+  target?.querySelectorAll?.("input.ed-input.mono, input.ed-slot-in, input[data-ref]")?.forEach?.(
+    (input) => {
+      const row = input.parentElement;
+      if (!row || row.querySelector?.(".dm-entity-picker, button[onclick*='wzPickEntity']")) return;
+      const button = globalThis.document.createElement("button");
+      button.type = "button";
+      button.className = "dm-entity-picker";
+      button.setAttribute("aria-label", "Seleziona entità");
+      button.textContent = "🔍";
+      button.addEventListener("click", () => globalThis.wzPickEntity?.(input));
+      row.appendChild(button);
+    },
+  );
   target?.querySelectorAll?.(".dm-entity-picker[data-entity-target]").forEach((button) => {
     if (button.dataset.pickerMounted === "true") return;
     button.dataset.pickerMounted = "true";
@@ -121,12 +134,12 @@ export function mountCurrentEditor(section, target = globalThis.document?.getEle
   target.querySelectorAll?.("details.ed-acc").forEach((details) => details.dataset.editorMounted = "true");
   target.dataset.mountedSection = section || "";
 }
-function mountLoadsEditor(target, editId = "") {
+function mountLoadsEditor(target, editId = "", mode = "loads") {
   const loads = store.getSection("loads");
   const appliances = store.getSection("appliances");
   const current = loads.find((item) => item.id === editId) || {};
   const cards = (items, manual, readOnly = false) => items.map((item) => `<div class="ed-row" data-load-id="${esc(item.id)}"><div class="ed-row-main"><div class="ed-row-new">${esc(item.icon || "🔌")} ${esc(item.name || "Carico")}</div><div class="ed-row-old">${esc(item.category || (manual ? "Voce report" : "Carico secondario"))}</div></div>${readOnly ? "" : `<button class="ed-del" data-edit-load="${esc(item.id)}" title="Modifica">✏️</button><button class="ed-del" data-delete-load="${esc(item.id)}" title="Elimina">🗑️</button>`}</div>`).join("") || '<div class="ed-empty">Nessuna voce configurata</div>';
-  target.innerHTML = `<details class="ed-acc" open><summary class="ed-acc-head">A. DISPOSITIVI / ELETTRODOMESTICI <span class="ed-acc-n">${appliances.length}</span></summary><div class="ed-acc-body"><div class="ed-intro">Collegati al modello canonico Elettrodomestici; si modificano una sola volta nella sezione dedicata.</div>${cards(appliances, false, true)}</div></details>
+  target.innerHTML = `<div class="ed-intro">${mode === "report" ? "Configura qui Elettrodomestici, Carichi secondari e Voci manuali usando il solo modello canonico." : "Carichi e Report condividono lo stesso modello: nessuna configurazione viene duplicata."}</div><details class="ed-acc" open><summary class="ed-acc-head">A. DISPOSITIVI / ELETTRODOMESTICI <span class="ed-acc-n">${appliances.length}</span></summary><div class="ed-acc-body"><div class="ed-intro">Collegati al modello canonico Elettrodomestici; si modificano una sola volta nella sezione dedicata.</div>${cards(appliances, false, true)}</div></details>
     <details class="ed-acc" open><summary class="ed-acc-head">B. CARICHI SECONDARI <span class="ed-acc-n">${loads.filter((x) => x.category !== "manual-report").length}</span></summary><div class="ed-acc-body">${cards(loads.filter((x) => x.category !== "manual-report"), false)}</div></details>
     <details class="ed-acc"><summary class="ed-acc-head">C. VOCI REPORT MANUALI <span class="ed-acc-n">${loads.filter((x) => x.category === "manual-report").length}</span></summary><div class="ed-acc-body">${cards(loads.filter((x) => x.category === "manual-report"), true)}</div></details>
     <div class="ed-form" data-load-form><div class="ed-sec-title">${editId ? "Modifica carico" : "Nuovo carico secondario"}</div><div class="ed-form-row"><input id="dm-load-name" class="ed-input" placeholder="Nome" value="${esc(current.name)}"><input id="dm-load-icon" class="ed-input ed-icon-input" placeholder="🔌 / mdi:power-plug" value="${esc(current.icon)}"></div><div class="ed-form-row"><input id="dm-load-category" class="ed-input" placeholder="Categoria" value="${esc(current.category || "secondary")}"><select id="dm-load-room" class="ed-input">${globalThis.cdRoomOptions?.(current.room_id) || ""}</select></div>${entityField("dm-load-power", "Entità potenza", current.power_entity, "sensor.carico_power")}${entityField("dm-load-day", "Energia giornaliera", current.daily_energy_entity)}${entityField("dm-load-month", "Energia mensile", current.monthly_energy_entity)}${entityField("dm-load-total", "Energia totale", current.total_energy_entity)}${entityField("dm-load-history", "Storico", current.history_entity)}${entityField("dm-load-state", "Stato", current.state_entity)}${entityField("dm-load-control", "Comando ON/OFF", current.control_entity, "switch.carico")}<label class="ed-intro"><input id="dm-load-report" type="checkbox" ${current.show_in_report !== false ? "checked" : ""}> Visibile nel report</label><label class="ed-intro"><input id="dm-load-dashboard" type="checkbox" ${current.show_in_dashboard !== false ? "checked" : ""}> Visibile nella dashboard</label><button class="ed-btn-add" data-save-load>💾 ${editId ? "Salva modifiche" : "Aggiungi carico"}</button></div>`;

--- a/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
+++ b/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
@@ -29,7 +29,15 @@ export function hasConfiguredData(section, value) {
           )),
     );
   if (!value || typeof value !== "object") return false;
-  if (section === "irrigation") return (value.zones || []).length > 0;
+  if (section === "irrigation")
+    return (
+      (value.zones || []).some((zone) => configured(zone?.entity)) ||
+      [value.rainEnt, value.weatherEnt].some(configured)
+    );
+  if (section === "pool")
+    return ["tempEnt", "phEnt", "clEnt", "pumpEnt", "heatEnt", "lightEnt"].some((key) =>
+      configured(value[key]),
+    );
   return Object.entries(value).some(
     ([key, entry]) =>
       key !== "metadata" &&

--- a/custom_components/dashboardmodern/frontend/src/core/migrations.js
+++ b/custom_components/dashboardmodern/frontend/src/core/migrations.js
@@ -148,7 +148,8 @@ export function readLegacyState(storage) {
     sections.appliances.push({
       id: "appliance-lavatrice",
       name: "Lavatrice",
-      icon: "mdi:washing-machine",
+      // Keep the project's original built-in washer artwork identifier.
+      icon: "lavatrice",
       device_type: "lavatrice",
       entities: washerEntities.map(([, entity]) => entity),
       state_entity: get("fase_corrente"),

--- a/custom_components/dashboardmodern/frontend/src/core/renderers.js
+++ b/custom_components/dashboardmodern/frontend/src/core/renderers.js
@@ -210,6 +210,10 @@ export function renderEnergyEditor(
   loadsButton.className = "ed-inner-tab";
   loadsButton.type = "button";
   loadsButton.textContent = locale === "it" ? "CARICHI" : "LOADS";
+  const reportButton = document.createElement("button");
+  reportButton.className = "ed-inner-tab";
+  reportButton.type = "button";
+  reportButton.textContent = "REPORT";
   const flows = document.createElement("section");
   flows.dataset.energyPanel = "flows";
   const settings = document.createElement("section");
@@ -218,20 +222,26 @@ export function renderEnergyEditor(
   const loads = document.createElement("section");
   loads.dataset.energyPanel = "loads";
   loads.hidden = true;
+  const report = document.createElement("section");
+  report.dataset.energyPanel = "report";
+  report.hidden = true;
   const selectTab = (name) => {
     flows.hidden = name !== "flows";
     settings.hidden = name !== "settings";
     loads.hidden = name !== "loads";
+    report.hidden = name !== "report";
     flowsButton.classList.toggle("active", name === "flows");
     settingsButton.classList.toggle("active", name === "settings");
     loadsButton.classList.toggle("active", name === "loads");
+    reportButton.classList.toggle("active", name === "report");
     handlers.onTabChange?.(name);
   };
   flowsButton.addEventListener("click", () => selectTab("flows"));
   settingsButton.addEventListener("click", () => selectTab("settings"));
   loadsButton.addEventListener("click", () => selectTab("loads"));
-  tabs.append(flowsButton, loadsButton, settingsButton);
-  root.append(tabs, flows, loads, settings);
+  reportButton.addEventListener("click", () => selectTab("report"));
+  tabs.append(flowsButton, loadsButton, reportButton, settingsButton);
+  root.append(tabs, flows, loads, report, settings);
   ENERGY_GROUPS.forEach(([group, title, fields], groupIndex) => {
     const block = document.createElement("details");
     block.className = "ed-acc";
@@ -265,6 +275,7 @@ export function renderEnergyEditor(
     flows.append(block);
   });
   handlers.renderLoads?.(loads);
+  handlers.renderReport?.(report);
   handlers.renderSettings?.(settings);
 }
 

--- a/custom_components/dashboardmodern/frontend/tests/dashboard-store.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/dashboard-store.test.js
@@ -1,9 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { DashboardStore } from "../src/core/dashboard-store.js";
+import { DashboardStore, hasConfiguredData } from "../src/core/dashboard-store.js";
 import { cloneValue, getDeviceDisplayName, getDeviceVisual } from "../src/core/device-model.js";
 import { migrateEnergy, migrateRooms, migrateState } from "../src/core/migrations.js";
 import { createEnergyReportRows, createRenderCoordinator } from "../src/core/renderers.js";
+
+test("visibility recognizes configured pool and irrigation entities without devices", () => {
+  assert.equal(hasConfiguredData("pool", { pumpEnt: "switch.pool" }), true);
+  assert.equal(hasConfiguredData("irrigation", { rainEnt: "sensor.rain", zones: [] }), true);
+  assert.equal(hasConfiguredData("irrigation", { zones: [{ entity: "switch.garden" }] }), true);
+  assert.equal(hasConfiguredData("pool", { filterHours: 8 }), false);
+});
 
 class MemoryStorage {
   values = new Map();
@@ -292,15 +299,7 @@ test("all CRUD editor sections are registered with the reactive coordinator", as
   const { store } = setup();
   const rendered = [];
   createRenderCoordinator(store, { renderCurrentEditor: (section) => rendered.push(section) });
-  for (const section of [
-    "appliances",
-    "cameras",
-    "rooms",
-    "ev",
-    "lights",
-    "climate",
-    "covers",
-  ]) {
+  for (const section of ["appliances", "cameras", "rooms", "ev", "lights", "climate", "covers"]) {
     await store.addItem(section, { name: section, entity: `sensor.${section}` });
   }
   await store.replaceSection("pool", { tempEnt: "sensor.pool" });

--- a/custom_components/dashboardmodern/frontend/tests/energy-loads-editor.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energy-loads-editor.test.js
@@ -91,9 +91,9 @@ test("Energy real DOM opens Flussi by default, switches settings and reuses the 
   const tabs = root.queryAll((node) => node.classList.contains("ed-inner-tab"));
   assert.deepEqual(
     tabs.map((tab) => tab.textContent),
-    ["FLUSSI ED ENTITÀ", "CARICHI", "IMPOSTAZIONI"],
+    ["FLUSSI ED ENTITÀ", "CARICHI", "REPORT", "IMPOSTAZIONI"],
   );
-  tabs[2].click();
+  tabs[3].click();
   assert.equal(panels.find((node) => node.dataset.energyPanel === "flows").hidden, true);
   assert.equal(panels.find((node) => node.dataset.energyPanel === "settings").hidden, false);
   const picker = root.queryAll((node) => node.classList.contains("dm-entity-picker"))[0];
@@ -141,6 +141,7 @@ test("legacy washer mappings migrate into the canonical appliance list", () => {
   const washer = state.sections.appliances.find((item) => item.id === "appliance-lavatrice");
   assert.equal(washer.control_entity, "switch.washer");
   assert.equal(washer.power_entity, "sensor.washer_power");
+  assert.equal(washer.icon, "lavatrice");
 });
 
 test("legacy secondary loads and manual report rows migrate once without duplicates", () => {

--- a/custom_components/dashboardmodern/frontend/tests/legacy-functional.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/legacy-functional.test.js
@@ -51,6 +51,18 @@ for (const [file, labels] of [
     assert.match(rooms, /ed-room-icon-preview/);
     assert.match(rooms, /dmIconPicker/);
     assert.match(source, /function cdIconMarkup[\s\S]*mdi:/);
+    const iconFilter = functionSource(source, "dmIconFilter");
+    assert.match(iconFilter, /const rows = q \? DM_ICONS\.filter/);
+    assert.doesNotMatch(iconFilter, /visible\.length/);
+  });
+
+  test(`${file}: camera has canonical Save and appliance page has no editor CTA`, () => {
+    const editor = functionSource(source, "editorRenderSezioni");
+    const cameraStart = editor.indexOf("ed-cam-room");
+    const camera = editor.slice(cameraStart, cameraStart + 500);
+    assert.match(camera, /class="ed-save-btn"/);
+    assert.doesNotMatch(source, /<button[^>]+appl-main-config/);
+    assert.doesNotMatch(source, /(?:Configura gli|Configure) entity_id/);
   });
 
   test(`${file}: adding an appliance reveals and synchronizes its section without reload`, () => {

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "0.13.3"
+  "version": "0.13.4"
 }


### PR DESCRIPTION
### Motivation

- Uniformare l'Editor Dashboard e riparare le regressioni residue dell'ultima serie 0.13.x senza aggiungere nuove funzionalità.
- Rendere coerenti i pulsanti Salva in tutte le sezioni dell'editor e ripristinare la gestione Report/Energia sul modello canonico condiviso con Carichi ed Elettrodomestici.
- Risolvere bug di visibilità automatica delle sezioni, mantenimento dei picker entità dopo i render e completare la migrazione della Lavatrice.

### Description

- Aggiunto tab/section `REPORT` all'Editor Energia e collegata la sua rendering pipeline condivisa con `mountLoadsEditor` usando il parametro `mode = "report"`, centralizzando Elettrodomestici / Carichi secondari / Voci manuali (file `src/core/renderers.js`, `legacy/modules-entry.js`).
- Trasformata la configurazione Costi Energia in una vera card editor coerente con gli altri componenti e relativo CSS `.dm-energy-cost-card` (file `legacy/modules-entry.js`, `legacy/dashboard-runtime.css`).
- Garantito che ogni campo `entity_id` riceva sempre il picker canonico dopo ogni render; `mountEntityPickers` ora arricchisce input vuoti e previene duplicazioni (file `legacy/modules-entry.js`).
- Migliorata la funzione di visibilità automatica `hasConfiguredData()` per considerare sensori/comandi/meteo/zone per `irrigation` e campi significativi per `pool` invece di contare solo elementi (file `src/core/dashboard-store.js`).
- Completata la migrazione della Lavatrice nel modello `appliances` preservando entità e ripristinando l'identificatore grafico originale `lavatrice` (file `src/core/migrations.js`).
- Aggiunto pulsante `💾 Salva sezione` nella UI editor per le Telecamere per uniformare il comportamento Salva in tutte le sezioni (file `legacy/dashboard.html` / `legacy/dashboard-en.html`).
- Rifattorizzazioni minori per evitare istruzioni/CTA ridondanti nella pagina pubblica Elettrodomestici e correzione del filtraggio icone Stanze (file `legacy/*`).
- Aggiornata la versione dell'integrazione a `0.13.4` e aggiornato `CHANGELOG.md` (file `custom_components/dashboardmodern/manifest.json`, `CHANGELOG.md`).

### Testing

- Eseguiti i test front-end con `npm run test:frontend` — 102 test superati con esito positivo.
- Compilati gli script inline delle dashboard con `npm run check:inline-syntax` con successo per le varianti `dashboard.html` e `dashboard-en.html`.
- Controllo formattazione `npm run format:check` (Prettier) passato per i file modificati.
- Eseguito `git diff --check` e verifiche statiche, non sono emersi errori bloccanti.
- Nota: `pytest -q` non è stato eseguito nell'ambiente di esecuzione per mancanza della dipendenza Python `homeassistant` (raccolta test non disponibile in questo runner).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68b4c59314832ebfa5e3f447255082)