### PR TITLE
[Draft] Fix canonical Temperature runtime and editor regressions

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/release-screenshots.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-screenshots.spec.js
@@ -102,7 +102,9 @@ async function boot(page) {
     () => window.__DASHBOARDMODERN_LEGACY_READY__ && window.DashboardModernModules,
   );
   await installHostedRuntime(page);
-  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await page
+    .locator("#setup-wizard")
+    .evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
   await page.evaluate((seededDevices) => {
     seededDevices.forEach((device) => {
       STATES[device.power_entity] = {
@@ -175,7 +177,9 @@ test("release evidence", async ({ page }, testInfo) => {
   });
   await expect(page.locator("#appl-grid-overview .dm-control-device")).toHaveCount(5);
   expect(
-    await page.locator("#page-appliances-main").evaluate((node) => node.scrollWidth <= node.clientWidth + 1),
+    await page
+      .locator("#page-appliances-main")
+      .evaluate((node) => node.scrollWidth <= node.clientWidth + 1),
   ).toBe(true);
   const screenshotDirectory = "docs/screenshots";
   await page.screenshot({

--- a/custom_components/dashboardmodern/frontend/e2e/runtime-ui-safari.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/runtime-ui-safari.spec.js
@@ -90,7 +90,9 @@ async function bootDashboard(page, variant) {
       window.editorRenderLuci?.__dmRealFix === true &&
       window.cdApplMainCard?.__dmRealFix === true,
   );
-  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await page
+    .locator("#setup-wizard")
+    .evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
   await page.evaluate(() => {
     window.cdSyncPush = async () => {};
     window.__pickedEntityInput = "";
@@ -137,9 +139,9 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     const lightRoomSelect = body.locator('select[data-light-entity="light.salone"]');
     await expect(lightRoomSelect).toHaveCount(1);
     await expect(lightRoomSelect).toHaveValue("room-salone");
-    expect(await page.evaluate(() => JSON.parse(localStorage.getItem("cd_luci_rooms"))["light.salone"])).toBe(
-      "room-salone",
-    );
+    expect(
+      await page.evaluate(() => JSON.parse(localStorage.getItem("cd_luci_rooms"))["light.salone"]),
+    ).toBe("room-salone");
     await expect(body).toContainText("Salone");
 
     let picker = body.locator(`.dm-entity-picker[data-entity-target="${lightId}"]`);
@@ -217,7 +219,8 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await expect(glyph).not.toHaveText("");
 
     const cardBox = await card.boundingBox();
-    if (testInfo.project.name === "desktop") expect(cardBox?.width ?? 9999).toBeLessThanOrEqual(540);
+    if (testInfo.project.name === "desktop")
+      expect(cardBox?.width ?? 9999).toBeLessThanOrEqual(540);
 
     await page.screenshot({
       path: `test-results/${testInfo.project.name}-${variant}-appliances-real.png`,

--- a/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
@@ -65,6 +65,12 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await page.waitForFunction(
       () => window.__DASHBOARDMODERN_LEGACY_READY__ && window.DashboardModernModules,
     );
+    // A fresh E2E profile intentionally has not completed onboarding.  The
+    // production wizard is therefore expected here, but Config must receive
+    // real pointer events for this editor-focused scenario.
+    await page
+      .locator("#setup-wizard")
+      .evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
     await page.evaluate((haStates) => {
       haStates.forEach((state) => {
         _RAW_STATES[state.entity_id] = state;
@@ -132,5 +138,24 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       path: `test-results/${testInfo.project.name}-${variant}-temperature-dashboard.png`,
       fullPage: true,
     });
+    await page.evaluate(() => {
+      apriConfigEntita();
+      editorSwitch("sez7");
+    });
+    await page.locator("[data-temperature-delete]").click();
+    await page.locator("[data-temperature-save]").click();
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const room = DashboardModernModules.store.getSection("rooms")[0];
+          return {
+            name: room.name,
+            icon: room.icon,
+            temp: room.temp,
+            hum: room.hum,
+          };
+        }),
+      )
+      .toEqual({ name: "Kitchen", icon: "🌡️", temp: "", hum: "" });
   });
 }

--- a/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
@@ -21,6 +21,38 @@ const states = [
   },
 ];
 
+async function waitForStableBox(locator) {
+  let previous = null;
+  let stableSamples = 0;
+  await expect
+    .poll(async () => {
+      const box = await locator.boundingBox();
+      if (!box) {
+        previous = null;
+        stableSamples = 0;
+        return false;
+      }
+      const current = {
+        x: Math.round(box.x),
+        y: Math.round(box.y),
+        width: Math.round(box.width),
+        height: Math.round(box.height),
+      };
+      if (
+        previous &&
+        current.x === previous.x &&
+        current.y === previous.y &&
+        current.width === previous.width &&
+        current.height === previous.height
+      )
+        stableSamples += 1;
+      else stableSamples = 0;
+      previous = current;
+      return stableSamples >= 3;
+    })
+    .toBeTruthy();
+}
+
 async function revealBottomNavigation(page, projectName) {
   const nav = page.locator("nav.bottom-nav-bar");
   if (projectName === "mobile") {
@@ -37,9 +69,13 @@ async function revealBottomNavigation(page, projectName) {
   await expect
     .poll(async () => {
       const box = await nav.boundingBox();
-      return Boolean(box && box.y < viewport.height);
+      return Boolean(box && box.y >= 0 && box.y + box.height <= viewport.height);
     })
     .toBeTruthy();
+  const navBox = await nav.boundingBox();
+  if (!navBox) throw new Error("Desktop navigation has no bounding box");
+  await page.mouse.move(navBox.x + 4, navBox.y + 4);
+  await waitForStableBox(nav);
 }
 
 for (const variant of ["dashboard.html", "dashboard-en.html"]) {
@@ -146,8 +182,20 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await revealBottomNavigation(page, testInfo.project.name);
     const temperatureTab = page.locator('.tab[data-tab="temp"]');
     await expect(temperatureTab).toBeVisible();
-    await temperatureTab.scrollIntoViewIfNeeded();
-    if (testInfo.project.name === "mobile") {
+    if (testInfo.project.name === "desktop") {
+      await waitForStableBox(temperatureTab);
+      const tabBox = await temperatureTab.boundingBox();
+      if (!tabBox) throw new Error("Temperature tab has no bounding box");
+      await page.mouse.move(tabBox.x + tabBox.width / 2, tabBox.y + tabBox.height / 2);
+      await waitForStableBox(temperatureTab);
+      const stableTabBox = await temperatureTab.boundingBox();
+      if (!stableTabBox) throw new Error("Temperature tab disappeared before click");
+      await page.mouse.click(
+        stableTabBox.x + stableTabBox.width / 2,
+        stableTabBox.y + stableTabBox.height / 2,
+      );
+    } else {
+      await temperatureTab.scrollIntoViewIfNeeded();
       await expect
         .poll(async () => {
           const box = await temperatureTab.boundingBox();
@@ -162,8 +210,8 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
           );
         })
         .toBeTruthy();
+      await temperatureTab.click();
     }
-    await temperatureTab.click();
     await expect(page.locator("#page-temp")).toHaveClass(/active/);
     await expect(page.locator("#temp-grid .cp-card")).toContainText("Kitchen");
     await expect(page.locator("#temp-grid .temp-value")).toContainText("21.5");

--- a/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
@@ -21,6 +21,27 @@ const states = [
   },
 ];
 
+async function revealBottomNavigation(page, projectName) {
+  const nav = page.locator("nav.bottom-nav-bar");
+  if (projectName === "mobile") {
+    const handle = page.locator("#bottomNavHandle");
+    await expect(handle).toBeVisible();
+    await handle.click();
+    await expect(nav).toHaveClass(/visible/);
+    return;
+  }
+
+  const viewport = page.viewportSize();
+  if (!viewport) throw new Error("Playwright viewport is unavailable");
+  await page.mouse.move(Math.floor(viewport.width / 2), viewport.height - 1);
+  await expect
+    .poll(async () => {
+      const box = await nav.boundingBox();
+      return Boolean(box && box.y < viewport.height);
+    })
+    .toBeTruthy();
+}
+
 for (const variant of ["dashboard.html", "dashboard-en.html"]) {
   test(`${variant}: Temperature editor, HA picker, persistence and live dashboard`, async ({
     page,
@@ -122,8 +143,26 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     });
     await page.locator("#editor-modal .ed-head-close").last().click();
     await expect(page.locator("#editor-modal")).toHaveCount(0);
+    await revealBottomNavigation(page, testInfo.project.name);
     const temperatureTab = page.locator('.tab[data-tab="temp"]');
     await expect(temperatureTab).toBeVisible();
+    await temperatureTab.scrollIntoViewIfNeeded();
+    if (testInfo.project.name === "mobile") {
+      await expect
+        .poll(async () => {
+          const box = await temperatureTab.boundingBox();
+          const viewport = page.viewportSize();
+          return Boolean(
+            box &&
+            viewport &&
+            box.x >= 0 &&
+            box.x + box.width <= viewport.width &&
+            box.y >= 0 &&
+            box.y + box.height <= viewport.height,
+          );
+        })
+        .toBeTruthy();
+    }
     await temperatureTab.click();
     await expect(page.locator("#page-temp")).toHaveClass(/active/);
     await expect(page.locator("#temp-grid .cp-card")).toContainText("Kitchen");
@@ -138,6 +177,14 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       path: `test-results/${testInfo.project.name}-${variant}-temperature-dashboard.png`,
       fullPage: true,
     });
+    const roomBeforeDelete = await page.evaluate(() => {
+      const {
+        temp: _temp,
+        hum: _hum,
+        ...room
+      } = DashboardModernModules.store.getSection("rooms")[0];
+      return room;
+    });
     await page.evaluate(() => {
       apriConfigEntita();
       editorSwitch("sez7");
@@ -148,14 +195,15 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       .poll(() =>
         page.evaluate(() => {
           const room = DashboardModernModules.store.getSection("rooms")[0];
+          const { temp, hum, ...preserved } = room;
           return {
-            name: room.name,
-            icon: room.icon,
-            temp: room.temp,
-            hum: room.hum,
+            preserved,
+            temp,
+            hum,
+            roomCount: DashboardModernModules.store.getSection("rooms").length,
           };
         }),
       )
-      .toEqual({ name: "Kitchen", icon: "🌡️", temp: "", hum: "" });
+      .toEqual({ preserved: roomBeforeDelete, temp: "", hum: "", roomCount: 1 });
   });
 }

--- a/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
@@ -1,0 +1,136 @@
+import { expect, test } from "@playwright/test";
+
+const states = [
+  {
+    entity_id: "sensor.kitchen_temperature",
+    state: "21.5",
+    attributes: {
+      friendly_name: "Kitchen temperature",
+      unit_of_measurement: "°C",
+      device_class: "temperature",
+    },
+  },
+  {
+    entity_id: "sensor.kitchen_humidity",
+    state: "48",
+    attributes: {
+      friendly_name: "Kitchen humidity",
+      unit_of_measurement: "%",
+      device_class: "humidity",
+    },
+  },
+];
+
+for (const variant of ["dashboard.html", "dashboard-en.html"]) {
+  test(`${variant}: Temperature editor, HA picker, persistence and live dashboard`, async ({
+    page,
+  }, testInfo) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await page.addInitScript((haStates) => {
+      window.WebSocket = class extends EventTarget {
+        static OPEN = 1;
+        readyState = 1;
+        constructor() {
+          super();
+          queueMicrotask(() =>
+            this.onmessage?.({ data: JSON.stringify({ type: "auth_required" }) }),
+          );
+        }
+        send(raw) {
+          const message = JSON.parse(raw);
+          if (message.type === "auth")
+            this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+          else
+            this.onmessage?.({
+              data: JSON.stringify({
+                id: message.id,
+                type: "result",
+                success: true,
+                result: message.type === "get_states" ? haStates : [],
+              }),
+            });
+        }
+        close() {}
+      };
+      localStorage.setItem(
+        "cd_connection",
+        JSON.stringify({ token: "e2e-token", ws_url: "ws://home-assistant.test/api/websocket" }),
+      );
+      localStorage.setItem(
+        "dm_dashboard_state",
+        JSON.stringify({ schema_version: 4, sections: { rooms: [] }, visibility: {} }),
+      );
+    }, states);
+    await page.goto(`/legacy/${variant}`);
+    await page.waitForFunction(
+      () => window.__DASHBOARDMODERN_LEGACY_READY__ && window.DashboardModernModules,
+    );
+    await page.evaluate((haStates) => {
+      haStates.forEach((state) => {
+        _RAW_STATES[state.entity_id] = state;
+        STATES[state.entity_id] = state;
+      });
+      apriConfigEntita();
+      editorSwitch("sez7");
+    }, states);
+    await expect(page.locator('#ed-body[data-renderer="temperature"]')).toBeVisible();
+    await expect(page.locator("#ed-pl-temp")).toBeVisible();
+    for (let index = 0; index < 20; index++) await page.evaluate(() => editorSwitch("sez7"));
+    expect(
+      await page.locator("#ed-body").evaluate((body) => ({
+        inputs: body.querySelectorAll("[data-entity-input]").length,
+        pickers: body.querySelectorAll(".dm-entity-picker").length,
+        targets: new Set(
+          [...body.querySelectorAll(".dm-entity-picker")].map(
+            (button) => button.dataset.entityTarget,
+          ),
+        ).size,
+      })),
+    ).toEqual({ inputs: 2, pickers: 2, targets: 2 });
+    await page.screenshot({
+      path: `test-results/${testInfo.project.name}-${variant}-temperature-config.png`,
+    });
+    await page.locator('.dm-entity-picker[data-entity-target="ed-pl-temp"]').click();
+    await expect(page.locator("#cd-entpick")).toBeVisible();
+    await page.locator("#cd-ep-search").fill("kitchen temperature");
+    await expect(page.locator("#cd-ep-list")).toContainText("sensor.kitchen_temperature");
+    await page.screenshot({
+      path: `test-results/${testInfo.project.name}-${variant}-temperature-picker.png`,
+    });
+    await page
+      .locator("#cd-ep-list", { hasText: "sensor.kitchen_temperature" })
+      .locator("div[onclick]")
+      .click();
+    await page.locator("#dm-temperature-new-name").fill("Kitchen");
+    await page.locator("[data-temperature-add]").click();
+    await expect(page.locator('[data-temperature-room] input[id^="dm-temperature-"]')).toHaveValue(
+      "sensor.kitchen_temperature",
+    );
+    await page.evaluate(() => editorSwitch("sez1"));
+    await page.evaluate(() => editorSwitch("sez7"));
+    await expect(page.locator('[data-temperature-room] input[id^="dm-temperature-"]')).toHaveValue(
+      "sensor.kitchen_temperature",
+    );
+    await page.screenshot({
+      path: `test-results/${testInfo.project.name}-${variant}-temperature-saved.png`,
+    });
+    await page.evaluate(() => {
+      document.getElementById("editor-modal")?.remove();
+      showPage("temp");
+      buildTempCards();
+      renderTemperature();
+    });
+    await expect(page.locator("#temp-grid .cp-card")).toContainText("Kitchen");
+    await expect(page.locator("#temp-grid .temp-value")).toContainText("21.5");
+    await page.evaluate(() => {
+      _RAW_STATES["sensor.kitchen_temperature"].state = "23.7";
+      STATES["sensor.kitchen_temperature"].state = "23.7";
+      renderTemperature();
+    });
+    await expect(page.locator("#temp-grid .temp-value")).toContainText("23.7");
+    await page.screenshot({
+      path: `test-results/${testInfo.project.name}-${variant}-temperature-dashboard.png`,
+      fullPage: true,
+    });
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
@@ -120,12 +120,12 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await page.screenshot({
       path: `test-results/${testInfo.project.name}-${variant}-temperature-saved.png`,
     });
-    await page.evaluate(() => {
-      document.getElementById("editor-modal")?.remove();
-      showPage("temp");
-      buildTempCards();
-      renderTemperature();
-    });
+    await page.locator("#editor-modal .ed-head-close").last().click();
+    await expect(page.locator("#editor-modal")).toHaveCount(0);
+    const temperatureTab = page.locator('.tab[data-tab="temp"]');
+    await expect(temperatureTab).toBeVisible();
+    await temperatureTab.click();
+    await expect(page.locator("#page-temp")).toHaveClass(/active/);
     await expect(page.locator("#temp-grid .cp-card")).toContainText("Kitchen");
     await expect(page.locator("#temp-grid .temp-value")).toContainText("21.5");
     await page.evaluate(() => {

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -55,6 +55,8 @@ createRenderCoordinator(store, {
     } else if (section === "cameras") {
       const grid = globalThis.document?.getElementById?.("cam-grid"); if (grid) grid._sig = "";
       globalThis.buildCamCards?.(); globalThis.refreshCameras?.();
+    } else if (section === "rooms") {
+      globalThis.buildTempCards?.(); globalThis.renderTemperature?.();
     }
   },
   renderEnergyReport() {
@@ -70,12 +72,16 @@ createRenderCoordinator(store, {
       ev: "sezioni", lights: "luci", climate: "sezioni", covers: "tapp",
       pool: "pool", irrigation: "irr",
     };
-    const expected = sectionTabs[section];
+    const expected = section === "rooms" && tab === "sez7" ? "sez7" : sectionTabs[section];
     const matches = expected === tab || (expected === "sezioni" && tab?.startsWith("sez"));
     if (!globalThis.document?.getElementById?.("ed-body") || !matches) return;
     // Re-render the active body directly; editorSwitch is navigation and was
     // the accidental refresh mechanism that left confirmed deletes visible.
     const body = globalThis.document.getElementById("ed-body");
+    if (tab === "sez7" && section === "rooms") {
+      renderEditorTab("sez7", body);
+      return;
+    }
     if (tab === "sez1" && section === "energy") {
       renderEditorTab("sez1", body);
       return;
@@ -155,6 +161,42 @@ function createIconField(id, value = "") {
   return `<span class="ed-form-row dm-icon-field" data-icon-field><input id="${esc(id)}" class="ed-input ed-icon-input" value="${esc(value)}"><button type="button" class="dm-icon-picker" data-icon-target="${esc(id)}" aria-label="${t("select")} icon">🎨</button></span>`;
 }
 const entityField = (id, label, value, placeholder) => createEntityField({ id, label, value, placeholder });
+
+export function renderTemperatureEditor(target) {
+  const rooms = store.getSection("rooms");
+  const rows = rooms.map((room, index) => `<fieldset class="ed-form dm-temperature-room" data-temperature-room data-room-id="${esc(room.id)}">
+    <legend>${esc(room.icon || "🌡️")} ${esc(room.name || `${t("name")} ${index + 1}`)}</legend>
+    <div class="ed-form-row"><input class="ed-input" data-temperature-name aria-label="${t("name")}" value="${esc(room.name)}"><input class="ed-input" data-temperature-icon aria-label="Icon" value="${esc(room.icon || "🌡️")}"><input class="ed-input" data-temperature-floor aria-label="Floor" value="${esc(room.floor)}"></div>
+    ${createEntityField({ id: `dm-temperature-${index}`, label: "Temperature entity_id", value: room.temp, optional: false })}
+    ${createEntityField({ id: `dm-humidity-${index}`, label: "Humidity entity_id", value: room.hum })}
+    <button type="button" class="ed-del" data-temperature-delete aria-label="${t("remove")}">🗑️</button>
+  </fieldset>`).join("");
+  target.innerHTML = `<div class="ed-intro" data-temperature-editor>${LOCALE === "en" ? "Configure real Home Assistant temperature and humidity entities for each room." : "Configura le entità reali di temperatura e umidità di Home Assistant per ogni stanza."}</div><div data-temperature-list>${rows || `<div class="ed-empty">${t("empty")}</div>`}</div>
+    <div class="ed-form" data-temperature-new><div class="ed-sec-title">＋ ${LOCALE === "en" ? "New temperature" : "Nuova temperatura"}</div><div class="ed-form-row"><input id="dm-temperature-new-name" class="ed-input" placeholder="${t("name")}"><input id="dm-temperature-new-icon" class="ed-input" value="🌡️" aria-label="Icon"><input id="dm-temperature-new-floor" class="ed-input" placeholder="Floor"></div>${createEntityField({ id: "ed-pl-temp", label: "Temperature entity_id", optional: false })}${createEntityField({ id: "dm-humidity-new", label: "Humidity entity_id" })}<button type="button" class="ed-btn-add" data-temperature-add>${t("add")}</button></div>
+    <button type="button" class="ed-save-btn" data-temperature-save>💾 ${LOCALE === "en" ? "Save temperatures" : "Salva temperature"}</button>`;
+}
+
+export function mountTemperatureEditor(_section, target) {
+  mountEntityPickers(target);
+  const readRooms = () => [...target.querySelectorAll("[data-temperature-room]")].map((row, index) => ({
+    ...(store.getSection("rooms").find((room) => room.id === row.dataset.roomId) || {}),
+    id: row.dataset.roomId,
+    name: row.querySelector("[data-temperature-name]").value.trim(),
+    icon: row.querySelector("[data-temperature-icon]").value.trim(),
+    floor: row.querySelector("[data-temperature-floor]").value.trim(),
+    temp: row.querySelector('[id^="dm-temperature-"]').value.trim(),
+    hum: row.querySelector('[id^="dm-humidity-"]').value.trim(),
+    order: index,
+  }));
+  target.querySelectorAll("[data-temperature-delete]").forEach((button) => button.addEventListener("click", () => button.closest("[data-temperature-room]").remove()));
+  target.querySelector("[data-temperature-add]")?.addEventListener("click", () => {
+    const name = target.querySelector("#dm-temperature-new-name").value.trim();
+    const temp = target.querySelector("#ed-pl-temp").value.trim();
+    if (!name || !temp.includes(".")) return globalThis.alert?.(t("required"));
+    store.replaceSection("rooms", [...readRooms(), { id: `room-${Date.now().toString(36)}`, name, icon: target.querySelector("#dm-temperature-new-icon").value.trim() || "🌡️", floor: target.querySelector("#dm-temperature-new-floor").value.trim(), temp, hum: target.querySelector("#dm-humidity-new").value.trim() }]);
+  });
+  target.querySelector("[data-temperature-save]")?.addEventListener("click", () => store.replaceSection("rooms", readRooms()));
+}
 
 export function mountEntityPickers(target) {
   if (!target?.querySelectorAll) return;
@@ -317,6 +359,7 @@ export const EDITOR_REGISTRY = Object.freeze({
   energy: { render: renderEnergyEditorTab, mount: mountCurrentEditor, visibilityKey: "energy" },
   loads: { render: mountLoadsEditor, mount: mountCurrentEditor, visibilityKey: "energy" },
   report: { render: renderReportEditor, mount: mountReportEditor, visibilityKey: "energy" },
+  temperature: { render: renderTemperatureEditor, mount: mountTemperatureEditor, visibilityKey: "temp" },
   diagnostics: { render: renderDiagnostics, mount: mountCurrentEditor, visibilityKey: null },
 });
 

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -163,7 +163,7 @@ function createIconField(id, value = "") {
 const entityField = (id, label, value, placeholder) => createEntityField({ id, label, value, placeholder });
 
 export function renderTemperatureEditor(target) {
-  const rooms = store.getSection("rooms");
+  const rooms = store.getSection("rooms").filter((room) => room.temp || room.hum);
   const rows = rooms.map((room, index) => `<fieldset class="ed-form dm-temperature-room" data-temperature-room data-room-id="${esc(room.id)}">
     <legend>${esc(room.icon || "🌡️")} ${esc(room.name || `${t("name")} ${index + 1}`)}</legend>
     <div class="ed-form-row"><input class="ed-input" data-temperature-name aria-label="${t("name")}" value="${esc(room.name)}"><input class="ed-input" data-temperature-icon aria-label="Icon" value="${esc(room.icon || "🌡️")}"><input class="ed-input" data-temperature-floor aria-label="Floor" value="${esc(room.floor)}"></div>
@@ -178,17 +178,28 @@ export function renderTemperatureEditor(target) {
 
 export function mountTemperatureEditor(_section, target) {
   mountEntityPickers(target);
-  const readRooms = () => [...target.querySelectorAll("[data-temperature-room]")].map((row, index) => ({
-    ...(store.getSection("rooms").find((room) => room.id === row.dataset.roomId) || {}),
-    id: row.dataset.roomId,
-    name: row.querySelector("[data-temperature-name]").value.trim(),
-    icon: row.querySelector("[data-temperature-icon]").value.trim(),
-    floor: row.querySelector("[data-temperature-floor]").value.trim(),
-    temp: row.querySelector('[id^="dm-temperature-"]').value.trim(),
-    hum: row.querySelector('[id^="dm-humidity-"]').value.trim(),
-    order: index,
+  const readRooms = () => {
+    const current = store.getSection("rooms");
+    const rows = new Map([...target.querySelectorAll("[data-temperature-room]")].map((row) => [row.dataset.roomId, row]));
+    return current.map((room) => {
+      const row = rows.get(room.id);
+      if (!row) return room;
+      if (row.dataset.temperatureDeleted === "true") return { ...room, temp: "", hum: "" };
+      return {
+        ...room,
+        name: row.querySelector("[data-temperature-name]").value.trim(),
+        icon: row.querySelector("[data-temperature-icon]").value.trim(),
+        floor: row.querySelector("[data-temperature-floor]").value.trim(),
+        temp: row.querySelector('[id^="dm-temperature-"]').value.trim(),
+        hum: row.querySelector('[id^="dm-humidity-"]').value.trim(),
+      };
+    });
+  };
+  target.querySelectorAll("[data-temperature-delete]").forEach((button) => button.addEventListener("click", () => {
+    const row = button.closest("[data-temperature-room]");
+    row.dataset.temperatureDeleted = "true";
+    row.hidden = true;
   }));
-  target.querySelectorAll("[data-temperature-delete]").forEach((button) => button.addEventListener("click", () => button.closest("[data-temperature-room]").remove()));
   target.querySelector("[data-temperature-add]")?.addEventListener("click", () => {
     const name = target.querySelector("#dm-temperature-new-name").value.trim();
     const temp = target.querySelector("#ed-pl-temp").value.trim();

--- a/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
+++ b/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
@@ -4,6 +4,7 @@ import { sectionForEditorSlot } from "./editor-slots.js";
 import { projectEnergySlots } from "./energy-projection.js";
 
 export const VISIBILITY_SECTION = Object.freeze({
+  rooms: "temp",
   cameras: "security",
   lights: "home",
   appliances: "appliances",
@@ -20,6 +21,8 @@ export const VISIBILITY_SECTION = Object.freeze({
 const configured = (value) =>
   typeof value === "string" ? value.trim().includes(".") : Boolean(value);
 export function hasConfiguredData(section, value) {
+  if (section === "rooms" && Array.isArray(value))
+    return value.some((room) => configured(room?.temp) || configured(room?.hum));
   if (Array.isArray(value))
     return value.some(
       (item) =>

--- a/custom_components/dashboardmodern/frontend/src/core/migrations.js
+++ b/custom_components/dashboardmodern/frontend/src/core/migrations.js
@@ -41,6 +41,12 @@ export function migrateRooms(input = []) {
       name: String(room.name || `Room ${index + 1}`),
       icon: room.icon || "",
       floor: room.floor || "",
+      // Temperature sensors historically lived on cd_stanze.  Keep these
+      // fields in the canonical room projection: dropping them here makes
+      // DashboardStore.persist() destructively rewrite cd_stanze.
+      temp: String(room.temp || room.temperature_entity || ""),
+      hum: String(room.hum || room.humidity_entity || ""),
+      rgb: room.rgb || "",
       order: Number.isFinite(+room.order) ? +room.order : index,
       metadata: { ...(room.metadata || {}) },
     };

--- a/custom_components/dashboardmodern/frontend/tests/dashboard-store.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/dashboard-store.test.js
@@ -14,6 +14,25 @@ test("visibility recognizes configured pool and irrigation entities without devi
   assert.equal(hasConfiguredData("pool", { filterHours: 8 }), false);
 });
 
+test("Temperature visibility requires a real room sensor instead of only a room name", () => {
+  assert.equal(hasConfiguredData("rooms", [{ name: "Kitchen" }]), false);
+  assert.equal(
+    hasConfiguredData("rooms", [{ name: "Kitchen", temp: "sensor.kitchen_temp" }]),
+    true,
+  );
+  assert.equal(hasConfiguredData("rooms", [{ name: "Bath", hum: "sensor.bath_humidity" }]), true);
+});
+
+test("saving the first canonical Temperature makes the public temp section visible", async () => {
+  const { store, storage } = setup();
+  await store.replaceSection("rooms", [
+    { id: "room-kitchen", name: "Kitchen", temp: "sensor.kitchen_temp" },
+  ]);
+  assert.equal(store.getState().visibility.temp, true);
+  assert.equal(JSON.parse(storage.getItem("cd_sections")).temp, true);
+  assert.equal(JSON.parse(storage.getItem("cd_stanze"))[0].temp, "sensor.kitchen_temp");
+});
+
 class MemoryStorage {
   values = new Map();
   getItem(key) {

--- a/custom_components/dashboardmodern/frontend/tests/dashboard-store.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/dashboard-store.test.js
@@ -610,3 +610,34 @@ test("Energy slot ownership is derived from the canonical projection without typ
     false,
   );
 });
+
+test("Temperature room migration preserves legacy entity ids and display metadata", () => {
+  const [room] = migrateRooms([
+    {
+      name: "Kitchen",
+      icon: "mdi:thermometer",
+      floor: "Ground",
+      temp: "sensor.kitchen_temperature",
+      hum: "sensor.kitchen_humidity",
+      rgb: "14,165,233",
+    },
+  ]);
+  assert.equal(room.temp, "sensor.kitchen_temperature");
+  assert.equal(room.hum, "sensor.kitchen_humidity");
+  assert.equal(room.icon, "mdi:thermometer");
+  assert.equal(room.rgb, "14,165,233");
+  const remounted = migrateRooms([room])[0];
+  assert.deepEqual(remounted, room);
+});
+
+test("Temperature migration accepts descriptive legacy entity field names", () => {
+  const [room] = migrateRooms([
+    {
+      name: "Office",
+      temperature_entity: "sensor.office_temperature",
+      humidity_entity: "sensor.office_humidity",
+    },
+  ]);
+  assert.equal(room.temp, "sensor.office_temperature");
+  assert.equal(room.hum, "sensor.office_humidity");
+});

--- a/custom_components/dashboardmodern/frontend/tests/editor-registry.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/editor-registry.test.js
@@ -11,6 +11,26 @@ test("real editor tab ids resolve to canonical ownership", async () => {
   assert.equal(resolveEditorTab("sez4"), "security");
   assert.equal(resolveEditorTab("runtime"), "diagnostics");
   assert.equal(resolveEditorTab("pool"), "pool");
+  assert.equal(resolveEditorTab("sez7"), "temperature");
+});
+
+test("Temperature is registry-owned and uses the canonical room store", async () => {
+  const module = await import(`${moduleUrl}?temperature=${Date.now()}`);
+  assert.equal(module.EDITOR_REGISTRY.temperature.render, module.renderTemperatureEditor);
+  assert.equal(module.EDITOR_REGISTRY.temperature.mount, module.mountTemperatureEditor);
+  const target = { innerHTML: "" };
+  module.renderTemperatureEditor(target);
+  assert.match(target.innerHTML, /data-temperature-editor/);
+  assert.match(target.innerHTML, /id="ed-pl-temp"/);
+  assert.equal((target.innerHTML.match(/dm-entity-picker/g) || []).length, 2);
+  const source = await readFile(moduleUrl, "utf8");
+  const renderer = source.slice(
+    source.indexOf("export function renderTemperatureEditor"),
+    source.indexOf("export function renderReportRow"),
+  );
+  assert.match(renderer, /store\.getSection\("rooms"\)/);
+  assert.match(renderer, /store\.replaceSection\("rooms"/);
+  assert.doesNotMatch(renderer, /sensor\.[a-z_]+["']/);
 });
 
 test("registry dispatch performs exactly one render and one mount", async () => {


### PR DESCRIPTION
### Motivation

- The Temperature UI stopped working because schema migrations dropped legacy `temp`/`hum`/`rgb` fields from rooms and the canonical store then projected an incomplete model back to `cd_stanze`, removing the real entity IDs used by the public renderer and editor. 
- The editor tab alias `sez7` resolved to `temperature` but no registry entry/renderer was mounted, so the editor workflow (`mountCurrentEditor` → pickers → save) was not executed.
- The change set aims to restore correct runtime data flow (canonical store → legacy bridge → legacy renderer) and to reintroduce a canonical Temperature editor that uses the shared HA entity picker and `DashboardStore` for persistence.

### Description

- Preserve legacy temperature fields in the canonical room projection by keeping `temp`, `hum` and `rgb` in `migrateRooms()` so `DashboardStore.persist()` no longer rewrites `cd_stanze` without entity IDs (`custom_components/dashboardmodern/frontend/src/core/migrations.js`).
- Register and implement a canonical Temperature editor and mount logic (`renderTemperatureEditor`, `mountTemperatureEditor`) and add `temperature` to `EDITOR_REGISTRY` so `sez7` is rendered/mounted via the canonical editor lifecycle (`custom_components/dashboardmodern/frontend/legacy/modules-entry.js`).
- Ensure room changes trigger Temperature card rebuilds and live rerenders by calling the temperature render path from the renderer coordinator (`createRenderCoordinator` adjustments in `modules-entry.js`).
- Reuse the shared entity picker invariant: mount a single `.dm-entity-picker` per input, attach deterministic `data-entity-target`, and register the click listener once (`mountEntityPickers` adjustments in `modules-entry.js`).
- Add unit tests for migration and registry ownership, and an E2E Playwright test that exercises the Temperature editor, HA picker, persistence and dashboard live updates (`custom_components/dashboardmodern/frontend/tests/*`, and new `custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js`).
- Minor Prettier formatting adjustments for existing E2E specs to conform to project style.

Files changed (key):
- custom_components/dashboardmodern/frontend/src/core/migrations.js
- custom_components/dashboardmodern/frontend/legacy/modules-entry.js
- custom_components/dashboardmodern/frontend/tests/dashboard-store.test.js
- custom_components/dashboardmodern/frontend/tests/editor-registry.test.js
- custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js (new)
- minor formatting changes in existing E2E specs

### Testing

- Ran `npm run check:inline-syntax` and both legacy HTML variants compiled their inline scripts successfully. (pass)
- Ran `npm run test:frontend` and the full frontend unit/test suite passed: 144 tests succeeded. (pass)
- Ran formatting checks: `npm run format:check` / `npx prettier` and code style checks passed after formatting. (pass)
- Ran Python tests: `python -m pytest -q` which returned 4 passed, 1 skipped (environment warnings only). (pass)
- Ran static checks: `ruff check .` and `ruff format --check .` — both passed. (pass)
- Verified `git diff --check` and repository tree cleanliness for this branch; no whitespace errors detected. (pass)
- Attempted Browser E2E: `npm run test:e2e` and local Playwright runs were triggered, but all Playwright jobs were blocked before executing due to the test environment missing the Playwright Chromium executable (`chromium_headless_shell`); traces were recorded but screenshots/artifacts were not produced locally. The E2E tests are present and will produce the configured screenshots when run on CI with Playwright browsers installed. (blocked — Playwright browsers missing locally)

Notes and follow-up

- This PR is intentionally left as Draft until CI runs the full Browser E2E suite (IT/EN × desktop/mobile) and maintainers validate behavior inside a real Home Assistant instance (persistence across HA restart, subscriptions to live HA state updates, Safari and iframe/panel embedding). 
- No manifest version bump, tags or releases were performed in this change; no merges were done here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a51e60fb0832e942af592515f692b)