### PR TITLE
release: DashboardModern 0.14.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,252 +1,81 @@
 # Changelog
 
-## 0.13.4 — 2026-07-28
+Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
+versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
-- Rifinitura finale dell'Editor: Salva Telecamere, Report Energia canonico e card Costi uniforme.
-- Corretti picker entità persistenti, ricerca icone Stanze, visibilità immediata e migrazione Lavatrice.
-- Rimossi dalla pagina Elettrodomestici i richiami ridondanti alla configurazione.
-
-## 0.13.2 — 2026-07-28
-
-- Unificato l'editor Energia con tab Flussi e Impostazioni e con il picker entità condiviso.
-- Consolidati Carichi secondari e voci report in un modello canonico migrato e reattivo.
-- Spostata la scheda Carichi subito dopo Energia nell'Editor Dashboard.
-
-## 0.13.1 — 2026-07-28
-
-- Editor Energia compatto e richiudibile, ottimizzato per mobile.
-- CRUD ottimistico aggiorna immediatamente editor, dashboard, report e selettori, incluso rollback.
-
-## 0.13.0 — 2026-07-28
-
-- Introduced the canonical DashboardStore, schema v2 migration and targeted reactive render coordination.
-- Unified device names/visuals, appliance/camera CRUD, section visibility, stable room references and the energy editor model.
-- Removed room lifecycle controls from the Lights editor.
-
-## 0.12.6 — 2026-07-28
-
-- Corrette le virgolette non bilanciate nell'HTML generato dall'editor stanze
-  che impedivano al browser di compilare il JavaScript inline.
-- Aggiunti compilazione reale di ogni blocco inline bilingue e test del
-  bootstrap con timeout e messaggio di errore al posto dello spinner infinito.
-
-## 0.12.4 — 2026-07-28
-
-- Unificati stanze, elettrodomestici e telecamere sul modello dati vendorizzato usato dall'integrazione.
-- Aggiunti tab dinamici per stanza, toggle comandabili e CRUD telecamere sincronizzato con Home Assistant.
-- Rimossa la patch runtime caricata in coda e aggiunti test funzionali bilingue del modello.
-- Verificata la localizzazione completa IT/EN con un glossario automatico che impedisce regressioni tra le due varianti.
-- Collaudati i flussi reali dei renderer vendorizzati e corretti il caricamento del modulo runtime, gli stati a potenza reale e i picker entità mancanti.
-
-Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/);
-le versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
-
-## 0.12.0 — 2026-07-27
-
-Prima versione candidata al rilascio pubblico.
+## 0.14.9 — 2026-07-31
 
 ### Aggiunto
 
-- **Plance multiple**: il config flow chiede il nome e permette più entry;
-  ogni plancia ha pannello, storage e chiave di sincronizzazione propri e
-  isolati. La prima plancia è *primaria* e mantiene URL e chiave storici
-  (migrazione automatica delle installazioni esistenti).
-- **Autorilevamento dai registri HA**: piani dal floor registry, aree come
-  stanze (col piano), stanza ereditata dall'area per luci, clima e
-  telecamere. Non sovrascrive mai le scelte manuali.
-- **Motore visibilità navbar**: al primo avvio le sezioni si mostrano solo se
-  popolate (plancia nuova = solo Home e Config) e si accendono da sole
-  appena ricevono contenuto; interruttore 🟢/⚪ in cima a ogni scheda
-  dell'editor; ordinamento linguette da Impostazioni.
-- **Editor ristrutturato**: una scheda per ogni sezione (via il vecchio tab
-  "Sezioni"), profili EV nella scheda EV con tendina di modifica, viste e
-  costi energia nella scheda Energia, Rileva e Reset dentro Impostazioni,
-  telecamere unite a Sicurezza, Salva in ogni sezione.
-- **Nuove sezioni e funzioni**: Tapparelle (card animate, Apri/Chiudi tutte,
-  avvisi cover aperta), Irrigazione (zone sequenziali, orario, salto
-  pioggia), Piscina (filtrazione fissa o automatica), profili multi-auto EV,
-  viste Energia configurabili, raggruppamento piano→stanza.
-- **Diagnostica**: riga di stato in Impostazioni (versione, hosted, bridge,
-  token, sync, istanza, primaria, query, chiave in uso).
-- **Brand**: nuovo logo generato da `scripts/make_logo.py` (icona app,
-  icone HACS/brands, lockup con wordmark).
-- Suite di regressione Node per il motore navbar eseguita sul file
-  vendorizzato; test Python per i pannelli multi-entry.
+- **Plancia Lovelace associata** a ogni istanza DashboardModern. Viene creata
+  alla prima apertura amministrativa, compare in **Impostazioni → Plance** e
+  può essere scelta come predefinita globale o personale.
+- **Selettore utenti autorizzati** nelle opzioni dell'integrazione. La lista è
+  applicata sia alla visibilità della vista Lovelace sia al controllo diretto
+  del pannello e della custom card.
+- Custom card globale `dashboardmodern-card`, caricata dal percorso statico
+  versionato dell'integrazione senza configurazione manuale delle risorse.
+- Test automatici per creazione plancia, visibilità per utente e derivazione
+  delle icone del Report Energia.
 
 ### Cambiato
 
-- Tag del custom element versionato per build: classi in cache di build
-  precedenti non pilotano più i pannelli nuovi.
-- Istanza e flag primaria viaggiano nell'URL dell'iframe (`?dmi=…&dmp=…`),
-  a prova di qualunque timing di mount.
-- Versione integrazione allineata al frontend (0.12.0).
+- Report Energia: eredita automaticamente l'icona o la visuale selezionata
+  nell'elettrodomestico; frigorifero, forno, lavatrice, lavastoviglie,
+  asciugatrice e altri tipi hanno fallback MDI coerenti.
+- Nuovo layout della card Temperatura: icona stanza più leggibile, gerarchia
+  compatta e griglia `auto-fit` senza spazi inutili.
+- Layout responsive basato sulla larghezza effettiva del viewport, con profili
+  compact/fold/wide, `ResizeObserver`, `visualViewport` e ricalcolo al cambio
+  di orientamento o apertura di un dispositivo pieghevole.
+- Immagini e icone degli elettrodomestici ridimensionate con limiti fluidi
+  anche sugli smartphone stretti.
+- README riscritto e allineato alle funzioni pubbliche della 0.14.9.
 
 ### Corretto
 
