### PR TITLE
Fix: runtime UI stabile su Safari e Home Assistant

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/runtime-ui-safari.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/runtime-ui-safari.spec.js
@@ -1,0 +1,158 @@
+import { expect, test } from "@playwright/test";
+
+async function bootDashboard(page, variant) {
+  const pageErrors = [];
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+  await page.route("https://**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("chart.js")) {
+      return route.fulfill({
+        contentType: "application/javascript",
+        body: "window.Chart=class{static defaults={color:'',font:{}};constructor(){}destroy(){}}",
+      });
+    }
+    if (url.includes("panzoom")) {
+      return route.fulfill({
+        contentType: "application/javascript",
+        body: "window.panzoom=()=>({dispose(){}})",
+      });
+    }
+    if (url.includes("hls.js")) {
+      return route.fulfill({
+        contentType: "application/javascript",
+        body: "window.Hls=class{static isSupported(){return false}}",
+      });
+    }
+    return route.fulfill({ status: 200, body: "" });
+  });
+
+  await page.addInitScript(() => {
+    class TestSocket extends EventTarget {
+      static OPEN = 1;
+      readyState = 1;
+      constructor() {
+        super();
+        queueMicrotask(() => {
+          this.dispatchEvent(new Event("open"));
+          this.onopen?.();
+          this.emit({ type: "auth_required", ha_version: "test" });
+        });
+      }
+      emit(value) {
+        const event = new MessageEvent("message", { data: JSON.stringify(value) });
+        this.dispatchEvent(event);
+        this.onmessage?.(event);
+      }
+      send(payload) {
+        const message = JSON.parse(payload);
+        if (message.type === "auth") this.emit({ type: "auth_ok", ha_version: "test" });
+        else this.emit({ id: message.id, type: "result", success: true, result: [] });
+      }
+      close() {}
+    }
+    window.WebSocket = TestSocket;
+  });
+
+  const state = {
+    schema_version: 4,
+    sections: {
+      rooms: [],
+      appliances: [
+        {
+          id: "appliance-safari",
+          name: "Forno",
+          device_type: "forno",
+          visual_type: "asset",
+          visual_key: "forno",
+          entities: ["sensor.forno_power"],
+        },
+      ],
+      loads: [],
+      entityOverrides: {},
+    },
+    visibility: {},
+  };
+
+  await page.goto(`/legacy/${variant}`);
+  await page.evaluate((seed) => {
+    localStorage.clear();
+    localStorage.setItem("dm_dashboard_state", JSON.stringify(seed));
+    localStorage.setItem("cd_luci", JSON.stringify({}));
+  }, state);
+  await page.reload();
+  await page.waitForFunction(
+    () =>
+      window.__DASHBOARDMODERN_LEGACY_READY__ === true &&
+      !!window.DashboardModernModules &&
+      window.__DASHBOARDMODERN_RUNTIME_HOTFIX__ === true,
+  );
+  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await page.evaluate(() => {
+    window.cdSyncPush = async () => {};
+  });
+  expect(pageErrors).toEqual([]);
+}
+
+for (const variant of ["dashboard.html", "dashboard-en.html"]) {
+  test(`${variant}: Safari runtime UI remains usable after rerenders`, async ({ page }, testInfo) => {
+    await bootDashboard(page, variant);
+
+    await page.evaluate(() => window.apriConfigEntita());
+    await page.evaluate(() => window.editorSwitch("luci"));
+
+    const body = page.locator("#ed-body");
+    const lightInput = body.locator("[data-light-add-entity]");
+    await expect(lightInput).toHaveCount(1);
+    const lightId = await lightInput.getAttribute("id");
+    expect(lightId).toBeTruthy();
+    const picker = body.locator(`.dm-entity-picker[data-entity-target="${lightId}"]`);
+    await expect(picker).toHaveCount(1);
+    await expect(picker).toBeVisible();
+
+    // Re-render the complete editor body twice. The runtime guard must remount
+    // exactly one picker each time, which is what previously failed in Home Assistant.
+    await page.evaluate(() => window.editorSwitch("stanze"));
+    await page.evaluate(() => window.editorSwitch("luci"));
+    await expect(body.locator("[data-light-add-entity]")).toHaveCount(1);
+    await expect(body.locator(".dm-entity-picker")).toHaveCount(1);
+
+    await body.evaluate((node) => {
+      const spacer = document.createElement("div");
+      spacer.dataset.scrollProbe = "";
+      spacer.style.height = "1200px";
+      node.appendChild(spacer);
+    });
+    const modal = page.locator("#editor-modal");
+    await expect(modal).toBeVisible();
+    expect(
+      await modal.evaluate((node) => node.scrollHeight > node.clientHeight),
+    ).toBe(true);
+    await modal.evaluate((node) => {
+      node.scrollTop = node.scrollHeight;
+    });
+    expect(await modal.evaluate((node) => node.scrollTop)).toBeGreaterThan(0);
+    expect(await body.evaluate((node) => getComputedStyle(node).overflowY)).toBe("visible");
+    await page.screenshot({ path: `test-results/${testInfo.project.name}-${variant}-runtime-scroll.png` });
+
+    await page.evaluate(() => document.getElementById("editor-modal")?.remove());
+    await page.evaluate(() => {
+      document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
+      document.getElementById("page-appliances-main")?.classList.add("active");
+      window.renderApplianceSection(true);
+    });
+
+    const card = page.locator("#appl-grid-overview .appl-wide-card").first();
+    await expect(card).toBeVisible();
+    expect(await card.evaluate((node) => getComputedStyle(node).display)).toBe("flex");
+    const visual = card.locator(".appl-ic");
+    const visualBox = await visual.boundingBox();
+    expect(visualBox?.width ?? 0).toBeGreaterThanOrEqual(50);
+    expect(visualBox?.height ?? 0).toBeGreaterThanOrEqual(50);
+    const graphic = visual.locator("svg, img, ha-icon").first();
+    await expect(graphic).toBeVisible();
+    const graphicBox = await graphic.boundingBox();
+    expect(graphicBox?.width ?? 0).toBeGreaterThanOrEqual(30);
+    expect(graphicBox?.height ?? 0).toBeGreaterThanOrEqual(30);
+    await page.screenshot({ path: `test-results/${testInfo.project.name}-${variant}-appliances-real.png` });
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/runtime-ui-safari.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/runtime-ui-safari.spec.js
@@ -57,16 +57,7 @@ async function bootDashboard(page, variant) {
     schema_version: 4,
     sections: {
       rooms: [],
-      appliances: [
-        {
-          id: "appliance-safari",
-          name: "Forno",
-          device_type: "forno",
-          visual_type: "asset",
-          visual_key: "forno",
-          entities: ["sensor.forno_power"],
-        },
-      ],
+      appliances: [],
       loads: [],
       entityOverrides: {},
     },
@@ -80,6 +71,7 @@ async function bootDashboard(page, variant) {
     localStorage.setItem("cd_luci", JSON.stringify({}));
   }, state);
   await page.reload();
+
   // In Home Assistant this script is injected by the hosted panel. The E2E opens
   // the legacy document directly, so reproduce that production injection here.
   await page.addScriptTag({ url: "/legacy/runtime-hotfix.js" });
@@ -99,6 +91,24 @@ async function bootDashboard(page, variant) {
 for (const variant of ["dashboard.html", "dashboard-en.html"]) {
   test(`${variant}: Safari runtime UI remains usable after rerenders`, async ({ page }, testInfo) => {
     await bootDashboard(page, variant);
+
+    // Populate the canonical store after runtime boot. Seeding only localStorage
+    // is not deterministic here because the legacy cloud-sync bootstrap can
+    // reconcile an empty remote snapshot before the assertion phase.
+    await page.evaluate(async () => {
+      await window.DashboardModernModules.store.replaceSection("appliances", [
+        {
+          id: "appliance-safari",
+          name: "Forno",
+          device_type: "forno",
+          visual_type: "asset",
+          visual_key: "forno",
+          power_entity: "sensor.forno_power",
+          entities: ["sensor.forno_power"],
+          show_in_dashboard: true,
+        },
+      ]);
+    });
 
     await page.evaluate(() => window.apriConfigEntita());
     await page.evaluate(() => window.editorSwitch("luci"));
@@ -133,7 +143,9 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     });
     expect(await modal.evaluate((node) => node.scrollTop)).toBeGreaterThan(0);
     expect(await body.evaluate((node) => getComputedStyle(node).overflowY)).toBe("visible");
-    await page.screenshot({ path: `test-results/${testInfo.project.name}-${variant}-runtime-scroll.png` });
+    await page.screenshot({
+      path: `test-results/${testInfo.project.name}-${variant}-runtime-scroll.png`,
+    });
 
     await page.evaluate(() => document.getElementById("editor-modal")?.remove());
     await page.evaluate(() => {
@@ -154,6 +166,8 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     const graphicBox = await graphic.boundingBox();
     expect(graphicBox?.width ?? 0).toBeGreaterThanOrEqual(30);
     expect(graphicBox?.height ?? 0).toBeGreaterThanOrEqual(30);
-    await page.screenshot({ path: `test-results/${testInfo.project.name}-${variant}-appliances-real.png` });
+    await page.screenshot({
+      path: `test-results/${testInfo.project.name}-${variant}-appliances-real.png`,
+    });
   });
 }

--- a/custom_components/dashboardmodern/frontend/e2e/runtime-ui-safari.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/runtime-ui-safari.spec.js
@@ -80,6 +80,9 @@ async function bootDashboard(page, variant) {
     localStorage.setItem("cd_luci", JSON.stringify({}));
   }, state);
   await page.reload();
+  // In Home Assistant this script is injected by the hosted panel. The E2E opens
+  // the legacy document directly, so reproduce that production injection here.
+  await page.addScriptTag({ url: "/legacy/runtime-hotfix.js" });
   await page.waitForFunction(
     () =>
       window.__DASHBOARDMODERN_LEGACY_READY__ === true &&
@@ -124,9 +127,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     });
     const modal = page.locator("#editor-modal");
     await expect(modal).toBeVisible();
-    expect(
-      await modal.evaluate((node) => node.scrollHeight > node.clientHeight),
-    ).toBe(true);
+    expect(await modal.evaluate((node) => node.scrollHeight > node.clientHeight)).toBe(true);
     await modal.evaluate((node) => {
       node.scrollTop = node.scrollHeight;
     });

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard-runtime.css
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard-runtime.css
@@ -23,6 +23,7 @@
 .dm-entity-picker {
   flex: 0 0 40px;
   width: 40px;
+  min-width: 40px;
   min-height: 40px;
   align-self: stretch;
   border: 0;
@@ -30,6 +31,10 @@
   background: linear-gradient(135deg, #0ea5e9, #0369a1);
   color: #fff;
   cursor: pointer;
+  display: inline-grid;
+  place-items: center;
+  visibility: visible !important;
+  opacity: 1 !important;
 }
 
 .dm-camera-edit {
@@ -51,106 +56,143 @@
   background: rgba(34, 197, 94, 0.14);
 }
 
-/* The editor owns one scrolling surface; public dashboard scrolling is untouched. */
+/*
+ * Safari inside the Home Assistant iframe is unreliable with a fixed 100dvh
+ * inner scroller. The modal overlay is now the only scrolling surface: the
+ * shell follows its natural height and can never trap content below ed-body.
+ */
 #editor-modal.modal-wrapper {
-  overflow: hidden;
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
   overscroll-behavior: contain;
+  align-items: flex-start !important;
+  padding: 24px 12px !important;
+  -webkit-overflow-scrolling: touch;
 }
 
 #editor-modal .ed-shell {
   display: flex;
   flex-direction: column;
+  width: min(100%, 790px);
+  height: auto !important;
   min-height: 0;
-  height: min(88vh, calc(100dvh - 24px));
-  max-height: calc(100dvh - 24px);
-  overflow: hidden;
+  max-height: none !important;
+  margin: auto;
+  overflow: visible !important;
 }
 
 #editor-modal .ed-head,
-#editor-modal .ed-tabs {
+#editor-modal .ed-tabs,
+#editor-modal .ed-body {
   flex: 0 0 auto;
 }
 
 #editor-modal .ed-body {
