### PR TITLE
chore: trigger DashboardModern 0.14.8 release

### DIFF
--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -1,9 +1,7 @@
 {
   "domain": "dashboardmodern",
   "name": "DashboardModern v2",
-  "codeowners": [
-    "@danigio15"
-  ],
+  "codeowners": ["@danigio15"],
   "config_flow": true,
   "dependencies": [
     "frontend",


### PR DESCRIPTION
Il workflow `Release` è ora già presente su `main`. Questa PR applica soltanto una formattazione JSON semanticamente neutra al manifest, mantenendo la versione **0.14.8**, per generare un nuovo push su `main` che attivi in modo deterministico la pubblicazione del tag e del pacchetto.

Nessuna modifica funzionale al componente.