-- Le plance mostravano lo stesso frame (riuso dell'elemento pannello di HA):
-  al cambio di entry il frame ora si smonta e rimonta.
-- Storage condiviso tra plance per fallback sull'hash del percorso.
-- Loop di ricarica su desktop (doppio import sync recintato, auto-update
-  legacy disattivato quando ospitato).
-- Il Reset lasciava la navbar piena (flag di boot orfano): la derivazione
-  riparte da sola quando manca la mappa sezioni.
-- Mappe sezioni dei motori precedenti senza le chiavi nuove
-  (Elettrodomestici, Tapparelle, Irrigazione, Piscina): migrazione delle
-  sole chiavi mancanti.
-- Il tab Impostazioni non si apriva; salvataggio profili EV con valori
-  digitati ma non confermati.
-- La pagina Temperatura restava vuota quando l'autorilevamento aggiungeva
-  stanze senza sensore (la prima stanza senza `temp` bloccava il render):
-  ora mostra solo le stanze con sensore, raggruppate per piano.
-- Gli elettrodomestici finivano tutti in "Altro": l'editor aveva due
-  selettori stanza duplicati e il salvataggio leggeva quello sbagliato.
-- Le luci rilevate automaticamente non si potevano rinominare né
-  eliminare: bottoni ✏️/🗑️ su ogni riga della sezione Luci.
-- Nel dettaglio elettrodomestici le entità switch/light/fan hanno ora un
-  vero pulsante di accensione/spegnimento.
-- Logo ridisegnato: geometria simmetrica centrata al pixel, gradiente
-  cielo→blu e saetta ambra nello stile della dashboard, resa a 1024px.
+- L'associazione manuale di una luce alla stanza ora prevale sempre
+  sull'inferenza ricavata dal nome dell'entità.
+- Le stanze senza entità luce associate non vengono più mostrate nella pagina
+  Luci.
+- Le righe del Report con icona vuota vengono riparate usando la visuale
+  canonica dell'elettrodomestico.
+- Il passaggio fra schermo chiuso e aperto dei dispositivi Fold non lascia più
+  card e immagini con le misure del viewport precedente.
 
-## 0.2.0
+## 0.14.8 — 2026-07-30
 
-### The hosted dashboard never receives a credential
+- Consolidate le regressioni UI reali di Tapparelle, Temperatura, Report,
+  Irrigazione e Avvisi.
+- Resi verdi HACS, hassfest, test applicativi e Browser E2E completi.
+- Introdotto il workflow automatico di release con tag e `dashboardmodern.zip`.
 
-An earlier build of this release handed the hosted dashboard a Home Assistant
-access token so its existing bootstrap could use it unchanged. That was wrong:
-the hosted page loads three scripts from a public CDN, and any script in a page
-can read that page's storage. No token crosses over now. The panel replaces the
-hosted document's WebSocket with a shim that forwards a fixed set of message
-types through its own authenticated connection, so the hosted page can do
-exactly what the dashboard needs and nothing else — a stronger guarantee than a
-token, which permits everything its owner can do.
+## 0.14.7 — 2026-07-30
 
-### The dashboard is visible to everyone in the house
+- Revisione di coerenza grafica e compatibilità sul runtime Home Assistant
+  reale, inclusi desktop, mobile e WebKit/iPad.
 
-The panel no longer requires an administrator account to appear. Every
-configuration change already requires admin at the API, so the editor is
-protected where it matters instead of by hiding the dashboard from the family.
+## 0.13.4 — 2026-07-28
 
-First release usable as a real dashboard rather than a skeleton.
+- Rifinitura finale dell'Editor: Salva Telecamere, Report Energia canonico e
+  card Costi uniforme.
+- Corretti picker entità persistenti, ricerca icone Stanze, visibilità
+  immediata e migrazione Lavatrice.
 
-### The dashboard now installs as an integration
+## 0.13.2 — 2026-07-28
 
-Install from HACS, restart, add the integration, and the panel is in the
-sidebar. No HTML file to download and place, no iframe panel to wire up by
-hand, and no long-lived token to create and paste: the panel hands the
-dashboard an already-authenticated session, so the wizard's connection step is
-skipped entirely when a session is present.
+- Unificato l'editor Energia con tab Flussi e Impostazioni.
+- Consolidati carichi secondari e voci report in un modello canonico migrato.
 
-Updates arrive as integration updates. The static mount is keyed on a content
-digest of every shipped asset, so a new build changes the URL and reaches
-browsers on the next load — no hard refresh, no incognito, no version bump
-needed to defeat a cache.
+## 0.13.0 — 2026-07-28
 
-### Configuration is shared across devices
+- Introdotti DashboardStore canonico, migrazione schema v2 e coordinamento dei
+  renderer reattivi.
+- Unificati nomi/visuali dispositivi, CRUD elettrodomestici e telecamere,
+  visibilità sezioni e riferimenti stanza stabili.
 
-Section configuration is stored server-side in Home Assistant, included in
-backups and identical on every phone, tablet and browser profile. Concurrent
-edits from two devices are detected and refused rather than silently
-overwriting each other. Reading is available to any authenticated user;
-writing requires an administrator.
+## 0.12.0 — 2026-07-27
 
-### Entities are found and suggested
-
-The integration reads the entity, device and area registries in-process and
-proposes rooms and sections. Suggestions are ranked on device class, unit,
-naming in Italian or English, device grouping and area, each with the reasons
-behind it, and a correction is remembered and outranks everything else the next
-time. Weak matches are withheld rather than guessed.
-
-Rooms are configured once and referenced everywhere: renaming or merging rooms
-changes every section that groups by them.
-
-### Cards read live state
-
-Cards can bind Home Assistant entities by role. Unbound, missing, unavailable,
-unknown and stale are distinguished throughout, and a missing reading is never
-rendered as a zero.
-
-- Appliance cards read power and energy as separate roles, each converted from
-  its declared unit, and track cycle duration with a configurable tolerance for
-  the pauses appliances make mid-cycle.
-- Light cards offer exactly the controls the bound light reports supporting and
-  show the colour the light reports.
-
-### Fixes carried from the legacy dashboard
-
-- Editing or deleting a camera no longer destroys the whole camera
-  configuration.
-- The alarm keypad now reaches the configured panel, so the code is actually
-  evaluated; a rejected code is reported instead of closing silently; and the
-  keypad is shown only when the panel requires a code, with codes longer than
-  four digits accepted.
-- Appliances keep the room they were assigned instead of collecting under one
-  bucket.
-
-### Every section reads live state
-
-Covers, climate, measurements, irrigation valves, cameras, media players,
-people, locks, fans, vacuums and vehicles all bind entities and render real
-readings. Controls follow what each device reports supporting, so a garage door
-is not offered a tilt control and a media player without track skipping does not
-show skip buttons.
-
-### Pool water assessment
-
-pH, redox, chlorine, salinity, temperature and filter pressure are assessed
-against configurable ranges. Every default can be overridden, because water
-chemistry depends on the pool. A missing reading is reported as unknown and
-never as fine, and the overall verdict follows the worst reading rather than an
-average that would hide it. Filter attention has two independent causes:
-pressure above its band, and time since the last backwash.
-
-This reads the numbers a pool reports; it is not advice about water safety, and
-anything you intend to swim in is worth confirming with a proper test kit.
-
-### The panel shows the dashboard
-
-Installing the integration and opening the panel shows the dashboard, filling
-the panel with no surrounding chrome. The native renderer that the sections
-below are built on is development scaffolding, not a second interface, and it
-is no longer put in front of anyone.
-
-### Arrange the navigation bar
-
-Sections can be reordered, hidden on one device while kept on another, and up
-to three pinned so they stay put while the rest scroll. The arrangement is
-stored server-side like everything else, so it is the same on every device. A
-newly detected section appears at the end rather than nowhere, and an entry for
-a section that no longer exists leaves no dead button behind.
-
-### Long-term statistics
-
-Cards can read Home Assistant's own long-term statistics: consumption over a
-window, mean, minimum and maximum, and a comparison against the preceding
-window. A meter reset is not counted as negative consumption, and "no previous
-data" is reported as unknown rather than as no change. Only entities with a
-state class produce statistics, and the editor says so up front instead of
-leaving the user to work it out from an empty chart.
-
-### The editor offers instead of asking
-
-Binding an entity used to mean typing `sensor.lavastoviglie_potenza` from
-memory into a blank field, and finding out whether you were right by looking at
-the card afterwards. Each binding now says what it is for in plain language,
-gives a concrete example, and offers the entities the integration ranked for it
-— each with the reason it was suggested, so a wrong suggestion can be judged
-rather than only overridden. An entity you corrected before is shown as your own
-previous choice.
-
-Every field is checked as you fill it: a typo is reported as a missing entity,
-the wrong kind of entity says which kind is needed, and an unexpected unit
-warns without refusing. The chosen entity's current reading is shown next to
-it, because seeing 1900 W while the dishwasher runs is the fastest way to know
-you picked the right sensor.
-
-### Existing configuration is imported
-
-Users already running the legacy dashboard hand their browser configuration
-over once and it is rewritten into shared storage. The saved token is
-deliberately not imported: no token needs to exist any more. The import runs
-once, because a second run would silently overwrite anything configured since,
-and it reports what crossed over, what had no mapping and what was skipped.
+- Prima candidata pubblica come integrazione HACS con plance multiple,
+  autorilevamento dai registri Home Assistant, editor visuale e storage isolato
+  per istanza.

--- a/README.md
+++ b/README.md
@@ -5,212 +5,208 @@
 <h1 align="center">DashboardModern</h1>
 
 <p align="center">
-  <b>La dashboard smart-home completa per Home Assistant, come integrazione nativa.</b><br>
-  Energia · Fotovoltaico · Auto elettrica · Clima · Luci · Sicurezza · Tapparelle · Irrigazione · Piscina
+  <b>Una plancia smart-home completa e responsive per Home Assistant.</b><br>
+  Energia · Fotovoltaico · EV · Clima · Luci · Sicurezza · Tapparelle · Irrigazione · Piscina
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.12.0-0ea5e9">
+  <img src="https://img.shields.io/badge/version-0.14.9-0ea5e9">
   <img src="https://img.shields.io/badge/HACS-custom-41BDF5">
   <img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-1e3a8a">
 </p>
 
-> **English** — DashboardModern is a full smart-home dashboard for Home Assistant,
-> packaged as a native custom integration: sidebar panels (as many as you want,
-> each fully isolated), a visual editor with per-section tabs, one-click entity
-> auto-detection powered by the HA registries (floors, areas, devices), and a
-> navbar that starts minimal and grows as you configure. Install via HACS,
-> add the integration, press *Autorilevamento*, done. Docs below are in Italian.
+> **English summary** — DashboardModern is a complete Home Assistant dashboard
+> distributed as a HACS custom integration. Version 0.14.9 adds a generated
+> Lovelace companion dashboard, exact per-user access lists, appliance visuals
+> in the Energy Report, reliable light-to-room assignments and adaptive layouts
+> for phones, tablets and foldable devices.
 
 ---
 
 ## Indice
 
-1. [Cos'è](#cosè)
+1. [Funzioni principali](#funzioni-principali)
 2. [Installazione](#installazione)
 3. [Prima configurazione](#prima-configurazione)
-4. [Più plance](#più-plance)
-5. [L'editor, tab per tab](#leditor-tab-per-tab)
-6. [Autorilevamento](#autorilevamento)
-7. [Visibilità delle sezioni e navbar](#visibilità-delle-sezioni-e-navbar)
-8. [Sincronizzazione e reset](#sincronizzazione-e-reset)
+4. [Plancia Home Assistant e preferita](#plancia-home-assistant-e-preferita)
+5. [Utenti autorizzati](#utenti-autorizzati)
+6. [Editor e sezioni](#editor-e-sezioni)
+7. [Responsive e dispositivi pieghevoli](#responsive-e-dispositivi-pieghevoli)
+8. [Aggiornamento e cache](#aggiornamento-e-cache)
 9. [Diagnostica](#diagnostica)
-10. [FAQ](#faq)
-11. [Per sviluppatori](#per-sviluppatori)
+10. [Sviluppo e test](#sviluppo-e-test)
 
----
+## Funzioni principali
 
-## Cos'è
-
-DashboardModern è una dashboard completa per la casa smart che gira **dentro
-Home Assistant come integrazione**: nessun file da copiare in `www/`, nessun
-token da generare, nessuna risorsa Lovelace. L'integrazione registra un
-pannello nella barra laterale, serve il frontend da un percorso versionato
-(le cache si invalidano da sole a ogni aggiornamento) e autentica tramite la
-sessione HA già attiva.
-
-Caratteristiche principali:
-
-- **Pannelli multipli** — crei quante plance vuoi, ognuna con il suo nome in
-  sidebar e una configurazione **totalmente isolata** (storage e
-  sincronizzazione separati per istanza).
-- **Editor visuale** — ogni sezione ha la sua scheda: mappi le entità con la
-  lente 🔍, salvi, fatto. Niente YAML.
-- **Autorilevamento** — un click analizza le entità e i **registri di Home
-  Assistant** (piani, aree, dispositivi): stanze e piani si creano da soli, e
-  luci, clima e telecamere ereditano la stanza dalla loro area.
-- **Navbar intelligente** — a una plancia nuova compaiono solo **Home** e
-  **Config**; ogni sezione si accende da sola appena la popoli (e la puoi
-  forzare on/off con l'interruttore nella sua scheda).
-- **Bilingue** — italiano e inglese.
+- **Più plance indipendenti**: casa, tablet, ospiti o altri impianti, ciascuna
+  con URL, storage, sincronizzazione e impostazioni separati.
+- **Plancia nativa Home Assistant**: oltre al pannello laterale, DashboardModern
+  registra una plancia Lovelace che compare in **Impostazioni → Plance** e può
+  essere scelta come predefinita globale o personale.
+- **Accesso per utente**: ogni istanza può essere visibile a tutti oppure a una
+  lista precisa di utenti Home Assistant.
+- **Editor visuale**: configurazione senza YAML per Energia, EV, Solare,
+  Sicurezza, Temperatura, Clima, Luci, Elettrodomestici, Piscina, Irrigazione,
+  Tapparelle, Stanze, Avvisi e altre sezioni.
+- **Autorilevamento**: usa registri di piani, aree, dispositivi ed entità per
+  proporre stanze e associazioni senza sovrascrivere le scelte manuali.
+- **Responsive reale**: griglie fluide, misure con `clamp()`, `ResizeObserver`,
+  `visualViewport` e ricalcolo al cambio di orientamento o apertura di un fold.
+- **Bilingue**: interfaccia italiana e inglese.
 
 ## Installazione
 
-### Con HACS (consigliato)
+### HACS
 
-1. HACS → menu ⋮ → **Repository personalizzati** → aggiungi
-   `https://github.com/danigio15/dashboardmodern-v2` come **Integrazione**.
-2. Cerca **DashboardModern**, installa, **riavvia Home Assistant**.
-3. *Impostazioni → Dispositivi e servizi → Aggiungi integrazione →
-   DashboardModern* → scegli il **nome della plancia** → Invia.
-4. La plancia appare nella barra laterale.
+1. Apri **HACS → Repository personalizzati**.
+2. Aggiungi `https://github.com/danigio15/dashboardmodern-v2` come
+   **Integrazione**.
+3. Installa DashboardModern e riavvia Home Assistant.
+4. Vai in **Impostazioni → Dispositivi e servizi → Aggiungi integrazione**,
+   cerca DashboardModern e assegna un nome alla plancia.
+5. Apri una volta la nuova voce laterale con un account amministratore.
 
-### Manuale
+L'ultima apertura serve a creare o aggiornare automaticamente la plancia
+Lovelace associata. Non occorrono token, file in `www/` o risorse Lovelace
+manuali.
 
-Copia la cartella `custom_components/dashboardmodern` dentro
-`config/custom_components/`, riavvia, poi aggiungi l'integrazione come sopra.
+### Installazione manuale
 
-**Requisiti**: Home Assistant 2025.1 o successivo. Nessuna dipendenza esterna.
+Copia `custom_components/dashboardmodern` in
+`config/custom_components/dashboardmodern`, riavvia Home Assistant e aggiungi
+l'integrazione dall'interfaccia.
 
 ## Prima configurazione
 
-Alla prima apertura la plancia mostra il banner *"La dashboard è quasi
-pronta!"* e la navbar contiene solo **Home** e **Config**:
+1. Apri DashboardModern dalla barra laterale.
+2. Entra in **Config → Configura entità**.
+3. In **Impostazioni**, avvia **Autorilevamento**.
+4. Controlla le associazioni proposte e salva ogni sezione modificata.
+5. Configura gli elettrodomestici scegliendo stanza, entità e visuale: la stessa
+   visuale viene ora ereditata dal Report Energia.
 
-1. Tocca **⚙️ Configura la dashboard** (o Config → Configura Entità).
-2. In **Impostazioni** premi **🪄 Avvia Autorilevamento**: compila da solo
-   luci, stanze, piani, clima, telecamere e collegamenti.
-3. Rifinisci nelle schede delle singole sezioni: ogni entità ha la lente 🔍
-   per cercarla tra quelle del tuo HA.
-4. Le sezioni popolate compaiono da sole nella navbar.
+La navbar mostra automaticamente le sezioni che contengono dati. Le sezioni
+vuote restano nascoste, salvo una scelta manuale nell'editor.
 
-## Più plance
+## Plancia Home Assistant e preferita
 
-Ripeti *Aggiungi integrazione* per ogni plancia che vuoi (casa, casa dei
-genitori, taverna…). Ogni entry ha:
+Dalla versione 0.14.9 ogni istanza genera una plancia Lovelace con URL stabile
+`dashboardmodern-<id>`:
 
-- il **suo pannello** in sidebar (titolo = nome scelto; rinominandola da HA
-  pannello e URL si aggiornano da soli);
-- **storage e sincronizzazione isolati** — le configurazioni non si toccano
-  tra loro;
-- le **sue opzioni** (es. *visibile solo agli amministratori*).
+1. Apri DashboardModern una volta come amministratore.
+2. Vai in **Impostazioni → Plance**: trovi la plancia col nome dell'istanza.
+3. Dal menu della plancia puoi impostarla come predefinita per tutti.
+4. Ogni utente può scegliere la propria da **Profilo → Plancia**.
 
-La **prima plancia** installata è la *primaria*: mantiene l'URL storico e la
-chiave di sincronizzazione storica, quindi chi aggiorna da una versione
-precedente non perde nulla.
+La plancia generata non viene aggiunta automaticamente una seconda volta alla
+barra laterale, per evitare il duplicato del pannello DashboardModern. Puoi
+abilitarla manualmente dalle impostazioni della plancia.
 
-## L'editor, tab per tab
+## Utenti autorizzati
 
-| Tab | Cosa configuri |
+Apri **Impostazioni → Dispositivi e servizi → DashboardModern → Configura**.
+Per ciascuna istanza puoi impostare:
+
+- **Utenti autorizzati**: lista precisa degli account ammessi; lista vuota =
+  tutti gli utenti autenticati.
+- **Registra anche come plancia Home Assistant**: crea e mantiene la plancia
+  Lovelace selezionabile come predefinita.
+- **Solo amministratori**: filtro nativo Home Assistant, più restrittivo della
+  lista utenti.
+
+La visibilità della vista Lovelace segue la lista utenti e il custom element
+esegue anche un controllo diretto: un utente escluso non vede i contenuti
+neppure aprendo l'URL manualmente.
+
+Esempio: autorizza **Giovanni** nella plancia Casa e **Donato** nella plancia
+Ospiti; poi imposta per ciascun profilo la relativa plancia predefinita.
+
+## Editor e sezioni
+
+| Sezione | Funzioni principali |
 |---|---|
-| **⚙️ Impostazioni** | Nome/sottotitolo dashboard, utente admin, **ordine della navbar** (frecce ▲▼), **Autorilevamento** e **Reset totale**, riga di diagnostica |
-| **🏠 Home** | Meteo e allarme della schermata principale |
-| **⚡ Energia** | Le entità del quadro energia (rete, FV, batteria, casa…), le **viste** da mostrare (istantanea/giornaliera/mensile/report), **costo energia** €/kWh e le voci del **Report Analisi** |
-| **🚗 EV** | Entità dell'auto elettrica e **profili multi-auto**: mappa, salva col nome, e con 2+ profili in pagina Auto appare la tendina |
-| **🌞 Solare** | Solare termico / boiler |
-| **🛡️ Sicurezza** | Allarme **e telecamere** (multi-engine WebRTC/HLS/MJPEG) |
-| **🧺 Lavatrice / 🖥️ MiniPC** | Le rispettive entità |
-| **🌡️ Temperatura** | Stanze con sensori di temperatura/umidità |
-| **⚡ Azioni** | Azioni rapide della Home |
-| **❄️ Clima** | Unità climatizzazione, raggruppate per piano/stanza |
-| **Carichi** | Prese e carichi monitorati |
-| **🏊 Piscina** | Temperatura, pH/cloro, pompa con **programmazione filtrazione** (ore fisse o automatiche in base alla temperatura) |
-| **💧 Irrigazione** | Zone sequenziali con durata, orario giornaliero e **salto pioggia** |
-| **🪟 Tapparelle** | Cover con card animate, **Apri/Chiudi tutte**, avvisi "aperta" |
-| **Stanze / Luci / Elettrodom. / Avvisi** | Registro stanze e piani, gestione luci per stanza, elettrodomestici con soglie di potenza, Quadro Avvisi personalizzato |
+| Impostazioni | Titolo, navbar, autorilevamento, reset, diagnostica |
+| Energia | Flussi, costi, carichi secondari, report e storico |
+| Elettrodomestici | Entità, stanza, soglie, immagini e icone |
+| Luci | Associazione esplicita alla stanza; le stanze senza luci non sono renderizzate |
+| Temperatura | Card compatte con icona stanza leggibile, temperatura e umidità |
+| EV | Profili multipli e dati veicolo |
+| Sicurezza | Allarme e telecamere WebRTC/HLS/MJPEG |
+| Tapparelle | Stato, comandi e avvisi cover aperte |
+| Piscina / Irrigazione | Programmi, sensori e automazioni operative |
 
-In cima a **ogni** scheda di sezione c'è l'interruttore
-**🟢 Sezione visibile / ⚪ nascosta** che governa la linguetta in navbar.
+Il Report Energia usa `report_icon` quando definita; altrimenti deriva l'icona
+dalla visuale dell'elettrodomestico, ad esempio `mdi:fridge-outline` per il
+frigorifero e `mdi:stove` per il forno.
 
-## Autorilevamento
+## Responsive e dispositivi pieghevoli
 
-Il pulsante in Impostazioni esegue due passaggi:
+La dashboard non usa un'unica larghezza “mobile”. Distingue automaticamente:
 
-1. **Scansione entità** — riconosce luci, clima, telecamere, sensori e
-   compila le mappature più probabili.
-2. **Registri HA** — legge piani (*floor registry*), aree, dispositivi ed
-   entità: i piani diventano i tuoi piani, le aree diventano stanze (col loro
-   piano) e luci/clima/telecamere ereditano la stanza dell'area. **Non
-   sovrascrive mai** ciò che hai impostato a mano: riempie solo i vuoti.
+- **compact** fino a 420 px;
+- **fold** da 421 a 760 px;
+- **wide** oltre 760 px.
 
-## Visibilità delle sezioni e navbar
+Un `ResizeObserver` ricalcola il layout quando cambia la dimensione reale del
+viewport, quindi un Samsung Galaxy Z Fold passa dalla vista chiusa a quella
+aperta senza richiedere un ricaricamento. Le immagini degli elettrodomestici e
+le card Temperatura usano dimensioni fluide e non provocano scorrimento
+orizzontale.
 
-- Al primo avvio (nessuna scelta salvata) il motore **deriva la visibilità
-  dal contenuto reale**: sezioni popolate visibili, vuote nascoste. Una
-  plancia nuova mostra quindi solo Home e Config.
-- Quando una sezione **si popola** (mappi uno slot, aggiungi un'unità clima,
-  l'autorilevamento trova qualcosa) la sua linguetta **si accende da sola**.
-- L'interruttore nella scheda della sezione **vince sempre** sulle regole
-  automatiche.
-- L'**ordine** delle linguette si cambia da Impostazioni → *Ordine navbar*.
+## Aggiornamento e cache
 
-## Sincronizzazione e reset
+Gli asset frontend sono serviti da un percorso basato sul loro contenuto. A
+ogni aggiornamento il percorso cambia, incluse la card Lovelace e tutte le sue
+importazioni, evitando che una vecchia build resti nella cache.
 
-La configurazione vive nello storage del browser **e** su Home Assistant
-(`user_data`), quindi si sincronizza tra i tuoi dispositivi. Ogni plancia usa
-la **propria** chiave. **🗑️ Reset totale** (in Impostazioni) azzera solo la
-plancia corrente — locale e cloud — e non tocca le altre.
+Dopo un aggiornamento HACS:
+
+1. riavvia Home Assistant;
+2. ricarica la pagina o riapri l'app;
+3. apri DashboardModern una volta come amministratore per sincronizzare la
+   plancia Lovelace generata.
 
 ## Diagnostica
 
-In fondo a Impostazioni c'è una riga tipo:
+La scheda Impostazioni mostra versione, stato bridge, sincronizzazione,
+identificativo istanza e flag primaria. In una segnalazione allega:
 
-```
-v0.12.0-int | hosted:1 | bridge:1 | token:1 | sync:… | inst:01KY… | prim:1 | q:?dmi=… | key:…
-```
+- riga diagnostica;
+- versione Home Assistant e DashboardModern;
+- dispositivo/browser;
+- screenshot e passaggi per riprodurre.
 
-`inst` è l'istanza di storage della plancia, `prim` se è la primaria, `key`
-la chiave di sincronizzazione in uso. Se apri una issue, **allega questa
-riga**: dice quasi tutto.
+## Sviluppo e test
 
-## FAQ
-
-**La navbar mostra una sezione che non uso.** Apri la sua scheda nell'editor
-e tocca l'interruttore in cima.
-
-**Ho due plance e voglio configurazioni diverse.** È il comportamento di
-default: ogni plancia è isolata. Verifica con la riga di diagnostica che gli
-`inst` siano diversi.
-
-**Compare il toast "È disponibile una nuova versione del Frontend".** È di
-Home Assistant (il suo frontend), non della dashboard: premi Ricarica.
-
-**Posso usare la vecchia versione file-singolo?** Il progetto storico resta
-su [dashboardmodern](https://github.com/danigio15/dashboardmodern); questa
-integrazione è la sua evoluzione consigliata.
-
-## Per sviluppatori
-
-```
+```text
 custom_components/dashboardmodern/
-├── __init__.py / config_flow.py     # entry multiple, migrazione primaria
-├── frontend.py                      # pannelli per-entry, static versionato
+├── __init__.py
+├── config_flow.py
+├── frontend.py
 └── frontend/
-    ├── panel.js                     # custom element (tag versionato)
-    ├── src/legacy/host.js           # mount iframe, ?dmi/?dmp, bridge
-    └── legacy/                      # dashboard vendorizzata IT/EN + prelude
-scripts/
-├── vendor_legacy.py / vendor_features.py   # pipeline patch riproducibile
-└── make_logo.py                            # brand rigenerabile
-tests/ + frontend/tests/                    # pytest + node:test
+    ├── panel.js
+    ├── dashboard-card.js
+    ├── src/core/
+    ├── src/legacy/
+    └── legacy/
+tests/
 ```
 
-Il frontend è la dashboard storica **vendorizzata**: `vendor_legacy.py`
-applica a monte le patch dichiarate in `vendor_features.py` (ancore esatte,
-fail-fast, build byte-riproducibile). Test: `pytest` (integrazione) e
-`node --test` (bridge, storage namespace, motore navbar eseguito estratto dal
-file servito). Le release seguono [SemVer](https://semver.org): vedi
-[CHANGELOG.md](CHANGELOG.md).
+Comandi principali:
+
+```bash
+python -m pytest
+npm run check:inline-syntax
+npm run test:frontend
+npm run format:check
+npm run test:e2e
+```
+
+La release stabile viene pubblicata soltanto dopo test Python, frontend,
+hassfest, HACS e matrice Browser E2E verdi. Il pacchetto HACS è
+`dashboardmodern.zip` allegato alla release GitHub.
+
+Consulta [CHANGELOG.md](CHANGELOG.md) per le modifiche di ogni versione.
 
 ---
 

--- a/custom_components/dashboardmodern/config_flow.py
+++ b/custom_components/dashboardmodern/config_flow.py
@@ -8,13 +8,18 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
 from .const import DOMAIN, NAME
 
-# When true, only administrators see the dashboard panel. Home Assistant offers
-# no per-user panel visibility, so admin-only is the finest control available —
-# useful when the dashboard should not appear for guest or child accounts.
 OPTION_ADMIN_ONLY = "admin_only"
+OPTION_ALLOWED_USERS = "allowed_users"
+OPTION_REGISTER_LOVELACE = "register_lovelace_dashboard"
 
 
 class DashboardModernConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -28,9 +33,6 @@ class DashboardModernConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Create a DashboardModern config entry (one per plancia)."""
         if user_input is not None:
             name = (user_input.get("name") or NAME).strip() or NAME
-            # The first plancia ever created is the primary one: it keeps the
-            # historical panel URL and the historical cloud-sync key, so
-            # existing installations upgrade without losing anything.
             primary = not self._async_current_entries()
             return self.async_create_entry(
                 title=name, data={"name": name, "primary": primary}
@@ -49,15 +51,54 @@ class DashboardModernConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class DashboardModernOptionsFlow(config_entries.OptionsFlow):
-    """Options: who can see the dashboard panel."""
+    """Configure panel visibility and its companion Lovelace dashboard."""
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Let the user restrict the panel to administrators."""
+        """Choose who can open this plancia and register it as a dashboard."""
         if user_input is not None:
+            user_input[OPTION_ALLOWED_USERS] = list(
+                dict.fromkeys(user_input.get(OPTION_ALLOWED_USERS, []))
+            )
             return self.async_create_entry(title="", data=user_input)
 
-        current = self.config_entry.options.get(OPTION_ADMIN_ONLY, False)
-        schema = vol.Schema({vol.Optional(OPTION_ADMIN_ONLY, default=current): bool})
+        current_users = list(self.config_entry.options.get(OPTION_ALLOWED_USERS, []))
+        users = await self.hass.auth.async_get_users()
+        options: list[SelectOptionDict] = [
+            SelectOptionDict(label=user.name or user.id, value=user.id)
+            for user in users
+            if user.is_active and not user.system_generated
+        ]
+        known = {option["value"] for option in options}
+        options.extend(
+            SelectOptionDict(label=user_id, value=user_id)
+            for user_id in current_users
+            if user_id not in known
+        )
+
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    OPTION_ALLOWED_USERS,
+                    description={"suggested_value": current_users},
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        options=options,
+                        multiple=True,
+                        mode=SelectSelectorMode.DROPDOWN,
+                    )
+                ),
+                vol.Optional(
+                    OPTION_REGISTER_LOVELACE,
+                    default=self.config_entry.options.get(
+                        OPTION_REGISTER_LOVELACE, True
+                    ),
+                ): bool,
+                vol.Optional(
+                    OPTION_ADMIN_ONLY,
+                    default=self.config_entry.options.get(OPTION_ADMIN_ONLY, False),
+                ): bool,
+            }
+        )
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/dashboardmodern/frontend.py
+++ b/custom_components/dashboardmodern/frontend.py
@@ -14,17 +14,14 @@ if TYPE_CHECKING:
 
 DATA_STATIC_REGISTERED = "static_registered"
 DATA_STATIC_BASE_REGISTERED = "static_base_registered"
+DATA_DASHBOARD_CARD_REGISTERED = "dashboard_card_registered"
+DATA_PANEL_PATHS = "panel_paths"
 PANEL_URL_PATH = DOMAIN
 PANEL_COMPONENT_NAME = "dashboardmodern-panel"
 STATIC_URL_PATH = "/dashboardmodern_static"
 FRONTEND_DIR = Path(__file__).parent / "frontend"
 LEGACY_DIR = FRONTEND_DIR / "legacy"
 
-
-# .html covers the vendored legacy dashboard, so shipping a new one changes
-# the versioned mount and users get it without clearing anything.
-# Images too: a release that only changes an icon must still change the
-# versioned mount, or browsers keep serving the old one indefinitely.
 ASSET_SUFFIXES = frozenset(
     {
         ".js",
@@ -44,16 +41,7 @@ ASSET_SUFFIXES = frozenset(
 
 @lru_cache(maxsize=1)
 def _frontend_asset_version() -> str:
-    """Return a version that changes whenever a shipped frontend asset changes.
-
-    The version is derived from asset content rather than modification times so
-    that the same installed release always produces the same URL. HACS and git
-    both rewrite mtimes on download, which previously invalidated the browser
-    cache on every reinstall even when nothing had changed.
-
-    Assets are read once per Home Assistant process; shipped files do not change
-    while Home Assistant is running.
-    """
+    """Return a stable digest that changes whenever a frontend asset changes."""
     digest = hashlib.blake2b(digest_size=8)
     for path in sorted(
         path
@@ -71,21 +59,14 @@ def _versioned_static_url_path() -> str:
 
 
 def legacy_variants() -> list[str]:
-    """Return the vendored legacy dashboards that are actually shipped.
-
-    Vendoring is a separate step, so a checkout may legitimately have none.
-    The panel reads this instead of probing with a request that 404s.
-    """
+    """Return the vendored legacy dashboards that are actually shipped."""
     if not LEGACY_DIR.is_dir():
         return []
     return sorted(path.name for path in LEGACY_DIR.glob("dashboard*.html"))
 
 
-DATA_PANEL_PATHS = "panel_paths"
-
-
 def _entry_is_primary(hass: HomeAssistant, entry: Any) -> bool:
-    """Whether this entry is the primary plancia (historic URL and sync key)."""
+    """Whether this entry is the primary plancia."""
     if entry.data.get("primary"):
         return True
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -107,15 +88,40 @@ def _panel_url_path(hass: HomeAssistant, entry: Any, taken: set[str]) -> str:
     return path
 
 
+def _lovelace_url_path(entry: Any) -> str:
+    """Return the stable URL of the companion Lovelace dashboard."""
+    return f"dashboardmodern-{entry.entry_id[:8].lower()}"
+
+
+def _allowed_user_ids(entry: Any) -> list[str]:
+    """Return the exact user allow-list stored in the entry options."""
+    from .config_flow import OPTION_ALLOWED_USERS
+
+    value = entry.options.get(OPTION_ALLOWED_USERS, [])
+    if not isinstance(value, list):
+        return []
+    return [str(user_id) for user_id in value if user_id]
+
+
 def _panel_config(hass: HomeAssistant, entry: Any) -> dict[str, Any]:
     """Build the panel config snapshot for one plancia."""
+    from .config_flow import OPTION_ADMIN_ONLY, OPTION_REGISTER_LOVELACE
+
     static_url_path = _versioned_static_url_path()
     return {
         "entry_ids": [entry.entry_id],
         "instance_id": entry.entry_id,
+        "title": entry.title or "DashboardModern",
         "primary": _entry_is_primary(hass, entry),
         "static_base": static_url_path,
         "legacy_variants": legacy_variants(),
+        "allowed_user_ids": _allowed_user_ids(entry),
+        "register_lovelace_dashboard": bool(
+            entry.options.get(OPTION_REGISTER_LOVELACE, True)
+        ),
+        "admin_only": bool(entry.options.get(OPTION_ADMIN_ONLY, False)),
+        "lovelace_url_path": _lovelace_url_path(entry),
+        "dashboard_card_module": f"{static_url_path}/dashboard-card.js",
         "_panel_custom": {
             "name": f"{PANEL_COMPONENT_NAME}-{_frontend_asset_version()[:8]}",
             "embed_iframe": False,
@@ -128,7 +134,7 @@ def _panel_config(hass: HomeAssistant, entry: Any) -> dict[str, Any]:
 def _register_or_update_panel(
     hass: HomeAssistant, entry: Any, url_path: str, *, update: bool
 ) -> None:
-    """Register or update the panel for one plancia."""
+    """Register or update the custom panel for one plancia."""
     from homeassistant.components import frontend
 
     from .config_flow import OPTION_ADMIN_ONLY
@@ -141,6 +147,7 @@ def _register_or_update_panel(
         frontend_url_path=url_path,
         config=_panel_config(hass, entry),
         require_admin=bool(entry.options.get(OPTION_ADMIN_ONLY, False)),
+        show_in_sidebar=True,
         update=update,
     )
 
@@ -173,8 +180,6 @@ async def _ensure_static_registered(
             cache_headers=False,
         )
     ]
-    # The stable mount serves shared assets and must be registered exactly once
-    # per process; re-registering the same aiohttp route raises at runtime.
     if not domain_data.get(DATA_STATIC_BASE_REGISTERED):
         configs.insert(
             0,
@@ -190,14 +195,37 @@ async def _ensure_static_registered(
     domain_data[DATA_STATIC_REGISTERED] = static_url_path
 
 
+def _ensure_dashboard_card_registered(
+    hass: HomeAssistant, domain_data: dict[str, Any]
+) -> None:
+    """Load the companion custom card on every Home Assistant frontend page."""
+    from homeassistant.components import frontend
+
+    module_url = f"{_versioned_static_url_path()}/dashboard-card.js"
+    if domain_data.get(DATA_DASHBOARD_CARD_REGISTERED) == module_url:
+        return
+
+    manager = hass.data.get(frontend.DATA_EXTRA_MODULE_URL)
+    if manager is None:
+        return
+
+    previous = domain_data.get(DATA_DASHBOARD_CARD_REGISTERED)
+    if previous and previous in manager.urls:
+        manager.remove(previous)
+    if module_url not in manager.urls:
+        manager.add(module_url)
+    domain_data[DATA_DASHBOARD_CARD_REGISTERED] = module_url
+
+
 async def async_register_frontend(hass: HomeAssistant, entry_id: str) -> None:
-    """Register static assets and this plancia's own sidebar panel."""
+    """Register static assets, custom card and this plancia's sidebar panel."""
     domain_data: dict[str, Any] = hass.data.setdefault(DOMAIN, {})
     entry = hass.config_entries.async_get_entry(entry_id)
     if entry is None:
         return
 
     await _ensure_static_registered(hass, domain_data)
+    _ensure_dashboard_card_registered(hass, domain_data)
 
     paths: dict[str, str] = domain_data.setdefault(DATA_PANEL_PATHS, {})
     taken = {p for eid, p in paths.items() if eid != entry_id}

--- a/custom_components/dashboardmodern/frontend/dashboard-card.js
+++ b/custom_components/dashboardmodern/frontend/dashboard-card.js
@@ -1,0 +1,106 @@
+/* Full-screen Lovelace wrapper used by the generated DashboardModern dashboard. */
+import { legacyVariantForLocale, mountLegacyHost } from "./src/legacy/host.js";
+
+export function canAccess(config = {}, user = {}) {
+  const allowed = Array.isArray(config.allowed_user_ids)
+    ? config.allowed_user_ids.filter(Boolean)
+    : [];
+  return allowed.length === 0 || allowed.includes(user?.id);
+}
+
+export class DashboardModernCard extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this.host = null;
+    this.mountedKey = "";
+  }
+
+  setConfig(config) {
+    if (!config?.entry_id || !config?.static_base) {
+      throw new Error("DashboardModern requires entry_id and static_base.");
+    }
+    const previous = JSON.stringify(this._config || {});
+    this._config = { ...config };
+    if (previous !== JSON.stringify(this._config)) this.resetHost();
+    this.render();
+  }
+
+  set hass(value) {
+    this._hass = value;
+    this.render();
+  }
+
+  resetHost() {
+    this.host?.destroy();
+    this.host = null;
+    this.mountedKey = "";
+  }
+
+  renderDenied() {
+    this.resetHost();
+    const style = document.createElement("style");
+    style.textContent = `:host{display:grid;min-height:calc(100dvh - var(--header-height,56px));place-items:center;background:var(--primary-background-color)}section{display:grid;gap:12px;max-width:420px;margin:24px;padding:28px;border-radius:22px;background:var(--card-background-color);box-shadow:var(--ha-card-box-shadow);color:var(--primary-text-color);text-align:center}strong{font-size:1.4rem}span{color:var(--secondary-text-color)}`;
+    const section = document.createElement("section");
+    section.setAttribute("role", "alert");
+    section.innerHTML = `<strong>DashboardModern</strong><span>${
+      this._hass?.locale?.language?.startsWith("it")
+        ? "Questa plancia non è abilitata per il tuo utente."
+        : "This dashboard is not enabled for your user."
+    }</span>`;
+    this.shadowRoot.replaceChildren(style, section);
+  }
+
+  render() {
+    if (!this._config || !this._hass?.connection?.sendMessagePromise) return;
+    if (!canAccess(this._config, this._hass.user)) {
+      this.renderDenied();
+      return;
+    }
+    const variant = legacyVariantForLocale(this._hass?.locale?.language);
+    const key = `${this._config.entry_id}|${this._config.static_base}|${variant}`;
+    if (this.host && this.mountedKey === key) return;
+    this.resetHost();
+
+    const style = document.createElement("style");
+    style.textContent = `:host{display:block;width:100%;height:calc(100dvh - var(--header-height,56px));min-height:420px;overflow:hidden;background:var(--primary-background-color)}.surface{width:100%;height:100%;min-width:0;min-height:0}@media(max-width:600px){:host{height:calc(100dvh - var(--header-height,56px));min-height:320px}}`;
+    const surface = document.createElement("div");
+    surface.className = "surface";
+    this.shadowRoot.replaceChildren(style, surface);
+    this.host = mountLegacyHost(surface, {
+      hass: this._hass,
+      connection: this._hass.connection,
+      staticBase: this._config.static_base,
+      variant,
+      instanceId: this._config.entry_id,
+      primary: this._config.primary !== false,
+    });
+    this.mountedKey = key;
+  }
+
+  getCardSize() {
+    return 1;
+  }
+
+  getGridOptions() {
+    return { columns: "full", rows: "full" };
+  }
+
+  disconnectedCallback() {
+    this.resetHost();
+  }
+}
+
+if (!customElements.get("dashboardmodern-card")) {
+  customElements.define("dashboardmodern-card", DashboardModernCard);
+}
+
+window.customCards = window.customCards || [];
+if (!window.customCards.some((card) => card.type === "dashboardmodern-card")) {
+  window.customCards.push({
+    type: "dashboardmodern-card",
+    name: "DashboardModern",
+    description: "Full-screen DashboardModern integration view",
+    preview: false,
+  });
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0149-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0149-fixes.js
@@ -201,7 +201,7 @@ function installResponsiveClasses() {
   const root = document.documentElement;
   const apply = () => {
     const width = Math.round(globalThis.visualViewport?.width || root.clientWidth || innerWidth);
-    root.dataset.dmViewport = width <= 420 ? "compact" : width <= 760 ? "fold" : "wide";
+    root.dataset.dmViewport = width <= 420 ? "compact" : width <= 820 ? "fold" : "wide";
     root.style.setProperty("--dm-viewport-width", `${width}px`);
     requestAnimationFrame(() => {
       globalThis.renderTemperature?.();
@@ -238,7 +238,7 @@ function installStyles() {
     .dm-report-icon-preview{width:42px;height:42px;border-radius:14px;display:grid;place-items:center;background:#e0f2fe;color:#0369a1;align-self:end}
     .dm-appliance-art,.appl-main-view [data-appliance-asset],.appl-main-view img,.appl-main-view svg{max-width:clamp(86px,22vw,210px)!important;max-height:clamp(86px,22vw,210px)!important;width:auto!important;height:auto!important;object-fit:contain!important}
     [data-dm-viewport="fold"] .dashboard-grid,[data-dm-viewport="fold"] .cards-grid,[data-dm-viewport="fold"] .appl-grid{grid-template-columns:repeat(auto-fit,minmax(min(100%,220px),1fr))!important}
-    @media(max-width:760px){
+    @media(max-width:820px){
       .main,.page,.page-content{padding-inline:clamp(10px,3vw,18px)!important}
       #temp-grid{grid-template-columns:1fr!important}
       #temp-grid .temp-card.dm-temperature-card-0149{grid-template-columns:54px minmax(0,1fr)!important;padding:16px!important;border-radius:22px!important}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0149-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0149-fixes.js
@@ -243,6 +243,9 @@ function installStyles() {
       #temp-grid{grid-template-columns:1fr!important}
       #temp-grid .temp-card.dm-temperature-card-0149{grid-template-columns:54px minmax(0,1fr)!important;padding:16px!important;border-radius:22px!important}
       #temp-grid .dm-temperature-room-icon{width:50px!important;height:50px!important;border-radius:16px!important}
+      #dp-report .dm-report-row,#dp-reports .dm-report-row,.dm-editor-report .dm-report-row{display:grid!important;grid-template-columns:44px minmax(0,1fr)!important;gap:10px!important}
+      #dp-report .dm-report-row>label,#dp-report .dm-report-row>.dm-icon-field,#dp-report .dm-report-row>.dm-entity-field,#dp-report .dm-report-row>span,#dp-reports .dm-report-row>label,#dp-reports .dm-report-row>.dm-icon-field,#dp-reports .dm-report-row>.dm-entity-field,#dp-reports .dm-report-row>span,.dm-editor-report .dm-report-row>label,.dm-editor-report .dm-report-row>.dm-icon-field,.dm-editor-report .dm-report-row>.dm-entity-field,.dm-editor-report .dm-report-row>span{grid-column:2!important;width:100%!important;min-width:0!important}
+      #dp-report .dm-report-row>.dm-report-icon-preview,#dp-reports .dm-report-row>.dm-report-icon-preview,.dm-editor-report .dm-report-row>.dm-report-icon-preview{grid-column:1!important;grid-row:1 / span 2!important}
       .dm-report-row{display:grid!important;grid-template-columns:44px minmax(0,1fr)!important;gap:10px!important}
       .dm-report-row>label,.dm-report-row>.dm-icon-field,.dm-report-row>.dm-entity-field,.dm-report-row>span{grid-column:2!important;width:100%!important;min-width:0!important}
       .dm-report-icon-preview{grid-column:1!important;grid-row:1 / span 2!important}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0149-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0149-fixes.js
@@ -1,0 +1,293 @@
+/* DashboardModern 0.14.9: room fidelity, report visuals and adaptive layouts. */
+const RELEASE_0149_FLAG = "__DASHBOARDMODERN_RELEASE_0149__";
+
+const ICON_BY_TYPE = Object.freeze({
+  forno: "mdi:stove",
+  oven: "mdi:stove",
+  frigo: "mdi:fridge-outline",
+  frigorifero: "mdi:fridge-outline",
+  fridge: "mdi:fridge-outline",
+  congelatore: "mdi:fridge-bottom",
+  freezer: "mdi:fridge-bottom",
+  lavatrice: "mdi:washing-machine",
+  washer: "mdi:washing-machine",
+  lavastoviglie: "mdi:dishwasher",
+  dishwasher: "mdi:dishwasher",
+  asciugatrice: "mdi:tumble-dryer",
+  dryer: "mdi:tumble-dryer",
+  microonde: "mdi:microwave",
+  microwave: "mdi:microwave",
+  boiler: "mdi:water-boiler",
+  scaldabagno: "mdi:water-boiler",
+  tv: "mdi:television",
+  condizionatore: "mdi:air-conditioner",
+  ventilatore: "mdi:fan",
+  robot: "mdi:robot-vacuum",
+  aspirapolvere: "mdi:vacuum",
+});
+
+export function normalizedToken(value) {
+  return String(value || "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function applianceReportIcon(item = {}) {
+  const explicit = item.report_icon || item.emoji_icon || item.icon;
+  if (explicit) return explicit;
+  const values = [item.visual_key, item.device_type, item.type, item.name].map(normalizedToken);
+  for (const value of values) {
+    if (ICON_BY_TYPE[value]) return ICON_BY_TYPE[value];
+    const key = Object.keys(ICON_BY_TYPE).find((candidate) => value.includes(candidate));
+    if (key) return ICON_BY_TYPE[key];
+  }
+  return "mdi:flash";
+}
+
+function readJson(key, fallback) {
+  try {
+    return JSON.parse(localStorage.getItem(key)) ?? fallback;
+  } catch (_error) {
+    return fallback;
+  }
+}
+
+function writeJson(key, value) {
+  localStorage.setItem(key, JSON.stringify(value));
+  try {
+    globalThis.cdMarkDirty?.();
+    globalThis.cdSyncPush?.();
+  } catch (_error) {}
+}
+
+function store() {
+  return globalThis.DashboardModernModules?.store;
+}
+
+function rooms() {
+  return store()?.getSection?.("rooms") || readJson("cd_stanze", []);
+}
+
+function resolveRoom(reference) {
+  const value = String(reference || "").trim();
+  if (!value) return null;
+  const target = normalizedToken(value).replace(/^room_/, "");
+  return rooms().find((room) => {
+    const id = normalizedToken(room.id).replace(/^room_/, "");
+    const name = normalizedToken(room.name);
+    return room.id === value || id === target || name === target;
+  }) || null;
+}
+
+function lightEntity(light = {}) {
+  return String(light.entity || light.entity_id || light.entities?.[0] || "").trim();
+}
+
+async function persistLightRoom(entityId, roomReference) {
+  const room = resolveRoom(roomReference);
+  if (!entityId || !room) return false;
+  const assignments = readJson("cd_luci_rooms", {});
+  if (assignments[entityId] !== room.id) {
+    assignments[entityId] = room.id;
+    writeJson("cd_luci_rooms", assignments);
+  }
+
+  const dataStore = store();
+  if (!dataStore?.getSection || !dataStore?.updateItem) return true;
+  const light = dataStore.getSection("lights").find((item) => lightEntity(item) === entityId);
+  if (light && light.room_id !== room.id) {
+    await dataStore.updateItem("lights", light.id, { ...light, room_id: room.id });
+  }
+  return true;
+}
+
+function repairLightAssignments() {
+  const dataStore = store();
+  if (!dataStore?.getSection) return;
+  const assignments = readJson("cd_luci_rooms", {});
+  let changed = false;
+  for (const light of dataStore.getSection("lights") || []) {
+    const entityId = lightEntity(light);
+    const explicit = resolveRoom(light.room_id || light.room);
+    if (entityId && explicit && assignments[entityId] !== explicit.id) {
+      assignments[entityId] = explicit.id;
+      changed = true;
+    }
+  }
+  if (changed) writeJson("cd_luci_rooms", assignments);
+}
+
+function installLightRoomHook() {
+  const original = globalThis.cdLuciSetRoom;
+  if (typeof original !== "function" || original.__dm0149) return false;
+  const wrapped = function cdLuciSetRoom0149(entityId, roomReference) {
+    const result = original.apply(this, arguments);
+    Promise.resolve(result)
+      .then(() => persistLightRoom(entityId, roomReference))
+      .then(() => {
+        globalThis.renderLuci?.();
+        globalThis.renderLights?.();
+      })
+      .catch((error) => console.warn("[DashboardModern] light room save", error));
+    return result;
+  };
+  wrapped.__dm0149 = true;
+  wrapped.__previous = original;
+  globalThis.cdLuciSetRoom = wrapped;
+  return true;
+}
+
+function hideEmptyLightRooms() {
+  const root = document.getElementById("page-luci") || document.getElementById("page-lights");
+  if (!root) return;
+  const candidates = root.querySelectorAll(
+    "[data-room-id], [data-light-room], .luci-room, .light-room, .room-section, .room-group",
+  );
+  candidates.forEach((section) => {
+    const entities = section.querySelectorAll(
+      "[data-entity-id], [data-light-entity], .light-card, .l-card, .luce-card, button[data-entity]",
+    );
+    const nestedRooms = section.querySelector("[data-room-id] [data-room-id]");
+    if (!nestedRooms) section.hidden = entities.length === 0;
+  });
+}
+
+function decorateReportIcons() {
+  const appliances = store()?.getSection?.("appliances") || [];
+  const loads = store()?.getSection?.("loads") || [];
+  const byId = new Map([...appliances, ...loads].map((item) => [String(item.id), item]));
+  document.querySelectorAll("[data-report-id]").forEach((row) => {
+    const item = byId.get(String(row.dataset.reportId));
+    if (!item) return;
+    const icon = applianceReportIcon(item);
+    const input = row.querySelector(".dm-icon-field input, [data-icon-field] input, [data-report-icon]");
+    if (input && !input.value) {
+      input.value = icon;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+    row.dataset.reportIcon = icon;
+    let preview = row.querySelector(".dm-report-icon-preview");
+    if (!preview) {
+      preview = document.createElement("span");
+      preview.className = "dm-report-icon-preview";
+      row.prepend(preview);
+    }
+    preview.innerHTML = globalThis.cdIconMarkup?.(icon, 24) || icon;
+  });
+}
+
+function decorateTemperatureCards() {
+  const configured = (store()?.getSection?.("rooms") || []).filter((room) => room.temp);
+  document.querySelectorAll("#temp-grid .temp-card").forEach((card, index) => {
+    const name = card.querySelector(".cp-name")?.textContent?.trim();
+    const room = configured.find((item) => item.name === name) || configured[index];
+    if (!room) return;
+    card.classList.add("dm-temperature-card-0149");
+    card.dataset.roomId = room.id || "";
+    const icon = card.querySelector(".cp-icon");
+    if (icon) {
+      const value = room.icon || "mdi:thermometer";
+      icon.classList.add("dm-temperature-room-icon");
+      icon.innerHTML = globalThis.cdIconMarkup?.(value, 30) || "🌡️";
+      icon.setAttribute("aria-label", room.name || "Temperature");
+    }
+  });
+}
+
+function installResponsiveClasses() {
+  const root = document.documentElement;
+  const apply = () => {
+    const width = Math.round(globalThis.visualViewport?.width || root.clientWidth || innerWidth);
+    root.dataset.dmViewport = width <= 420 ? "compact" : width <= 760 ? "fold" : "wide";
+    root.style.setProperty("--dm-viewport-width", `${width}px`);
+    requestAnimationFrame(() => {
+      globalThis.renderTemperature?.();
+      globalThis.renderApplianceSection?.();
+      hideEmptyLightRooms();
+      decorateTemperatureCards();
+    });
+  };
+  if (typeof ResizeObserver === "function") {
+    const observer = new ResizeObserver(apply);
+    observer.observe(root);
+  } else {
+    globalThis.addEventListener("resize", apply, { passive: true });
+  }
+  globalThis.visualViewport?.addEventListener("resize", apply, { passive: true });
+  globalThis.addEventListener("orientationchange", apply, { passive: true });
+  apply();
+}
+
+function installStyles() {
+  if (document.getElementById("dm-release-0149-styles")) return;
+  const style = document.createElement("style");
+  style.id = "dm-release-0149-styles";
+  style.textContent = `
+    html,body{max-width:100%;overflow-x:hidden}
+    #app,.app,.page,.page-content{min-width:0;max-width:100%}
+    #temp-grid{display:grid!important;grid-template-columns:repeat(auto-fit,minmax(min(100%,260px),1fr))!important;gap:clamp(12px,2vw,22px)!important;align-items:stretch}
+    #temp-grid .temp-card.dm-temperature-card-0149{box-sizing:border-box!important;width:100%!important;min-width:0!important;max-width:none!important;aspect-ratio:auto!important;display:grid!important;grid-template-columns:64px minmax(0,1fr)!important;grid-template-areas:"icon title" "icon values"!important;gap:6px 16px!important;align-items:center!important;padding:clamp(18px,3vw,26px)!important;border-radius:26px!important;background:linear-gradient(145deg,rgba(255,255,255,.98),rgba(246,250,255,.94))!important;box-shadow:0 18px 45px rgba(15,23,42,.12)!important}
+    #temp-grid .dm-temperature-room-icon{grid-area:icon!important;width:58px!important;height:58px!important;border-radius:19px!important;display:grid!important;place-items:center!important;background:linear-gradient(145deg,#e0f2fe,#dbeafe)!important;color:#0284c7!important;overflow:hidden!important}
+    #temp-grid .dm-temperature-room-icon ha-icon{width:32px!important;height:32px!important}
+    #temp-grid .cp-name{grid-area:title!important;margin:0!important;font-size:clamp(16px,2vw,20px)!important;font-weight:800!important;text-transform:none!important;white-space:nowrap!important;overflow:hidden!important;text-overflow:ellipsis!important}
+    #temp-grid .temp-value,#temp-grid .cp-values,#temp-grid .temp-metrics{grid-area:values!important}
+    .dm-report-row{grid-template-columns:auto minmax(120px,1fr) minmax(120px,.65fr) minmax(220px,1.4fr) auto!important;align-items:end!important}
+    .dm-report-icon-preview{width:42px;height:42px;border-radius:14px;display:grid;place-items:center;background:#e0f2fe;color:#0369a1;align-self:end}
+    .dm-appliance-art,.appl-main-view [data-appliance-asset],.appl-main-view img,.appl-main-view svg{max-width:clamp(86px,22vw,210px)!important;max-height:clamp(86px,22vw,210px)!important;width:auto!important;height:auto!important;object-fit:contain!important}
+    [data-dm-viewport="fold"] .dashboard-grid,[data-dm-viewport="fold"] .cards-grid,[data-dm-viewport="fold"] .appl-grid{grid-template-columns:repeat(auto-fit,minmax(min(100%,220px),1fr))!important}
+    @media(max-width:760px){
+      .main,.page,.page-content{padding-inline:clamp(10px,3vw,18px)!important}
+      #temp-grid{grid-template-columns:1fr!important}
+      #temp-grid .temp-card.dm-temperature-card-0149{grid-template-columns:54px minmax(0,1fr)!important;padding:16px!important;border-radius:22px!important}
+      #temp-grid .dm-temperature-room-icon{width:50px!important;height:50px!important;border-radius:16px!important}
+      .dm-report-row{display:grid!important;grid-template-columns:44px minmax(0,1fr)!important;gap:10px!important}
+      .dm-report-row>label,.dm-report-row>.dm-icon-field,.dm-report-row>.dm-entity-field,.dm-report-row>span{grid-column:2!important;width:100%!important;min-width:0!important}
+      .dm-report-icon-preview{grid-column:1!important;grid-row:1 / span 2!important}
+      .dm-appliance-art,.appl-main-view [data-appliance-asset],.appl-main-view img,.appl-main-view svg{max-width:clamp(72px,28vw,132px)!important;max-height:clamp(72px,28vw,132px)!important}
+    }
+    @media(max-width:420px){
+      #temp-grid .temp-card.dm-temperature-card-0149{grid-template-columns:46px minmax(0,1fr)!important;gap:4px 12px!important;padding:14px!important}
+      #temp-grid .dm-temperature-room-icon{width:44px!important;height:44px!important;border-radius:14px!important}
+      .dm-appliance-art,.appl-main-view [data-appliance-asset],.appl-main-view img,.appl-main-view svg{max-width:96px!important;max-height:96px!important}
+      .navbar,.bottom-nav{max-width:100vw!important;overflow-x:auto!important;scrollbar-width:none}
+    }
+  `;
+  document.head.append(style);
+}
+
+function decorateAll() {
+  installLightRoomHook();
+  repairLightAssignments();
+  hideEmptyLightRooms();
+  decorateReportIcons();
+  decorateTemperatureCards();
+}
+
+function install() {
+  if (globalThis[RELEASE_0149_FLAG]?.installed) return;
+  globalThis[RELEASE_0149_FLAG] = { installed: true };
+  installStyles();
+  installResponsiveClasses();
+  let frame = 0;
+  const schedule = () => {
+    cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(decorateAll);
+  };
+  new MutationObserver(schedule).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["class", "data-room-id"],
+  });
+  globalThis.addEventListener("dashboardmodern:legacy-ready", schedule);
+  setInterval(decorateAll, 1200);
+  schedule();
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", install, { once: true });
+  else install();
+}

--- a/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
@@ -1,4 +1,4 @@
-/* Responsive Report editor and 0.14.7 regression fixes. */
+/* Responsive Report editor and runtime regression fixes. */
 import "./release-0147-fixes.js";
 import "./release-0147-store-fixes.js";
 import "./release-0147-dom-compat.js";
@@ -12,12 +12,13 @@ import "./real-ha-0147-layout-lock.js";
 import "./real-ha-0147-data-repair.js";
 import "./real-ha-0147-alert-compat.js";
 import "./real-ha-0147-popup-layout.js";
+import "./release-0149-fixes.js";
 
 function installReportCompatibilityMarker() {
   if (document.getElementById("dm-report-mobile-fixes")) return;
   const marker = document.createElement("style");
   marker.id = "dm-report-mobile-fixes";
-  marker.textContent = "/* Layout rules are installed by release-0147-fixes.js. */";
+  marker.textContent = "/* Layout rules are installed by the release compatibility modules. */";
   document.head.append(marker);
 }
 

--- a/custom_components/dashboardmodern/frontend/panel.js
+++ b/custom_components/dashboardmodern/frontend/panel.js
@@ -1,25 +1,113 @@
-/*
- * DashboardModern panel.
- *
- * One job: serve the dashboardmodern HTML dashboard, hosted by the integration
- * so there is no file for the user to save and extract. The panel mounts the
- * vendored HTML in a same-origin iframe and gives it an authenticated
- * connection through a WebSocket shim — no token is written anywhere, so the
- * user's own iframe plancia keeps its own token untouched.
- *
- * There is deliberately no native renderer here. New features are added inside
- * the HTML dashboard itself, applied as reproducible patches by
- * scripts/vendor_legacy.py.
- */
-
+/* DashboardModern custom panel and companion Lovelace dashboard registration. */
 import { legacyVariantForLocale, mountLegacyHost } from "./src/legacy/host.js";
 
-/** Choose which vendored HTML variant to serve, from what the backend reports. */
+const dashboardJobs = new Map();
+
 export function resolveLegacyVariant(panel, hass) {
   const variants = panel?.config?.legacy_variants;
   if (!Array.isArray(variants) || variants.length === 0) return null;
   const preferred = legacyVariantForLocale(hass?.locale?.language);
   return variants.includes(preferred) ? preferred : variants[0];
+}
+
+export function userCanAccess(config = {}, user = {}) {
+  const allowed = Array.isArray(config.allowed_user_ids)
+    ? config.allowed_user_ids.filter(Boolean)
+    : [];
+  return allowed.length === 0 || allowed.includes(user?.id);
+}
+
+function dashboardView(config) {
+  const allowed = Array.isArray(config.allowed_user_ids)
+    ? config.allowed_user_ids.filter(Boolean)
+    : [];
+  const visible = allowed.length ? allowed.map((user) => ({ user })) : true;
+  return {
+    title: config.title || "DashboardModern",
+    path: "home",
+    type: "panel",
+    panel: true,
+    visible,
+    cards: [
+      {
+        type: "custom:dashboardmodern-card",
+        entry_id: config.entry_ids?.[0] || config.instance_id,
+        title: config.title || "DashboardModern",
+        primary: config.primary !== false,
+        static_base: config.static_base,
+        allowed_user_ids: allowed,
+      },
+    ],
+  };
+}
+
+async function listDashboards(hass) {
+  return hass.connection.sendMessagePromise({ type: "lovelace/dashboards/list" });
+}
+
+export async function ensureCompanionDashboard(hass, panel) {
+  const config = panel?.config || {};
+  if (
+    !config.register_lovelace_dashboard ||
+    !config.lovelace_url_path ||
+    !config.static_base ||
+    !hass?.user?.is_admin ||
+    !hass.connection?.sendMessagePromise
+  ) {
+    return null;
+  }
+
+  const entryId = config.entry_ids?.[0] || config.instance_id || config.lovelace_url_path;
+  const signature = JSON.stringify([
+    entryId,
+    config.title,
+    config.primary,
+    config.static_base,
+    config.allowed_user_ids,
+    config.admin_only,
+  ]);
+  const key = `${entryId}:${signature}`;
+  if (dashboardJobs.has(key)) return dashboardJobs.get(key);
+
+  const job = (async () => {
+    let dashboards = await listDashboards(hass);
+    let dashboard = dashboards.find((item) => item.url_path === config.lovelace_url_path);
+    if (!dashboard) {
+      try {
+        dashboard = await hass.connection.sendMessagePromise({
+          type: "lovelace/dashboards/create",
+          title: config.title || "DashboardModern",
+          icon: "mdi:view-dashboard-edit",
+          url_path: config.lovelace_url_path,
+          show_in_sidebar: false,
+          require_admin: Boolean(config.admin_only),
+        });
+      } catch (error) {
+        dashboards = await listDashboards(hass);
+        dashboard = dashboards.find((item) => item.url_path === config.lovelace_url_path);
+        if (!dashboard) throw error;
+      }
+    } else if (dashboard.title !== config.title) {
+      dashboard = await hass.connection.sendMessagePromise({
+        type: "lovelace/dashboards/update",
+        dashboard_id: dashboard.id,
+        title: config.title || "DashboardModern",
+        require_admin: Boolean(config.admin_only),
+      });
+    }
+
+    await hass.connection.sendMessagePromise({
+      type: "lovelace/config/save",
+      url_path: config.lovelace_url_path,
+      config: { views: [dashboardView(config)] },
+    });
+    return dashboard;
+  })().catch((error) => {
+    console.warn("[DashboardModern] companion dashboard registration failed", error);
+    return null;
+  });
+  dashboardJobs.set(key, job);
+  return job;
 }
 
 export class DashboardModernPanel extends HTMLElement {
@@ -39,19 +127,38 @@ export class DashboardModernPanel extends HTMLElement {
     const prevEntry = this._panel?.config?.entry_ids?.[0];
     this._panel = value;
     const nextEntry = value?.config?.entry_ids?.[0];
-    // Home Assistant reuses one custom element for panels sharing a
-    // component name: switching plancia must tear the old frame down and
-    // mount the new one, or every panel shows the first dashboard.
-    if (this.mounted && nextEntry && prevEntry !== nextEntry) {
-      this.host?.destroy();
-      this.host = null;
-      this.mounted = false;
-    }
+    if (this.mounted && nextEntry && prevEntry !== nextEntry) this.resetHost();
     this.bootstrap();
   }
 
+  resetHost() {
+    this.host?.destroy();
+    this.host = null;
+    this.mounted = false;
+  }
+
+  renderDenied() {
+    this.resetHost();
+    const denied = document.createElement("section");
+    denied.setAttribute("role", "alert");
+    denied.innerHTML = `<strong>DashboardModern</strong><span>${
+      this._hass?.locale?.language?.startsWith("it")
+        ? "Questa plancia non è abilitata per il tuo utente."
+        : "This dashboard is not enabled for your user."
+    }</span>`;
+    const style = document.createElement("style");
+    style.textContent = `:host{display:grid;min-height:100%;place-items:center;background:var(--primary-background-color)}section{display:grid;gap:12px;max-width:420px;margin:24px;padding:28px;border-radius:22px;background:var(--card-background-color);box-shadow:var(--ha-card-box-shadow);color:var(--primary-text-color);text-align:center}strong{font-size:1.4rem}span{color:var(--secondary-text-color)}`;
+    this.shadowRoot.replaceChildren(style, denied);
+  }
+
   bootstrap() {
-    if (!this._hass || !this._panel || this.mounted) return;
+    if (!this._hass || !this._panel) return;
+    ensureCompanionDashboard(this._hass, this._panel);
+    if (!userCanAccess(this._panel.config, this._hass.user)) {
+      this.renderDenied();
+      return;
+    }
+    if (this.mounted) return;
     const variant = resolveLegacyVariant(this._panel, this._hass);
     const staticBase = this._panel.config?.static_base;
     if (!variant || !staticBase || !this._hass.connection?.sendMessagePromise) return;
@@ -59,45 +166,32 @@ export class DashboardModernPanel extends HTMLElement {
     this.mounted = true;
     this.style.display = "block";
     this.style.height = "100%";
-
     const surface = document.createElement("div");
-    surface.style.width = "100%";
-    surface.style.height = "100%";
+    surface.style.cssText = "width:100%;height:100%;min-height:0";
     this.shadowRoot.replaceChildren(surface);
-
     this.host = mountLegacyHost(surface, {
       hass: this._hass,
       connection: this._hass.connection,
       staticBase,
       variant,
-      // Each plancia (config entry) gets its own storage namespace, so
-      // multiple panels never share cd_* keys; the historical fallback keeps
-      // pre-multi installations on their existing namespace.
       instanceId:
         (this._panel.config?.entry_ids && this._panel.config.entry_ids[0]) ||
         "integration",
-      // The primary plancia keeps the historical cloud-sync key.
       primary: this._panel.config?.primary !== false,
     });
   }
 
   disconnectedCallback() {
-    this.host?.destroy();
-    this.host = null;
-    this.mounted = false;
+    this.resetHost();
   }
 }
 
 const PANEL_TAG = (() => {
   try {
     const m = /dashboardmodern_static\/([a-z0-9]+)\//.exec(import.meta.url);
-    if (m && m[1]) return `dashboardmodern-panel-${m[1].slice(0, 8)}`;
-  } catch (e) {
-    /* fall through to the unversioned tag */
-  }
+    if (m?.[1]) return `dashboardmodern-panel-${m[1].slice(0, 8)}`;
+  } catch (_error) {}
   return "dashboardmodern-panel";
 })();
 
-if (!customElements.get(PANEL_TAG)) {
-  customElements.define(PANEL_TAG, DashboardModernPanel);
-}
+if (!customElements.get(PANEL_TAG)) customElements.define(PANEL_TAG, DashboardModernPanel);

--- a/custom_components/dashboardmodern/frontend/src/core/energy-projection.js
+++ b/custom_components/dashboardmodern/frontend/src/core/energy-projection.js
@@ -1,5 +1,6 @@
 import "../../legacy/mobile-ui-fixes.js";
 import "../../legacy/report-mobile-fixes.js";
+import { getDeviceVisual } from "./device-model.js";
 
 export const ENERGY_SLOT_MAP = Object.freeze({
   "house.power": "dm.energy_potenza_consumo_casa",
@@ -20,6 +21,50 @@ export const ENERGY_SLOT_MAP = Object.freeze({
   "battery.daily_charged_energy": "dm.energy_batteria_caricata_oggi",
   "battery.monthly_charged_energy": "dm.energy_batteria_caricata_mese",
 });
+
+const REPORT_ICON_BY_TYPE = Object.freeze({
+  forno: "mdi:stove",
+  oven: "mdi:stove",
+  frigo: "mdi:fridge-outline",
+  frigorifero: "mdi:fridge-outline",
+  fridge: "mdi:fridge-outline",
+  refrigerator: "mdi:fridge-outline",
+  congelatore: "mdi:fridge-bottom",
+  freezer: "mdi:fridge-bottom",
+  lavatrice: "mdi:washing-machine",
+  washer: "mdi:washing-machine",
+  washing_machine: "mdi:washing-machine",
+  lavastoviglie: "mdi:dishwasher",
+  dishwasher: "mdi:dishwasher",
+  asciugatrice: "mdi:tumble-dryer",
+  dryer: "mdi:tumble-dryer",
+  microonde: "mdi:microwave",
+  microwave: "mdi:microwave",
+  boiler: "mdi:water-boiler",
+  scaldabagno: "mdi:water-boiler",
+  tv: "mdi:television",
+  televisore: "mdi:television",
+  condizionatore: "mdi:air-conditioner",
+  climatizzatore: "mdi:air-conditioner",
+  ventilatore: "mdi:fan",
+  fan: "mdi:fan",
+  robot: "mdi:robot-vacuum",
+  aspirapolvere: "mdi:vacuum",
+  piano_cottura: "mdi:stove",
+  cappa: "mdi:fan",
+  caffe: "mdi:coffee-maker",
+  bollitore: "mdi:kettle",
+  tostapane: "mdi:toaster",
+});
+
+function normalizedToken(value) {
+  return String(value || "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
 
 export function projectEnergySlots(energy = {}, overrides = {}) {
   const result = { ...overrides };
@@ -91,6 +136,29 @@ export function reportEntityForDevice(item = {}, states = globalThis.STATES || {
   );
 }
 
+/** Resolve the Report icon from the visual/type selected in Appliances. */
+export function reportIconForDevice(item = {}) {
+  const explicit = String(item.report_icon || item.emoji_icon || item.icon || "").trim();
+  if (explicit) return explicit;
+
+  const candidates = [
+    item.visual_key,
+    item.device_type,
+    item.type,
+    item.category,
+    item.name,
+  ].map(normalizedToken);
+  for (const candidate of candidates) {
+    if (REPORT_ICON_BY_TYPE[candidate]) return REPORT_ICON_BY_TYPE[candidate];
+    const match = Object.keys(REPORT_ICON_BY_TYPE).find((key) => candidate.includes(key));
+    if (match) return REPORT_ICON_BY_TYPE[match];
+  }
+
+  const visual = getDeviceVisual(item);
+  if (visual?.kind === "icon" && visual.value) return visual.value;
+  return "mdi:flash";
+}
+
 export function canonicalReportDevices(
   appliances = [],
   loads = [],
@@ -106,10 +174,14 @@ export function canonicalReportDevices(
     .sort((a, b) => (a.report_order ?? a.order ?? 0) - (b.report_order ?? b.order ?? 0))
     .map((item, index) => {
       const entity = reportEntityForDevice(item, states);
+      const visual = getDeviceVisual(item);
       return {
         key: item.id || `report-${index}`,
         name: item.report_label || item.name || item.id,
-        icon: item.report_icon || item.emoji_icon || item.icon || "⚡",
+        icon: reportIconForDevice(item),
+        visual,
+        visual_key: item.visual_key || "",
+        image: visual?.kind === "image" ? visual.value : "",
         entity,
         history: item.history_entity || entity,
       };

--- a/custom_components/dashboardmodern/frontend/tests/energy-report-inference.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energy-report-inference.test.js
@@ -23,7 +23,10 @@ test("infers a report entity from a generic kWh appliance entity", () => {
     {
       key: "appliance-forno",
       name: "Forno",
-      icon: "⚡",
+      icon: "mdi:stove",
+      visual: { kind: "icon", value: "mdi:devices" },
+      visual_key: "",
+      image: "",
       entity: "sensor.forno_consumo",
       history: "sensor.forno_consumo",
     },

--- a/custom_components/dashboardmodern/frontend/tests/release-0149.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-0149.test.js
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applianceReportIcon,
+  normalizedToken,
+} from "../legacy/release-0149-fixes.js";
+
+const originalHTMLElement = globalThis.HTMLElement;
+const originalCustomElements = globalThis.customElements;
+if (!globalThis.HTMLElement) globalThis.HTMLElement = class {};
+if (!globalThis.customElements) {
+  const registry = new Map();
+  globalThis.customElements = {
+    define: (name, value) => registry.set(name, value),
+    get: (name) => registry.get(name),
+  };
+}
+
+const { ensureCompanionDashboard, userCanAccess } = await import("../panel.js");
+
+test("report icon follows the appliance visual when no report override exists", () => {
+  assert.equal(applianceReportIcon({ visual_key: "frigo" }), "mdi:fridge-outline");
+  assert.equal(applianceReportIcon({ device_type: "forno" }), "mdi:stove");
+  assert.equal(
+    applianceReportIcon({ visual_key: "frigo", report_icon: "mdi:snowflake" }),
+    "mdi:snowflake",
+  );
+  assert.equal(normalizedToken("Piano cottura"), "piano_cottura");
+});
+
+test("user allow-list is exact and an empty list means every authenticated user", () => {
+  assert.equal(userCanAccess({ allowed_user_ids: [] }, { id: "giovanni" }), true);
+  assert.equal(
+    userCanAccess({ allowed_user_ids: ["giovanni"] }, { id: "giovanni" }),
+    true,
+  );
+  assert.equal(
+    userCanAccess({ allowed_user_ids: ["giovanni"] }, { id: "donato" }),
+    false,
+  );
+});
+
+test("admin bootstrap creates a Lovelace dashboard with per-user view visibility", async () => {
+  const messages = [];
+  const hass = {
+    user: { id: "admin", is_admin: true },
+    connection: {
+      async sendMessagePromise(message) {
+        messages.push(structuredClone(message));
+        if (message.type === "lovelace/dashboards/list") return [];
+        if (message.type === "lovelace/dashboards/create") {
+          return { id: "dash-id", url_path: message.url_path, title: message.title };
+        }
+        return null;
+      },
+    },
+  };
+  await ensureCompanionDashboard(hass, {
+    config: {
+      entry_ids: ["entry-12345678"],
+      instance_id: "entry-12345678",
+      title: "Casa",
+      static_base: "/dashboardmodern_static/hash",
+      allowed_user_ids: ["giovanni"],
+      register_lovelace_dashboard: true,
+      lovelace_url_path: "dashboardmodern-entry123",
+      primary: true,
+      admin_only: false,
+    },
+  });
+
+  assert.equal(messages.some((message) => message.type === "lovelace/dashboards/create"), true);
+  const save = messages.find((message) => message.type === "lovelace/config/save");
+  assert.deepEqual(save.config.views[0].visible, [{ user: "giovanni" }]);
+  assert.equal(save.config.views[0].cards[0].type, "custom:dashboardmodern-card");
+});
+
+test.after(() => {
+  if (originalHTMLElement === undefined) delete globalThis.HTMLElement;
+  else globalThis.HTMLElement = originalHTMLElement;
+  if (originalCustomElements === undefined) delete globalThis.customElements;
+  else globalThis.customElements = originalCustomElements;
+});

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -5,12 +5,13 @@
   "config_flow": true,
   "dependencies": [
     "frontend",
-    "http"
+    "http",
+    "lovelace"
   ],
   "documentation": "https://github.com/danigio15/dashboardmodern-v2",
   "integration_type": "hub",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "0.14.8"
+  "version": "0.14.9"
 }

--- a/custom_components/dashboardmodern/strings.json
+++ b/custom_components/dashboardmodern/strings.json
@@ -15,8 +15,17 @@
   "options": {
     "step": {
       "init": {
+        "title": "Accesso e integrazione con le plance",
+        "description": "Scegli gli utenti autorizzati. Lascia vuoto per consentire l'accesso a tutti. La registrazione Lovelace fa comparire DashboardModern in Impostazioni → Plance e consente di sceglierla come plancia predefinita.",
         "data": {
+          "allowed_users": "Utenti autorizzati",
+          "register_lovelace_dashboard": "Registra anche come plancia Home Assistant",
           "admin_only": "Visibile solo agli amministratori"
+        },
+        "data_description": {
+          "allowed_users": "Gli utenti non selezionati ricevono un blocco di accesso anche aprendo direttamente l'URL.",
+          "register_lovelace_dashboard": "La plancia viene creata alla prima apertura effettuata da un amministratore.",
+          "admin_only": "Filtro nativo Home Assistant; prevale sulla selezione utenti per gli account non amministratori."
         }
       }
     }

--- a/custom_components/dashboardmodern/translations/en.json
+++ b/custom_components/dashboardmodern/translations/en.json
@@ -15,8 +15,17 @@
   "options": {
     "step": {
       "init": {
+        "title": "Access and dashboard integration",
+        "description": "Choose the users allowed to open this dashboard. Leave the list empty to allow everyone. Lovelace registration makes DashboardModern appear in Settings → Dashboards and lets users choose it as their default dashboard.",
         "data": {
+          "allowed_users": "Allowed users",
+          "register_lovelace_dashboard": "Also register as a Home Assistant dashboard",
           "admin_only": "Visible to administrators only"
+        },
+        "data_description": {
+          "allowed_users": "Users not selected are denied even when they open the URL directly.",
+          "register_lovelace_dashboard": "The dashboard is created the first time an administrator opens DashboardModern.",
+          "admin_only": "Native Home Assistant filter; it takes precedence for non-administrator accounts."
         }
       }
     }

--- a/custom_components/dashboardmodern/translations/it.json
+++ b/custom_components/dashboardmodern/translations/it.json
@@ -15,8 +15,17 @@
   "options": {
     "step": {
       "init": {
+        "title": "Accesso e integrazione con le plance",
+        "description": "Scegli gli utenti autorizzati. Lascia vuoto per consentire l'accesso a tutti. La registrazione Lovelace fa comparire DashboardModern in Impostazioni → Plance e consente di sceglierla come plancia predefinita.",
         "data": {
+          "allowed_users": "Utenti autorizzati",
+          "register_lovelace_dashboard": "Registra anche come plancia Home Assistant",
           "admin_only": "Visibile solo agli amministratori"
+        },
+        "data_description": {
+          "allowed_users": "Gli utenti non selezionati ricevono un blocco di accesso anche aprendo direttamente l'URL.",
+          "register_lovelace_dashboard": "La plancia viene creata alla prima apertura effettuata da un amministratore.",
+          "admin_only": "Filtro nativo Home Assistant; prevale sulla selezione utenti per gli account non amministratori."
         }
       }
     }

--- a/tests/test_user_visibility.py
+++ b/tests/test_user_visibility.py
@@ -1,0 +1,40 @@
+"""Per-user and Lovelace companion configuration tests."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip(
+    "homeassistant", reason="Home Assistant test dependency is not installed"
+)
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.dashboardmodern.config_flow import (
+    OPTION_ALLOWED_USERS,
+    OPTION_REGISTER_LOVELACE,
+)
+from custom_components.dashboardmodern.const import DOMAIN
+from custom_components.dashboardmodern.frontend import _panel_config
+
+
+def test_panel_config_exposes_user_allow_list_and_companion_dashboard(hass) -> None:
+    """The frontend gets the exact users and a stable Lovelace path."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="0123456789abcdef",
+        title="Casa",
+        data={"name": "Casa", "primary": True},
+        options={
+            OPTION_ALLOWED_USERS: ["giovanni", "donato"],
+            OPTION_REGISTER_LOVELACE: True,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    config = _panel_config(hass, entry)
+
+    assert config["allowed_user_ids"] == ["giovanni", "donato"]
+    assert config["register_lovelace_dashboard"] is True
+    assert config["lovelace_url_path"] == "dashboardmodern-01234567"
+    assert config["dashboard_card_module"].endswith("/dashboard-card.js")

--- a/tests/test_user_visibility.py
+++ b/tests/test_user_visibility.py
@@ -8,6 +8,7 @@ pytest.importorskip(
     "homeassistant", reason="Home Assistant test dependency is not installed"
 )
 
+from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.dashboardmodern.config_flow import (
@@ -18,7 +19,9 @@ from custom_components.dashboardmodern.const import DOMAIN
 from custom_components.dashboardmodern.frontend import _panel_config
 
 
-def test_panel_config_exposes_user_allow_list_and_companion_dashboard(hass) -> None:
+def test_panel_config_exposes_user_allow_list_and_companion_dashboard(
+    hass: HomeAssistant,
+) -> None:
     """The frontend gets the exact users and a stable Lovelace path."""
     entry = MockConfigEntry(
         domain=DOMAIN,


### PR DESCRIPTION
## DashboardModern 0.14.9

### Home Assistant integration
- Generates one companion Lovelace dashboard for each DashboardModern instance so it appears under Settings → Dashboards and can be selected as a default dashboard.
- Adds exact per-user allow-lists in the integration options, with direct access checks in both the sidebar panel and Lovelace custom card.
- Loads the versioned `dashboardmodern-card` module automatically; no manual Lovelace resource is required.

### Runtime fixes
- Energy Report inherits the visual/icon selected for each appliance, including refrigerator and oven fallbacks.
- Explicit Light → Room assignments are persisted in the canonical store and take precedence over entity-name inference.
- Empty light rooms are hidden.
- Temperature cards receive a clearer room icon and responsive compact layout.
- Appliance visuals and dashboard grids adapt to compact, Fold and wide viewports, including live resize/open-close changes.

### Release and documentation
- Bumps the integration to `0.14.9`.
- Rewrites README and adds a complete 0.14.9 changelog.
- Adds Python and Node coverage for user visibility, companion dashboard creation and report icon inheritance.

### Validation required before merge
- HACS
- hassfest
- Python/frontend tests
- full Browser E2E matrix