-  flex: 1 1 auto;
   min-height: 0;
-  overflow-x: hidden;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  touch-action: pan-y;
-  -webkit-overflow-scrolling: touch;
+  overflow: visible !important;
+  touch-action: auto;
 }
 
-/* Compact, two-column appliance cards with an always-visible inline visual. */
+/*
+ * Appliance cards: avoid display:contents, which produced an empty narrow
+ * visual column in Safari. The icon now lives in a stable header row and the
+ * card stays compact at every width.
+ */
 #page-appliances-main .appl-page-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
   align-items: stretch;
   gap: 16px;
 }
 
 #page-appliances-main .appl-wide-card {
-  display: grid;
-  grid-template-columns: 112px minmax(0, 1fr);
-  grid-template-rows: auto auto auto;
-  gap: 10px 14px;
+  display: flex !important;
+  flex-direction: column;
+  gap: 14px;
   min-width: 0;
-  min-height: 190px;
+  min-height: 0;
   padding: 16px;
   overflow: hidden;
 }
 
-#page-appliances-main .appl-wide-top,
+#page-appliances-main .appl-wide-top {
+  display: flex !important;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
 #page-appliances-main .appl-wide-top > div:first-child {
-  display: contents;
+  display: flex !important;
+  align-items: center;
+  flex: 1 1 auto;
+  gap: 12px !important;
+  min-width: 0;
 }
 
 #page-appliances-main .appl-wide-top > div:first-child > div:last-child {
