### PR TITLE
fix: real Home Assistant UI regressions before 0.14.7 release

### DIFF
--- a/.github/workflows/pr34-test-package.yml
+++ b/.github/workflows/pr34-test-package.yml
@@ -1,0 +1,27 @@
+name: Build PR34 test package
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    if: github.head_ref == 'fix/real-ha-ui-regressions-0.14.7'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Build integration package
+        run: python scripts/build_release.py --expected-commit "$GITHUB_SHA" --output dashboardmodern-pr34-test.zip
+      - name: Upload integration package
+        uses: actions/upload-artifact@v4
+        with:
+          name: dashboardmodern-pr34-test
+          path: dashboardmodern-pr34-test.zip
+          if-no-files-found: error

--- a/.github/workflows/pr34-test-package.yml
+++ b/.github/workflows/pr34-test-package.yml
@@ -1,27 +1,26 @@
-name: Build PR34 test package
+name: Build Home Assistant test package
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   package:
-    if: github.head_ref == 'fix/real-ha-ui-regressions-0.14.7'
     runs-on: ubuntu-latest
     steps:
-      - name: Check out pull request
+      - name: Check out selected revision
         uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - name: Build integration package
-        run: python scripts/build_release.py --expected-commit "$GITHUB_SHA" --output dashboardmodern-pr34-test.zip
+        run: python scripts/build_release.py --expected-commit "$GITHUB_SHA" --output dashboardmodern-test.zip
       - name: Upload integration package
         uses: actions/upload-artifact@v4
         with:
-          name: dashboardmodern-pr34-test
-          path: dashboardmodern-pr34-test.zip
+          name: dashboardmodern-test
+          path: dashboardmodern-test.zip
           if-no-files-found: error

--- a/custom_components/dashboardmodern/frontend/e2e/real-ha-acceptance.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/real-ha-acceptance.spec.js
@@ -1,0 +1,166 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const states = [
+  { entity_id: "light.salone", state: "on", attributes: { friendly_name: "Luce salone" } },
+  { entity_id: "switch.forno", state: "off", attributes: { friendly_name: "Forno" } },
+  { entity_id: "cover.salone", state: "open", attributes: { friendly_name: "Tapparella salone", current_position: 65 } },
+  { entity_id: "sensor.forno_power", state: "850", attributes: { friendly_name: "Forno power", unit_of_measurement: "W", device_class: "power" } },
+  { entity_id: "sensor.forno_energy", state: "4.2", attributes: { friendly_name: "Forno energy", unit_of_measurement: "kWh", device_class: "energy" } },
+  { entity_id: "sensor.salone_temperature", state: "22.4", attributes: { unit_of_measurement: "°C", device_class: "temperature" } },
+];
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [{ id: "room-salone", name: "Salone", icon: "mdi:sofa", temp: "sensor.salone_temperature" }],
+    lights: [{ id: "light-salone", name: "Luce salone", entities: ["light.salone"] }],
+    appliances: [{
+      id: "appl-forno",
+      name: "Forno",
+      device_type: "forno",
+      visual_type: "asset",
+      visual_key: "forno",
+      entities: ["sensor.forno_power", "sensor.forno_energy", "switch.forno"],
+      room_id: "room-salone",
+      show_in_report: true,
+    }],
+    loads: [],
+    covers: [{ id: "cover-salone", name: "Tapparella salone", entity: "cover.salone", entities: ["cover.salone"], room_id: "room-salone" }],
+  },
+  visibility: { home: true, energy: true, appliances: true, tapparelle: true, temp: true },
+};
+
+async function boot(page, variant, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript((haStates) => {
+    class MockBridgeSocket extends EventTarget {
+      readyState = 1;
+      onopen = null;
+      onmessage = null;
+      onclose = null;
+      onerror = null;
+      constructor() {
+        super();
+        queueMicrotask(() => {
+          this.onopen?.({});
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+        });
+      }
+      send(raw) {
+        const message = JSON.parse(raw);
+        window.__REAL_HA_CALLS__ ||= [];
+        if (message.type === "call_service") window.__REAL_HA_CALLS__.push(message);
+        if (message.type === "auth") return;
+        const result = message.type === "get_states" ? haStates : message.type === "frontend/get_user_data" ? { value: null } : null;
+        this.onmessage?.({ data: JSON.stringify({ id: message.id, type: "result", success: true, result }) });
+      }
+      close() {
+        this.readyState = 3;
+        this.onclose?.({});
+      }
+    }
+    window.__DASHBOARDMODERN_BRIDGE_WS__ = MockBridgeSocket;
+    window.WebSocket = MockBridgeSocket;
+  }, states);
+
+  await bootNamespacedDashboard(page, variant, testInfo, seed);
+  await page.evaluate(() => {
+    localStorage.setItem("cd_gruppi_extra", JSON.stringify({ luci: ["light.salone"] }));
+    localStorage.setItem("cd_avvisi_names_extra", JSON.stringify({ "light.salone": "Luce salone" }));
+    localStorage.setItem("cd_luci", JSON.stringify({ "light.salone": "Luce salone" }));
+    localStorage.setItem("cd_luci_rooms", JSON.stringify({ "light.salone": "Salone" }));
+  });
+  await page.reload();
+  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await page.evaluate((haStates) => haStates.forEach((state) => {
+    _RAW_STATES[state.entity_id] = structuredClone(state);
+    STATES[state.entity_id] = structuredClone(state);
+  }), states);
+  await expect.poll(() => page.evaluate(() => window.__DASHBOARDMODERN_REAL_HA_0147__?.installed === true)).toBe(true);
+  await page.evaluate(() => window.render?.());
+}
+
+async function openEditor(page, tab) {
+  await page.evaluate(() => {
+    if (!document.getElementById("editor-modal")?.classList.contains("show")) apriConfigEntita();
+  });
+  await expect(page.locator("#editor-modal")).toBeVisible();
+  await page.evaluate((target) => editorSwitch(target), tab);
+  await expect(page.locator(`.ed-tab[data-tab="${tab}"]`)).toHaveClass(/active/);
+}
+
+for (const variant of ["dashboard.html", "dashboard-en.html"]) {
+  test(`${variant}: real Home Assistant acceptance fixes preserve entities and editing`, async ({ page }, testInfo) => {
+    test.setTimeout(testInfo.project.name === "webkit-ipad" ? 180_000 : 100_000);
+    await boot(page, variant, testInfo);
+
+    await expect.poll(() => page.evaluate(() => DashboardModernModules.store.getSection("appliances")[0])).toMatchObject({
+      power_entity: "sensor.forno_power",
+      energy_entity: "sensor.forno_energy",
+      report_entity: "sensor.forno_energy",
+      control_entity: "switch.forno",
+    });
+
+    await expect.poll(() => page.evaluate(() => WebSocket.OPEN)).toBe(1);
+    await page.evaluate(() => dmCallHaService("cover", "close_cover", { entity_id: "cover.salone" }));
+    await expect.poll(() => page.evaluate(() => window.__REAL_HA_CALLS__)).toContainEqual(expect.objectContaining({
+      type: "call_service",
+      domain: "cover",
+      service: "close_cover",
+      service_data: { entity_id: "cover.salone" },
+    }));
+
+    await page.evaluate(() => {
+      document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
+      document.getElementById("page-appliances-main").classList.add("active");
+      renderApplianceSection(true);
+    });
+    const card = page.locator("#appl-view-overview.active .appl-wide-card.dm-control-device").filter({ hasText: "Forno" }).first();
+    await expect(card).toBeVisible();
+    await expect(card.locator(".appl-spark")).toHaveCount(0);
+    const cardBox = await card.boundingBox();
+    expect(cardBox.width).toBeLessThanOrEqual(410);
+    expect(cardBox.height).toBeLessThanOrEqual(190);
+    const toggle = card.locator('[data-dm-power-toggle="true"]');
+    await expect(toggle).toHaveText(/Accendi|Spegni|Turn on|Turn off/);
+    await expect(toggle).not.toHaveText(/[⏻×✕]/);
+
+    await openEditor(page, "sez1");
+    await page.locator(".ed-inner-tab", { hasText: /^REPORT$/i }).click();
+    await expect(page.locator("#dm-report-entity-appl-forno")).toHaveValue("sensor.forno_energy");
+    await page.evaluate(() => {
+      cdRebuildReportDevices();
+      buildReportSelect();
+    });
+    await expect(page.locator('#ed-dev-selector option[value="sensor.forno_energy"]')).toContainText("Forno");
+
+    await openEditor(page, "avvisi");
+    await page.locator('[data-real-alert-edit=""]').first().click();
+    await expect(page.locator("#ed-avv-ent")).toHaveValue("light.salone");
+    await page.locator("#ed-avv-name").fill("Luce principale");
+    await page.locator('button[onclick="edAddAvviso()"]:visible').click();
+    await expect.poll(() => page.evaluate(() => ({
+      groups: JSON.parse(localStorage.getItem("cd_gruppi_extra") || "{}"),
+      names: JSON.parse(localStorage.getItem("cd_avvisi_names_extra") || "{}"),
+    }))).toEqual({ groups: { luci: ["light.salone"] }, names: { "light.salone": "Luce principale" } });
+
+    await openEditor(page, "luci");
+    await page.locator(".ed-lrow .dm-edit-button").first().click();
+    await expect(page.locator("#luce-add-ent")).toHaveValue("light.salone");
+    await page.locator("#luce-add-name").fill("Luce principale");
+    await page.locator("#luce-add-room").selectOption({ label: "Salone" });
+    await page.locator('button[onclick="cdLuceAdd()"]:visible').click();
+    await expect.poll(() => page.evaluate(() => ({
+      lights: JSON.parse(localStorage.getItem("cd_luci") || "{}"),
+      rooms: JSON.parse(localStorage.getItem("cd_luci_rooms") || "{}"),
+    }))).toEqual({ lights: { "light.salone": "Luce principale" }, rooms: { "light.salone": "Salone" } });
+
+    await openEditor(page, "temperature");
+    const actions = page.locator(".dm-temperature-actions");
+    await expect(actions).toBeVisible();
+    await expect(actions.locator("button").first()).toHaveCSS("min-height", "44px");
+
+    await page.screenshot({ path: `test-results/${testInfo.project.name}-${variant}-real-ha-acceptance.png`, fullPage: true });
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/real-ha-acceptance.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/real-ha-acceptance.spec.js
@@ -156,7 +156,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       rooms: JSON.parse(localStorage.getItem("cd_luci_rooms") || "{}"),
     }))).toEqual({ lights: { "light.salone": "Luce principale" }, rooms: { "light.salone": "Salone" } });
 
-    await openEditor(page, "temperature");
+    await openEditor(page, "sez7");
     const actions = page.locator(".dm-temperature-actions");
     await expect(actions).toBeVisible();
     await expect(actions.locator("button").first()).toHaveCSS("min-height", "44px");

