### PR TITLE
Fix reale: stanze, icone e picker nel runtime Home Assistant

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/runtime-ui-safari.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/runtime-ui-safari.spec.js
@@ -59,6 +59,7 @@ async function bootDashboard(page, variant) {
       rooms: [],
       appliances: [],
       loads: [],
+      lights: [],
       entityOverrides: {},
     },
     visibility: {},
@@ -68,9 +69,15 @@ async function bootDashboard(page, variant) {
   await page.evaluate((seed) => {
     localStorage.clear();
     localStorage.setItem("dm_dashboard_state", JSON.stringify(seed));
-    localStorage.setItem("cd_luci", JSON.stringify({}));
   }, state);
   await page.reload();
+
+  // Simulate the real regression: light.salone was persisted against the legacy
+  // room name "terrazza" before stable room IDs were introduced.
+  await page.evaluate(() => {
+    localStorage.setItem("cd_luci", JSON.stringify({ "light.salone": "Salone" }));
+    localStorage.setItem("cd_luci_rooms", JSON.stringify({ "light.salone": "terrazza" }));
+  });
 
   // In Home Assistant this script is injected by the hosted panel. The E2E opens
   // the legacy document directly, so reproduce that production injection here.
@@ -79,23 +86,30 @@ async function bootDashboard(page, variant) {
     () =>
       window.__DASHBOARDMODERN_LEGACY_READY__ === true &&
       !!window.DashboardModernModules &&
-      window.__DASHBOARDMODERN_RUNTIME_HOTFIX__ === true,
+      window.__DASHBOARDMODERN_RUNTIME_HOTFIX__ === true &&
+      window.editorRenderLuci?.__dmRealFix === true &&
+      window.cdApplMainCard?.__dmRealFix === true,
   );
   await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
   await page.evaluate(() => {
     window.cdSyncPush = async () => {};
+    window.__pickedEntityInput = "";
+    window.wzPickEntity = (input) => {
+      window.__pickedEntityInput = input?.id || "";
+    };
   });
   expect(pageErrors).toEqual([]);
 }
 
 for (const variant of ["dashboard.html", "dashboard-en.html"]) {
-  test(`${variant}: Safari runtime UI remains usable after rerenders`, async ({ page }, testInfo) => {
+  test(`${variant}: real Safari/HA regressions stay fixed`, async ({ page }, testInfo) => {
     await bootDashboard(page, variant);
 
-    // Populate the canonical store after runtime boot. Seeding only localStorage
-    // is not deterministic here because the legacy cloud-sync bootstrap can
-    // reconcile an empty remote snapshot before the assertion phase.
     await page.evaluate(async () => {
+      await window.DashboardModernModules.store.replaceSection("rooms", [
+        { id: "room-terrazza", name: "Terrazza", icon: "🏠", order: 0 },
+        { id: "room-salone", name: "Salone", icon: "🛋️", order: 1 },
+      ]);
       await window.DashboardModernModules.store.replaceSection("appliances", [
         {
           id: "appliance-safari",
@@ -103,6 +117,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
           device_type: "forno",
           visual_type: "asset",
           visual_key: "forno",
+          room_id: "room-salone",
           power_entity: "sensor.forno_power",
           entities: ["sensor.forno_power"],
           show_in_dashboard: true,
@@ -118,16 +133,34 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await expect(lightInput).toHaveCount(1);
     const lightId = await lightInput.getAttribute("id");
     expect(lightId).toBeTruthy();
-    const picker = body.locator(`.dm-entity-picker[data-entity-target="${lightId}"]`);
+
+    const lightRoomSelect = body.locator('select[data-light-entity="light.salone"]');
+    await expect(lightRoomSelect).toHaveCount(1);
+    await expect(lightRoomSelect).toHaveValue("room-salone");
+    expect(await page.evaluate(() => JSON.parse(localStorage.getItem("cd_luci_rooms"))["light.salone"])).toBe(
+      "room-salone",
+    );
+    await expect(body).toContainText("Salone");
+
+    let picker = body.locator(`.dm-entity-picker[data-entity-target="${lightId}"]`);
     await expect(picker).toHaveCount(1);
     await expect(picker).toBeVisible();
+    await picker.click();
+    await expect.poll(() => page.evaluate(() => window.__pickedEntityInput)).toBe(lightId);
 
-    // Re-render the complete editor body twice. The runtime guard must remount
-    // exactly one picker each time, which is what previously failed in Home Assistant.
+    // Re-render the complete editor body twice. The picker must still exist and
+    // its delegated click must still reach the current input, not a detached node.
     await page.evaluate(() => window.editorSwitch("stanze"));
     await page.evaluate(() => window.editorSwitch("luci"));
     await expect(body.locator("[data-light-add-entity]")).toHaveCount(1);
-    await expect(body.locator(".dm-entity-picker")).toHaveCount(1);
+    picker = body.locator(`.dm-entity-picker[data-entity-target="${lightId}"]`);
+    await expect(picker).toHaveCount(1);
+    await expect(picker).toBeVisible();
+    await page.evaluate(() => {
+      window.__pickedEntityInput = "";
+    });
+    await picker.click();
+    await expect.poll(() => page.evaluate(() => window.__pickedEntityInput)).toBe(lightId);
 
     await body.evaluate((node) => {
       const spacer = document.createElement("div");
@@ -157,15 +190,21 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     const card = page.locator("#appl-grid-overview .appl-wide-card").first();
     await expect(card).toBeVisible();
     expect(await card.evaluate((node) => getComputedStyle(node).display)).toBe("flex");
+    const roomLabel = card.locator(".appl-wide-cat");
+    await expect(roomLabel).toContainText("Salone");
+    await expect(roomLabel).not.toContainText(/other|altro/i);
+
     const visual = card.locator(".appl-ic");
     const visualBox = await visual.boundingBox();
     expect(visualBox?.width ?? 0).toBeGreaterThanOrEqual(50);
     expect(visualBox?.height ?? 0).toBeGreaterThanOrEqual(50);
-    const graphic = visual.locator("svg, img, ha-icon").first();
-    await expect(graphic).toBeVisible();
-    const graphicBox = await graphic.boundingBox();
-    expect(graphicBox?.width ?? 0).toBeGreaterThanOrEqual(30);
-    expect(graphicBox?.height ?? 0).toBeGreaterThanOrEqual(30);
+    const glyph = visual.locator(".dm-appliance-glyph");
+    await expect(glyph).toBeVisible();
+    await expect(glyph).not.toHaveText("");
+
+    const cardBox = await card.boundingBox();
+    if (testInfo.project.name === "desktop") expect(cardBox?.width ?? 9999).toBeLessThanOrEqual(540);
+
     await page.screenshot({
       path: `test-results/${testInfo.project.name}-${variant}-appliances-real.png`,
     });

--- a/custom_components/dashboardmodern/frontend/legacy/runtime-hotfix.js
+++ b/custom_components/dashboardmodern/frontend/legacy/runtime-hotfix.js
@@ -4,15 +4,345 @@
   if (window.__DASHBOARDMODERN_RUNTIME_HOTFIX__) return;
   window.__DASHBOARDMODERN_RUNTIME_HOTFIX__ = true;
 
+  const GLYPHS = Object.freeze({
+    lavatrice: "🧺",
+    lavastoviglie: "🍽️",
+    asciugatrice: "💨",
+    forno: "♨️",
+    microonde: "〰️",
+    frigo: "❄️",
+    congelatore: "🧊",
+    piano_cottura: "🔥",
+    cappa: "🌬️",
+    ferro: "♨️",
+    aspirapolvere: "🧹",
+    robot: "🤖",
+    condizionatore: "❄️",
+    ventilatore: "🌀",
+    scaldabagno: "🚿",
+    tv: "📺",
+    caffe: "☕",
+    tostapane: "🍞",
+    bollitore: "🫖",
+    generico: "🔌",
+  });
+
   let editorBody = null;
   let editorObserver = null;
   let pickerPassQueued = false;
+  let appliancePassQueued = false;
+  let legacyInstallTimer = null;
+  let originalApplianceCard = null;
+  let originalLightRenderer = null;
+  let originalLightRoom = null;
+
+  function injectRuntimeStyles() {
+    if (document.getElementById("dm-runtime-real-fixes")) return;
+    const style = document.createElement("style");
+    style.id = "dm-runtime-real-fixes";
+    style.textContent = `
+      #page-appliances-main .appl-page-grid {
+        grid-template-columns: repeat(auto-fill, minmax(340px, 520px)) !important;
+        justify-content: start !important;
+        align-items: stretch;
+      }
+      #page-appliances-main .appl-wide-card {
+        width: 100%;
+        max-width: 520px;
+      }
+      #page-appliances-main .appl-ic .dm-appliance-glyph {
+        display: grid !important;
+        place-items: center;
+        width: 52px !important;
+        height: 52px !important;
+        font-size: 38px !important;
+        line-height: 1 !important;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI Emoji", sans-serif !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        filter: none !important;
+      }
+      #page-appliances-main .appl-wide-cat.dm-room-label {
+        color: var(--text-dim, #64748b);
+        text-transform: none;
+        letter-spacing: .2px;
+      }
+      .dm-entity-picker {
+        display: inline-grid !important;
+        place-items: center !important;
+        flex: 0 0 40px !important;
+        width: 40px !important;
+        min-width: 40px !important;
+        min-height: 40px !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        pointer-events: auto !important;
+      }
+      @media (max-width: 760px) {
+        #page-appliances-main .appl-page-grid {
+          grid-template-columns: 1fr !important;
+        }
+        #page-appliances-main .appl-wide-card {
+          max-width: none;
+        }
+        #page-appliances-main .appl-ic .dm-appliance-glyph {
+          width: 42px !important;
+          height: 42px !important;
+          font-size: 31px !important;
+        }
+      }
+    `;
+    document.head.append(style);
+  }
+
+  function slug(value) {
+    return String(value || "")
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "");
+  }
+
+  function readJson(key, fallback) {
+    try {
+      return JSON.parse(localStorage.getItem(key)) ?? fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  }
+
+  function roomCatalog() {
+    let rooms = [];
+    try {
+      if (typeof window.cdRoomList === "function") rooms = window.cdRoomList() || [];
+      else if (typeof window.getStanze === "function") rooms = window.getStanze() || [];
+    } catch (_error) {
+      rooms = [];
+    }
+    return rooms.filter(Boolean).map(function (room, index) {
+      return {
+        ...room,
+        id: String(room.id || room.room_id || `room-${slug(room.name) || index + 1}`),
+        name: String(room.name || room.id || `Stanza ${index + 1}`),
+      };
+    });
+  }
+
+  function resolveRoom(ref, rooms) {
+    const value = String(ref || "").trim();
+    if (!value) return null;
+    const lower = value.toLowerCase();
+    const token = slug(value).replace(/^room-/, "");
+    return (
+      rooms.find((room) => room.id === value) ||
+      rooms.find((room) => room.name.toLowerCase() === lower) ||
+      rooms.find((room) => slug(room.name) === token) ||
+      null
+    );
+  }
+
+  function exactRoomFromEntity(entityId, rooms) {
+    const objectId = String(entityId || "").split(".").pop() || "";
+    const token = slug(objectId);
+    return rooms.find(function (room) {
+      const roomToken = slug(room.name);
+      const idToken = slug(room.id).replace(/^room-/, "");
+      return token === roomToken || token === idToken;
+    }) || null;
+  }
+
+  function migrateLightRoomIds() {
+    const rooms = roomCatalog();
+    if (!rooms.length) return false;
+    const lights = readJson("cd_luci", {});
+    const assigned = readJson("cd_luci_rooms", {});
+    let changed = false;
+
+    Object.keys(lights).forEach(function (entityId) {
+      const exact = exactRoomFromEntity(entityId, rooms);
+      const current = resolveRoom(assigned[entityId], rooms);
+      const wanted = exact || current;
+      if (wanted && assigned[entityId] !== wanted.id) {
+        assigned[entityId] = wanted.id;
+        changed = true;
+      }
+    });
+
+    Object.keys(assigned).forEach(function (entityId) {
+      if (!Object.prototype.hasOwnProperty.call(lights, entityId)) return;
+      const current = resolveRoom(assigned[entityId], rooms);
+      if (current && assigned[entityId] !== current.id) {
+        assigned[entityId] = current.id;
+        changed = true;
+      }
+    });
+
+    if (changed) {
+      localStorage.setItem("cd_luci_rooms", JSON.stringify(assigned));
+      try {
+        window.cdMarkDirty?.();
+        window.cdSyncPush?.();
+      } catch (_error) {}
+    }
+    return changed;
+  }
+
+  function applianceType(appliance) {
+    try {
+      if (typeof window.cdApplianceType === "function") return window.cdApplianceType(appliance);
+    } catch (_error) {}
+    return String(appliance?.device_type || appliance?.type || appliance?.icon || "generico").toLowerCase();
+  }
+
+  function applianceGlyph(appliance) {
+    return GLYPHS[applianceType(appliance)] || GLYPHS.generico;
+  }
+
+  function applianceRoom(appliance) {
+    const rooms = roomCatalog();
+    const api = window.DashboardModernModules?.data;
+    let roomId = "";
+    try {
+      if (typeof api?.applianceRoomId === "function") roomId = api.applianceRoomId(appliance, rooms);
+    } catch (_error) {}
+    return resolveRoom(roomId || appliance?.room_id || appliance?.room, rooms);
+  }
+
+  function repairApplianceMarkup(html, appliance) {
+    const template = document.createElement("template");
+    template.innerHTML = String(html || "").trim();
+    const card = template.content.firstElementChild;
+    if (!card) return html;
+
+    card.dataset.applianceId = String(appliance?.id || "");
+    const room = applianceRoom(appliance);
+    const roomLabel = card.querySelector(".appl-wide-cat");
+    if (roomLabel) {
+      roomLabel.classList.add("dm-room-label");
+      roomLabel.textContent = room
+        ? `🏠 ${room.name}`
+        : document.documentElement.lang === "en"
+          ? "No room"
+          : "Nessuna stanza";
+    }
+
+    const visual = card.querySelector(".appl-ic");
+    if (visual) {
+      visual.dataset.applianceType = applianceType(appliance);
+      visual.innerHTML = `<span class="dm-appliance-glyph" aria-hidden="true">${applianceGlyph(appliance)}</span>`;
+    }
+
+    return card.outerHTML;
+  }
+
+  function installApplianceRenderer() {
+    if (window.cdApplMainCard?.__dmRealFix) return true;
+    if (typeof window.cdApplMainCard !== "function") return false;
+    originalApplianceCard = window.cdApplMainCard;
+    const wrapped = function (appliance) {
+      return repairApplianceMarkup(originalApplianceCard(appliance), appliance);
+    };
+    wrapped.__dmRealFix = true;
+    window.cdApplMainCard = wrapped;
+    try {
+      window.renderApplianceSection?.(true);
+    } catch (_error) {}
+    return true;
+  }
+
+  function rebuildLightSelect(select, entityId) {
+    const rooms = roomCatalog();
+    const assigned = readJson("cd_luci_rooms", {});
+    const current = resolveRoom(assigned[entityId], rooms);
+    const empty = document.createElement("option");
+    empty.value = "";
+    empty.textContent = document.documentElement.lang === "en" ? "— Other areas —" : "— Altre zone —";
+    select.replaceChildren(empty);
+    rooms.forEach(function (room) {
+      const option = document.createElement("option");
+      option.value = room.id;
+      option.textContent = `${room.icon && !String(room.icon).startsWith("mdi:") ? `${room.icon} ` : ""}${room.name}`;
+      option.selected = current?.id === room.id;
+      select.append(option);
+    });
+    select.dataset.lightEntity = entityId;
+  }
+
+  function repairLightEditorMarkup(html) {
+    const template = document.createElement("template");
+    template.innerHTML = String(html || "");
+    template.content.querySelectorAll(".ed-lrow select").forEach(function (select) {
+      const handler = select.getAttribute("onchange") || "";
+      const match = handler.match(/cdLuciSetRoom\('([^']+)'/);
+      if (match) rebuildLightSelect(select, match[1]);
+    });
+    return template.innerHTML;
+  }
+
+  function installLightRoomRuntime() {
+    if (window.editorRenderLuci?.__dmRealFix) return true;
+    if (typeof window.editorRenderLuci !== "function" || typeof window.cdLightRoom !== "function") return false;
+
+    originalLightRoom = window.cdLightRoom;
+    originalLightRenderer = window.editorRenderLuci;
+
+    window.cdLightRoom = function (entityId) {
+      const rooms = roomCatalog();
+      const assigned = readJson("cd_luci_rooms", {});
+      const room = resolveRoom(assigned[entityId], rooms);
+      return room?.name || originalLightRoom(entityId);
+    };
+
+    window.cdLuciSetRoom = function (entityId, roomRef) {
+      const rooms = roomCatalog();
+      const assigned = readJson("cd_luci_rooms", {});
+      const room = resolveRoom(roomRef, rooms);
+      if (room) assigned[entityId] = room.id;
+      else delete assigned[entityId];
+      localStorage.setItem("cd_luci_rooms", JSON.stringify(assigned));
+      try {
+        window.cdMarkDirty?.();
+        window.cdSyncPush?.();
+      } catch (_error) {}
+      window.editorSwitch?.("luci");
+    };
+
+    const wrapped = function () {
+      migrateLightRoomIds();
+      return repairLightEditorMarkup(originalLightRenderer());
+    };
+    wrapped.__dmRealFix = true;
+    window.editorRenderLuci = wrapped;
+
+    migrateLightRoomIds();
+    const activeTab = document.querySelector(".ed-tab.active")?.dataset?.tab;
+    if (activeTab === "luci") {
+      try {
+        window.editorSwitch("luci");
+      } catch (_error) {}
+    }
+    return true;
+  }
 
   function mountEntityPickers() {
     const body = document.getElementById("ed-body");
     const mount = window.DashboardModernModules?.render?.mountEntityPickers;
-    if (!body || typeof mount !== "function") return;
-    mount(body);
+    if (!body) return;
+    if (typeof mount === "function") mount(body);
+
+    body.querySelectorAll("#luce-add-ent, #light-add-ent, [data-entity-input]").forEach(function (input) {
+      if (!input.id) input.id = `dm-entity-${Math.random().toString(36).slice(2)}`;
+      let button = input.nextElementSibling;
+      if (!button?.matches?.(".dm-entity-picker")) {
+        button = document.createElement("button");
+        button.type = "button";
+        button.className = "dm-entity-picker";
+        button.textContent = "🔍";
+        input.insertAdjacentElement("afterend", button);
+      }
+      button.dataset.entityTarget = input.id;
+    });
   }
 
   function queuePickerPass() {
@@ -27,31 +357,23 @@
   function attachEditorObserver() {
     const nextBody = document.getElementById("ed-body");
     if (!nextBody) return;
-
     if (nextBody !== editorBody) {
       editorObserver?.disconnect();
       editorBody = nextBody;
       editorObserver = new MutationObserver(queuePickerPass);
       editorObserver.observe(nextBody, { childList: true, subtree: true });
     }
-
     queuePickerPass();
   }
 
   function ensureApplianceVisuals() {
     document.querySelectorAll("#page-appliances-main .appl-ic").forEach(function (visual) {
-      const hasGraphic = visual.querySelector("svg, img, ha-icon");
-      if (hasGraphic) return;
-
-      const fallback =
-        typeof window.cdApplianceIcon === "function"
-          ? window.cdApplianceIcon("generico", 52)
-          : "⚙️";
-      visual.innerHTML = fallback;
+      if (visual.querySelector(".dm-appliance-glyph")) return;
+      const type = visual.dataset.applianceType || "generico";
+      visual.innerHTML = `<span class="dm-appliance-glyph" aria-hidden="true">${GLYPHS[type] || GLYPHS.generico}</span>`;
     });
   }
 
-  let appliancePassQueued = false;
   function queueAppliancePass() {
     if (appliancePassQueued) return;
     appliancePassQueued = true;
@@ -61,18 +383,46 @@
     });
   }
 
+  function delegatedPickerClick(event) {
+    const button = event.target.closest?.(".dm-entity-picker");
+    if (!button) return;
+    const targetId = button.dataset.entityTarget;
+    const input = (targetId && document.getElementById(targetId)) || button.previousElementSibling;
+    if (!input) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    window.wzPickEntity?.(input);
+  }
+
+  function installLegacyOverrides() {
+    const appliancesReady = installApplianceRenderer();
+    const lightsReady = installLightRoomRuntime();
+    if (appliancesReady && lightsReady && legacyInstallTimer) {
+      clearInterval(legacyInstallTimer);
+      legacyInstallTimer = null;
+    }
+  }
+
   const documentObserver = new MutationObserver(function () {
     attachEditorObserver();
     queueAppliancePass();
+    installLegacyOverrides();
   });
 
   function start() {
-    documentObserver.observe(document.documentElement, {
-      childList: true,
-      subtree: true,
-    });
+    injectRuntimeStyles();
+    document.addEventListener("click", delegatedPickerClick, true);
+    documentObserver.observe(document.documentElement, { childList: true, subtree: true });
     attachEditorObserver();
     queueAppliancePass();
+    installLegacyOverrides();
+    legacyInstallTimer = setInterval(installLegacyOverrides, 100);
+    setTimeout(function () {
+      if (legacyInstallTimer) {
+        clearInterval(legacyInstallTimer);
+        legacyInstallTimer = null;
+      }
+    }, 10000);
   }
 
   if (document.readyState === "loading") {

--- a/custom_components/dashboardmodern/frontend/legacy/runtime-hotfix.js
+++ b/custom_components/dashboardmodern/frontend/legacy/runtime-hotfix.js
@@ -27,11 +27,15 @@
     generico: "🔌",
   });
 
-  let passQueued = false;
-  let installTimer = null;
   let originalApplianceCard = null;
   let originalLightRenderer = null;
   let originalLightRoom = null;
+  let originalEditorSwitch = null;
+  let bodyObserver = null;
+  let observedBody = null;
+  let documentObserver = null;
+  let installTimer = null;
+  let passScheduled = false;
 
   function readJson(key, fallback) {
     try {
@@ -80,18 +84,14 @@
       append(typeof window.getStanze === "function" ? window.getStanze() : []);
     } catch (_error) {}
 
-    const byId = new Map();
-    const byName = new Map();
+    const byIdentity = new Map();
     sources.forEach(function (source, index) {
       const room = normalizeRoom(source, index);
       if (!room) return;
-      const idKey = room.id.toLowerCase();
-      const nameKey = room.name.toLowerCase();
-      if (byId.has(idKey) || byName.has(nameKey)) return;
-      byId.set(idKey, room);
-      byName.set(nameKey, room);
+      const key = `${room.id.toLowerCase()}|${room.name.toLowerCase()}`;
+      if (!byIdentity.has(key)) byIdentity.set(key, room);
     });
-    return Array.from(byId.values());
+    return Array.from(byIdentity.values());
   }
 
   function resolveRoom(ref, rooms) {
@@ -125,28 +125,26 @@
     return handler.match(/cdLuciSetRoom\('([^']+)'/)?.[1] || "";
   }
 
-  function knownLightEntities() {
+  function knownLightEntities(root) {
     const entities = new Set(Object.keys(readJson("cd_luci", {})));
-    document.querySelectorAll(".ed-lrow select, select[data-light-entity]").forEach(function (select) {
+    (root || document).querySelectorAll?.(".ed-lrow select, select[data-light-entity]").forEach(function (select) {
       const entityId = lightEntityFromSelect(select);
       if (entityId) entities.add(entityId);
     });
     return entities;
   }
 
-  function migrateLightRoomIds() {
+  function migrateLightRoomIds(root) {
     const rooms = roomCatalog();
     if (!rooms.length) return false;
 
     const assigned = readJson("cd_luci_rooms", {});
-    let changed = false;
-    const entities = knownLightEntities();
+    const entities = knownLightEntities(root);
     Object.keys(assigned).forEach((entityId) => entities.add(entityId));
+    let changed = false;
 
     entities.forEach(function (entityId) {
-      const exact = exactRoomFromEntity(entityId, rooms);
-      const current = resolveRoom(assigned[entityId], rooms);
-      const wanted = exact || current;
+      const wanted = exactRoomFromEntity(entityId, rooms) || resolveRoom(assigned[entityId], rooms);
       if (wanted && assigned[entityId] !== wanted.id) {
         assigned[entityId] = wanted.id;
         changed = true;
@@ -157,7 +155,6 @@
       localStorage.setItem("cd_luci_rooms", JSON.stringify(assigned));
       try {
         window.cdMarkDirty?.();
-        window.cdSyncPush?.();
       } catch (_error) {}
     }
     return changed;
@@ -167,8 +164,7 @@
     if (!select || !entityId) return;
     const rooms = roomCatalog();
     const assigned = readJson("cd_luci_rooms", {});
-    const exact = exactRoomFromEntity(entityId, rooms);
-    const current = exact || resolveRoom(assigned[entityId], rooms);
+    const current = exactRoomFromEntity(entityId, rooms) || resolveRoom(assigned[entityId], rooms);
     const selectedId = current?.id || "";
     const signature = `${entityId}|${selectedId}|${rooms
       .map((room) => `${room.id}:${room.name}:${room.icon || ""}`)
@@ -176,20 +172,22 @@
 
     if (select.dataset.dmRoomSignature === signature && select.value === selectedId) return;
 
+    const fragment = document.createDocumentFragment();
     const empty = document.createElement("option");
     empty.value = "";
     empty.textContent = document.documentElement.lang === "en" ? "— Other areas —" : "— Altre zone —";
-    if (!selectedId) empty.setAttribute("selected", "selected");
-    select.replaceChildren(empty);
+    empty.selected = !selectedId;
+    fragment.append(empty);
 
     rooms.forEach(function (room) {
       const option = document.createElement("option");
       option.value = room.id;
       option.textContent = `${room.icon && !String(room.icon).startsWith("mdi:") ? `${room.icon} ` : ""}${room.name}`;
-      if (selectedId === room.id) option.setAttribute("selected", "selected");
-      select.append(option);
+      option.selected = selectedId === room.id;
+      fragment.append(option);
     });
 
+    select.replaceChildren(fragment);
     select.dataset.lightEntity = entityId;
     select.dataset.dmRoomSignature = signature;
     select.value = selectedId;
@@ -205,6 +203,7 @@
   function repairLightEditorMarkup(html) {
     const template = document.createElement("template");
     template.innerHTML = String(html || "");
+    migrateLightRoomIds(template.content);
     template.content.querySelectorAll(".ed-lrow select, select[data-light-entity]").forEach(function (select) {
       const entityId = lightEntityFromSelect(select);
       if (entityId) rebuildLightSelect(select, entityId);
@@ -215,7 +214,7 @@
   function repairRenderedLightEditor(root) {
     const body = root || document.getElementById("ed-body");
     if (!body) return;
-    migrateLightRoomIds();
+    migrateLightRoomIds(body);
     body.querySelectorAll(".ed-lrow select, select[data-light-entity]").forEach(function (select) {
       const entityId = lightEntityFromSelect(select);
       if (entityId) rebuildLightSelect(select, entityId);
@@ -227,18 +226,6 @@
       if (typeof window.cdApplianceType === "function") return window.cdApplianceType(appliance);
     } catch (_error) {}
     return String(appliance?.device_type || appliance?.type || appliance?.icon || "generico").toLowerCase();
-  }
-
-  function currentAppliances() {
-    try {
-      const canonical = window.DashboardModernModules?.store?.getSection?.("appliances");
-      if (Array.isArray(canonical) && canonical.length) return canonical;
-    } catch (_error) {}
-    try {
-      const legacy = typeof window.getAppliances === "function" ? window.getAppliances() : [];
-      if (Array.isArray(legacy) && legacy.length) return legacy;
-    } catch (_error) {}
-    return readJson("cd_appliances", []);
   }
 
   function applianceRoom(appliance) {
@@ -253,25 +240,33 @@
 
   function repairApplianceCard(card, appliance) {
     if (!card || !appliance) return;
-    card.dataset.applianceId = String(appliance.id || "");
-
     const room = applianceRoom(appliance);
+    const type = applianceType(appliance);
+    const roomText = room
+      ? `🏠 ${room.name}`
+      : document.documentElement.lang === "en"
+        ? "No room"
+        : "Nessuna stanza";
+    const signature = `${appliance.id || ""}|${room?.id || ""}|${roomText}|${type}`;
+    if (card.dataset.dmApplianceSignature === signature) return;
+
+    card.dataset.applianceId = String(appliance.id || "");
     const roomLabel = card.querySelector(".appl-wide-cat");
     if (roomLabel) {
       roomLabel.classList.add("dm-room-label");
-      roomLabel.textContent = room
-        ? `🏠 ${room.name}`
-        : document.documentElement.lang === "en"
-          ? "No room"
-          : "Nessuna stanza";
+      if (roomLabel.textContent !== roomText) roomLabel.textContent = roomText;
     }
 
-    const type = applianceType(appliance);
     const visual = card.querySelector(".appl-ic");
     if (visual) {
+      const glyph = GLYPHS[type] || GLYPHS.generico;
       visual.dataset.applianceType = type;
-      visual.innerHTML = `<span class="dm-appliance-glyph" aria-hidden="true">${GLYPHS[type] || GLYPHS.generico}</span>`;
+      const currentGlyph = visual.querySelector(".dm-appliance-glyph");
+      if (!currentGlyph || currentGlyph.textContent !== glyph) {
+        visual.innerHTML = `<span class="dm-appliance-glyph" aria-hidden="true">${glyph}</span>`;
+      }
     }
+    card.dataset.dmApplianceSignature = signature;
   }
 
   function repairApplianceMarkup(html, appliance) {
@@ -281,6 +276,18 @@
     if (!card) return html;
     repairApplianceCard(card, appliance);
     return card.outerHTML;
+  }
+
+  function currentAppliances() {
+    try {
+      const canonical = window.DashboardModernModules?.store?.getSection?.("appliances");
+      if (Array.isArray(canonical) && canonical.length) return canonical;
+    } catch (_error) {}
+    try {
+      const legacy = typeof window.getAppliances === "function" ? window.getAppliances() : [];
+      if (Array.isArray(legacy) && legacy.length) return legacy;
+    } catch (_error) {}
+    return readJson("cd_appliances", []);
   }
 
   function repairRenderedAppliances() {
@@ -341,12 +348,12 @@
     };
 
     const wrapped = function () {
-      migrateLightRoomIds();
+      migrateLightRoomIds(document);
       return repairLightEditorMarkup(originalLightRenderer());
     };
     wrapped.__dmRealFix = true;
     window.editorRenderLuci = wrapped;
-    migrateLightRoomIds();
+    migrateLightRoomIds(document);
     return true;
   }
 
@@ -368,7 +375,7 @@
         button.textContent = "🔍";
         input.insertAdjacentElement("afterend", button);
       }
-      button.dataset.entityTarget = input.id;
+      if (button.dataset.entityTarget !== input.id) button.dataset.entityTarget = input.id;
     });
   }
 
@@ -381,6 +388,20 @@
     event.preventDefault();
     event.stopImmediatePropagation();
     window.wzPickEntity?.(input);
+  }
+
+  function installEditorSwitch() {
+    if (window.editorSwitch?.__dmRealFix) return true;
+    if (typeof window.editorSwitch !== "function") return false;
+    originalEditorSwitch = window.editorSwitch;
+    const wrapped = function () {
+      const result = originalEditorSwitch.apply(this, arguments);
+      schedulePass();
+      return result;
+    };
+    wrapped.__dmRealFix = true;
+    window.editorSwitch = wrapped;
+    return true;
   }
 
   function injectStyles() {
@@ -419,45 +440,57 @@
     document.head.append(style);
   }
 
-  function installOverrides() {
+  function attachBodyObserver() {
+    const body = document.getElementById("ed-body");
+    if (!body || body === observedBody) return;
+    bodyObserver?.disconnect();
+    observedBody = body;
+    bodyObserver = new MutationObserver(schedulePass);
+    bodyObserver.observe(body, { childList: true, subtree: true });
+  }
+
+  function installAll() {
     const appliancesReady = installApplianceRenderer();
     const lightsReady = installLightRuntime();
-    if (appliancesReady && lightsReady && installTimer) {
+    const editorReady = installEditorSwitch();
+    attachBodyObserver();
+    if (appliancesReady && lightsReady && editorReady && installTimer) {
       clearInterval(installTimer);
       installTimer = null;
     }
   }
 
   function runPass() {
-    passQueued = false;
-    installOverrides();
+    passScheduled = false;
+    installAll();
     repairRenderedLightEditor();
     mountEntityPickers();
     repairRenderedAppliances();
   }
 
-  function queuePass() {
-    if (passQueued) return;
-    passQueued = true;
-    queueMicrotask(runPass);
+  function schedulePass() {
+    if (passScheduled) return;
+    passScheduled = true;
+    setTimeout(runPass, 0);
   }
 
   function start() {
     injectStyles();
     document.addEventListener("click", delegatedPickerClick, true);
-    new MutationObserver(queuePass).observe(document.documentElement, { childList: true, subtree: true });
+    documentObserver = new MutationObserver(function () {
+      attachBodyObserver();
+      schedulePass();
+    });
+    documentObserver.observe(document.documentElement, { childList: true, subtree: true });
 
     try {
       const store = window.DashboardModernModules?.store;
-      if (typeof store?.subscribe === "function") store.subscribe(queuePass);
+      if (typeof store?.subscribe === "function") store.subscribe(schedulePass);
     } catch (_error) {}
 
-    installOverrides();
-    queuePass();
-    installTimer = setInterval(function () {
-      installOverrides();
-      queuePass();
-    }, 100);
+    installAll();
+    schedulePass();
+    installTimer = setInterval(installAll, 100);
     setTimeout(function () {
       if (installTimer) {
         clearInterval(installTimer);

--- a/custom_components/dashboardmodern/frontend/legacy/runtime-hotfix.js
+++ b/custom_components/dashboardmodern/frontend/legacy/runtime-hotfix.js
@@ -31,69 +31,10 @@
   let editorObserver = null;
   let pickerPassQueued = false;
   let appliancePassQueued = false;
-  let legacyInstallTimer = null;
+  let installTimer = null;
   let originalApplianceCard = null;
   let originalLightRenderer = null;
   let originalLightRoom = null;
-
-  function injectRuntimeStyles() {
-    if (document.getElementById("dm-runtime-real-fixes")) return;
-    const style = document.createElement("style");
-    style.id = "dm-runtime-real-fixes";
-    style.textContent = `
-      #page-appliances-main .appl-page-grid {
-        grid-template-columns: repeat(auto-fill, minmax(340px, 520px)) !important;
-        justify-content: start !important;
-        align-items: stretch;
-      }
-      #page-appliances-main .appl-wide-card {
-        width: 100%;
-        max-width: 520px;
-      }
-      #page-appliances-main .appl-ic .dm-appliance-glyph {
-        display: grid !important;
-        place-items: center;
-        width: 52px !important;
-        height: 52px !important;
-        font-size: 38px !important;
-        line-height: 1 !important;
-        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI Emoji", sans-serif !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        filter: none !important;
-      }
-      #page-appliances-main .appl-wide-cat.dm-room-label {
-        color: var(--text-dim, #64748b);
-        text-transform: none;
-        letter-spacing: .2px;
-      }
-      .dm-entity-picker {
-        display: inline-grid !important;
-        place-items: center !important;
-        flex: 0 0 40px !important;
-        width: 40px !important;
-        min-width: 40px !important;
-        min-height: 40px !important;
-        visibility: visible !important;
-        opacity: 1 !important;
-        pointer-events: auto !important;
-      }
-      @media (max-width: 760px) {
-        #page-appliances-main .appl-page-grid {
-          grid-template-columns: 1fr !important;
-        }
-        #page-appliances-main .appl-wide-card {
-          max-width: none;
-        }
-        #page-appliances-main .appl-ic .dm-appliance-glyph {
-          width: 42px !important;
-          height: 42px !important;
-          font-size: 31px !important;
-        }
-      }
-    `;
-    document.head.append(style);
-  }
 
   function slug(value) {
     return String(value || "")
@@ -112,21 +53,47 @@
     }
   }
 
+  function normalizeRoom(room, index) {
+    if (!room) return null;
+    const name = String(room.name || room.id || room.room_id || `Stanza ${index + 1}`);
+    return {
+      ...room,
+      id: String(room.id || room.room_id || `room-${slug(name) || index + 1}`),
+      name,
+    };
+  }
+
   function roomCatalog() {
-    let rooms = [];
+    const sources = [];
+
     try {
-      if (typeof window.cdRoomList === "function") rooms = window.cdRoomList() || [];
-      else if (typeof window.getStanze === "function") rooms = window.getStanze() || [];
-    } catch (_error) {
-      rooms = [];
-    }
-    return rooms.filter(Boolean).map(function (room, index) {
-      return {
-        ...room,
-        id: String(room.id || room.room_id || `room-${slug(room.name) || index + 1}`),
-        name: String(room.name || room.id || `Stanza ${index + 1}`),
-      };
+      const canonical = window.DashboardModernModules?.store?.getSection?.("rooms");
+      if (Array.isArray(canonical)) sources.push(...canonical);
+    } catch (_error) {}
+
+    try {
+      const legacy = typeof window.cdRoomList === "function" ? window.cdRoomList() : [];
+      if (Array.isArray(legacy)) sources.push(...legacy);
+    } catch (_error) {}
+
+    try {
+      const rooms = typeof window.getStanze === "function" ? window.getStanze() : [];
+      if (Array.isArray(rooms)) sources.push(...rooms);
+    } catch (_error) {}
+
+    const byId = new Map();
+    const byName = new Map();
+    sources.forEach(function (source, index) {
+      const room = normalizeRoom(source, index);
+      if (!room) return;
+      const idKey = room.id.toLowerCase();
+      const nameKey = room.name.toLowerCase();
+      if (!byId.has(idKey) && !byName.has(nameKey)) {
+        byId.set(idKey, room);
+        byName.set(nameKey, room);
+      }
     });
+    return Array.from(byId.values());
   }
 
   function resolveRoom(ref, rooms) {
@@ -136,8 +103,10 @@
     const token = slug(value).replace(/^room-/, "");
     return (
       rooms.find((room) => room.id === value) ||
+      rooms.find((room) => room.id.toLowerCase() === lower) ||
       rooms.find((room) => room.name.toLowerCase() === lower) ||
       rooms.find((room) => slug(room.name) === token) ||
+      rooms.find((room) => slug(room.id).replace(/^room-/, "") === token) ||
       null
     );
   }
@@ -145,16 +114,19 @@
   function exactRoomFromEntity(entityId, rooms) {
     const objectId = String(entityId || "").split(".").pop() || "";
     const token = slug(objectId);
-    return rooms.find(function (room) {
-      const roomToken = slug(room.name);
-      const idToken = slug(room.id).replace(/^room-/, "");
-      return token === roomToken || token === idToken;
-    }) || null;
+    return (
+      rooms.find(function (room) {
+        const roomToken = slug(room.name);
+        const idToken = slug(room.id).replace(/^room-/, "");
+        return token === roomToken || token === idToken;
+      }) || null
+    );
   }
 
   function migrateLightRoomIds() {
     const rooms = roomCatalog();
     if (!rooms.length) return false;
+
     const lights = readJson("cd_luci", {});
     const assigned = readJson("cd_luci_rooms", {});
     let changed = false;
@@ -171,9 +143,11 @@
 
     Object.keys(assigned).forEach(function (entityId) {
       if (!Object.prototype.hasOwnProperty.call(lights, entityId)) return;
+      const exact = exactRoomFromEntity(entityId, rooms);
       const current = resolveRoom(assigned[entityId], rooms);
-      if (current && assigned[entityId] !== current.id) {
-        assigned[entityId] = current.id;
+      const wanted = exact || current;
+      if (wanted && assigned[entityId] !== wanted.id) {
+        assigned[entityId] = wanted.id;
         changed = true;
       }
     });
@@ -195,18 +169,14 @@
     return String(appliance?.device_type || appliance?.type || appliance?.icon || "generico").toLowerCase();
   }
 
-  function applianceGlyph(appliance) {
-    return GLYPHS[applianceType(appliance)] || GLYPHS.generico;
-  }
-
   function applianceRoom(appliance) {
     const rooms = roomCatalog();
     const api = window.DashboardModernModules?.data;
-    let roomId = "";
+    let ref = appliance?.room_id || appliance?.room || "";
     try {
-      if (typeof api?.applianceRoomId === "function") roomId = api.applianceRoomId(appliance, rooms);
+      if (typeof api?.applianceRoomId === "function") ref = api.applianceRoomId(appliance, rooms) || ref;
     } catch (_error) {}
-    return resolveRoom(roomId || appliance?.room_id || appliance?.room, rooms);
+    return resolveRoom(ref, rooms);
   }
 
   function repairApplianceMarkup(html, appliance) {
@@ -227,18 +197,19 @@
           : "Nessuna stanza";
     }
 
+    const type = applianceType(appliance);
     const visual = card.querySelector(".appl-ic");
     if (visual) {
-      visual.dataset.applianceType = applianceType(appliance);
-      visual.innerHTML = `<span class="dm-appliance-glyph" aria-hidden="true">${applianceGlyph(appliance)}</span>`;
+      visual.dataset.applianceType = type;
+      visual.innerHTML = `<span class="dm-appliance-glyph" aria-hidden="true">${GLYPHS[type] || GLYPHS.generico}</span>`;
     }
-
     return card.outerHTML;
   }
 
   function installApplianceRenderer() {
     if (window.cdApplMainCard?.__dmRealFix) return true;
     if (typeof window.cdApplMainCard !== "function") return false;
+
     originalApplianceCard = window.cdApplMainCard;
     const wrapped = function (appliance) {
       return repairApplianceMarkup(originalApplianceCard(appliance), appliance);
@@ -254,11 +225,14 @@
   function rebuildLightSelect(select, entityId) {
     const rooms = roomCatalog();
     const assigned = readJson("cd_luci_rooms", {});
-    const current = resolveRoom(assigned[entityId], rooms);
+    const exact = exactRoomFromEntity(entityId, rooms);
+    const current = exact || resolveRoom(assigned[entityId], rooms);
+
     const empty = document.createElement("option");
     empty.value = "";
     empty.textContent = document.documentElement.lang === "en" ? "— Other areas —" : "— Altre zone —";
     select.replaceChildren(empty);
+
     rooms.forEach(function (room) {
       const option = document.createElement("option");
       option.value = room.id;
@@ -266,6 +240,7 @@
       option.selected = current?.id === room.id;
       select.append(option);
     });
+    select.value = current?.id || "";
     select.dataset.lightEntity = entityId;
   }
 
@@ -280,7 +255,7 @@
     return template.innerHTML;
   }
 
-  function installLightRoomRuntime() {
+  function installLightRuntime() {
     if (window.editorRenderLuci?.__dmRealFix) return true;
     if (typeof window.editorRenderLuci !== "function" || typeof window.cdLightRoom !== "function") return false;
 
@@ -290,7 +265,7 @@
     window.cdLightRoom = function (entityId) {
       const rooms = roomCatalog();
       const assigned = readJson("cd_luci_rooms", {});
-      const room = resolveRoom(assigned[entityId], rooms);
+      const room = exactRoomFromEntity(entityId, rooms) || resolveRoom(assigned[entityId], rooms);
       return room?.name || originalLightRoom(entityId);
     };
 
@@ -316,8 +291,7 @@
     window.editorRenderLuci = wrapped;
 
     migrateLightRoomIds();
-    const activeTab = document.querySelector(".ed-tab.active")?.dataset?.tab;
-    if (activeTab === "luci") {
+    if (document.querySelector(".ed-tab.active")?.dataset?.tab === "luci") {
       try {
         window.editorSwitch("luci");
       } catch (_error) {}
@@ -325,11 +299,48 @@
     return true;
   }
 
+  function injectStyles() {
+    if (document.getElementById("dm-runtime-real-fixes")) return;
+    const style = document.createElement("style");
+    style.id = "dm-runtime-real-fixes";
+    style.textContent = `
+      #page-appliances-main .appl-page-grid {
+        grid-template-columns: repeat(auto-fill, minmax(340px, 520px)) !important;
+        justify-content: start !important;
+        align-items: stretch;
+      }
+      #page-appliances-main .appl-wide-card { width: 100%; max-width: 520px; }
+      #page-appliances-main .appl-ic .dm-appliance-glyph {
+        display: grid !important; place-items: center; width: 52px !important; height: 52px !important;
+        font-size: 38px !important; line-height: 1 !important;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI Emoji", sans-serif !important;
+        visibility: visible !important; opacity: 1 !important; filter: none !important;
+      }
+      #page-appliances-main .appl-wide-cat.dm-room-label {
+        color: var(--text-dim, #64748b); text-transform: none; letter-spacing: .2px;
+      }
+      .dm-entity-picker {
+        display: inline-grid !important; place-items: center !important; flex: 0 0 40px !important;
+        width: 40px !important; min-width: 40px !important; min-height: 40px !important;
+        visibility: visible !important; opacity: 1 !important; pointer-events: auto !important;
+      }
+      @media (max-width: 760px) {
+        #page-appliances-main .appl-page-grid { grid-template-columns: 1fr !important; }
+        #page-appliances-main .appl-wide-card { max-width: none; }
+        #page-appliances-main .appl-ic .dm-appliance-glyph {
+          width: 42px !important; height: 42px !important; font-size: 31px !important;
+        }
+      }
+    `;
+    document.head.append(style);
+  }
+
   function mountEntityPickers() {
     const body = document.getElementById("ed-body");
-    const mount = window.DashboardModernModules?.render?.mountEntityPickers;
     if (!body) return;
-    if (typeof mount === "function") mount(body);
+    try {
+      window.DashboardModernModules?.render?.mountEntityPickers?.(body);
+    } catch (_error) {}
 
     body.querySelectorAll("#luce-add-ent, #light-add-ent, [data-entity-input]").forEach(function (input) {
       if (!input.id) input.id = `dm-entity-${Math.random().toString(36).slice(2)}`;
@@ -394,33 +405,33 @@
     window.wzPickEntity?.(input);
   }
 
-  function installLegacyOverrides() {
+  function installOverrides() {
     const appliancesReady = installApplianceRenderer();
-    const lightsReady = installLightRoomRuntime();
-    if (appliancesReady && lightsReady && legacyInstallTimer) {
-      clearInterval(legacyInstallTimer);
-      legacyInstallTimer = null;
+    const lightsReady = installLightRuntime();
+    if (appliancesReady && lightsReady && installTimer) {
+      clearInterval(installTimer);
+      installTimer = null;
     }
   }
 
   const documentObserver = new MutationObserver(function () {
     attachEditorObserver();
     queueAppliancePass();
-    installLegacyOverrides();
+    installOverrides();
   });
 
   function start() {
-    injectRuntimeStyles();
+    injectStyles();
     document.addEventListener("click", delegatedPickerClick, true);
     documentObserver.observe(document.documentElement, { childList: true, subtree: true });
     attachEditorObserver();
     queueAppliancePass();
-    installLegacyOverrides();
-    legacyInstallTimer = setInterval(installLegacyOverrides, 100);
+    installOverrides();
+    installTimer = setInterval(installOverrides, 100);
     setTimeout(function () {
-      if (legacyInstallTimer) {
-        clearInterval(legacyInstallTimer);
-        legacyInstallTimer = null;
+      if (installTimer) {
+        clearInterval(installTimer);
+        installTimer = null;
       }
     }, 10000);
   }

--- a/custom_components/dashboardmodern/frontend/legacy/runtime-hotfix.js
+++ b/custom_components/dashboardmodern/frontend/legacy/runtime-hotfix.js
@@ -27,14 +27,19 @@
     generico: "🔌",
   });
 
-  let editorBody = null;
-  let editorObserver = null;
-  let pickerPassQueued = false;
-  let appliancePassQueued = false;
+  let passQueued = false;
   let installTimer = null;
   let originalApplianceCard = null;
   let originalLightRenderer = null;
   let originalLightRoom = null;
+
+  function readJson(key, fallback) {
+    try {
+      return JSON.parse(localStorage.getItem(key)) ?? fallback;
+    } catch (_error) {
+      return fallback;
+    }
+  }
 
   function slug(value) {
     return String(value || "")
@@ -43,14 +48,6 @@
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-|-$/g, "");
-  }
-
-  function readJson(key, fallback) {
-    try {
-      return JSON.parse(localStorage.getItem(key)) ?? fallback;
-    } catch (_error) {
-      return fallback;
-    }
   }
 
   function normalizeRoom(room, index) {
@@ -65,20 +62,22 @@
 
   function roomCatalog() {
     const sources = [];
+    const append = (value) => {
+      if (Array.isArray(value)) sources.push(...value);
+    };
+
+    const saved = readJson("dm_dashboard_state", {});
+    append(saved?.sections?.rooms);
+    append(readJson("cd_stanze", []));
 
     try {
-      const canonical = window.DashboardModernModules?.store?.getSection?.("rooms");
-      if (Array.isArray(canonical)) sources.push(...canonical);
+      append(window.DashboardModernModules?.store?.getSection?.("rooms"));
     } catch (_error) {}
-
     try {
-      const legacy = typeof window.cdRoomList === "function" ? window.cdRoomList() : [];
-      if (Array.isArray(legacy)) sources.push(...legacy);
+      append(typeof window.cdRoomList === "function" ? window.cdRoomList() : []);
     } catch (_error) {}
-
     try {
-      const rooms = typeof window.getStanze === "function" ? window.getStanze() : [];
-      if (Array.isArray(rooms)) sources.push(...rooms);
+      append(typeof window.getStanze === "function" ? window.getStanze() : []);
     } catch (_error) {}
 
     const byId = new Map();
@@ -88,10 +87,9 @@
       if (!room) return;
       const idKey = room.id.toLowerCase();
       const nameKey = room.name.toLowerCase();
-      if (!byId.has(idKey) && !byName.has(nameKey)) {
-        byId.set(idKey, room);
-        byName.set(nameKey, room);
-      }
+      if (byId.has(idKey) || byName.has(nameKey)) return;
+      byId.set(idKey, room);
+      byName.set(nameKey, room);
     });
     return Array.from(byId.values());
   }
@@ -116,33 +114,36 @@
     const token = slug(objectId);
     return (
       rooms.find(function (room) {
-        const roomToken = slug(room.name);
-        const idToken = slug(room.id).replace(/^room-/, "");
-        return token === roomToken || token === idToken;
+        return token === slug(room.name) || token === slug(room.id).replace(/^room-/, "");
       }) || null
     );
+  }
+
+  function lightEntityFromSelect(select) {
+    if (select?.dataset?.lightEntity) return select.dataset.lightEntity;
+    const handler = select?.getAttribute?.("onchange") || "";
+    return handler.match(/cdLuciSetRoom\('([^']+)'/)?.[1] || "";
+  }
+
+  function knownLightEntities() {
+    const entities = new Set(Object.keys(readJson("cd_luci", {})));
+    document.querySelectorAll(".ed-lrow select, select[data-light-entity]").forEach(function (select) {
+      const entityId = lightEntityFromSelect(select);
+      if (entityId) entities.add(entityId);
+    });
+    return entities;
   }
 
   function migrateLightRoomIds() {
     const rooms = roomCatalog();
     if (!rooms.length) return false;
 
-    const lights = readJson("cd_luci", {});
     const assigned = readJson("cd_luci_rooms", {});
     let changed = false;
+    const entities = knownLightEntities();
+    Object.keys(assigned).forEach((entityId) => entities.add(entityId));
 
-    Object.keys(lights).forEach(function (entityId) {
-      const exact = exactRoomFromEntity(entityId, rooms);
-      const current = resolveRoom(assigned[entityId], rooms);
-      const wanted = exact || current;
-      if (wanted && assigned[entityId] !== wanted.id) {
-        assigned[entityId] = wanted.id;
-        changed = true;
-      }
-    });
-
-    Object.keys(assigned).forEach(function (entityId) {
-      if (!Object.prototype.hasOwnProperty.call(lights, entityId)) return;
+    entities.forEach(function (entityId) {
       const exact = exactRoomFromEntity(entityId, rooms);
       const current = resolveRoom(assigned[entityId], rooms);
       const wanted = exact || current;
@@ -162,6 +163,65 @@
     return changed;
   }
 
+  function rebuildLightSelect(select, entityId) {
+    if (!select || !entityId) return;
+    const rooms = roomCatalog();
+    const assigned = readJson("cd_luci_rooms", {});
+    const exact = exactRoomFromEntity(entityId, rooms);
+    const current = exact || resolveRoom(assigned[entityId], rooms);
+    const selectedId = current?.id || "";
+    const signature = `${entityId}|${selectedId}|${rooms
+      .map((room) => `${room.id}:${room.name}:${room.icon || ""}`)
+      .join("|")}`;
+
+    if (select.dataset.dmRoomSignature === signature && select.value === selectedId) return;
+
+    const empty = document.createElement("option");
+    empty.value = "";
+    empty.textContent = document.documentElement.lang === "en" ? "— Other areas —" : "— Altre zone —";
+    if (!selectedId) empty.setAttribute("selected", "selected");
+    select.replaceChildren(empty);
+
+    rooms.forEach(function (room) {
+      const option = document.createElement("option");
+      option.value = room.id;
+      option.textContent = `${room.icon && !String(room.icon).startsWith("mdi:") ? `${room.icon} ` : ""}${room.name}`;
+      if (selectedId === room.id) option.setAttribute("selected", "selected");
+      select.append(option);
+    });
+
+    select.dataset.lightEntity = entityId;
+    select.dataset.dmRoomSignature = signature;
+    select.value = selectedId;
+
+    if (!select.getAttribute("onchange") && select.dataset.dmRoomChangeBound !== "true") {
+      select.dataset.dmRoomChangeBound = "true";
+      select.addEventListener("change", function () {
+        window.cdLuciSetRoom?.(entityId, select.value);
+      });
+    }
+  }
+
+  function repairLightEditorMarkup(html) {
+    const template = document.createElement("template");
+    template.innerHTML = String(html || "");
+    template.content.querySelectorAll(".ed-lrow select, select[data-light-entity]").forEach(function (select) {
+      const entityId = lightEntityFromSelect(select);
+      if (entityId) rebuildLightSelect(select, entityId);
+    });
+    return template.innerHTML;
+  }
+
+  function repairRenderedLightEditor(root) {
+    const body = root || document.getElementById("ed-body");
+    if (!body) return;
+    migrateLightRoomIds();
+    body.querySelectorAll(".ed-lrow select, select[data-light-entity]").forEach(function (select) {
+      const entityId = lightEntityFromSelect(select);
+      if (entityId) rebuildLightSelect(select, entityId);
+    });
+  }
+
   function applianceType(appliance) {
     try {
       if (typeof window.cdApplianceType === "function") return window.cdApplianceType(appliance);
@@ -169,23 +229,32 @@
     return String(appliance?.device_type || appliance?.type || appliance?.icon || "generico").toLowerCase();
   }
 
+  function currentAppliances() {
+    try {
+      const canonical = window.DashboardModernModules?.store?.getSection?.("appliances");
+      if (Array.isArray(canonical) && canonical.length) return canonical;
+    } catch (_error) {}
+    try {
+      const legacy = typeof window.getAppliances === "function" ? window.getAppliances() : [];
+      if (Array.isArray(legacy) && legacy.length) return legacy;
+    } catch (_error) {}
+    return readJson("cd_appliances", []);
+  }
+
   function applianceRoom(appliance) {
     const rooms = roomCatalog();
-    const api = window.DashboardModernModules?.data;
     let ref = appliance?.room_id || appliance?.room || "";
     try {
+      const api = window.DashboardModernModules?.data;
       if (typeof api?.applianceRoomId === "function") ref = api.applianceRoomId(appliance, rooms) || ref;
     } catch (_error) {}
     return resolveRoom(ref, rooms);
   }
 
-  function repairApplianceMarkup(html, appliance) {
-    const template = document.createElement("template");
-    template.innerHTML = String(html || "").trim();
-    const card = template.content.firstElementChild;
-    if (!card) return html;
+  function repairApplianceCard(card, appliance) {
+    if (!card || !appliance) return;
+    card.dataset.applianceId = String(appliance.id || "");
 
-    card.dataset.applianceId = String(appliance?.id || "");
     const room = applianceRoom(appliance);
     const roomLabel = card.querySelector(".appl-wide-cat");
     if (roomLabel) {
@@ -203,13 +272,34 @@
       visual.dataset.applianceType = type;
       visual.innerHTML = `<span class="dm-appliance-glyph" aria-hidden="true">${GLYPHS[type] || GLYPHS.generico}</span>`;
     }
+  }
+
+  function repairApplianceMarkup(html, appliance) {
+    const template = document.createElement("template");
+    template.innerHTML = String(html || "").trim();
+    const card = template.content.firstElementChild;
+    if (!card) return html;
+    repairApplianceCard(card, appliance);
     return card.outerHTML;
+  }
+
+  function repairRenderedAppliances() {
+    const appliances = currentAppliances();
+    const cards = Array.from(document.querySelectorAll("#page-appliances-main .appl-wide-card"));
+    cards.forEach(function (card, index) {
+      const id = card.dataset.applianceId;
+      const name = String(card.querySelector(".appl-wide-name")?.textContent || "").trim().toLowerCase();
+      const appliance =
+        appliances.find((item) => id && String(item.id) === id) ||
+        appliances.find((item) => String(item.name || "").trim().toLowerCase() === name) ||
+        appliances[index];
+      if (appliance) repairApplianceCard(card, appliance);
+    });
   }
 
   function installApplianceRenderer() {
     if (window.cdApplMainCard?.__dmRealFix) return true;
     if (typeof window.cdApplMainCard !== "function") return false;
-
     originalApplianceCard = window.cdApplMainCard;
     const wrapped = function (appliance) {
       return repairApplianceMarkup(originalApplianceCard(appliance), appliance);
@@ -220,39 +310,6 @@
       window.renderApplianceSection?.(true);
     } catch (_error) {}
     return true;
-  }
-
-  function rebuildLightSelect(select, entityId) {
-    const rooms = roomCatalog();
-    const assigned = readJson("cd_luci_rooms", {});
-    const exact = exactRoomFromEntity(entityId, rooms);
-    const current = exact || resolveRoom(assigned[entityId], rooms);
-
-    const empty = document.createElement("option");
-    empty.value = "";
-    empty.textContent = document.documentElement.lang === "en" ? "— Other areas —" : "— Altre zone —";
-    select.replaceChildren(empty);
-
-    rooms.forEach(function (room) {
-      const option = document.createElement("option");
-      option.value = room.id;
-      option.textContent = `${room.icon && !String(room.icon).startsWith("mdi:") ? `${room.icon} ` : ""}${room.name}`;
-      option.selected = current?.id === room.id;
-      select.append(option);
-    });
-    select.value = current?.id || "";
-    select.dataset.lightEntity = entityId;
-  }
-
-  function repairLightEditorMarkup(html) {
-    const template = document.createElement("template");
-    template.innerHTML = String(html || "");
-    template.content.querySelectorAll(".ed-lrow select").forEach(function (select) {
-      const handler = select.getAttribute("onchange") || "";
-      const match = handler.match(/cdLuciSetRoom\('([^']+)'/);
-      if (match) rebuildLightSelect(select, match[1]);
-    });
-    return template.innerHTML;
   }
 
   function installLightRuntime() {
@@ -289,14 +346,41 @@
     };
     wrapped.__dmRealFix = true;
     window.editorRenderLuci = wrapped;
-
     migrateLightRoomIds();
-    if (document.querySelector(".ed-tab.active")?.dataset?.tab === "luci") {
-      try {
-        window.editorSwitch("luci");
-      } catch (_error) {}
-    }
     return true;
+  }
+
+  function mountEntityPickers() {
+    const body = document.getElementById("ed-body");
+    if (!body) return;
+    try {
+      window.DashboardModernModules?.render?.mountEntityPickers?.(body);
+    } catch (_error) {}
+
+    body.querySelectorAll("#luce-add-ent, #light-add-ent, [data-entity-input]").forEach(function (input) {
+      if (!input.id) input.id = `dm-entity-${Math.random().toString(36).slice(2)}`;
+      if (/^(?:luce|light)-add-ent$/.test(input.id)) input.dataset.lightAddEntity = "";
+      let button = input.nextElementSibling;
+      if (!button?.matches?.(".dm-entity-picker")) {
+        button = document.createElement("button");
+        button.type = "button";
+        button.className = "dm-entity-picker";
+        button.textContent = "🔍";
+        input.insertAdjacentElement("afterend", button);
+      }
+      button.dataset.entityTarget = input.id;
+    });
+  }
+
+  function delegatedPickerClick(event) {
+    const button = event.target.closest?.(".dm-entity-picker");
+    if (!button) return;
+    const targetId = button.dataset.entityTarget;
+    const input = (targetId && document.getElementById(targetId)) || button.previousElementSibling;
+    if (!input) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    window.wzPickEntity?.(input);
   }
 
   function injectStyles() {
@@ -335,76 +419,6 @@
     document.head.append(style);
   }
 
-  function mountEntityPickers() {
-    const body = document.getElementById("ed-body");
-    if (!body) return;
-    try {
-      window.DashboardModernModules?.render?.mountEntityPickers?.(body);
-    } catch (_error) {}
-
-    body.querySelectorAll("#luce-add-ent, #light-add-ent, [data-entity-input]").forEach(function (input) {
-      if (!input.id) input.id = `dm-entity-${Math.random().toString(36).slice(2)}`;
-      let button = input.nextElementSibling;
-      if (!button?.matches?.(".dm-entity-picker")) {
-        button = document.createElement("button");
-        button.type = "button";
-        button.className = "dm-entity-picker";
-        button.textContent = "🔍";
-        input.insertAdjacentElement("afterend", button);
-      }
-      button.dataset.entityTarget = input.id;
-    });
-  }
-
-  function queuePickerPass() {
-    if (pickerPassQueued) return;
-    pickerPassQueued = true;
-    queueMicrotask(function () {
-      pickerPassQueued = false;
-      mountEntityPickers();
-    });
-  }
-
-  function attachEditorObserver() {
-    const nextBody = document.getElementById("ed-body");
-    if (!nextBody) return;
-    if (nextBody !== editorBody) {
-      editorObserver?.disconnect();
-      editorBody = nextBody;
-      editorObserver = new MutationObserver(queuePickerPass);
-      editorObserver.observe(nextBody, { childList: true, subtree: true });
-    }
-    queuePickerPass();
-  }
-
-  function ensureApplianceVisuals() {
-    document.querySelectorAll("#page-appliances-main .appl-ic").forEach(function (visual) {
-      if (visual.querySelector(".dm-appliance-glyph")) return;
-      const type = visual.dataset.applianceType || "generico";
-      visual.innerHTML = `<span class="dm-appliance-glyph" aria-hidden="true">${GLYPHS[type] || GLYPHS.generico}</span>`;
-    });
-  }
-
-  function queueAppliancePass() {
-    if (appliancePassQueued) return;
-    appliancePassQueued = true;
-    requestAnimationFrame(function () {
-      appliancePassQueued = false;
-      ensureApplianceVisuals();
-    });
-  }
-
-  function delegatedPickerClick(event) {
-    const button = event.target.closest?.(".dm-entity-picker");
-    if (!button) return;
-    const targetId = button.dataset.entityTarget;
-    const input = (targetId && document.getElementById(targetId)) || button.previousElementSibling;
-    if (!input) return;
-    event.preventDefault();
-    event.stopImmediatePropagation();
-    window.wzPickEntity?.(input);
-  }
-
   function installOverrides() {
     const appliancesReady = installApplianceRenderer();
     const lightsReady = installLightRuntime();
@@ -414,20 +428,36 @@
     }
   }
 
-  const documentObserver = new MutationObserver(function () {
-    attachEditorObserver();
-    queueAppliancePass();
+  function runPass() {
+    passQueued = false;
     installOverrides();
-  });
+    repairRenderedLightEditor();
+    mountEntityPickers();
+    repairRenderedAppliances();
+  }
+
+  function queuePass() {
+    if (passQueued) return;
+    passQueued = true;
+    queueMicrotask(runPass);
+  }
 
   function start() {
     injectStyles();
     document.addEventListener("click", delegatedPickerClick, true);
-    documentObserver.observe(document.documentElement, { childList: true, subtree: true });
-    attachEditorObserver();
-    queueAppliancePass();
+    new MutationObserver(queuePass).observe(document.documentElement, { childList: true, subtree: true });
+
+    try {
+      const store = window.DashboardModernModules?.store;
+      if (typeof store?.subscribe === "function") store.subscribe(queuePass);
+    } catch (_error) {}
+
     installOverrides();
-    installTimer = setInterval(installOverrides, 100);
+    queuePass();
+    installTimer = setInterval(function () {
+      installOverrides();
+      queuePass();
+    }, 100);
     setTimeout(function () {
       if (installTimer) {
         clearInterval(installTimer);


### PR DESCRIPTION
### Problemi verificati sulle schermate reali
- la card mostrava `OTHER` perché il sottotitolo stampava la categoria, non la stanza configurata;
- il riquadro icona poteva contenere un SVG presente nel DOM ma invisibile, superando comunque il vecchio test;
- una sola card si allargava su tutta la pagina;
- Luci conservava nomi stanza legacy invece degli ID stabili: `light.salone` poteva restare assegnata a Terrazza;
- la lente dipendeva dal listener montato sul singolo nodo e poteva smettere di funzionare dopo un rerender.

### Correzione
- stanza reale risolta da `room_id` e visualizzata nella card;
- visuale elettrodomestico sostituita da un glifo sempre visibile e coerente col tipo;
- griglia limitata a card compatte, senza espansione a tutta larghezza;
- migrazione runtime di `cd_luci_rooms` verso ID stanza stabili, con correzione esatta entity→stanza (`light.salone`→Salone);
- select Luci ricostruite con ID stabili e nomi leggibili;
- click della lente gestito per delegazione sul documento, quindi resta attivo anche dopo la sostituzione completa del DOM;
- E2E aggiornato per verificare il caso reale, non soltanto la presenza di un elemento grafico nel DOM.

Nessun bump versione, tag o release. La PR resta Draft finché CI e screenshot dell’artifact non confermano il risultato.