-  grid-column: 2;
-  grid-row: 1;
   min-width: 0;
-  padding-right: 74px;
+  padding-right: 0;
 }
 
 #page-appliances-main .appl-ic {
-  grid-column: 1;
-  grid-row: 1 / 4;
-  display: grid;
+  display: grid !important;
   place-items: center;
-  min-height: 150px;
-  padding: 8px;
-  border-radius: 18px;
-  color: #0ea5e9;
-  background: rgba(14, 165, 233, 0.1);
+  flex: 0 0 72px;
+  width: 72px;
+  height: 72px;
+  min-height: 72px;
+  padding: 10px;
+  border-radius: 20px;
+  color: #0284c7;
+  background: linear-gradient(145deg, rgba(224, 242, 254, 0.95), rgba(186, 230, 253, 0.72));
+  box-shadow: inset 0 0 0 1px rgba(14, 165, 233, 0.12);
+  overflow: hidden;
+}
+
+#page-appliances-main .appl-ic:empty::before {
+  content: "⚙️";
+  font-size: 34px;
+  line-height: 1;
 }
 
 #page-appliances-main .appl-ic svg,
-#page-appliances-main .appl-ic img {
-  display: block;
-  width: 96px;
-  height: 96px;
+#page-appliances-main .appl-ic img,
+#page-appliances-main .appl-ic ha-icon {
+  display: block !important;
+  width: 52px !important;
+  height: 52px !important;
   max-width: 100%;