--- a/custom_components/dashboardmodern/frontend/e2e/real-ha-appliance-recovery.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/real-ha-appliance-recovery.spec.js
@@ -1,0 +1,104 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const states = [
+  {
+    entity_id: "sensor.frigo_power",
+    state: "82",
+    attributes: { friendly_name: "Frigo potenza", unit_of_measurement: "W", device_class: "power" },
+  },
+  {
+    entity_id: "sensor.frigo_energy",
+    state: "12.7",
+    attributes: { friendly_name: "Frigo energia", unit_of_measurement: "kWh", device_class: "energy" },
+  },
+  {
+    entity_id: "switch.frigo",
+    state: "on",
+    attributes: { friendly_name: "Frigo" },
+  },
+];
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [{ id: "room-cucina", name: "Cucina", icon: "mdi:silverware-fork-knife" }],
+    lights: [],
+    appliances: [{
+      id: "appl-frigo",
+      name: "Frigo",
+      device_type: "frigo",
+      visual_type: "asset",
+      visual_key: "frigo",
+      entities: [],
+      room_id: "room-cucina",
+      show_in_report: true,
+    }],
+    loads: [],
+    covers: [],
+  },
+  visibility: { energy: true, appliances: true },
+};
+
+async function boot(page, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript((haStates) => {
+    class MockSocket extends EventTarget {
+      static OPEN = 1;
+      readyState = 1;
+      onopen = null;
+      onmessage = null;
+      constructor() {
+        super();
+        queueMicrotask(() => {
+          this.onopen?.({});
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+        });
+      }
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") return;
+        const result = message.type === "get_states" ? haStates : message.type === "frontend/get_user_data" ? { value: null } : null;
+        this.onmessage?.({ data: JSON.stringify({ id: message.id, type: "result", success: true, result }) });
+      }
+      close() {}
+    }
+    window.__DASHBOARDMODERN_BRIDGE_WS__ = MockSocket;
+    window.WebSocket = MockSocket;
+  }, states);
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await page.evaluate((haStates) => haStates.forEach((state) => {
+    _RAW_STATES[state.entity_id] = structuredClone(state);
+    STATES[state.entity_id] = structuredClone(state);
+  }), states);
+  await expect.poll(() => page.evaluate(() => window.__DASHBOARDMODERN_REAL_HA_0147_DATA_REPAIR__?.installed === true)).toBe(true);
+}
+
+test("real HA: recover a saved Frigo with missing power, energy and control entities", async ({ page }, testInfo) => {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 60_000);
+  await boot(page, testInfo);
+
+  await expect.poll(() => page.evaluate(() => DashboardModernModules.store.getSection("appliances")[0])).toMatchObject({
+    id: "appl-frigo",
+    power_entity: "sensor.frigo_power",
+    energy_entity: "sensor.frigo_energy",
+    report_entity: "sensor.frigo_energy",
+    control_entity: "switch.frigo",
+    show_in_report: true,
+  });
+
+  await page.evaluate(() => {
+    apriConfigEntita();
+    editorSwitch("sez1");
+  });
+  await expect(page.locator("#editor-modal")).toBeVisible();
+  await page.locator(".ed-inner-tab", { hasText: /^REPORT$/i }).click();
+  await expect(page.locator("#dm-report-entity-appl-frigo")).toHaveValue("sensor.frigo_energy");
+
+  await page.evaluate(() => {
+    cdRebuildReportDevices();
+    buildReportSelect();
+  });
+  await expect(page.locator('#ed-dev-selector option[value="sensor.frigo_energy"]')).toContainText("Frigo");
+});

--- a/custom_components/dashboardmodern/frontend/e2e/real-ha-shutter-popup-layout.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/real-ha-shutter-popup-layout.spec.js
@@ -1,0 +1,83 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const state = {
+  entity_id: "cover.salone",
+  state: "open",
+  attributes: { friendly_name: "Tapparella salone", current_position: 65 },
+};
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [{ id: "room-salone", name: "Salone", icon: "mdi:sofa" }],
+    lights: [],
+    appliances: [],
+    loads: [],
+    covers: [{ id: "cover-salone", name: "Tapparella salone", entity: "cover.salone", entities: ["cover.salone"], room_id: "room-salone" }],
+  },
+  visibility: { home: true, tapparelle: true },
+};
+
+async function boot(page, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript((haState) => {
+    class MockSocket extends EventTarget {
+      static OPEN = 1;
+      readyState = 1;
+      onopen = null;
+      onmessage = null;
+      constructor() {
+        super();
+        queueMicrotask(() => {
+          this.onopen?.({});
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+        });
+      }
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") return;
+        const result = message.type === "get_states" ? [haState] : message.type === "frontend/get_user_data" ? { value: null } : null;
+        this.onmessage?.({ data: JSON.stringify({ id: message.id, type: "result", success: true, result }) });
+      }
+      close() {}
+    }
+    window.__DASHBOARDMODERN_BRIDGE_WS__ = MockSocket;
+    window.WebSocket = MockSocket;
+  }, state);
+
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await page.evaluate((haState) => {
+    _RAW_STATES[haState.entity_id] = structuredClone(haState);
+    STATES[haState.entity_id] = structuredClone(haState);
+  }, state);
+  await page.addScriptTag({ url: "/legacy/runtime-hotfix.js" });
+  await page.waitForFunction(() => window.__DASHBOARDMODERN_RUNTIME_HOTFIX__);
+  await page.evaluate(() => window.render?.());
+}
+
+test("real HA: shutter popup keeps close control and three actions aligned", async ({ page }, testInfo) => {
+  await boot(page, testInfo);
+  const alert = page.locator("#tapp-avvisi .dm-shutter-alert");
+  await expect(alert).toBeVisible();
+  await alert.click();
+
+  const popup = page.locator("#dm-shutter-popup");
+  const title = popup.locator("header h2");
+  const close = popup.locator("[data-shutter-popup-close]");
+  const actions = popup.locator(".dm-shutter-actions button");
+  await expect(popup).toBeVisible();
+  await expect(actions).toHaveCount(3);
+
+  const [titleBox, closeBox] = await Promise.all([title.boundingBox(), close.boundingBox()]);
+  if (!titleBox || !closeBox) throw new Error("Shutter popup header has no bounding box");
+  expect(Math.abs((titleBox.y + titleBox.height / 2) - (closeBox.y + closeBox.height / 2))).toBeLessThanOrEqual(8);
+  expect(closeBox.x).toBeGreaterThan(titleBox.x + titleBox.width);
+
+  const widths = await actions.evaluateAll((buttons) => buttons.map((button) => button.getBoundingClientRect().width));
+  expect(Math.max(...widths) - Math.min(...widths)).toBeLessThanOrEqual(2);
+  for (const width of widths) expect(width).toBeGreaterThan(60);
+
+  await page.screenshot({ path: `test-results/${testInfo.project.name}-real-ha-shutter-popup-layout.png` });
+});

--- a/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-alert-compat.js
+++ b/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-alert-compat.js
@@ -1,0 +1,71 @@
+/* Language-independent edit controls for saved standard alerts. */
+const ALERT_COMPAT_FLAG = "__DASHBOARDMODERN_REAL_HA_0147_ALERT_COMPAT__";
+
+function readGroups() {
+  try {
+    return JSON.parse(localStorage.getItem("cd_gruppi_extra")) || {};
+  } catch (_error) {
+    return {};
+  }
+}
+
+function entityFromRow(row) {
+  const text = row.querySelector(".ed-row-old.mono")?.textContent || "";
+  return text.match(/\b[a-z_][a-z0-9_]*\.[a-z0-9_]+\b/i)?.[0] || "";
+}
+
+function groupForEntity(entity, row) {
+  const groups = readGroups();
+  const saved = Object.entries(groups).find(([, ids]) => Array.isArray(ids) && ids.includes(entity));
+  if (saved) return saved[0];
+  const text = `${row.textContent || ""} ${row.closest("details")?.querySelector("summary")?.textContent || ""}`.toLowerCase();
+  if (/apert|contact|door|window/.test(text)) return "win";
+  if (/batter/.test(text)) return "batt";
+  if (/luc|light/.test(text)) return "luci";
+  if (/clima|climate/.test(text)) return "clima";
+  if (/riscald|heating/.test(text)) return "risc";
+  return "";
+}
+
+function installAlertEditButtons(root = document) {
+  root.querySelectorAll("#editor-modal .ed-row").forEach((row) => {
+    const entity = entityFromRow(row);
+    const group = entity && groupForEntity(entity, row);
+    if (!entity || !group || typeof globalThis.dmRealEditAlert !== "function") return;
+
+    row.querySelectorAll("[data-standard-alert-edit]").forEach((button) => button.remove());
+    if (row.querySelector("[data-real-alert-edit]")) return;
+
+    const remove = [...row.querySelectorAll(".ed-del")].find((button) =>
+      /edDelAvviso/.test(button.getAttribute("onclick") || ""),
+    );
+    if (!remove) return;
+
+    const edit = document.createElement("button");
+    edit.type = "button";
+    edit.className = "ed-del dm-edit-button";
+    edit.dataset.realAlertEdit = "";
+    edit.textContent = "✏️";
+    edit.title = document.documentElement.lang === "en" ? "Edit" : "Modifica";
+    edit.setAttribute("aria-label", edit.title);
+    edit.addEventListener("click", () => globalThis.dmRealEditAlert(group, entity));
+    remove.before(edit);
+  });
+}
+
+function install() {
+  installAlertEditButtons();
+  if (globalThis[ALERT_COMPAT_FLAG]?.installed) return;
+  globalThis[ALERT_COMPAT_FLAG] = { installed: true };
+  let frame = 0;
+  new MutationObserver(() => {
+    cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(() => installAlertEditButtons());
+  }).observe(document.documentElement, { childList: true, subtree: true });
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", install, { once: true });
+  else install();
+  window.addEventListener("dashboardmodern:legacy-ready", install);
+}