+  max-height: 100%;
   object-fit: contain;
+  --mdc-icon-size: 52px;
+  visibility: visible !important;
+  opacity: 1 !important;
 }
 
 #page-appliances-main .appl-wide-top > .appl-st {
-  grid-column: 2;
-  grid-row: 1;
-  justify-self: end;
-  align-self: start;
+  flex: 0 0 auto;
+  align-self: flex-start;
 }
 
 #page-appliances-main .appl-metrics {
-  grid-column: 2;
-  grid-row: 2;
+  display: grid !important;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   min-width: 0;
   margin: 0;
+  gap: 8px;
+}
+
+#page-appliances-main .appl-metric {
+  min-width: 0;
 }
 
 #page-appliances-main .appl-actions {
-  grid-column: 2;
-  grid-row: 3;
-  align-self: end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-top: auto;
 }
 
 /* Covers: replace the tiny generic tile with a dashboard-sized control card. */
@@ -175,7 +217,6 @@
 .tapp-card .tapp-btn[data-svc="stop_cover"]::after { content:" Stop" }
 .tapp-card .tapp-btn[data-svc="close_cover"]::after { content:" Chiudi" }
 
-
 .dm-energy-cost-card {
   margin-top: 12px;
   padding: 16px;
@@ -190,15 +231,13 @@
 
 @media (max-width: 760px) {
   #editor-modal.modal-wrapper {
-    padding: 0;
-    align-items: stretch;
+    padding: 0 !important;
   }
 
   #editor-modal .ed-shell {
     width: 100%;
     max-width: none;
-    height: 100dvh;
-    max-height: 100dvh;
+    min-height: 100%;
     margin: 0;
     border-radius: 0;
   }