--- a/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-data-repair.js
+++ b/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-data-repair.js
@@ -1,0 +1,173 @@
+/* Repair appliance entity assignments that were lost by the previous editor. */
+const DATA_REPAIR_FLAG = "__DASHBOARDMODERN_REAL_HA_0147_DATA_REPAIR__";
+
+function normalizedToken(value) {
+  return String(value || "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function statesObject() {
+  try {
+    if (typeof STATES !== "undefined") return STATES;
+  } catch (_error) {}
+  return globalThis.STATES || {};
+}
+
+function stateInfo(entityId, state) {
+  const attributes = state?.attributes || {};
+  return {
+    entityId,
+    domain: entityId.split(".")[0],
+    unit: String(attributes.unit_of_measurement || "").toLowerCase().replace(/\s+/g, ""),
+    deviceClass: String(attributes.device_class || "").toLowerCase(),
+    searchable: normalizedToken(`${entityId} ${attributes.friendly_name || ""}`),
+  };
+}
+
+function deviceTokens(device) {
+  const aliases = {
+    forno: ["forno", "oven"],
+    frigo: ["frigo", "frigorifero", "fridge", "refrigerator"],
+    lavatrice: ["lavatrice", "washer", "washing_machine"],
+    lavastoviglie: ["lavastoviglie", "dishwasher"],
+    asciugatrice: ["asciugatrice", "dryer"],
+    microonde: ["microonde", "microwave"],
+    congelatore: ["congelatore", "freezer"],
+    scaldabagno: ["scaldabagno", "boiler", "water_heater"],
+  };
+  const values = [device.name, device.visual_key, device.device_type, device.type]
+    .map(normalizedToken)
+    .filter((value) => value.length >= 3);
+  values.forEach((value) => {
+    (aliases[value] || []).forEach((alias) => values.push(normalizedToken(alias)));
+  });
+  return [...new Set(values)];
+}
+
+function belongsToDevice(info, tokens) {
+  return tokens.some((token) =>
+    info.searchable === token ||
+    info.searchable.startsWith(`${token}_`) ||
+    info.searchable.endsWith(`_${token}`) ||
+    info.searchable.includes(`_${token}_`),
+  );
+}
+
+function isEnergy(info) {
+  return /^(wh|kwh|mwh)$/.test(info.unit) ||
+    info.deviceClass === "energy" ||
+    /(?:^|_)(energy|energia|kwh|consumo|consumi)(?:_|$)/.test(info.searchable);
+}
+
+function isPower(info) {
+  return /^(w|kw)$/.test(info.unit) ||
+    info.deviceClass === "power" ||
+    /(?:^|_)(power|potenza|watt)(?:_|$)/.test(info.searchable);
+}
+
+function scoreEnergy(info) {
+  let score = 0;
+  if (info.deviceClass === "energy") score += 50;
+  if (/^(wh|kwh|mwh)$/.test(info.unit)) score += 40;
+  if (/(?:month|monthly|mese|mensile)/.test(info.searchable)) score += 20;
+  if (/(?:total|totale|lifetime)/.test(info.searchable)) score += 15;
+  if (/(?:day|daily|oggi|giorn)/.test(info.searchable)) score += 10;
+  return score;
+}
+
+function repairCandidate(device, allStates) {
+  const tokens = deviceTokens(device);
+  const existing = [...new Set([
+    ...(device.entities || []),
+    device.control_entity,
+    device.power_entity,
+    device.energy_entity,
+    device.daily_energy_entity,
+    device.monthly_energy_entity,
+    device.total_energy_entity,
+    device.report_entity,
+    device.history_entity,
+  ].filter(Boolean))];
+
+  const matching = Object.entries(allStates)
+    .map(([entityId, state]) => stateInfo(entityId, state))
+    .filter((info) => belongsToDevice(info, tokens));
+
+  const energy = matching.filter(isEnergy).sort((a, b) => scoreEnergy(b) - scoreEnergy(a))[0]?.entityId || "";
+  const power = matching.find(isPower)?.entityId || "";
+  const control = matching.find((info) => /^(switch|light|input_boolean|fan)$/.test(info.domain))?.entityId || "";
+
+  const result = {
+    ...device,
+    power_entity: device.power_entity || power,
+    energy_entity: device.energy_entity || device.report_entity || energy,
+    report_entity: device.report_entity || device.energy_entity || energy,
+    history_entity: device.history_entity || device.report_entity || device.energy_entity || energy || power,
+    control_entity: device.control_entity || control,
+    show_in_report: device.show_in_report !== false,
+  };
+  result.entities = [...new Set([
+    ...existing,
+    result.power_entity,
+    result.energy_entity,
+    result.report_entity,
+    result.control_entity,
+  ].filter(Boolean))];
+  return result;
+}
+
+function relevant(device) {
+  return JSON.stringify({
+    entities: device.entities || [],
+    power_entity: device.power_entity || "",
+    energy_entity: device.energy_entity || "",
+    report_entity: device.report_entity || "",
+    history_entity: device.history_entity || "",
+    control_entity: device.control_entity || "",
+    show_in_report: device.show_in_report !== false,
+  });
+}
+
+async function repairLostApplianceEntities() {
+  const store = globalThis.DashboardModernModules?.store;
+  if (!store?.getSection || !store?.updateItem) return false;
+  const appliances = store.getSection("appliances");
+  if (!Array.isArray(appliances) || !appliances.length) return true;
+  const allStates = statesObject();
+  for (const device of appliances) {
+    const repaired = repairCandidate(device, allStates);
+    if (relevant(device) !== relevant(repaired)) {
+      await store.updateItem("appliances", device.id, repaired);
+    }
+  }
+  try {
+    globalThis.cdRebuildReportDevices?.();
+    globalThis.buildReportSelect?.();
+  } catch (_error) {}
+  return true;
+}
+
+function install() {
+  if (globalThis[DATA_REPAIR_FLAG]?.installed) return;
+  globalThis[DATA_REPAIR_FLAG] = { installed: true };
+  let attempts = 0;
+  const timer = setInterval(async () => {
+    attempts += 1;
+    try {
+      await repairLostApplianceEntities();
+    } catch (error) {
+      globalThis.console?.warn?.("[DashboardModern] appliance data repair", error);
+    }
+    if (attempts >= 30) clearInterval(timer);
+  }, 1000);
+  repairLostApplianceEntities().catch(() => {});
+}
+
+if (typeof window !== "undefined") {
+  install();
+  window.addEventListener("dashboardmodern:legacy-ready", install);
+}

--- a/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-fixes.js
@@ -1,0 +1,677 @@
+/* Real Home Assistant acceptance fixes for the blocked 0.14.7 release. */
+const FLAG = "__DASHBOARDMODERN_REAL_HA_0147__";
+const isEnglish = () => document.documentElement.lang === "en";
+const escapeHtml = (value) => String(value ?? "")
+  .replace(/&/g, "&amp;")
+  .replace(/</g, "&lt;")
+  .replace(/"/g, "&quot;");
+const readJson = (key, fallback) => {
+  try {
+    return JSON.parse(localStorage.getItem(key)) ?? fallback;
+  } catch (_error) {
+    return fallback;
+  }
+};
+const writeJson = (key, value) => {
+  localStorage.setItem(key, JSON.stringify(value));
+  try {
+    globalThis.cdMarkDirty?.();
+    globalThis.cdSyncPush?.();
+  } catch (_error) {}
+};
+
+let applianceEditId = "";
+let alertEdit = null;
+let lightEditEntity = "";
+let repairingAppliances = false;
+
+function parentHass() {
+  try {
+    if (window.parent === window) return null;
+    return window.parent.document.querySelector("home-assistant")?.hass || null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function installSocketConstants() {
+  const constructors = [globalThis.WebSocket];
+  try {
+    constructors.push(window.parent.__DASHBOARDMODERN_BRIDGE_WS__);
+  } catch (_error) {}
+  constructors.filter((value) => typeof value === "function").forEach((Socket) => {
+    [["CONNECTING", 0], ["OPEN", 1], ["CLOSING", 2], ["CLOSED", 3]].forEach(([key, value]) => {
+      if (Socket[key] == null) {
+        try {
+          Object.defineProperty(Socket, key, { value, configurable: true });
+        } catch (_error) {}
+      }
+    });
+  });
+}
+
+function installServiceBridgeFix() {
+  installSocketConstants();
+  const previous = globalThis.dmCallHaService;
+  if (previous?.__dmRealHa0147) return true;
+  if (typeof previous !== "function") return false;
+
+  const fixed = async function dmCallHaServiceReal(domain, service, serviceData = {}) {
+    const hass = parentHass();
+    if (globalThis.__DASHBOARDMODERN_HOSTED__ && typeof hass?.callService === "function") {
+      return hass.callService(domain, service, serviceData);
+    }
+    return previous.call(this, domain, service, serviceData);
+  };
+  fixed.__dmRealHa0147 = true;
+  fixed.__dmPrevious = previous;
+  globalThis.dmCallHaService = fixed;
+
+  globalThis.cdTappCmd = async function cdTappCmdReal(button) {
+    try {
+      navigator.vibrate?.(15);
+      const service = button?.getAttribute?.("data-svc");
+      if (!service) return;
+      const entities = button.hasAttribute("data-all")
+        ? (globalThis.getTapparelle?.() || []).map((item) => item?.entity).filter(Boolean)
+        : [button.closest?.("[data-tapp]")?.getAttribute?.("data-tapp")].filter(Boolean);
+      if (!entities.length) return;
+      button.disabled = true;
+      await Promise.all(entities.map((entityId) => fixed("cover", service, { entity_id: entityId })));
+    } catch (error) {
+      globalThis.console?.error?.("[Tapparelle] servizio fallito", error);
+      globalThis.alert?.(error?.message || String(error));
+    } finally {
+      if (button) button.disabled = false;
+    }
+  };
+  return true;
+}
+
+function entityId(value) {
+  return typeof value === "string" ? value.trim() : String(value?.entity || value?.entity_id || "").trim();
+}
+
+function dashboardStates() {
+  try {
+    return globalThis.eval("STATES") || {};
+  } catch (_error) {
+    return globalThis.STATES || {};
+  }
+}
+
+function entityMetadata(id) {
+  const state = dashboardStates()?.[id];
+  const attributes = state?.attributes || {};
+  return {
+    id,
+    domain: id.split(".")[0],
+    unit: String(attributes.unit_of_measurement || "").toLowerCase().replace(/\s+/g, ""),
+    deviceClass: String(attributes.device_class || "").toLowerCase(),
+    name: id.toLowerCase(),
+  };
+}
+
+function classifyAppliance(item = {}) {
+  const ids = [...new Set([
+    item.control_entity,
+    item.power_entity,
+    item.energy_entity,
+    item.daily_energy_entity,
+    item.monthly_energy_entity,
+    item.total_energy_entity,
+    item.report_entity,
+    item.history_entity,
+    ...(item.entities || []),
+  ].map(entityId).filter(Boolean))];
+  const meta = ids.map(entityMetadata);
+  const control = meta.find((entry) => /^(switch|light|input_boolean|fan)$/.test(entry.domain))?.id || "";
+  const energyCandidates = meta.filter((entry) =>
+    /^(wh|kwh|mwh)$/.test(entry.unit) ||
+    entry.deviceClass === "energy" ||
+    /(?:^|[_-])(energy|energia|kwh|consumo|consumi|total_energy)(?:[_-]|$)/.test(entry.name),
+  );
+  const power = meta.find((entry) =>
+    /^(w|kw)$/.test(entry.unit) ||
+    entry.deviceClass === "power" ||
+    /(?:^|[_-])(power|potenza|watt)(?:[_-]|$)/.test(entry.name),
+  )?.id || "";
+  const daily = energyCandidates.find((entry) => /(?:oggi|today|daily|giorn|day)/.test(entry.name))?.id || "";
+  const monthly = energyCandidates.find((entry) => /(?:mese|month|monthly)/.test(entry.name))?.id || "";
+  const total = energyCandidates.find((entry) => /(?:totale|total|lifetime)/.test(entry.name))?.id || "";
+  const energy = monthly || total || daily || energyCandidates[0]?.id || "";
+  const report = entityId(item.report_entity) || monthly || total || daily || energy;
+  return {
+    ...item,
+    entities: ids,
+    control_entity: entityId(item.control_entity) || control,
+    power_entity: entityId(item.power_entity) || power,
+    energy_entity: entityId(item.energy_entity) || energy,
+    daily_energy_entity: entityId(item.daily_energy_entity) || daily,
+    monthly_energy_entity: entityId(item.monthly_energy_entity) || monthly,
+    total_energy_entity: entityId(item.total_energy_entity) || total,
+    report_entity: report,
+    history_entity: entityId(item.history_entity) || report || power,
+    show_in_report: item.show_in_report !== false,
+  };
+}
+
+function relevantApplianceFields(item) {
+  return JSON.stringify({
+    entities: item.entities || [],
+    control_entity: item.control_entity || "",
+    power_entity: item.power_entity || "",
+    energy_entity: item.energy_entity || "",
+    daily_energy_entity: item.daily_energy_entity || "",
+    monthly_energy_entity: item.monthly_energy_entity || "",
+    total_energy_entity: item.total_energy_entity || "",
+    report_entity: item.report_entity || "",
+    history_entity: item.history_entity || "",
+    show_in_report: item.show_in_report !== false,
+  });
+}
+
+function refreshReportRuntime() {
+  try {
+    globalThis.cdRebuildReportDevices?.();
+    globalThis.buildReportSelect?.();
+    if (document.querySelector("#view-panoramica.active")) globalThis.renderEnergyDashboard?.();
+  } catch (error) {
+    globalThis.console?.warn?.("[Report] refresh", error);
+  }
+}
+
+async function repairApplianceEntities() {
+  const store = globalThis.DashboardModernModules?.store;
+  if (!store?.getSection || !store?.replaceSection || repairingAppliances) return false;
+  const current = store.getSection("appliances");
+  if (!Array.isArray(current) || !current.length) return true;
+  const repaired = current.map(classifyAppliance);
+  if (current.every((item, index) => relevantApplianceFields(item) === relevantApplianceFields(repaired[index]))) {
+    refreshReportRuntime();
+    return true;
+  }
+  repairingAppliances = true;
+  try {
+    await store.replaceSection("appliances", repaired);
+    refreshReportRuntime();
+  } finally {
+    repairingAppliances = false;
+  }
+  return true;
+}
+
+function createEntityField(id, label, value = "", placeholder = "sensor.entity") {
+  return `<label class="ed-slot dm-entity-field dm-config-field" data-entity-field><span class="ed-slot-lbl">${escapeHtml(label)}</span><span class="ed-form-row"><input id="${escapeHtml(id)}" class="ed-input mono" data-entity-input value="${escapeHtml(value)}" placeholder="${escapeHtml(placeholder)}"><button type="button" class="dm-entity-picker" data-entity-target="${escapeHtml(id)}" aria-label="${escapeHtml(label)}">🔍</button></span></label>`;
+}
+
+function installApplianceEditorFix() {
+  const renderer = globalThis.editorRenderAppliances;
+  const save = globalThis.edApplSave;
+  const edit = globalThis.edApplEdit;
+  const cancel = globalThis.edApplCancel;
+  if (![renderer, save, edit, cancel].every((fn) => typeof fn === "function")) return false;
+  if (renderer.__dmRealHa0147) return true;
+
+  globalThis.edApplEdit = function edApplEditReal(index) {
+    applianceEditId = (globalThis.getAppliances?.() || [])[Number(index)]?.id || "";
+    return edit.apply(this, arguments);
+  };
+  globalThis.edApplCancel = function edApplCancelReal() {
+    applianceEditId = "";
+    return cancel.apply(this, arguments);
+  };
+
+  const wrappedRenderer = function editorRenderAppliancesReal() {
+    const template = document.createElement("template");
+    template.innerHTML = renderer.apply(this, arguments);
+    const form = [...template.content.querySelectorAll(".ed-form")].at(-1);
+    if (!form || form.querySelector("[data-appliance-canonical-fields]")) return template.innerHTML;
+    const items = globalThis.DashboardModernModules?.store?.getSection?.("appliances") || globalThis.getAppliances?.() || [];
+    const item = items.find((entry) => entry.id === applianceEditId) || {};
+    const group = document.createElement("section");
+    group.className = "dm-config-subsection";
+    group.dataset.applianceCanonicalFields = "";
+    group.innerHTML = `<div class="ed-sec-title">⚡ ${isEnglish() ? "Entities and Energy Report" : "Entità e Report Energia"}</div>
+      <div class="ed-intro">${isEnglish() ? "Assign power, energy and control explicitly. The Energy Report uses the energy entity." : "Assegna esplicitamente potenza, energia e comando. Il Report Energia usa l’entità energia."}</div>
+      <div class="dm-config-grid">${createEntityField("appl-power-entity", isEnglish() ? "Power entity" : "Entità potenza", item.power_entity, "sensor.forno_potenza")}${createEntityField("appl-energy-entity", isEnglish() ? "Energy / Report entity" : "Entità energia / Report", item.report_entity || item.energy_entity, "sensor.forno_energia")}${createEntityField("appl-control-entity", isEnglish() ? "On/off control" : "Comando ON/OFF", item.control_entity, "switch.forno")}</div>`;
+    const threshold = form.querySelector("#appl-thr");
+    if (threshold) form.insertBefore(group, threshold);
+    else form.append(group);
+    form.classList.add("dm-config-form");
+    return template.innerHTML;
+  };
+  wrappedRenderer.__dmRealHa0147 = true;
+  globalThis.editorRenderAppliances = wrappedRenderer;
+
+  const wrappedSave = async function edApplSaveReal() {
+    const explicit = {
+      power_entity: document.getElementById("appl-power-entity")?.value.trim() || "",
+      energy_entity: document.getElementById("appl-energy-entity")?.value.trim() || "",
+      control_entity: document.getElementById("appl-control-entity")?.value.trim() || "",
+    };
+    const name = document.getElementById("appl-name")?.value.trim() || "";
+    const editId = applianceEditId;
+    const result = await save.apply(this, arguments);
+    const store = globalThis.DashboardModernModules?.store;
+    if (!store?.getSection || !store?.updateItem) return result;
+    const items = store.getSection("appliances");
+    const item = items.find((entry) => entry.id === editId) || [...items].reverse().find((entry) => !name || entry.name === name);
+    if (!item) return result;
+    const entities = [...new Set([...(item.entities || []), explicit.power_entity, explicit.energy_entity, explicit.control_entity].filter(Boolean))];
+    const classified = classifyAppliance({
+      ...item,
+      ...explicit,
+      report_entity: explicit.energy_entity || item.report_entity,
+      history_entity: explicit.energy_entity || item.history_entity,
+      entities,
+    });
+    await store.updateItem("appliances", item.id, classified);
+    applianceEditId = "";
+    refreshReportRuntime();
+    return result;
+  };
+  wrappedSave.__dmRealHa0147 = true;
+  globalThis.edApplSave = wrappedSave;
+  return true;
+}
+
+function inferAlertGroup(details) {
+  const text = details?.querySelector("summary")?.textContent?.toLowerCase() || "";
+  if (/apert|contact|door|window/.test(text)) return "win";
+  if (/batter/.test(text)) return "batt";
+  if (/luc|light/.test(text)) return "luci";
+  if (/clima|climate/.test(text)) return "clima";
+  if (/riscald|heating/.test(text)) return "risc";
+  return "";
+}
+
+function updateRuntimeAlert(group, oldEntity, newEntity, name) {
+  try {
+    const groups = globalThis.eval("GRUPPI_MONITORAGGIO");
+    if (groups?.[group]) {
+      groups[group] = groups[group].filter((id) => id !== oldEntity);
+      if (!groups[group].includes(newEntity)) groups[group].push(newEntity);
+    }
+  } catch (_error) {}
+  try {
+    const names = globalThis.eval("AVVISI_NAMES");
+    if (names) {
+      delete names[oldEntity];
+      if (name) names[newEntity] = name;
+    }
+  } catch (_error) {}
+}
+
+function saveEditedStandardAlert() {
+  if (!alertEdit || alertEdit.kind !== "standard") return false;
+  const group = document.getElementById("ed-avv-grp")?.value || alertEdit.group;
+  const entity = document.getElementById("ed-avv-ent")?.value.trim() || "";
+  const name = document.getElementById("ed-avv-name")?.value.trim() || "";
+  if (!entity.includes(".")) {
+    globalThis.alert?.(isEnglish() ? "Enter a valid entity." : "Inserisci una entità valida.");
+    return true;
+  }
+  const extras = readJson("cd_gruppi_extra", {});
+  const removed = readJson("cd_gruppi_removed", {});
+  const names = readJson("cd_avvisi_names_extra", {});
+  const old = alertEdit;
+  if (extras[old.group]?.includes(old.entity)) {
+    extras[old.group] = extras[old.group].filter((id) => id !== old.entity);
+    if (!extras[old.group].length) delete extras[old.group];
+  } else {
+    removed[old.group] ||= [];
+    if (!removed[old.group].includes(old.entity)) removed[old.group].push(old.entity);
+  }
+  extras[group] ||= [];
+  if (!extras[group].includes(entity)) extras[group].push(entity);
+  delete names[old.entity];
+  if (name) names[entity] = name;
+  writeJson("cd_gruppi_extra", extras);
+  writeJson("cd_gruppi_removed", removed);
+  writeJson("cd_avvisi_names_extra", names);
+  updateRuntimeAlert(old.group, old.entity, entity, name);
+  if (group !== old.group) updateRuntimeAlert(group, "", entity, name);
+  alertEdit = null;
+  globalThis.editorSwitch?.("avvisi");
+  globalThis.edToast?.(isEnglish() ? "Alert updated" : "Avviso aggiornato");
+  return true;
+}
+
+function installAlertsEditorFix() {
+  const renderer = globalThis.editorRenderAvvisi;
+  const add = globalThis.edAddAvviso;
+  if (typeof renderer !== "function" || typeof add !== "function") return false;
+  if (renderer.__dmRealHa0147) return true;
+
+  globalThis.dmRealEditAlert = (group, entity) => {
+    alertEdit = { kind: "standard", group, entity };
+    globalThis.editorSwitch?.("avvisi");
+  };
+  globalThis.dmRealCancelAlert = () => {
+    alertEdit = null;
+    globalThis.editorSwitch?.("avvisi");
+  };
+
+  const wrapped = function editorRenderAvvisiReal() {
+    const template = document.createElement("template");
+    template.innerHTML = renderer.apply(this, arguments);
+    template.content.querySelectorAll("details.ed-acc").forEach((details) => {
+      const group = inferAlertGroup(details);
+      if (!group) return;
+      details.open = true;
+      details.querySelectorAll(".ed-row").forEach((row) => {
+        const entity = row.querySelector(".ed-row-old.mono")?.textContent?.trim();
+        if (!entity || row.querySelector("[data-real-alert-edit]")) return;
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "ed-del dm-edit-button";
+        button.dataset.realAlertEdit = "";
+        button.textContent = "✏️";
+        button.title = isEnglish() ? "Edit" : "Modifica";
+        button.setAttribute("onclick", `dmRealEditAlert(${JSON.stringify(group)},${JSON.stringify(entity)})`);
+        row.querySelector(".ed-del")?.before(button);
+      });
+    });
+    const form = [...template.content.querySelectorAll(".ed-form")].at(-1);
+    form?.classList.add("dm-config-form");
+    if (alertEdit?.kind === "standard") {
+      const names = readJson("cd_avvisi_names_extra", {});
+      const select = template.content.querySelector("#ed-avv-grp");
+      select?.querySelectorAll("option").forEach((option) => option.toggleAttribute("selected", option.value === alertEdit.group));
+      template.content.querySelector("#ed-avv-ent")?.setAttribute("value", alertEdit.entity);
+      template.content.querySelector("#ed-avv-name")?.setAttribute("value", names[alertEdit.entity] || dashboardStates()?.[alertEdit.entity]?.attributes?.friendly_name || alertEdit.entity);
+      const saveButton = form?.querySelector("button[onclick='edAddAvviso()']");
+      if (saveButton) {
+        saveButton.textContent = isEnglish() ? "💾 Save changes" : "💾 Salva modifiche";
+        const cancel = document.createElement("button");
+        cancel.type = "button";
+        cancel.className = "ed-btn-secondary";
+        cancel.textContent = isEnglish() ? "Cancel" : "Annulla";
+        cancel.setAttribute("onclick", "dmRealCancelAlert()");
+        saveButton.after(cancel);
+      }
+    }
+    return template.innerHTML;
+  };
+  wrapped.__dmRealHa0147 = true;
+  globalThis.editorRenderAvvisi = wrapped;
+  globalThis.edAddAvviso = function edAddAvvisoReal() {
+    if (saveEditedStandardAlert()) return;
+    return add.apply(this, arguments);
+  };
+  return true;
+}
+
+function roomOptions(selected = "") {
+  const rooms = globalThis.cdRoomList?.() || globalThis.getStanze?.() || [];
+  return [`<option value="">— ${isEnglish() ? "No room" : "Nessuna stanza"} —</option>`, ...rooms.map((room) => {
+    const value = String(room.name || room.id || "");
+    const label = String(room.name || room.id || "");
+    return `<option value="${escapeHtml(value)}"${value === selected || label === selected ? " selected" : ""}>${escapeHtml(label)}</option>`;
+  })].join("");
+}
+
+function installLightsEditorFix() {
+  const renderer = globalThis.editorRenderLuci;
+  const add = globalThis.cdLuceAdd;
+  if (typeof renderer !== "function" || typeof add !== "function") return false;
+  if (renderer.__dmRealHa0147) return true;
+
+  globalThis.dmRealEditLight = (entity) => {
+    lightEditEntity = entity;
+    globalThis.editorSwitch?.("luci");
+  };
+  globalThis.dmRealCancelLight = () => {
+    lightEditEntity = "";
+    globalThis.editorSwitch?.("luci");
+  };
+
+  const wrapped = function editorRenderLuciReal() {
+    const template = document.createElement("template");
+    template.innerHTML = renderer.apply(this, arguments);
+    template.content.querySelectorAll(".ed-lrow").forEach((row) => {
+      const entity = row.querySelector("div[style*='font-family:monospace']")?.textContent?.trim();
+      if (!entity) return;
+      const buttons = [...row.querySelectorAll("button")];
+      const editButton = buttons.find((button) => /Rinomina|Rename/i.test(button.title || ""));
+      if (editButton) {
+        editButton.title = isEnglish() ? "Edit" : "Modifica";
+        editButton.setAttribute("onclick", `dmRealEditLight(${JSON.stringify(entity)})`);
+        editButton.classList.add("dm-edit-button");
+      }
+    });
+    const form = template.content.querySelector("[data-light-add-form], .dm-light-add-form");
+    if (form) {
+      form.classList.add("dm-config-form");
+      const lights = readJson("cd_luci", {});
+      const rooms = readJson("cd_luci_rooms", {});
+      const inputEntity = form.querySelector("#luce-add-ent");
+      const inputName = form.querySelector("#luce-add-name");
+      let roomSelect = form.querySelector("#luce-add-room");
+      if (!roomSelect) {
+        const label = document.createElement("label");
+        label.className = "ed-slot dm-config-field";
+        label.innerHTML = `<span class="ed-slot-lbl">${isEnglish() ? "Room" : "Stanza"}</span><select id="luce-add-room" class="ed-input">${roomOptions(lightEditEntity ? rooms[lightEditEntity] || "" : "")}</select>`;
+        inputName?.insertAdjacentElement("afterend", label);
+        roomSelect = label.querySelector("select");
+      }
+      if (lightEditEntity) {
+        inputEntity?.setAttribute("value", lightEditEntity);
+        inputName?.setAttribute("value", lights[lightEditEntity] || "");
+        if (roomSelect) roomSelect.value = rooms[lightEditEntity] || "";
+        const submit = [...form.querySelectorAll("button")].find((button) => /cdLuceAdd/.test(button.getAttribute("onclick") || ""));
+        if (submit) {
+          submit.textContent = isEnglish() ? "💾 Save changes" : "💾 Salva modifiche";
+          const cancel = document.createElement("button");
+          cancel.type = "button";
+          cancel.className = "ed-btn-secondary";
+          cancel.textContent = isEnglish() ? "Cancel" : "Annulla";
+          cancel.setAttribute("onclick", "dmRealCancelLight()");
+          submit.after(cancel);
+        }
+      }
+    }
+    return template.innerHTML;
+  };
+  wrapped.__dmRealHa0147 = true;
+  globalThis.editorRenderLuci = wrapped;
+
+  globalThis.cdLuceAdd = function cdLuceAddReal() {
+    const newEntity = document.getElementById("luce-add-ent")?.value.trim() || "";
+    const name = document.getElementById("luce-add-name")?.value.trim() || "";
+    const room = document.getElementById("luce-add-room")?.value.trim() || "";
+    if (!/^(light|switch)\.[a-z0-9_]+$/i.test(newEntity)) {
+      globalThis.alert?.(isEnglish() ? "Enter a valid light or switch entity." : "Inserisci una entità light o switch valida.");
+      return;
+    }
+    const wasEdit = Boolean(lightEditEntity);
+    const lights = readJson("cd_luci", {});
+    const rooms = readJson("cd_luci_rooms", {});
+    const order = readJson("cd_luci_order", {});
+    if (lightEditEntity) {
+      delete lights[lightEditEntity];
+      delete rooms[lightEditEntity];
+    }
+    lights[newEntity] = name || newEntity.split(".")[1];
+    if (room) rooms[newEntity] = room;
+    Object.values(order).forEach((ids) => {
+      if (!Array.isArray(ids)) return;
+      const index = lightEditEntity ? ids.indexOf(lightEditEntity) : -1;
+      if (index >= 0) ids[index] = newEntity;
+    });
+    writeJson("cd_luci", lights);
+    writeJson("cd_luci_rooms", rooms);
+    writeJson("cd_luci_order", order);
+    lightEditEntity = "";
+    globalThis.updateGestioneLuci?.();
+    globalThis.editorSwitch?.("luci");
+    globalThis.edToast?.(wasEdit ? (isEnglish() ? "Light updated" : "Luce aggiornata") : (isEnglish() ? "Light added" : "Luce aggiunta"));
+  };
+  return true;
+}
+
+function decorateReportRows(root = document) {
+  root.querySelectorAll("#editor-modal .dm-report-row").forEach((row) => {
+    if (row.dataset.realReportLayout === "true") return;
+    row.dataset.realReportLayout = "true";
+    const toggle = row.querySelector(":scope > label:first-child");
+    const labelInput = row.querySelector("[data-report-label]");
+    const iconField = row.querySelector("[data-icon-field]");
+    const entityField = row.querySelector("[data-entity-field]");
+    const actions = [...row.children].find((child) => child.querySelector?.("[data-report-up]"));
+    if (toggle) toggle.classList.add("dm-report-toggle");
+    if (actions) actions.classList.add("dm-report-actions");
+    const fields = document.createElement("div");
+    fields.className = "dm-report-fields";
+    const wrap = (node, label) => {
+      if (!node) return;
+      if (node.matches("label")) {
+        node.classList.add("dm-config-field");
+        fields.append(node);
+        return;
+      }
+      const holder = document.createElement("label");
+      holder.className = "dm-config-field";
+      holder.innerHTML = `<span class="ed-slot-lbl">${label}</span>`;
+      holder.append(node);
+      fields.append(holder);
+    };
+    wrap(labelInput, isEnglish() ? "Report name" : "Nome nel Report");
+    wrap(iconField, isEnglish() ? "Icon" : "Icona");
+    wrap(entityField, isEnglish() ? "Energy entity" : "Entità energia");
+    if (actions) row.insertBefore(fields, actions);
+    else row.append(fields);
+  });
+}
+
+function decorateApplianceCards(root = document) {
+  root.querySelectorAll("#page-appliances-main .appl-wide-card.dm-control-device").forEach((card) => {
+    card.querySelector(".appl-spark")?.remove();
+    const toggle = [...card.querySelectorAll(".appl-action-btn")].find((button) => button.textContent.trim() === "⏻" || button.dataset.dmPowerToggle === "true");
+    if (toggle) {
+      toggle.dataset.dmPowerToggle = "true";
+      const on = toggle.classList.contains("on");
+      toggle.textContent = on ? (isEnglish() ? "Turn off" : "Spegni") : (isEnglish() ? "Turn on" : "Accendi");
+      toggle.setAttribute("aria-label", toggle.textContent);
+    }
+  });
+  const grid = root.querySelector("#tapp-grid");
+  const bulk = grid?.firstElementChild;
+  if (bulk && bulk.querySelector("[data-all]")) bulk.classList.add("dm-shutter-bulk-actions");
+}
+
+function installCss() {
+  if (document.getElementById("dm-real-ha-0147-css")) return;
+  const style = document.createElement("style");
+  style.id = "dm-real-ha-0147-css";
+  style.textContent = `
+    #editor-modal .ed-form.dm-config-form,
+    #editor-modal .dm-temperature-form,
+    #editor-modal .dm-config-subsection {
+      padding: 16px !important;
+      border: 1px solid var(--card-border, var(--divider-color, #dbe4ee)) !important;
+      border-radius: 18px !important;
+      background: var(--surface-2, var(--secondary-background-color, #f8fafc)) !important;
+      box-shadow: none !important;
+      gap: 12px !important;
+    }
+    #editor-modal .ed-row { min-height: 58px; padding: 11px 13px !important; gap: 9px !important; }
+    #editor-modal .ed-del,
+    #editor-modal .dm-edit-button { width: 38px !important; height: 38px !important; border-radius: 11px !important; display: inline-grid !important; place-items: center !important; border: 1px solid var(--card-border, #dbe4ee) !important; }
+    #editor-modal .ed-btn-add,
+    #editor-modal .ed-save-btn,
+    #editor-modal .ed-btn-secondary { min-height: 44px !important; border-radius: 13px !important; padding: 10px 16px !important; font-weight: 850 !important; }
+    #editor-modal .ed-btn-secondary { border: 1px solid var(--card-border, #dbe4ee); background: var(--surface-3, #f1f5f9); color: var(--text, #0f172a); cursor: pointer; }
+    #editor-modal .dm-temperature-actions { display: grid !important; grid-template-columns: 1fr 1fr; gap: 9px !important; }
+    #editor-modal .dm-temperature-actions > button:only-child { grid-column: 1 / -1; }
+    #editor-modal .dm-config-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+    #editor-modal .dm-config-field { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+    #editor-modal .dm-config-field .ed-input { width: 100% !important; min-width: 0 !important; margin: 0 !important; }
+
+    #editor-modal .dm-report-row { display: grid !important; grid-template-columns: minmax(0, 1fr) auto !important; grid-template-areas: "toggle actions" "fields fields" !important; gap: 12px !important; align-items: center !important; padding: 14px !important; }
+    #editor-modal .dm-report-toggle { grid-area: toggle; width: max-content; display: inline-flex !important; align-items: center; gap: 8px; padding: 7px 11px; border-radius: 999px; background: rgba(14,165,233,.11); font-weight: 800; }
+    #editor-modal .dm-report-fields { grid-area: fields; display: grid; grid-template-columns: minmax(150px,.75fr) minmax(130px,.45fr) minmax(240px,1.3fr); gap: 10px; align-items: end; min-width: 0; }
+    #editor-modal .dm-report-actions { grid-area: actions; display: flex !important; gap: 7px !important; }
+    #editor-modal .dm-report-actions button { width: 38px !important; height: 38px !important; border-radius: 11px !important; border: 1px solid var(--card-border, #dbe4ee) !important; background: var(--surface-3, #f1f5f9) !important; color: var(--text, #0f172a) !important; }
+
+    #page-appliances-main .appl-page-grid { grid-template-columns: repeat(auto-fit, minmax(280px, 390px)) !important; justify-content: center !important; align-items: start !important; gap: 14px !important; }
+    #page-appliances-main .appl-wide-card.dm-control-device { grid-template-columns: 94px minmax(0,1fr) !important; width: 100% !important; max-width: 390px !important; min-height: 128px !important; border-radius: 20px !important; }
+    #page-appliances-main .appl-wide-card.dm-control-device .appl-info { padding: 12px !important; gap: 8px !important; }
+    #page-appliances-main .appl-wide-card.dm-control-device .appl-visual { min-height: 128px !important; }
+    #page-appliances-main .appl-spark { display: none !important; }
+    #page-appliances-main .appl-action-btn[data-dm-power-toggle="true"] { min-width: 86px !important; min-height: 38px !important; font-size: 12px !important; }
+    #page-appliances-main .appl-actions { margin-top: auto !important; }
+
+    #page-tapparelle > div { max-width: 980px !important; }
+    #tapp-grid { grid-template-columns: repeat(auto-fit, minmax(270px, 330px)) !important; gap: 14px !important; padding: 12px 0 70px !important; }
+    #tapp-grid .tapp-card { min-height: 0 !important; padding: 14px !important; border-radius: 20px !important; gap: 10px !important; }
+    #tapp-grid .tapp-win { height: 126px !important; border-radius: 16px !important; }
+    #tapp-grid .tapp-pos { font-size: 17px !important; min-height: 22px !important; }
+    #tapp-grid .tapp-btn,
+    .dm-shutter-popup .dm-shutter-actions button { min-height: 42px !important; border-radius: 12px !important; border: 1px solid var(--card-border, #dbe4ee) !important; box-shadow: none !important; font-weight: 800 !important; }
+    #tapp-grid .tapp-btn[data-svc="open_cover"] { background: rgba(16,185,129,.14) !important; color: #047857 !important; }
+    #tapp-grid .tapp-btn[data-svc="stop_cover"] { background: var(--surface-3, #f1f5f9) !important; color: var(--text, #0f172a) !important; }
+    #tapp-grid .tapp-btn[data-svc="close_cover"] { background: rgba(14,165,233,.14) !important; color: #0369a1 !important; }
+    #tapp-grid .dm-shutter-bulk-actions { width: min(100%, 680px) !important; margin: 0 auto 4px !important; padding: 8px !important; border: 1px solid var(--card-border, #dbe4ee) !important; border-radius: 16px !important; background: var(--card-bg, #fff) !important; box-shadow: var(--shadow-sculpted) !important; }
+
+    @media (max-width: 700px) {
+      #editor-modal .dm-config-grid,
+      #editor-modal .dm-report-fields { grid-template-columns: 1fr !important; }
+      #editor-modal .dm-temperature-actions { grid-template-columns: 1fr !important; }
+      #page-appliances-main .appl-page-grid { grid-template-columns: 1fr !important; }
+      #page-appliances-main .appl-wide-card.dm-control-device { grid-template-columns: 82px minmax(0,1fr) !important; max-width: none !important; min-height: 118px !important; }
+      #page-appliances-main .appl-wide-card.dm-control-device .appl-visual { min-height: 118px !important; }
+      #page-appliances-main .appl-wide-card.dm-control-device .appl-primary strong { font-size: 20px !important; }
+      #page-appliances-main .appl-wide-card.dm-control-device .appl-st { font-size: 9px !important; }
+      #page-appliances-main .appl-action-btn[data-dm-power-toggle="true"] { min-width: 78px !important; font-size: 11px !important; }
+      #tapp-grid { grid-template-columns: 1fr !important; }
+      #tapp-grid .tapp-card { max-width: 330px !important; width: 100% !important; margin: 0 auto !important; }
+      #tapp-grid .dm-shutter-bulk-actions { display: grid !important; grid-template-columns: 1fr 1fr !important; }
+    }
+  `;
+  document.head.append(style);
+}
+
+function installRuntimePatches() {
+  const results = [
+    installServiceBridgeFix(),
+    installApplianceEditorFix(),
+    installAlertsEditorFix(),
+    installLightsEditorFix(),
+  ];
+  return results.every(Boolean);
+}
+
+function decorate() {
+  decorateReportRows();
+  decorateApplianceCards();
+}
+
+function install() {
+  installCss();
+  installRuntimePatches();
+  repairApplianceEntities();
+  decorate();
+  if (globalThis[FLAG]?.installed) return;
+  globalThis[FLAG] = { installed: true };
+  let frame = 0;
+  new MutationObserver(() => {
+    cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(decorate);
+  }).observe(document.documentElement, { childList: true, subtree: true });
+  let attempts = 0;
+  const timer = setInterval(() => {
+    attempts += 1;
+    installRuntimePatches();
+    repairApplianceEntities();
+    decorate();
+    if (attempts >= 30) clearInterval(timer);
+  }, 500);
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", install, { once: true });
+  else install();
+  window.addEventListener("dashboardmodern:legacy-ready", install);
+}

--- a/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-layout-lock.js
+++ b/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-layout-lock.js
@@ -1,0 +1,172 @@
+/* Final high-specificity layout lock based on real Home Assistant screenshots. */
+function installRealHaLayoutLock() {
+  if (document.getElementById("dm-real-ha-0147-layout-lock")) return;
+  const style = document.createElement("style");
+  style.id = "dm-real-ha-0147-layout-lock";
+  style.textContent = `
+    html body #page-appliances-main .appl-page-grid {
+      grid-template-columns: repeat(auto-fit, minmax(280px, 380px)) !important;
+      justify-content: center !important;
+      align-items: start !important;
+      gap: 14px !important;
+    }
+    html body #page-appliances-main .appl-wide-card.dm-control-device {
+      display: grid !important;
+      grid-template-columns: 94px minmax(0, 1fr) !important;
+      width: 100% !important;
+      max-width: 380px !important;
+      min-height: 128px !important;
+      border-radius: 20px !important;
+      overflow: hidden !important;
+    }
+    html body #page-appliances-main .appl-wide-card.dm-control-device .appl-visual {
+      width: 94px !important;
+      min-width: 94px !important;
+      min-height: 128px !important;
+      padding: 0 !important;
+      overflow: hidden !important;
+    }
+    html body #page-appliances-main .appl-wide-card.dm-control-device .appl-ic,
+    html body #page-appliances-main .appl-wide-card.dm-control-device .appl-ic.dm-appliance-image-wrap,
+    html body #page-appliances-main .appl-wide-card.dm-control-device .dm-appliance-art,
+    html body #page-appliances-main .appl-wide-card.dm-control-device .dm-appliance-image-wrap {
+      display: block !important;
+      width: 100% !important;
+      min-width: 0 !important;
+      max-width: none !important;
+      height: 100% !important;
+      min-height: 128px !important;
+      max-height: none !important;
+      padding: 0 !important;
+      border: 0 !important;
+      border-radius: 0 !important;
+      box-shadow: none !important;
+      overflow: hidden !important;
+    }
+    html body #page-appliances-main .appl-wide-card.dm-control-device .appl-ic img,
+    html body #page-appliances-main .appl-wide-card.dm-control-device .appl-ic svg,
+    html body #page-appliances-main .appl-wide-card.dm-control-device .dm-appliance-art svg,
+    html body #page-appliances-main .appl-wide-card.dm-control-device .dm-appliance-image {
+      display: block !important;
+      width: 100% !important;
+      height: 100% !important;
+      min-width: 0 !important;
+      min-height: 0 !important;
+      max-width: none !important;
+      max-height: none !important;
+      object-fit: cover !important;
+      object-position: center !important;
+    }
+    html body #page-appliances-main .appl-wide-card.dm-control-device .appl-info {
+      min-width: 0 !important;
+      padding: 12px !important;
+      gap: 8px !important;
+    }
+    html body #page-appliances-main .appl-wide-card.dm-control-device .appl-spark {
+      display: none !important;
+    }
+
+    html body #page-tapparelle > div {
+      max-width: 980px !important;
+      padding-inline: 14px !important;
+    }
+    html body #tapp-grid {
+      grid-template-columns: repeat(auto-fit, minmax(270px, 330px)) !important;
+      justify-content: center !important;
+      align-items: start !important;
+      gap: 14px !important;
+      padding: 12px 0 70px !important;
+    }
+    html body #tapp-grid .tapp-card {
+      width: 100% !important;
+      max-width: 330px !important;
+      min-height: 0 !important;
+      padding: 14px !important;
+      gap: 10px !important;
+      border-radius: 20px !important;
+    }
+    html body #tapp-grid .tapp-win {
+      height: 126px !important;
+      min-height: 126px !important;
+      border-radius: 16px !important;
+    }
+    html body #tapp-grid .tapp-pos {
+      min-height: 22px !important;
+      font-size: 17px !important;
+      line-height: 22px !important;
+    }
+    html body #tapp-grid .tapp-btn,
+    html body .dm-shutter-popup .dm-shutter-actions button {
+      min-height: 42px !important;
+      padding: 8px 12px !important;
+      border: 1px solid var(--card-border, #dbe4ee) !important;
+      border-radius: 12px !important;
+      background: var(--surface-3, #f1f5f9) !important;
+      color: var(--text, #0f172a) !important;
+      box-shadow: none !important;
+      font-weight: 800 !important;
+    }
+    html body #tapp-grid .tapp-btn[data-svc="open_cover"],
+    html body .dm-shutter-popup .dm-shutter-actions button[data-shutter-service="open_cover"] {
+      background: rgba(16,185,129,.14) !important;
+      border-color: rgba(16,185,129,.24) !important;
+      color: #047857 !important;
+    }
+    html body #tapp-grid .tapp-btn[data-svc="close_cover"],
+    html body .dm-shutter-popup .dm-shutter-actions button[data-shutter-service="close_cover"] {
+      background: rgba(14,165,233,.14) !important;
+      border-color: rgba(14,165,233,.24) !important;
+      color: #0369a1 !important;
+    }
+    html body #tapp-grid > .dm-shutter-bulk-actions,
+    html body #tapp-grid > div:first-child:has([data-all]) {
+      width: min(100%, 680px) !important;
+      padding: 8px !important;
+      margin: 0 auto 4px !important;
+      border: 1px solid var(--card-border, #dbe4ee) !important;
+      border-radius: 16px !important;
+      background: var(--card-bg, #fff) !important;
+      box-shadow: var(--shadow-sculpted) !important;
+    }
+
+    @media (max-width: 700px) {
+      html body #page-appliances-main .appl-page-grid {
+        grid-template-columns: 1fr !important;
+      }
+      html body #page-appliances-main .appl-wide-card.dm-control-device {
+        grid-template-columns: 82px minmax(0, 1fr) !important;
+        max-width: none !important;
+        min-height: 118px !important;
+      }
+      html body #page-appliances-main .appl-wide-card.dm-control-device .appl-visual {
+        width: 82px !important;
+        min-width: 82px !important;
+        min-height: 118px !important;
+      }
+      html body #page-appliances-main .appl-wide-card.dm-control-device .appl-ic,
+      html body #page-appliances-main .appl-wide-card.dm-control-device .appl-ic.dm-appliance-image-wrap,
+      html body #page-appliances-main .appl-wide-card.dm-control-device .dm-appliance-art,
+      html body #page-appliances-main .appl-wide-card.dm-control-device .dm-appliance-image-wrap {
+        min-height: 118px !important;
+      }
+      html body #tapp-grid {
+        grid-template-columns: 1fr !important;
+      }
+      html body #tapp-grid .tapp-card {
+        margin-inline: auto !important;
+      }
+      html body #tapp-grid > .dm-shutter-bulk-actions,
+      html body #tapp-grid > div:first-child:has([data-all]) {
+        display: grid !important;
+        grid-template-columns: 1fr 1fr !important;
+      }
+    }
+  `;
+  document.head.append(style);
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", installRealHaLayoutLock, { once: true });
+  else installRealHaLayoutLock();
+  window.addEventListener("dashboardmodern:legacy-ready", installRealHaLayoutLock);
+}

--- a/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-popup-layout.js
+++ b/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-popup-layout.js
@@ -1,0 +1,99 @@
+/* Compact, dashboard-consistent shutter popup layout. */
+function installShutterPopupLayout() {
+  if (document.getElementById("dm-real-ha-0147-popup-layout")) return;
+  const style = document.createElement("style");
+  style.id = "dm-real-ha-0147-popup-layout";
+  style.textContent = `
+    html body .dm-shutter-popup {
+      width: min(520px, 100%) !important;
+      padding: 16px !important;
+      border-radius: 22px !important;
+    }
+    html body .dm-shutter-popup > header {
+      display: grid !important;
+      grid-template-columns: minmax(0, 1fr) 42px !important;
+      align-items: center !important;
+      gap: 12px !important;
+      margin-bottom: 12px !important;
+    }
+    html body .dm-shutter-popup > header h2 {
+      min-width: 0 !important;
+      margin: 0 !important;
+      font-size: 20px !important;
+      line-height: 1.2 !important;
+      letter-spacing: .5px !important;
+    }
+    html body .dm-shutter-popup > header [data-shutter-popup-close] {
+      grid-column: 2 !important;
+      justify-self: end !important;
+      align-self: center !important;
+      width: 42px !important;
+      height: 42px !important;
+      margin: 0 !important;
+      border: 1px solid var(--card-border, #dbe4ee) !important;
+      border-radius: 50% !important;
+      background: var(--surface-3, #f1f5f9) !important;
+      color: var(--text, #0f172a) !important;
+      font-size: 24px !important;
+      line-height: 1 !important;
+    }
+    html body .dm-shutter-popup-row {
+      display: grid !important;
+      grid-template-columns: 52px minmax(0, 1fr) !important;
+      grid-template-areas: "icon details" "actions actions" !important;
+      align-items: center !important;
+      gap: 10px 12px !important;
+      padding: 12px !important;
+      border-radius: 16px !important;
+    }
+    html body .dm-shutter-popup-row > .g-icon-wrap {
+      grid-area: icon !important;
+      width: 52px !important;
+      height: 52px !important;
+      margin: 0 !important;
+    }
+    html body .dm-shutter-popup-row > .dm-shutter-details {
+      grid-area: details !important;
+    }
+    html body .dm-shutter-popup-row > .dm-shutter-actions {
+      grid-area: actions !important;
+      display: grid !important;
+      grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+      gap: 8px !important;
+      width: 100% !important;
+    }
+    html body .dm-shutter-popup-row > .dm-shutter-actions button {
+      width: 100% !important;
+      min-width: 0 !important;
+      min-height: 42px !important;
+      padding: 8px 6px !important;
+      white-space: nowrap !important;
+    }
+    @media (max-width: 430px) {
+      html body .dm-shutter-popup {
+        padding: 14px !important;
+      }
+      html body .dm-shutter-popup > header h2 {
+        font-size: 18px !important;
+      }
+      html body .dm-shutter-popup-row {
+        grid-template-columns: 46px minmax(0, 1fr) !important;
+        padding: 11px !important;
+      }
+      html body .dm-shutter-popup-row > .g-icon-wrap {
+        width: 46px !important;
+        height: 46px !important;
+      }
+      html body .dm-shutter-popup-row > .dm-shutter-actions button {
+        font-size: 12px !important;
+      }
+    }
+  `;
+  document.head.append(style);
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", installShutterPopupLayout, { once: true });
+  else installShutterPopupLayout();
+  window.addEventListener("dashboardmodern:legacy-ready", installShutterPopupLayout);
+}

--- a/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-stability.js
@@ -11,10 +11,9 @@ function readJson(key, fallback) {
 }
 
 /*
- * runtime-hotfix.js can replace a legacy renderer after real-ha-0147-fixes.js
- * has already wrapped it. Mark the currently installed renderer as accepted
- * before the retry loop runs, otherwise the two compatibility layers wrap one
- * another repeatedly and eventually overflow the call stack.
+ * runtime-hotfix.js and real-ha-0147-fixes.js use different wrapper markers.
+ * Mark the current implementation for both layers before either retry loop can
+ * wrap it again. This prevents A -> B -> A recursion regardless of load order.
  */
 function markCurrentWrappers() {
   [
@@ -30,6 +29,7 @@ function markCurrentWrappers() {
     if (typeof value !== "function") return;
     try {
       value.__dmRealHa0147 = true;
+      value.__dmRealFix = true;
     } catch (_error) {}
   });
 }

--- a/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-stability.js
@@ -1,0 +1,80 @@
+/* Stability layer for the real Home Assistant 0.14.7 acceptance fixes. */
+const STABILITY_FLAG = "__DASHBOARDMODERN_REAL_HA_0147_STABILITY__";
+const isEnglish = () => document.documentElement.lang === "en";
+
+function stabilizePowerButtons(root = document) {
+  root.querySelectorAll("#page-appliances-main .appl-wide-card.dm-control-device").forEach((card) => {
+    const button = [...card.querySelectorAll(".appl-action-btn, .dm-appliance-power-toggle")].find(
+      (candidate) =>
+        candidate.classList.contains("dm-appliance-power-toggle") ||
+        candidate.textContent.trim() === "⏻" ||
+        candidate.dataset.dmPowerToggle === "true",
+    );
+    if (!button) return;
+    const on = button.classList.contains("on");
+    const label = on
+      ? isEnglish()
+        ? "Turn off"
+        : "Spegni"
+      : isEnglish()
+        ? "Turn on"
+        : "Accendi";
+    if (button.textContent.trim() !== label) button.textContent = label;
+    button.dataset.dmPowerToggle = "true";
+    button.classList.remove("appl-action-btn");
+    button.classList.add("dm-appliance-power-toggle");
+    button.setAttribute("aria-label", label);
+  });
+}
+
+function install() {
+  if (!document.getElementById("dm-real-ha-0147-stability-css")) {
+    const style = document.createElement("style");
+    style.id = "dm-real-ha-0147-stability-css";
+    style.textContent = `
+      #page-appliances-main .dm-appliance-power-toggle {
+        min-width: 86px;
+        min-height: 38px;
+        padding: 8px 12px;
+        border: 1px solid var(--card-border, #dbe4ee);
+        border-radius: 11px;
+        background: var(--surface-3, #f1f5f9);
+        color: var(--text, #0f172a);
+        font: inherit;
+        font-size: 12px;
+        font-weight: 850;
+        cursor: pointer;
+      }
+      #page-appliances-main .dm-appliance-power-toggle.on {
+        background: rgba(239,68,68,.12);
+        border-color: rgba(239,68,68,.24);
+        color: #b91c1c;
+      }
+      #editor-modal .ed-row:has([data-real-alert-edit]) [data-standard-alert-edit] {
+        display: none !important;
+      }
+      @media (max-width: 700px) {
+        #page-appliances-main .dm-appliance-power-toggle {
+          min-width: 78px;
+          min-height: 38px;
+          padding-inline: 9px;
+          font-size: 11px;
+        }
+      }
+    `;
+    document.head.append(style);
+  }
+  stabilizePowerButtons();
+  if (globalThis[STABILITY_FLAG]?.installed) return;
+  globalThis[STABILITY_FLAG] = { installed: true };
+  new MutationObserver(() => stabilizePowerButtons()).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", install, { once: true });
+  else install();
+  window.addEventListener("dashboardmodern:legacy-ready", install);
+}

--- a/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-stability.js
@@ -2,6 +2,38 @@
 const STABILITY_FLAG = "__DASHBOARDMODERN_REAL_HA_0147_STABILITY__";
 const isEnglish = () => document.documentElement.lang === "en";
 
+function readJson(key, fallback) {
+  try {
+    return JSON.parse(localStorage.getItem(key)) ?? fallback;
+  } catch (_error) {
+    return fallback;
+  }
+}
+
+/*
+ * runtime-hotfix.js can replace a legacy renderer after real-ha-0147-fixes.js
+ * has already wrapped it. Mark the currently installed renderer as accepted
+ * before the retry loop runs, otherwise the two compatibility layers wrap one
+ * another repeatedly and eventually overflow the call stack.
+ */
+function markCurrentWrappers() {
+  [
+    "editorRenderAppliances",
+    "editorRenderAvvisi",
+    "editorRenderLuci",
+    "edApplSave",
+    "edAddAvviso",
+    "cdLuceAdd",
+    "dmCallHaService",
+  ].forEach((name) => {
+    const value = globalThis[name];
+    if (typeof value !== "function") return;
+    try {
+      value.__dmRealHa0147 = true;
+    } catch (_error) {}
+  });
+}
+
 function stabilizePowerButtons(root = document) {
   root.querySelectorAll("#page-appliances-main .appl-wide-card.dm-control-device").forEach((card) => {
     const button = [...card.querySelectorAll(".appl-action-btn, .dm-appliance-power-toggle")].find(
@@ -27,50 +59,161 @@ function stabilizePowerButtons(root = document) {
   });
 }
 
-function install() {
-  if (!document.getElementById("dm-real-ha-0147-stability-css")) {
-    const style = document.createElement("style");
-    style.id = "dm-real-ha-0147-stability-css";
-    style.textContent = `
+function alertGroupForEntity(entity, row) {
+  const extras = readJson("cd_gruppi_extra", {});
+  const explicit = Object.entries(extras).find(([, ids]) => Array.isArray(ids) && ids.includes(entity));
+  if (explicit) return explicit[0];
+  const text = row.closest("details")?.querySelector("summary")?.textContent?.toLowerCase() || "";
+  if (/apert|contact|door|window/.test(text)) return "win";
+  if (/batter/.test(text)) return "batt";
+  if (/luc|light/.test(text)) return "luci";
+  if (/clima|climate/.test(text)) return "clima";
+  if (/riscald|heating/.test(text)) return "risc";
+  return "";
+}
+
+function stabilizeAlertEditButtons(root = document) {
+  root.querySelectorAll("#editor-modal .ed-row").forEach((row) => {
+    const entity = row.querySelector(".ed-row-old.mono")?.textContent?.trim();
+    if (!entity || !entity.includes(".")) return;
+    const group = alertGroupForEntity(entity, row);
+    if (!group) return;
+
+    row.querySelectorAll("[data-standard-alert-edit]").forEach((button) => button.remove());
+    if (row.querySelector("[data-real-alert-edit]")) return;
+
+    const removeButton = [...row.querySelectorAll(".ed-del")].find(
+      (button) => /edDelAvviso/.test(button.getAttribute("onclick") || ""),
+    );
+    if (!removeButton || typeof globalThis.dmRealEditAlert !== "function") return;
+
+    const editButton = document.createElement("button");
+    editButton.type = "button";
+    editButton.className = "ed-del dm-edit-button";
+    editButton.dataset.realAlertEdit = "";
+    editButton.textContent = "✏️";
+    editButton.title = isEnglish() ? "Edit" : "Modifica";
+    editButton.setAttribute("aria-label", editButton.title);
+    editButton.addEventListener("click", () => globalThis.dmRealEditAlert(group, entity));
+    removeButton.before(editButton);
+  });
+}
+
+function stabilizeReportRows(root = document) {
+  root.querySelectorAll("#editor-modal [data-energy-panel='report'] .dm-report-row").forEach((row) => {
+    row.dataset.realReportStable = "true";
+    const fields = row.querySelector(":scope > .dm-report-fields");
+    if (!fields) return;
+    fields.querySelectorAll(".dm-config-field, [data-entity-field], [data-icon-field]").forEach((field) => {
+      field.style.gridArea = "auto";
+      field.style.width = "100%";
+      field.style.minWidth = "0";
+    });
+  });
+}
+
+function stabilize(root = document) {
+  markCurrentWrappers();
+  stabilizePowerButtons(root);
+  stabilizeAlertEditButtons(root);
+  stabilizeReportRows(root);
+}
+
+function installCss() {
+  if (document.getElementById("dm-real-ha-0147-stability-css")) return;
+  const style = document.createElement("style");
+  style.id = "dm-real-ha-0147-stability-css";
+  style.textContent = `
+    #page-appliances-main .dm-appliance-power-toggle {
+      min-width: 86px;
+      min-height: 38px;
+      padding: 8px 12px;
+      border: 1px solid var(--card-border, #dbe4ee);
+      border-radius: 11px;
+      background: var(--surface-3, #f1f5f9);
+      color: var(--text, #0f172a);
+      font: inherit;
+      font-size: 12px;
+      font-weight: 850;
+      cursor: pointer;
+    }
+    #page-appliances-main .dm-appliance-power-toggle.on {
+      background: rgba(239,68,68,.12);
+      border-color: rgba(239,68,68,.24);
+      color: #b91c1c;
+    }
+
+    #editor-modal [data-energy-panel="report"] .dm-report-row[data-real-report-layout="true"] {
+      display: grid !important;
+      grid-template-columns: minmax(0, 1fr) auto !important;
+      grid-template-areas: "toggle actions" "fields fields" !important;
+      gap: 12px !important;
+      align-items: center !important;
+    }
+    #editor-modal [data-energy-panel="report"] .dm-report-row[data-real-report-layout="true"] > .dm-report-toggle {
+      grid-area: toggle !important;
+    }
+    #editor-modal [data-energy-panel="report"] .dm-report-row[data-real-report-layout="true"] > .dm-report-fields {
+      grid-area: fields !important;
+      display: grid !important;
+      grid-template-columns: minmax(150px,.75fr) minmax(130px,.45fr) minmax(240px,1.3fr) !important;
+      gap: 10px !important;
+      align-items: end !important;
+      width: 100% !important;
+      min-width: 0 !important;
+    }
+    #editor-modal [data-energy-panel="report"] .dm-report-row[data-real-report-layout="true"] > .dm-report-actions {
+      grid-area: actions !important;
+    }
+    #editor-modal [data-energy-panel="report"] .dm-report-fields > .dm-config-field,
+    #editor-modal [data-energy-panel="report"] .dm-report-fields > [data-entity-field],
+    #editor-modal [data-energy-panel="report"] .dm-report-fields > [data-icon-field],
+    #editor-modal [data-energy-panel="report"] .dm-report-fields [data-report-label] {
+      grid-area: auto !important;
+      width: 100% !important;
+      min-width: 0 !important;
+      margin: 0 !important;
+    }
+    #editor-modal [data-energy-panel="report"] .dm-report-fields [data-entity-field] .ed-form-row {
+      display: grid !important;
+      grid-template-columns: minmax(0, 1fr) 42px !important;
+      gap: 8px !important;
+      width: 100% !important;
+    }
+
+    @media (max-width: 700px) {
       #page-appliances-main .dm-appliance-power-toggle {
-        min-width: 86px;
+        min-width: 78px;
         min-height: 38px;
-        padding: 8px 12px;
-        border: 1px solid var(--card-border, #dbe4ee);
-        border-radius: 11px;
-        background: var(--surface-3, #f1f5f9);
-        color: var(--text, #0f172a);
-        font: inherit;
-        font-size: 12px;
-        font-weight: 850;
-        cursor: pointer;
+        padding-inline: 9px;
+        font-size: 11px;
       }
-      #page-appliances-main .dm-appliance-power-toggle.on {
-        background: rgba(239,68,68,.12);
-        border-color: rgba(239,68,68,.24);
-        color: #b91c1c;
+      #editor-modal [data-energy-panel="report"] .dm-report-row[data-real-report-layout="true"] > .dm-report-fields {
+        grid-template-columns: 1fr !important;
       }
-      #editor-modal .ed-row:has([data-real-alert-edit]) [data-standard-alert-edit] {
-        display: none !important;
-      }
-      @media (max-width: 700px) {
-        #page-appliances-main .dm-appliance-power-toggle {
-          min-width: 78px;
-          min-height: 38px;
-          padding-inline: 9px;
-          font-size: 11px;
-        }
-      }
-    `;
-    document.head.append(style);
-  }
-  stabilizePowerButtons();
+    }
+  `;
+  document.head.append(style);
+}
+
+function install() {
+  installCss();
+  stabilize();
   if (globalThis[STABILITY_FLAG]?.installed) return;
   globalThis[STABILITY_FLAG] = { installed: true };
-  new MutationObserver(() => stabilizePowerButtons()).observe(document.documentElement, {
-    childList: true,
-    subtree: true,
-  });
+
+  let frame = 0;
+  new MutationObserver(() => {
+    cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(() => stabilize());
+  }).observe(document.documentElement, { childList: true, subtree: true });
+
+  let attempts = 0;
+  const guardTimer = setInterval(() => {
+    attempts += 1;
+    stabilize();
+    if (attempts >= 300) clearInterval(guardTimer);
+  }, 50);
 }
 
 if (typeof window !== "undefined" && typeof document !== "undefined") {

--- a/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
@@ -9,6 +9,7 @@ import "./release-0147-editor-theme.js";
 import "./real-ha-0147-fixes.js";
 import "./real-ha-0147-stability.js";
 import "./real-ha-0147-layout-lock.js";
+import "./real-ha-0147-data-repair.js";
 
 function installReportCompatibilityMarker() {
   if (document.getElementById("dm-report-mobile-fixes")) return;

--- a/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
@@ -8,6 +8,7 @@ import "./release-0147-report-polish.js";
 import "./release-0147-editor-theme.js";
 import "./real-ha-0147-fixes.js";
 import "./real-ha-0147-stability.js";
+import "./real-ha-0147-layout-lock.js";
 
 function installReportCompatibilityMarker() {
   if (document.getElementById("dm-report-mobile-fixes")) return;

--- a/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
@@ -7,6 +7,7 @@ import "./release-0147-appliance-theme.js";
 import "./release-0147-report-polish.js";
 import "./release-0147-editor-theme.js";
 import "./real-ha-0147-fixes.js";
+import "./real-ha-0147-stability.js";
 
 function installReportCompatibilityMarker() {
   if (document.getElementById("dm-report-mobile-fixes")) return;

--- a/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
@@ -6,6 +6,7 @@ import "./release-0147-appliance-store.js";
 import "./release-0147-appliance-theme.js";
 import "./release-0147-report-polish.js";
 import "./release-0147-editor-theme.js";
+import "./real-ha-0147-fixes.js";
 
 function installReportCompatibilityMarker() {
   if (document.getElementById("dm-report-mobile-fixes")) return;

--- a/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
@@ -11,6 +11,7 @@ import "./real-ha-0147-stability.js";
 import "./real-ha-0147-layout-lock.js";
 import "./real-ha-0147-data-repair.js";
 import "./real-ha-0147-alert-compat.js";
+import "./real-ha-0147-popup-layout.js";
 
 function installReportCompatibilityMarker() {
   if (document.getElementById("dm-report-mobile-fixes")) return;

--- a/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
@@ -10,6 +10,7 @@ import "./real-ha-0147-fixes.js";
 import "./real-ha-0147-stability.js";
 import "./real-ha-0147-layout-lock.js";
 import "./real-ha-0147-data-repair.js";
+import "./real-ha-0147-alert-compat.js";
 
 function installReportCompatibilityMarker() {
   if (document.getElementById("dm-report-mobile-fixes")) return;

--- a/docs/.release-blocked-0.14.7
+++ b/docs/.release-blocked-0.14.7
@@ -1,0 +1,1 @@
+Release 0.14.7 blocked pending real Home Assistant acceptance verification.

--- a/docs/REAL_HA_0147_ACCEPTANCE.md
+++ b/docs/REAL_HA_0147_ACCEPTANCE.md
@@ -1,0 +1,42 @@
+# Verifica reale Home Assistant — blocchi 0.14.7
+
+Questa checklist deriva da prove manuali effettuate in una vera installazione Home Assistant dopo il merge della PR #33. La release pubblica resta bloccata finché ogni voce non è verificata sia in Home Assistant sia nei test automatici.
+
+## Elettrodomestici
+- [ ] Card proporzionata su desktop, tablet e smartphone.
+- [ ] Eliminare o spiegare visivamente le barre blu prive di funzione comprensibile.
+- [ ] Stato ON/OFF leggibile su smartphone senza simboli errati o `X`.
+- [ ] Immagine full-bleed mantenuta.
+
+## Report Energia
+- [ ] Editor Report coerente graficamente con gli altri editor.
+- [ ] Ogni elettrodomestico mostra e conserva l'entità energia configurata.
+- [ ] Le entità energia vengono inferite e persistite senza cancellazioni.
+- [ ] Gli elettrodomestici configurati compaiono nel Report e nel selettore Dettaglio dispositivo.
+- [ ] Salvataggio e reload mantengono ordine, nome, icona ed entità.
+
+## Tapparelle
+- [ ] I comandi Apri/Stop/Chiudi nel popup usano il bridge Home Assistant reale e non mostrano "Home Assistant non connesso" quando la dashboard è ospitata in HA.
+- [ ] Card più compatte e coerenti con il design generale.
+- [ ] Pulsanti singoli e Apri tutte/Chiudi tutte uniformi alle altre sezioni.
+- [ ] Stato e percentuale restano leggibili su smartphone.
+
+## Avvisi
+- [ ] Ogni avviso salvato, compresi quelli standard, dispone di Modifica e Elimina.
+- [ ] Modifica precompila il form e aggiorna l'elemento esistente senza duplicarlo.
+
+## Luci
+- [ ] Ogni luce salvata dispone di Modifica e Elimina.
+- [ ] Modifica precompila nome, entità e stanza e aggiorna senza duplicati.
+
+## Temperatura
+- [ ] Editor allineato alla struttura comune: lista, Modifica/Elimina, form, Salva modifiche e Annulla.
+- [ ] Nessun controllo sproporzionato o fuori griglia.
+
+## Coerenza Editor
+- [ ] Tutte le sezioni condividono la stessa struttura visuale e gli stessi componenti.
+- [ ] Azioni Modifica, Elimina, Salva modifiche e Annulla sono presenti dove applicabili.
+- [ ] Tema chiaro/scuro, spaziature, campi entità, pulsanti e righe sono uniformi.
+
+## Regola di rilascio
+Non creare il tag `v0.14.7` e non pubblicare la release finché la checklist non è completata e verificata in una vera installazione Home Assistant.


### PR DESCRIPTION
## Blocco rilascio

Le verifiche in una vera installazione Home Assistant hanno mostrato che la PR #33, pur con CI verde, non risolve ancora diversi flussi reali. Non creare il tag `v0.14.7` e non pubblicare la release finché questa PR non è completata e verificata manualmente in Home Assistant.

## Difetti confermati dagli screenshot reali

### Elettrodomestici
- card sproporzionata;
- barre blu senza funzione comprensibile;
- stato ON/OFF non leggibile su smartphone e simbolo errato `X`;
- mantenere l'immagine full-bleed, che è l'unica parte risultata corretta.

### Report Energia
- editor Report graficamente non uniforme;
- nomi elettrodomestici presenti ma entità energia mancanti;
- entità non persistite dopo salvataggio/reload;
- elettrodomestici assenti dal Report e dal selettore Dettaglio dispositivo.

### Tapparelle
- popup comandi mostra `Home Assistant non connesso` nella vera installazione HA;
- card e immagine troppo grandi;
- comandi Apri/Stop/Chiudi e Apri tutte/Chiudi tutte non coerenti col design generale.

### Avvisi
- manca la modifica degli avvisi già salvati.

### Luci
- manca la modifica delle luci già salvate.

### Temperatura
- editor graficamente non adeguato e non uniforme.

### Coerenza Editor
- tutte le sezioni devono condividere struttura, spaziature, campi, pulsanti e azioni;
- dove applicabile devono essere sempre presenti Modifica, Elimina, Salva modifiche e Annulla;
- nessun salvataggio deve duplicare o perdere dati.

## Criterio di accettazione

La checklist completa è in `docs/REAL_HA_0147_ACCEPTANCE.md`. La PR resta Draft finché ogni voce non è verificata nei test e in una vera installazione Home Assistant.