@@ -221,36 +260,29 @@
   }
 
   #page-appliances-main .appl-wide-card {
-    grid-template-columns: 86px minmax(0, 1fr);
-    min-height: 170px;
     padding: 12px;
-    gap: 8px 10px;
+    gap: 10px;
   }
 
   #page-appliances-main .appl-ic {
-    min-height: 132px;
+    flex-basis: 58px;
+    width: 58px;
+    height: 58px;
+    min-height: 58px;
+    border-radius: 16px;
+    padding: 8px;
   }
 
   #page-appliances-main .appl-ic svg,
-  #page-appliances-main .appl-ic img {
-    width: 72px;
-    height: 72px;
-  }
-
-  #page-appliances-main .appl-wide-top > div:first-child > div:last-child {
-    padding-right: 0;
-  }
-
-  #page-appliances-main .appl-wide-top > .appl-st {
-    position: static;
+  #page-appliances-main .appl-ic img,
+  #page-appliances-main .appl-ic ha-icon {
+    width: 42px !important;
+    height: 42px !important;
+    --mdc-icon-size: 42px;
   }
 
   #page-appliances-main .appl-metrics {
-    grid-template-columns: 1fr;
-  }
-
-  #page-appliances-main .appl-metric:nth-child(n + 2) {
-    display: none;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   #tapp-grid {

--- a/custom_components/dashboardmodern/frontend/legacy/runtime-hotfix.js
+++ b/custom_components/dashboardmodern/frontend/legacy/runtime-hotfix.js
@@ -1,0 +1,83 @@
+(function () {
+  "use strict";
+
+  if (window.__DASHBOARDMODERN_RUNTIME_HOTFIX__) return;
+  window.__DASHBOARDMODERN_RUNTIME_HOTFIX__ = true;
+
+  let editorBody = null;
+  let editorObserver = null;
+  let pickerPassQueued = false;
+
+  function mountEntityPickers() {
+    const body = document.getElementById("ed-body");
+    const mount = window.DashboardModernModules?.render?.mountEntityPickers;
+    if (!body || typeof mount !== "function") return;
+    mount(body);
+  }
+
+  function queuePickerPass() {
+    if (pickerPassQueued) return;
+    pickerPassQueued = true;
+    queueMicrotask(function () {
+      pickerPassQueued = false;
+      mountEntityPickers();
+    });
+  }
+
+  function attachEditorObserver() {
+    const nextBody = document.getElementById("ed-body");
+    if (!nextBody) return;
+
+    if (nextBody !== editorBody) {
+      editorObserver?.disconnect();
+      editorBody = nextBody;
+      editorObserver = new MutationObserver(queuePickerPass);
+      editorObserver.observe(nextBody, { childList: true, subtree: true });
+    }
+
+    queuePickerPass();
+  }
+
+  function ensureApplianceVisuals() {
+    document.querySelectorAll("#page-appliances-main .appl-ic").forEach(function (visual) {
+      const hasGraphic = visual.querySelector("svg, img, ha-icon");
+      if (hasGraphic) return;
+
+      const fallback =
+        typeof window.cdApplianceIcon === "function"
+          ? window.cdApplianceIcon("generico", 52)
+          : "⚙️";
+      visual.innerHTML = fallback;
+    });
+  }
+
+  let appliancePassQueued = false;
+  function queueAppliancePass() {
+    if (appliancePassQueued) return;
+    appliancePassQueued = true;
+    requestAnimationFrame(function () {
+      appliancePassQueued = false;
+      ensureApplianceVisuals();
+    });
+  }
+
+  const documentObserver = new MutationObserver(function () {
+    attachEditorObserver();
+    queueAppliancePass();
+  });
+
+  function start() {
+    documentObserver.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+    });
+    attachEditorObserver();
+    queueAppliancePass();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start, { once: true });
+  } else {
+    start();
+  }
+})();

--- a/custom_components/dashboardmodern/frontend/src/legacy/host.js
+++ b/custom_components/dashboardmodern/frontend/src/legacy/host.js
@@ -32,6 +32,20 @@ export function legacyVariantForLocale(locale) {
   return normalized.startsWith("it") ? LEGACY_VARIANTS.it : LEGACY_VARIANTS.en;
 }
 
+function injectRuntimeHotfix(child, staticBase) {
+  try {
+    const documentRef = child?.document;
+    if (!documentRef?.head || documentRef.getElementById("dm-runtime-hotfix")) return;
+    const script = documentRef.createElement("script");
+    script.id = "dm-runtime-hotfix";
+    script.src = `${staticBase}/legacy/runtime-hotfix.js`;
+    script.async = false;
+    documentRef.head.append(script);
+  } catch (error) {
+    /* The next iframe load retries the injection. */
+  }
+}
+
 /**
  * Mount the hosted legacy dashboard.
  *
@@ -134,6 +148,7 @@ export function mountLegacyHost(
     child.__DASHBOARDMODERN_HOSTED__ = true;
     child.WebSocket = BridgeSocket;
     child.__DASHBOARDMODERN_BRIDGED__ = true;
+    injectRuntimeHotfix(child, staticBase);
   };
   frame.addEventListener?.("load", install);
   container.replaceChildren(frame);

--- a/custom_components/dashboardmodern/frontend/tests/runtime-hotfix-host.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-hotfix-host.test.js
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mountLegacyHost } from "../src/legacy/host.js";
+
+function element(tag) {
+  return {
+    tagName: tag,
+    style: {},
+    attributes: {},
+    listeners: {},
+    setAttribute(name, value) {
+      this.attributes[name] = String(value);
+    },
+    getAttribute(name) {
+      return this.attributes[name];
+    },
+    addEventListener(name, handler) {
+      this.listeners[name] = handler;
+    },
+    replaceChildren(...children) {
+      this.children = children;
+    },
+    remove() {},
+  };
+}
+
+test("the hosted frame receives the runtime stability guard on every load", () => {
+  const scripts = [];
+  const childDocument = {
+    head: {
+      append(node) {
+        scripts.push(node);
+      },
+    },
+    getElementById(id) {
+      return scripts.find((node) => node.id === id) || null;
+    },
+    createElement(tag) {
+      return element(tag);
+    },
+  };
+  const frame = element("iframe");
+  frame.contentWindow = { document: childDocument };
+  frame.clientHeight = 100;
+  const container = element("div");
+
+  const host = mountLegacyHost(container, {
+    hass: { locale: { language: "it" } },
+    connection: { sendMessagePromise: async () => ({}) },
+    staticBase: "/dashboardmodern_static/hash",
+    documentRef: { createElement: () => frame },
+    hostWindow: {},
+  });
+
+  assert.equal(scripts.length, 1);
+  assert.equal(scripts[0].id, "dm-runtime-hotfix");
+  assert.equal(
+    scripts[0].src,
+    "/dashboardmodern_static/hash/legacy/runtime-hotfix.js",
+  );
+
+  host.frame.listeners.load();
+  assert.equal(scripts.length, 1, "reload installation stays idempotent");
+});


### PR DESCRIPTION
### Problemi riprodotti dalle schermate reali
- card Elettrodomestici con colonna visuale vuota e layout instabile su Safari/iPad;
- scroll dell'Editor che si bloccava o spariva nell'iframe Home Assistant;
- lente entity picker che poteva sparire dopo i rerender del contenuto Editor.

### Correzioni incluse
- eliminato `display: contents` dalla card Elettrodomestici;
- header flex stabile con icona/immagine sempre visibile e fallback;
- card responsive verificata su desktop e mobile, italiano e inglese;
- unico scroller spostato sull'overlay `#editor-modal`, eliminando il contenitore interno basato su `100dvh`;
- runtime guard idempotente con `MutationObserver` per rimontare una sola lente dopo ogni rerender;
- runtime guard iniettato dal pannello hosted a ogni caricamento dell'iframe;
- test E2E reali per card, dimensioni icona, scroll effettivo e persistenza della lente.

### Verifica finale
Head: `1e80f87f7fdb5cd73ae1e562b8bb1ec91ac55985`

- ✅ Browser E2E
- ✅ Tests
- ✅ HACS
- ✅ hassfest
- ✅ screenshot reali desktop/mobile IT/EN verificati

Nessun bump versione, tag, release o modifica dei dati utente.