### PR TITLE
release: DashboardModern 0.14.10

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   playwright:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -20,7 +21,19 @@ jobs:
         with:
           python-version: "3.13"
       - run: npm ci
-      - run: npx playwright install --with-deps chromium webkit
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright system dependencies
+        timeout-minutes: 8
+        run: npx playwright install-deps chromium webkit
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 8
+        run: npx playwright install chromium webkit
       - run: python scripts/generate_build_info.py --expected-commit "$GITHUB_SHA"
       - run: npm run test:e2e
       - uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 0.14.10 — 2026-07-31
+
+### Aggiunto
+
+- Campi **contatore totale cumulativo** per consumo casa, prelievo e immissione
+  rete, produzione fotovoltaica, carica e scarica batteria.
+- Validazione nel Config Energia di unità, `device_class` e `state_class`; i
+  sensori W/kW vengono riconosciuti come potenza e rifiutati per i totali.
+- Proiezione automatica di un contatore totale sui periodi mancanti. Giorno,
+  mese, mesi passati e anno vengono ricavati dalle Long-Term Statistics di Home
+  Assistant; i sensori specifici per periodo restano override prioritari.
+- Test unitari ed E2E dedicati a contatori cumulativi, report con icone,
+  Temperatura e layout WebKit/iPad/Fold.
+
+### Cambiato
+
+- Il Report Energia preferisce l'entità totale o un'altra entità con
+  `state_class: total_increasing`/`total` rispetto a sensori mensili o
+  giornalieri, così può ricostruire correttamente lo storico per mese e anno.
+- Le visuali del Report usano immagine, SVG dell'elettrodomestico o glifo
+  leggibile. Le stringhe `mdi:*` non vengono più stampate nell'interfaccia o nel
+  selettore dispositivo.
+- I pulsanti **Aggiungi**, **Salva** e **Annulla** sono uniformati per altezza,
+  raggio, gerarchia cromatica e comportamento responsive.
+- README ampliato con configurazione Energia raccomandata, precedenza dei campi,
+  requisiti dei contatori e diagnostica dei valori a zero.
+
+### Corretto
+
+- Card Temperatura con nome, icona, valore e umidità sovrapposti a causa di
+  `grid-area` applicate a elementi annidati: la struttura interna ora usa una
+  griglia stabile e selettori più specifici delle regole legacy.
+- Icona forno/frigorifero assente nel Report e testo letterale `mdi:stove`.
+- Simbolo batteria associato impropriamente al totale consumato nella card
+  Elettrodomestici; sostituito da **∑ Totale**.
+- Config Energia privo dell'ingresso necessario per usare direttamente contatori
+  lifetime come `sensor.solarman_total_grid_energy`.
+
 ## 0.14.9 — 2026-07-31
 
 ### Aggiunto
@@ -10,38 +48,19 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 - **Plancia Lovelace associata** a ogni istanza DashboardModern. Viene creata
   alla prima apertura amministrativa, compare in **Impostazioni → Plance** e
   può essere scelta come predefinita globale o personale.
-- **Selettore utenti autorizzati** nelle opzioni dell'integrazione. La lista è
-  applicata sia alla visibilità della vista Lovelace sia al controllo diretto
-  del pannello e della custom card.
-- Custom card globale `dashboardmodern-card`, caricata dal percorso statico
-  versionato dell'integrazione senza configurazione manuale delle risorse.
-- Test automatici per creazione plancia, visibilità per utente e derivazione
-  delle icone del Report Energia.
+- **Selettore utenti autorizzati** nelle opzioni dell'integrazione.
+- Custom card globale `dashboardmodern-card` caricata automaticamente.
 
 ### Cambiato
 
-- Report Energia: eredita automaticamente l'icona o la visuale selezionata
-  nell'elettrodomestico; frigorifero, forno, lavatrice, lavastoviglie,
-  asciugatrice e altri tipi hanno fallback MDI coerenti.
-- Nuovo layout della card Temperatura: icona stanza più leggibile, gerarchia
-  compatta e griglia `auto-fit` senza spazi inutili.
-- Layout responsive basato sulla larghezza effettiva del viewport, con profili
-  compact/fold/wide, `ResizeObserver`, `visualViewport` e ricalcolo al cambio
-  di orientamento o apertura di un dispositivo pieghevole.
-- Immagini e icone degli elettrodomestici ridimensionate con limiti fluidi
-  anche sugli smartphone stretti.
-- README riscritto e allineato alle funzioni pubbliche della 0.14.9.
+- Report Energia collegato alla visuale canonica dell'elettrodomestico.
+- Layout responsive con profili compact/fold/wide e ricalcolo del viewport.
+- Associazione manuale Luce → Stanza resa prioritaria.
 
 ### Corretto
 
-- L'associazione manuale di una luce alla stanza ora prevale sempre
-  sull'inferenza ricavata dal nome dell'entità.
-- Le stanze senza entità luce associate non vengono più mostrate nella pagina
-  Luci.
-- Le righe del Report con icona vuota vengono riparate usando la visuale
-  canonica dell'elettrodomestico.
-- Il passaggio fra schermo chiuso e aperto dei dispositivi Fold non lascia più
-  card e immagini con le misure del viewport precedente.
+- Stanze senza luci nascoste.
+- Ricalcolo delle card al passaggio fra schermo chiuso e aperto dei Fold.
 
 ## 0.14.8 — 2026-07-30
 

--- a/README.md
+++ b/README.md
@@ -5,36 +5,59 @@
 <h1 align="center">DashboardModern</h1>
 
 <p align="center">
-  <b>Una plancia smart-home completa e responsive per Home Assistant.</b><br>
+  <b>Una plancia smart-home completa, multiutente e responsive per Home Assistant.</b><br>
   Energia · Fotovoltaico · EV · Clima · Luci · Sicurezza · Tapparelle · Irrigazione · Piscina
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.14.9-0ea5e9">
+  <img src="https://img.shields.io/badge/version-0.14.10-0ea5e9">
   <img src="https://img.shields.io/badge/HACS-custom-41BDF5">
   <img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-1e3a8a">
 </p>
 
 > **English summary** — DashboardModern is a complete Home Assistant dashboard
-> distributed as a HACS custom integration. Version 0.14.9 adds a generated
-> Lovelace companion dashboard, exact per-user access lists, appliance visuals
-> in the Energy Report, reliable light-to-room assignments and adaptive layouts
-> for phones, tablets and foldable devices.
+> distributed as a HACS custom integration. Version 0.14.10 restores cumulative
+> energy meters as first-class inputs, derives day/month/year values from Home
+> Assistant Long-Term Statistics, fixes appliance icons in the Energy Report,
+> rebuilds the Temperature card layout and standardizes editor actions.
 
 ---
 
 ## Indice
 
-1. [Funzioni principali](#funzioni-principali)
-2. [Installazione](#installazione)
-3. [Prima configurazione](#prima-configurazione)
-4. [Plancia Home Assistant e preferita](#plancia-home-assistant-e-preferita)
-5. [Utenti autorizzati](#utenti-autorizzati)
-6. [Editor e sezioni](#editor-e-sezioni)
-7. [Responsive e dispositivi pieghevoli](#responsive-e-dispositivi-pieghevoli)
-8. [Aggiornamento e cache](#aggiornamento-e-cache)
-9. [Diagnostica](#diagnostica)
-10. [Sviluppo e test](#sviluppo-e-test)
+1. [Novità 0.14.10](#novità-01410)
+2. [Funzioni principali](#funzioni-principali)
+3. [Installazione](#installazione)
+4. [Prima configurazione](#prima-configurazione)
+5. [Energia: configurazione consigliata](#energia-configurazione-consigliata)
+6. [Report Energia ed elettrodomestici](#report-energia-ed-elettrodomestici)
+7. [Plancia Home Assistant e preferita](#plancia-home-assistant-e-preferita)
+8. [Utenti autorizzati](#utenti-autorizzati)
+9. [Editor e sezioni](#editor-e-sezioni)
+10. [Responsive e dispositivi pieghevoli](#responsive-e-dispositivi-pieghevoli)
+11. [Aggiornamento, cache e diagnostica](#aggiornamento-cache-e-diagnostica)
+12. [Sviluppo e test](#sviluppo-e-test)
+
+## Novità 0.14.10
+
+- I **contatori totali cumulativi** tornano disponibili nel Config Energia per
+  Casa, Rete, Fotovoltaico e Batteria.
+- Da un solo contatore con `state_class: total_increasing` o `total`, la
+  dashboard calcola automaticamente giorno, mese corrente, mesi passati e anno
+  tramite le Long-Term Statistics di Home Assistant.
+- I sensori giornalieri, mensili e annuali restano disponibili come override:
+  quando sono configurati hanno precedenza sul contatore totale.
+- Il Report preferisce il contatore totale dell'elettrodomestico, così può
+  ricostruire correttamente i periodi invece di dipendere da un sensore mensile
+  che si azzera.
+- Le icone `mdi:*` non vengono più stampate come testo. Il Report usa immagine,
+  visuale o glifo coerente con l'elettrodomestico selezionato.
+- La card Temperatura è stata ricostruita con una griglia interna stabile: nome,
+  icona, temperatura e umidità non si sovrappongono.
+- Il simbolo batteria è stato rimosso dal totale consumato degli
+  elettrodomestici e sostituito da **∑ Totale**.
+- I pulsanti **Aggiungi**, **Salva** e **Annulla** hanno stile e dimensioni
+  uniformi in tutto l'editor.
 
 ## Funzioni principali
 
@@ -47,11 +70,11 @@
   lista precisa di utenti Home Assistant.
 - **Editor visuale**: configurazione senza YAML per Energia, EV, Solare,
   Sicurezza, Temperatura, Clima, Luci, Elettrodomestici, Piscina, Irrigazione,
-  Tapparelle, Stanze, Avvisi e altre sezioni.
-- **Autorilevamento**: usa registri di piani, aree, dispositivi ed entità per
-  proporre stanze e associazioni senza sovrascrivere le scelte manuali.
-- **Responsive reale**: griglie fluide, misure con `clamp()`, `ResizeObserver`,
-  `visualViewport` e ricalcolo al cambio di orientamento o apertura di un fold.
+  Tapparelle, Stanze e Avvisi.
+- **Autorilevamento**: usa piani, aree, dispositivi ed entità per proporre
+  associazioni senza sovrascrivere le scelte manuali.
+- **Responsive reale**: griglie fluide, `ResizeObserver`, `visualViewport` e
+  ricalcolo al cambio di orientamento o apertura di un dispositivo Fold.
 - **Bilingue**: interfaccia italiana e inglese.
 
 ## Installazione
@@ -66,9 +89,8 @@
    cerca DashboardModern e assegna un nome alla plancia.
 5. Apri una volta la nuova voce laterale con un account amministratore.
 
-L'ultima apertura serve a creare o aggiornare automaticamente la plancia
-Lovelace associata. Non occorrono token, file in `www/` o risorse Lovelace
-manuali.
+L'ultima apertura crea o aggiorna automaticamente la plancia Lovelace associata.
+Non occorrono token, file in `www/` o risorse Lovelace manuali.
 
 ### Installazione manuale
 
@@ -82,25 +104,100 @@ l'integrazione dall'interfaccia.
 2. Entra in **Config → Configura entità**.
 3. In **Impostazioni**, avvia **Autorilevamento**.
 4. Controlla le associazioni proposte e salva ogni sezione modificata.
-5. Configura gli elettrodomestici scegliendo stanza, entità e visuale: la stessa
-   visuale viene ora ereditata dal Report Energia.
+5. Configura stanze, luci ed elettrodomestici.
+6. Completa **Energia → Flussi ed entità** seguendo la configurazione consigliata
+   qui sotto.
 
-La navbar mostra automaticamente le sezioni che contengono dati. Le sezioni
-vuote restano nascoste, salvo una scelta manuale nell'editor.
+La navbar mostra automaticamente le sezioni che contengono dati. Le stanze
+senza entità associate non vengono renderizzate nelle relative pagine.
+
+## Energia: configurazione consigliata
+
+### Contatore totale oppure sensori per periodo
+
+Per ogni flusso energetico puoi scegliere una delle due modalità.
+
+**Modalità consigliata — un contatore totale cumulativo**
+
+Inserisci un'entità che:
+
+- misuri energia, normalmente in `Wh`, `kWh` o `MWh`;
+- abbia `device_class: energy`;
+- abbia `state_class: total_increasing` oppure `total`;
+- non sia un sensore di potenza istantanea in `W` o `kW`.
+
+Esempio valido:
+
+```text
+sensor.solarman_total_grid_energy
+unit_of_measurement: kWh
+device_class: energy
+state_class: total_increasing
+```
+
+Il nome dell'entità può contenere anche la parola `power`, ma sono unità,
+`device_class` e `state_class` a determinare se il dato è utilizzabile. Il Config
+segnala in rosso un sensore W/kW o non cumulativo.
+
+**Modalità alternativa — sensori già calcolati**
+
+Puoi continuare a indicare entità giornaliere, mensili o annuali. Questi campi
+sono override facoltativi e, se compilati, hanno precedenza sul contatore totale
+per il relativo periodo.
+
+### Campi totali disponibili
+
+| Gruppo | Campo totale | Periodi derivati automaticamente |
+|---|---|---|
+| Casa | Contatore totale consumo casa | oggi, mese, anno |
+| Rete | Totale energia prelevata | oggi, mese, mesi passati, anno |
+| Rete | Totale energia immessa | oggi, mese, mesi passati, anno |
+| Fotovoltaico | Totale produzione | oggi, mese, anno |
+| Batteria | Totale caricata / scaricata | oggi, mese e analisi storiche |
+
+DashboardModern interroga le statistiche del recorder e usa il delta del
+periodo richiesto. Non crea helper e non modifica l'entità originale.
+
+### Valori a zero
+
+Quando il Report resta a zero, verifica in **Strumenti per sviluppatori →
+Statistiche** che l'entità non presenti errori e disponga di statistiche a lungo
+termine. Controlla inoltre che il contatore non sia espresso in `W` o `kW`.
+Dopo aver corretto l'entità, salva nuovamente Energia e riapri il Report.
+
+## Report Energia ed elettrodomestici
+
+Per ciascun elettrodomestico configura, quando disponibili:
+
+- entità di potenza istantanea;
+- comando ON/OFF;
+- **entità energia totale cumulativa**;
+- stanza e visuale.
+
+Il Report sceglie l'entità in questo ordine:
+
+1. entità Report esplicita valida;
+2. entità energia totale;
+3. altra entità cumulativa `total`/`total_increasing`;
+4. entità energia mensile, giornaliera o generica in Wh/kWh.
+
+Un'entità W/kW viene sempre esclusa dai calcoli energetici. Il Report usa
+l'immagine configurata oppure una visuale coerente con il tipo: forno,
+frigorifero, lavatrice, lavastoviglie, asciugatrice e altri dispositivi non
+mostrano più stringhe come `mdi:stove`.
 
 ## Plancia Home Assistant e preferita
 
-Dalla versione 0.14.9 ogni istanza genera una plancia Lovelace con URL stabile
+Ogni istanza genera una plancia Lovelace con URL stabile
 `dashboardmodern-<id>`:
 
 1. Apri DashboardModern una volta come amministratore.
-2. Vai in **Impostazioni → Plance**: trovi la plancia col nome dell'istanza.
+2. Vai in **Impostazioni → Plance**.
 3. Dal menu della plancia puoi impostarla come predefinita per tutti.
 4. Ogni utente può scegliere la propria da **Profilo → Plancia**.
 
 La plancia generata non viene aggiunta automaticamente una seconda volta alla
-barra laterale, per evitare il duplicato del pannello DashboardModern. Puoi
-abilitarla manualmente dalle impostazioni della plancia.
+barra laterale, per evitare il duplicato del pannello DashboardModern.
 
 ## Utenti autorizzati
 
@@ -109,72 +206,58 @@ Per ciascuna istanza puoi impostare:
 
 - **Utenti autorizzati**: lista precisa degli account ammessi; lista vuota =
   tutti gli utenti autenticati.
-- **Registra anche come plancia Home Assistant**: crea e mantiene la plancia
-  Lovelace selezionabile come predefinita.
-- **Solo amministratori**: filtro nativo Home Assistant, più restrittivo della
-  lista utenti.
+- **Registra anche come plancia Home Assistant**.
+- **Solo amministratori**: filtro nativo Home Assistant più restrittivo.
 
-La visibilità della vista Lovelace segue la lista utenti e il custom element
-esegue anche un controllo diretto: un utente escluso non vede i contenuti
-neppure aprendo l'URL manualmente.
-
-Esempio: autorizza **Giovanni** nella plancia Casa e **Donato** nella plancia
-Ospiti; poi imposta per ciascun profilo la relativa plancia predefinita.
+Esempio: autorizza Giovanni nella plancia Casa e Donato nella plancia Ospiti,
+poi seleziona la rispettiva plancia predefinita nei due profili.
 
 ## Editor e sezioni
 
 | Sezione | Funzioni principali |
 |---|---|
 | Impostazioni | Titolo, navbar, autorilevamento, reset, diagnostica |
-| Energia | Flussi, costi, carichi secondari, report e storico |
-| Elettrodomestici | Entità, stanza, soglie, immagini e icone |
-| Luci | Associazione esplicita alla stanza; le stanze senza luci non sono renderizzate |
-| Temperatura | Card compatte con icona stanza leggibile, temperatura e umidità |
+| Energia | Contatori totali, flussi, costi, carichi, Report e storico |
+| Elettrodomestici | Entità, stanza, soglie, immagini, icone e totale energia |
+| Luci | Associazione esplicita alla stanza; stanze vuote nascoste |
+| Temperatura | Card senza sovrapposizioni, icona stanza, temperatura e umidità |
 | EV | Profili multipli e dati veicolo |
 | Sicurezza | Allarme e telecamere WebRTC/HLS/MJPEG |
 | Tapparelle | Stato, comandi e avvisi cover aperte |
 | Piscina / Irrigazione | Programmi, sensori e automazioni operative |
 
-Il Report Energia usa `report_icon` quando definita; altrimenti deriva l'icona
-dalla visuale dell'elettrodomestico, ad esempio `mdi:fridge-outline` per il
-frigorifero e `mdi:stove` per il forno.
+I comandi principali dell'editor adottano una gerarchia comune:
+
+- **Aggiungi**: azzurro;
+- **Salva**: verde;
+- **Annulla**: grigio;
+- picker entità: pulsante lente separato.
 
 ## Responsive e dispositivi pieghevoli
 
-La dashboard non usa un'unica larghezza “mobile”. Distingue automaticamente:
+La dashboard distingue automaticamente:
 
 - **compact** fino a 420 px;
-- **fold** da 421 a 760 px;
-- **wide** oltre 760 px.
+- **fold/tablet verticale** da 421 a 820 px;
+- **wide** oltre 820 px.
 
-Un `ResizeObserver` ricalcola il layout quando cambia la dimensione reale del
-viewport, quindi un Samsung Galaxy Z Fold passa dalla vista chiusa a quella
-aperta senza richiedere un ricaricamento. Le immagini degli elettrodomestici e
-le card Temperatura usano dimensioni fluide e non provocano scorrimento
-orizzontale.
+Un `ResizeObserver` ricalcola il layout quando cambia il viewport. Le card
+Temperatura usano una griglia interna a due colonne e le immagini degli
+elettrodomestici hanno limiti fluidi, quindi il passaggio fra Samsung Galaxy Z
+Fold chiuso e aperto non richiede il ricaricamento.
 
-## Aggiornamento e cache
+## Aggiornamento, cache e diagnostica
 
-Gli asset frontend sono serviti da un percorso basato sul loro contenuto. A
-ogni aggiornamento il percorso cambia, incluse la card Lovelace e tutte le sue
-importazioni, evitando che una vecchia build resti nella cache.
-
-Dopo un aggiornamento HACS:
+Gli asset frontend sono serviti da un percorso basato sul contenuto. Dopo un
+aggiornamento HACS:
 
 1. riavvia Home Assistant;
 2. ricarica la pagina o riapri l'app;
-3. apri DashboardModern una volta come amministratore per sincronizzare la
-   plancia Lovelace generata.
+3. apri DashboardModern una volta come amministratore.
 
-## Diagnostica
-
-La scheda Impostazioni mostra versione, stato bridge, sincronizzazione,
-identificativo istanza e flag primaria. In una segnalazione allega:
-
-- riga diagnostica;
-- versione Home Assistant e DashboardModern;
-- dispositivo/browser;
-- screenshot e passaggi per riprodurre.
+La scheda Impostazioni mostra versione, bridge, sincronizzazione e identificativo
+istanza. In una segnalazione allega versione, dispositivo/browser, screenshot,
+passaggi per riprodurre e, per Energia, attributi dell'entità usata.
 
 ## Sviluppo e test
 
@@ -202,9 +285,9 @@ npm run format:check
 npm run test:e2e
 ```
 
-La release stabile viene pubblicata soltanto dopo test Python, frontend,
-hassfest, HACS e matrice Browser E2E verdi. Il pacchetto HACS è
-`dashboardmodern.zip` allegato alla release GitHub.
+La release viene pubblicata soltanto dopo test Python, frontend, hassfest, HACS
+e matrice Browser E2E verdi. Il pacchetto HACS è `dashboardmodern.zip` allegato
+alla release GitHub.
 
 Consulta [CHANGELOG.md](CHANGELOG.md) per le modifiche di ogni versione.
 

--- a/custom_components/dashboardmodern/frontend/e2e/helpers/namespaced-dashboard.js
+++ b/custom_components/dashboardmodern/frontend/e2e/helpers/namespaced-dashboard.js
@@ -8,20 +8,37 @@ export async function bootNamespacedDashboard(page, variant, testInfo, seed) {
     Math.random().toString(36).slice(2),
   ].join("-");
 
+  // Seed the raw namespaced keys before dashboard scripts start. This avoids a
+  // WebKit race where the first runtime writes an empty migrated state between
+  // the post-load seed and page.reload(). The guard keeps later reloads from
+  // resetting changes made by the test.
+  await page.addInitScript(
+    ({ dashboardSeed, storageInstance }) => {
+      const storage = window.localStorage;
+      const prefix = `cd_${storageInstance}_`;
+      const getItem = Storage.prototype.getItem;
+      const setItem = Storage.prototype.setItem;
+      const setIfMissing = (key, value) => {
+        const rawKey = `${prefix}${key}`;
+        if (getItem.call(storage, rawKey) === null) {
+          setItem.call(storage, rawKey, value);
+        }
+      };
+
+      setIfMissing("dm_dashboard_state", JSON.stringify(dashboardSeed));
+      setIfMissing(
+        "cd_connection",
+        JSON.stringify({
+          token: "e2e-token",
+          ws_url: "ws://home-assistant.test/api/websocket",
+        }),
+      );
+    },
+    { dashboardSeed: seed, storageInstance: instance },
+  );
+
   await page.goto(`/legacy/${variant}?dmi=${encodeURIComponent(instance)}`);
   await page.waitForFunction(() => Boolean(window.__DASHBOARDMODERN_STORAGE_NS__));
-  await page.evaluate((dashboardSeed) => {
-    localStorage.clear();
-    localStorage.setItem("dm_dashboard_state", JSON.stringify(dashboardSeed));
-    localStorage.setItem(
-      "cd_connection",
-      JSON.stringify({
-        token: "e2e-token",
-        ws_url: "ws://home-assistant.test/api/websocket",
-      }),
-    );
-  }, seed);
-  await page.reload();
   await page.waitForFunction(
     () => window.__DASHBOARDMODERN_LEGACY_READY__ && window.DashboardModernModules,
   );

--- a/custom_components/dashboardmodern/frontend/e2e/release-0150-structural.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0150-structural.spec.js
@@ -209,15 +209,21 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await expect(card).toContainText("Salone");
     await expect(card).toContainText("29.0");
     const layout = await card.evaluate((node) => {
-      const name = node.querySelector(".cp-name")?.getBoundingClientRect();
-      const values = node.querySelector(".temp-values")?.getBoundingClientRect();
-      const info = node.querySelector(".cp-info")?.getBoundingClientRect();
+      const nameNode = node.querySelector(".cp-name");
+      const valuesNode = node.querySelector(".temp-values, .temp-card-body");
+      const infoNode = node.querySelector(".cp-info, .temp-card-body");
+      if (!nameNode || !valuesNode || !infoNode) {
+        throw new Error("Temperature card is missing its name, values or info structure");
+      }
+      const name = nameNode.getBoundingClientRect();
+      const values = valuesNode.getBoundingClientRect();
+      const info = infoNode.getBoundingClientRect();
       const cardBox = node.getBoundingClientRect();
       return {
-        nameBottom: name?.bottom,
-        valuesTop: values?.top,
-        infoLeft: info?.left,
-        infoRight: info?.right,
+        nameBottom: name.bottom,
+        valuesTop: values.top,
+        infoLeft: info.left,
+        infoRight: info.right,
         cardLeft: cardBox.left,
         cardRight: cardBox.right,
         height: cardBox.height,

--- a/custom_components/dashboardmodern/frontend/e2e/release-0150-structural.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0150-structural.spec.js
@@ -235,9 +235,13 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     expect(layout.height).toBeGreaterThan(90);
 
     await clickBottomTab(page, "appliances", testInfo);
-    await expect(page.locator(".appl-wide-card")).toContainText("Forno");
-    await expect(page.locator(".appl-wide-card .appl-mini")).toContainText(/Totale|Total/);
-    await expect(page.locator(".appl-wide-card .appl-mini")).not.toContainText("🔋");
+    const applianceCard = page
+      .locator("#page-appliances-main .appl-main-view.active .appl-wide-card")
+      .first();
+    await expect(applianceCard).toContainText("Forno");
+    const applianceTotal = applianceCard.locator(".appl-mini");
+    await expect(applianceTotal).toContainText(/Totale|Total/);
+    await expect(applianceTotal).not.toContainText("🔋");
 
     await openEnergyAnalysis(page, testInfo);
     const option = page.locator("#ed-dev-selector option", { hasText: "Forno" });

--- a/custom_components/dashboardmodern/frontend/e2e/release-0150-structural.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0150-structural.spec.js
@@ -1,0 +1,248 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { clickBottomTab, clickStableButton } from "./helpers/navigation.js";
+
+const states = [
+  {
+    entity_id: "sensor.salone_temperature",
+    state: "29.0",
+    attributes: {
+      friendly_name: "Temperatura salone",
+      unit_of_measurement: "°C",
+      device_class: "temperature",
+      state_class: "measurement",
+    },
+  },
+  {
+    entity_id: "sensor.salone_humidity",
+    state: "29",
+    attributes: {
+      friendly_name: "Umidità salone",
+      unit_of_measurement: "%",
+      device_class: "humidity",
+      state_class: "measurement",
+    },
+  },
+  {
+    entity_id: "sensor.forno_totale",
+    state: "412.8",
+    attributes: {
+      friendly_name: "Forno energia totale",
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "total_increasing",
+    },
+  },
+  {
+    entity_id: "sensor.solarman_total_grid_energy",
+    state: "9842.2",
+    attributes: {
+      friendly_name: "Energia totale rete",
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "total_increasing",
+    },
+  },
+];
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [
+      {
+        id: "room-salone",
+        name: "Salone",
+        icon: "mdi:sofa",
+        temp: "sensor.salone_temperature",
+        hum: "sensor.salone_humidity",
+      },
+    ],
+    appliances: [
+      {
+        id: "appliance-forno",
+        section: "appliances",
+        name: "Forno",
+        icon: "mdi:stove",
+        device_type: "forno",
+        room_id: "room-salone",
+        entities: ["sensor.forno_totale"],
+        total_energy_entity: "sensor.forno_totale",
+        show_in_report: true,
+        show_in_dashboard: true,
+      },
+    ],
+    loads: [],
+    lights: [],
+    energy: { house: {}, grid: {}, solar: {}, battery: {}, metadata: {} },
+  },
+  visibility: { temp: true, energy: true, appliances: true },
+};
+
+async function boot(page, variant, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript((haStates) => {
+    window.WebSocket = class extends EventTarget {
+      static OPEN = 1;
+      readyState = 1;
+      constructor() {
+        super();
+        queueMicrotask(() =>
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_required" }) }),
+        );
+      }
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") {
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+          return;
+        }
+        let result = [];
+        if (message.type === "get_states") result = haStates;
+        else if (message.type === "frontend/get_user_data") result = { value: null };
+        else if (message.type === "recorder/statistics_during_period") {
+          result = Object.fromEntries(
+            (message.statistic_ids || []).map((id) => [
+              id,
+              [
+                {
+                  start: new Date().toISOString(),
+                  change: id.includes("forno") ? 12.4 : 42.6,
+                  sum: id.includes("forno") ? 412.8 : 9842.2,
+                  state: id.includes("forno") ? 412.8 : 9842.2,
+                },
+              ],
+            ]),
+          );
+        }
+        this.onmessage?.({
+          data: JSON.stringify({
+            id: message.id,
+            type: "result",
+            success: true,
+            result,
+          }),
+        });
+      }
+      close() {}
+    };
+  }, states);
+  await bootNamespacedDashboard(page, variant, testInfo, seed);
+  await page
+    .locator("#setup-wizard")
+    .evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await page.evaluate((haStates) => {
+    haStates.forEach((state) => {
+      _RAW_STATES[state.entity_id] = structuredClone(state);
+      STATES[state.entity_id] = structuredClone(state);
+    });
+    render?.();
+    cdRebuildReportDevices?.();
+    buildReportSelect?.();
+  }, states);
+  await page.waitForFunction(() => window.__DASHBOARDMODERN_RELEASE_0150__?.installed);
+}
+
+async function openEnergyAnalysis(page, testInfo) {
+  await clickBottomTab(page, "energy", testInfo);
+  const energyPage = page.locator("#page-energy.active");
+  await clickStableButton(
+    page,
+    energyPage.getByRole("button", { name: /^📊?\s*Report$/i }),
+    testInfo,
+  );
+  await clickStableButton(
+    page,
+    energyPage.getByRole("button", { name: /Analisi|Analysis/i }),
+    testInfo,
+  );
+  await expect(page.locator("#ed-pane-analisi")).toBeVisible();
+}
+
+for (const variant of ["dashboard.html", "dashboard-en.html"]) {
+  test(`${variant}: cumulative Energy, report icon and Temperature structure`, async ({
+    page,
+  }, testInfo) => {
+    if (testInfo.project.name === "webkit-ipad") test.slow(true);
+    await boot(page, variant, testInfo);
+
+    await page.evaluate(() => {
+      apriConfigEntita();
+      editorSwitch("energy");
+    });
+    await expect(page.locator('[data-editor="energy"]')).toBeVisible();
+    const grid = page.locator('[data-editor="energy"] details.ed-acc', {
+      hasText: /Rete|Grid/,
+    });
+    await grid.locator("summary").click();
+    const total = page.locator("#dm-energy-grid-total_import_energy");
+    await expect(total).toBeVisible();
+    await total.fill("sensor.solarman_total_grid_energy");
+    await expect(total).toHaveAttribute("data-validation", "valid");
+    await page.locator("[data-energy-save]").click();
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          DashboardModernModules.store.getSection("energy").grid?.total_import_energy,
+        ),
+      )
+      .toBe("sensor.solarman_total_grid_energy");
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const overrides = JSON.parse(localStorage.getItem("cd_entity_overrides") || "{}");
+          return {
+            total: overrides["dm.core_045"],
+            day: overrides["dm.energy_energia_prelevata_oggi"],
+            month: overrides["dm.energy_rete_acquistata_mese"],
+          };
+        }),
+      )
+      .toEqual({
+        total: "sensor.solarman_total_grid_energy",
+        day: "sensor.solarman_total_grid_energy",
+        month: "sensor.solarman_total_grid_energy",
+      });
+    await page.locator("#editor-modal .ed-head-close").last().click();
+
+    await clickBottomTab(page, "temp", testInfo);
+    const card = page.locator("#temp-grid .temp-card").first();
+    await expect(card).toContainText("Salone");
+    await expect(card).toContainText("29.0");
+    const layout = await card.evaluate((node) => {
+      const name = node.querySelector(".cp-name")?.getBoundingClientRect();
+      const values = node.querySelector(".temp-values")?.getBoundingClientRect();
+      const info = node.querySelector(".cp-info")?.getBoundingClientRect();
+      const cardBox = node.getBoundingClientRect();
+      return {
+        nameBottom: name?.bottom,
+        valuesTop: values?.top,
+        infoLeft: info?.left,
+        infoRight: info?.right,
+        cardLeft: cardBox.left,
+        cardRight: cardBox.right,
+        height: cardBox.height,
+      };
+    });
+    expect(layout.nameBottom).toBeLessThanOrEqual(layout.valuesTop + 1);
+    expect(layout.infoLeft).toBeGreaterThanOrEqual(layout.cardLeft);
+    expect(layout.infoRight).toBeLessThanOrEqual(layout.cardRight + 1);
+    expect(layout.height).toBeGreaterThan(90);
+
+    await clickBottomTab(page, "appliances", testInfo);
+    await expect(page.locator(".appl-wide-card")).toContainText("Forno");
+    await expect(page.locator(".appl-wide-card .appl-mini")).toContainText(/Totale|Total/);
+    await expect(page.locator(".appl-wide-card .appl-mini")).not.toContainText("🔋");
+
+    await openEnergyAnalysis(page, testInfo);
+    const option = page.locator("#ed-dev-selector option", { hasText: "Forno" });
+    await expect(option).toHaveAttribute("value", "sensor.forno_totale");
+    await expect(option).not.toContainText("mdi:");
+    await expect(option).toContainText("♨️");
+    await expect(page.locator("#ed-pane-analisi")).not.toContainText("mdi:stove");
+
+    await page.screenshot({
+      path: `test-results/${testInfo.project.name}-${variant}-release-0150-structural.png`,
+      fullPage: true,
+    });
+  });
+}

--- a/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-alert-compat.js
+++ b/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-alert-compat.js
@@ -1,11 +1,28 @@
 /* Language-independent edit controls for saved standard alerts. */
 const ALERT_COMPAT_FLAG = "__DASHBOARDMODERN_REAL_HA_0147_ALERT_COMPAT__";
+const ALERT_EDIT_PATCH_FLAG = "__DASHBOARDMODERN_REAL_HA_0147_ALERT_EDIT_PATCH__";
 
 function readGroups() {
   try {
     return JSON.parse(localStorage.getItem("cd_gruppi_extra")) || {};
   } catch (_error) {
     return {};
+  }
+}
+
+function readNames() {
+  try {
+    return JSON.parse(localStorage.getItem("cd_avvisi_names_extra")) || {};
+  } catch (_error) {
+    return {};
+  }
+}
+
+function runtimeStates() {
+  try {
+    return globalThis.eval("STATES") || {};
+  } catch (_error) {
+    return globalThis.STATES || {};
   }
 }
 
@@ -27,6 +44,46 @@ function groupForEntity(entity, row) {
   return "";
 }
 
+function alertName(entity) {
+  return readNames()[entity] || runtimeStates()?.[entity]?.attributes?.friendly_name || entity;
+}
+
+function applyAlertEditForm(group, entity, force = false) {
+  const entityInput = document.getElementById("ed-avv-ent");
+  const groupInput = document.getElementById("ed-avv-grp");
+  const nameInput = document.getElementById("ed-avv-name");
+  if (!entityInput || !groupInput || !nameInput) return false;
+
+  // A later scheduled pass must never overwrite genuine user edits. Forced
+  // passes only cover the immediate editor re-render after pressing Edit.
+  if (!force && entityInput.value && entityInput.value !== entity) return true;
+  if (force || !entityInput.value) entityInput.value = entity;
+  if (force || !groupInput.value) groupInput.value = group;
+  if (force || !nameInput.value) nameInput.value = alertName(entity);
+  return true;
+}
+
+function patchAlertEditHandler() {
+  const edit = globalThis.dmRealEditAlert;
+  if (typeof edit !== "function") return false;
+  if (edit[ALERT_EDIT_PATCH_FLAG]) return true;
+
+  const patched = function dmRealEditAlertStable(group, entity) {
+    const result = edit.apply(this, arguments);
+    const forceApply = () => applyAlertEditForm(group, entity, true);
+    const safeApply = () => applyAlertEditForm(group, entity, false);
+    queueMicrotask(forceApply);
+    requestAnimationFrame(forceApply);
+    for (const delay of [50, 150]) setTimeout(forceApply, delay);
+    for (const delay of [400, 800]) setTimeout(safeApply, delay);
+    return result;
+  };
+  patched[ALERT_EDIT_PATCH_FLAG] = true;
+  patched.__dmPrevious = edit;
+  globalThis.dmRealEditAlert = patched;
+  return true;
+}
+
 function installAlertEditButtons(root = document) {
   root.querySelectorAll("#editor-modal .ed-row").forEach((row) => {
     const entity = entityFromRow(row);
@@ -45,6 +102,8 @@ function installAlertEditButtons(root = document) {
     edit.type = "button";
     edit.className = "ed-del dm-edit-button";
     edit.dataset.realAlertEdit = "";
+    edit.dataset.alertGroup = group;
+    edit.dataset.alertEntity = entity;
     edit.textContent = "✏️";
     edit.title = document.documentElement.lang === "en" ? "Edit" : "Modifica";
     edit.setAttribute("aria-label", edit.title);
@@ -53,15 +112,27 @@ function installAlertEditButtons(root = document) {
   });
 }
 
-function install() {
+function reconcile() {
+  patchAlertEditHandler();
   installAlertEditButtons();
+}
+
+function install() {
+  reconcile();
   if (globalThis[ALERT_COMPAT_FLAG]?.installed) return;
   globalThis[ALERT_COMPAT_FLAG] = { installed: true };
   let frame = 0;
   new MutationObserver(() => {
     cancelAnimationFrame(frame);
-    frame = requestAnimationFrame(() => installAlertEditButtons());
+    frame = requestAnimationFrame(reconcile);
   }).observe(document.documentElement, { childList: true, subtree: true });
+
+  let attempts = 0;
+  const timer = setInterval(() => {
+    attempts += 1;
+    reconcile();
+    if (patchAlertEditHandler() || attempts >= 300) clearInterval(timer);
+  }, 50);
 }
 
 if (typeof window !== "undefined" && typeof document !== "undefined") {

--- a/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-alert-compat.js
+++ b/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-alert-compat.js
@@ -1,28 +1,11 @@
 /* Language-independent edit controls for saved standard alerts. */
 const ALERT_COMPAT_FLAG = "__DASHBOARDMODERN_REAL_HA_0147_ALERT_COMPAT__";
-const ALERT_EDIT_PATCH_FLAG = "__DASHBOARDMODERN_REAL_HA_0147_ALERT_EDIT_PATCH__";
 
 function readGroups() {
   try {
     return JSON.parse(localStorage.getItem("cd_gruppi_extra")) || {};
   } catch (_error) {
     return {};
-  }
-}
-
-function readNames() {
-  try {
-    return JSON.parse(localStorage.getItem("cd_avvisi_names_extra")) || {};
-  } catch (_error) {
-    return {};
-  }
-}
-
-function runtimeStates() {
-  try {
-    return globalThis.eval("STATES") || {};
-  } catch (_error) {
-    return globalThis.STATES || {};
   }
 }
 
@@ -44,95 +27,60 @@ function groupForEntity(entity, row) {
   return "";
 }
 
-function alertName(entity) {
-  return readNames()[entity] || runtimeStates()?.[entity]?.attributes?.friendly_name || entity;
-}
-
-function applyAlertEditForm(group, entity, force = false) {
-  const entityInput = document.getElementById("ed-avv-ent");
-  const groupInput = document.getElementById("ed-avv-grp");
-  const nameInput = document.getElementById("ed-avv-name");
-  if (!entityInput || !groupInput || !nameInput) return false;
-
-  // A later scheduled pass must never overwrite genuine user edits. Forced
-  // passes only cover the immediate editor re-render after pressing Edit.
-  if (!force && entityInput.value && entityInput.value !== entity) return true;
-  if (force || !entityInput.value) entityInput.value = entity;
-  if (force || !groupInput.value) groupInput.value = group;
-  if (force || !nameInput.value) nameInput.value = alertName(entity);
-  return true;
-}
-
-function patchAlertEditHandler() {
-  const edit = globalThis.dmRealEditAlert;
-  if (typeof edit !== "function") return false;
-  if (edit[ALERT_EDIT_PATCH_FLAG]) return true;
-
-  const patched = function dmRealEditAlertStable(group, entity) {
-    const result = edit.apply(this, arguments);
-    const forceApply = () => applyAlertEditForm(group, entity, true);
-    const safeApply = () => applyAlertEditForm(group, entity, false);
-    queueMicrotask(forceApply);
-    requestAnimationFrame(forceApply);
-    for (const delay of [50, 150]) setTimeout(forceApply, delay);
-    for (const delay of [400, 800]) setTimeout(safeApply, delay);
-    return result;
-  };
-  patched[ALERT_EDIT_PATCH_FLAG] = true;
-  patched.__dmPrevious = edit;
-  globalThis.dmRealEditAlert = patched;
-  return true;
+function bindAlertEditButton(button, group, entity) {
+  button.removeAttribute("onclick");
+  button.type = "button";
+  button.classList.add("ed-del", "dm-edit-button");
+  button.dataset.standardAlertEdit = "";
+  button.dataset.realAlertEdit = "";
+  button.dataset.standardAlertGroup = group;
+  button.dataset.standardAlertEntity = entity;
+  button.dataset.alertGroup = group;
+  button.dataset.alertEntity = entity;
+  button.textContent = "✏️";
+  button.title = document.documentElement.lang === "en" ? "Edit" : "Modifica";
+  button.setAttribute("aria-label", button.title);
+  if (button.dataset.alertEditMounted !== "true") {
+    button.dataset.alertEditMounted = "true";
+    button.addEventListener("click", () => {
+      const edit = globalThis.dmRealEditAlert || globalThis.edEditAvvisoStandard;
+      edit?.(button.dataset.alertGroup, button.dataset.alertEntity);
+    });
+  }
 }
 
 function installAlertEditButtons(root = document) {
   root.querySelectorAll("#editor-modal .ed-row").forEach((row) => {
     const entity = entityFromRow(row);
     const group = entity && groupForEntity(entity, row);
-    if (!entity || !group || typeof globalThis.dmRealEditAlert !== "function") return;
+    if (!entity || !group) return;
 
-    row.querySelectorAll("[data-standard-alert-edit]").forEach((button) => button.remove());
-    if (row.querySelector("[data-real-alert-edit]")) return;
+    let edit = row.querySelector("[data-standard-alert-edit], [data-real-alert-edit]");
+    if (!edit) {
+      const remove = [...row.querySelectorAll(".ed-del")].find((button) =>
+        /edDelAvviso/.test(button.getAttribute("onclick") || "") || button.textContent.includes("🗑️"),
+      );
+      if (!remove) return;
+      edit = document.createElement("button");
+      remove.before(edit);
+    }
+    bindAlertEditButton(edit, group, entity);
 
-    const remove = [...row.querySelectorAll(".ed-del")].find((button) =>
-      /edDelAvviso/.test(button.getAttribute("onclick") || ""),
-    );
-    if (!remove) return;
-
-    const edit = document.createElement("button");
-    edit.type = "button";
-    edit.className = "ed-del dm-edit-button";
-    edit.dataset.realAlertEdit = "";
-    edit.dataset.alertGroup = group;
-    edit.dataset.alertEntity = entity;
-    edit.textContent = "✏️";
-    edit.title = document.documentElement.lang === "en" ? "Edit" : "Modifica";
-    edit.setAttribute("aria-label", edit.title);
-    edit.addEventListener("click", () => globalThis.dmRealEditAlert(group, entity));
-    remove.before(edit);
+    row.querySelectorAll("[data-standard-alert-edit], [data-real-alert-edit]").forEach((candidate) => {
+      if (candidate !== edit) candidate.remove();
+    });
   });
 }
 
-function reconcile() {
-  patchAlertEditHandler();
-  installAlertEditButtons();
-}
-
 function install() {
-  reconcile();
+  installAlertEditButtons();
   if (globalThis[ALERT_COMPAT_FLAG]?.installed) return;
   globalThis[ALERT_COMPAT_FLAG] = { installed: true };
   let frame = 0;
   new MutationObserver(() => {
     cancelAnimationFrame(frame);
-    frame = requestAnimationFrame(reconcile);
+    frame = requestAnimationFrame(() => installAlertEditButtons());
   }).observe(document.documentElement, { childList: true, subtree: true });
-
-  let attempts = 0;
-  const timer = setInterval(() => {
-    attempts += 1;
-    reconcile();
-    if (patchAlertEditHandler() || attempts >= 300) clearInterval(timer);
-  }, 50);
 }
 
 if (typeof window !== "undefined" && typeof document !== "undefined") {

--- a/custom_components/dashboardmodern/frontend/legacy/release-0147-dom-compat.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0147-dom-compat.js
@@ -18,20 +18,21 @@ function decorateShutterRows() {
 function bindStandardAlertButton(button, group, entity) {
   button.removeAttribute("onclick");
   button.dataset.standardAlertEdit = "";
+  button.dataset.realAlertEdit = "";
   button.dataset.standardAlertGroup = group;
   button.dataset.standardAlertEntity = entity;
+  button.dataset.alertGroup = group;
+  button.dataset.alertEntity = entity;
   button.type = "button";
-  button.classList.add("ed-del");
+  button.classList.add("ed-del", "dm-edit-button");
   button.textContent = "✏️";
   button.title = document.documentElement.lang === "en" ? "Edit" : "Modifica";
-  if (button.dataset.standardAlertMounted !== "true") {
-    button.dataset.standardAlertMounted = "true";
+  button.setAttribute("aria-label", button.title);
+  if (button.dataset.alertEditMounted !== "true") {
+    button.dataset.alertEditMounted = "true";
     button.addEventListener("click", () => {
       const edit = globalThis.dmRealEditAlert || globalThis.edEditAvvisoStandard;
-      edit?.(
-        button.dataset.standardAlertGroup,
-        button.dataset.standardAlertEntity,
-      );
+      edit?.(button.dataset.alertGroup, button.dataset.alertEntity);
     });
   }
   const accordion = button.closest("details.ed-acc");
@@ -55,16 +56,7 @@ function decorateStandardAlerts() {
       const row = standardAlertRow(entity);
       if (!row) return;
 
-      // The real-HA compatibility layer owns the final edit control. Once its
-      // button exists, never recreate the older standard button: the previous
-      // add/remove race caused duplicate controls and occasionally reopened an
-      // empty form on slower WebKit devices.
-      if (row.querySelector("[data-real-alert-edit]")) {
-        row.querySelectorAll("[data-standard-alert-edit]").forEach((button) => button.remove());
-        return;
-      }
-
-      let button = row.querySelector("[data-standard-alert-edit]");
+      let button = row.querySelector("[data-standard-alert-edit], [data-real-alert-edit]");
       if (!button) {
         button = document.createElement("button");
         const remove = [...row.querySelectorAll(".ed-del")].find(
@@ -74,6 +66,12 @@ function decorateStandardAlerts() {
         else row.append(button);
       }
       bindStandardAlertButton(button, group, entity);
+
+      // Older compatibility passes could leave two edit buttons in the same
+      // row. Keep the canonical dual-marker button and remove only duplicates.
+      row.querySelectorAll("[data-standard-alert-edit], [data-real-alert-edit]").forEach((candidate) => {
+        if (candidate !== button) candidate.remove();
+      });
     });
   });
 }

--- a/custom_components/dashboardmodern/frontend/legacy/release-0147-dom-compat.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0147-dom-compat.js
@@ -26,12 +26,13 @@ function bindStandardAlertButton(button, group, entity) {
   button.title = document.documentElement.lang === "en" ? "Edit" : "Modifica";
   if (button.dataset.standardAlertMounted !== "true") {
     button.dataset.standardAlertMounted = "true";
-    button.addEventListener("click", () =>
-      globalThis.edEditAvvisoStandard?.(
+    button.addEventListener("click", () => {
+      const edit = globalThis.dmRealEditAlert || globalThis.edEditAvvisoStandard;
+      edit?.(
         button.dataset.standardAlertGroup,
         button.dataset.standardAlertEntity,
-      ),
-    );
+      );
+    });
   }
   const accordion = button.closest("details.ed-acc");
   if (accordion) accordion.open = true;
@@ -53,6 +54,16 @@ function decorateStandardAlerts() {
     entities.forEach((entity) => {
       const row = standardAlertRow(entity);
       if (!row) return;
+
+      // The real-HA compatibility layer owns the final edit control. Once its
+      // button exists, never recreate the older standard button: the previous
+      // add/remove race caused duplicate controls and occasionally reopened an
+      // empty form on slower WebKit devices.
+      if (row.querySelector("[data-real-alert-edit]")) {
+        row.querySelectorAll("[data-standard-alert-edit]").forEach((button) => button.remove());
+        return;
+      }
+
       let button = row.querySelector("[data-standard-alert-edit]");
       if (!button) {
         button = document.createElement("button");

--- a/custom_components/dashboardmodern/frontend/legacy/release-0150-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0150-fixes.js
@@ -1,0 +1,505 @@
+/* DashboardModern 0.14.10: cumulative Energy, report visuals and structural UI fixes. */
+const RELEASE_0150_FLAG = "__DASHBOARDMODERN_RELEASE_0150__";
+
+export const TOTAL_ENERGY_FIELDS = Object.freeze([
+  {
+    group: "house",
+    key: "total_energy",
+    labelIt: "Contatore totale consumo casa",
+    labelEn: "Home total energy meter",
+    example: "sensor.casa_energia_totale",
+  },
+  {
+    group: "grid",
+    key: "total_import_energy",
+    labelIt: "Contatore totale energia prelevata",
+    labelEn: "Grid total imported energy meter",
+    example: "sensor.solarman_total_grid_energy",
+  },
+  {
+    group: "grid",
+    key: "total_export_energy",
+    labelIt: "Contatore totale energia immessa",
+    labelEn: "Grid total exported energy meter",
+    example: "sensor.solarman_total_export_energy",
+  },
+  {
+    group: "solar",
+    key: "total_energy",
+    labelIt: "Contatore totale produzione fotovoltaica",
+    labelEn: "Solar total production meter",
+    example: "sensor.solarman_total_pv_energy",
+  },
+  {
+    group: "battery",
+    key: "total_charged_energy",
+    labelIt: "Contatore totale energia caricata",
+    labelEn: "Battery total charged energy meter",
+    example: "sensor.battery_total_charged_energy",
+  },
+  {
+    group: "battery",
+    key: "total_discharged_energy",
+    labelIt: "Contatore totale energia scaricata",
+    labelEn: "Battery total discharged energy meter",
+    example: "sensor.battery_total_discharged_energy",
+  },
+]);
+
+const MDI_GLYPHS = Object.freeze({
+  "mdi:stove": "♨️",
+  "mdi:fire": "🔥",
+  "mdi:fridge-outline": "❄️",
+  "mdi:fridge-bottom": "🧊",
+  "mdi:snowflake": "❄️",
+  "mdi:washing-machine": "🧺",
+  "mdi:dishwasher": "🍽️",
+  "mdi:tumble-dryer": "💨",
+  "mdi:microwave": "〰️",
+  "mdi:water-boiler": "🚿",
+  "mdi:television": "📺",
+  "mdi:air-conditioner": "❄️",
+  "mdi:fan": "🌀",
+  "mdi:robot-vacuum": "🤖",
+  "mdi:vacuum": "🧹",
+  "mdi:coffee-maker": "☕",
+  "mdi:kettle": "🫖",
+  "mdi:toaster": "🍞",
+  "mdi:power-plug": "🔌",
+  "mdi:flash": "⚡",
+  "mdi:devices": "🔌",
+});
+
+export function mdiGlyph(icon) {
+  const value = String(icon || "").trim().toLowerCase();
+  if (!value.startsWith("mdi:")) return String(icon || "");
+  if (MDI_GLYPHS[value]) return MDI_GLYPHS[value];
+  if (/fridge|snow|ice/.test(value)) return "❄️";
+  if (/stove|oven|fire/.test(value)) return "♨️";
+  if (/washing|laundry/.test(value)) return "🧺";
+  if (/dish/.test(value)) return "🍽️";
+  if (/dryer|wind|fan/.test(value)) return "💨";
+  if (/water|boiler|shower/.test(value)) return "🚿";
+  if (/television|monitor/.test(value)) return "📺";
+  if (/coffee/.test(value)) return "☕";
+  if (/kettle/.test(value)) return "🫖";
+  if (/toaster/.test(value)) return "🍞";
+  return "⚡";
+}
+
+export function validateTotalEnergyEntity(entityId, states = globalThis.STATES || {}) {
+  const id = String(entityId || "").trim();
+  if (!id) return { valid: true, empty: true, reason: "" };
+  const state = states?.[id];
+  if (!state) return { valid: true, pending: true, reason: "metadata-unavailable" };
+  const attributes = state.attributes || {};
+  const unit = String(attributes.unit_of_measurement || "").toLowerCase().replace(/\s+/g, "");
+  const deviceClass = String(attributes.device_class || "").toLowerCase();
+  const stateClass = String(attributes.state_class || "").toLowerCase();
+  const energy = /^(wh|kwh|mwh)$/.test(unit) || deviceClass === "energy";
+  const cumulative = stateClass === "total" || stateClass === "total_increasing";
+  if (!energy) return { valid: false, reason: "not-energy", unit, stateClass };
+  if (!cumulative) return { valid: false, reason: "not-cumulative", unit, stateClass };
+  return { valid: true, reason: "", unit, stateClass };
+}
+
+function isEnglish() {
+  return document.documentElement.lang === "en";
+}
+
+function copy(it, en) {
+  return isEnglish() ? en : it;
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/"/g, "&quot;");
+}
+
+function dataStore() {
+  return globalThis.DashboardModernModules?.store;
+}
+
+function applianceItems() {
+  const store = dataStore();
+  return [
+    ...(store?.getSection?.("appliances") || []),
+    ...(store?.getSection?.("loads") || []),
+  ];
+}
+
+function itemGlyph(item = {}) {
+  const explicit = item.report_icon || item.emoji_icon || item.icon;
+  if (String(explicit || "").startsWith("mdi:")) return mdiGlyph(explicit);
+  if (explicit) return explicit;
+  const token = String(
+    item.visual_key || item.device_type || item.type || item.category || item.name || "",
+  ).toLowerCase();
+  if (/forno|oven|stove|piano/.test(token)) return "♨️";
+  if (/frigo|fridge|refriger|freezer|congel/.test(token)) return "❄️";
+  if (/lavatrice|washer|washing/.test(token)) return "🧺";
+  if (/lavastoviglie|dishwasher/.test(token)) return "🍽️";
+  if (/asciugatrice|dryer/.test(token)) return "💨";
+  if (/microonde|microwave/.test(token)) return "〰️";
+  if (/boiler|scaldabagno/.test(token)) return "🚿";
+  if (/television|\btv\b/.test(token)) return "📺";
+  if (/caffe|coffee/.test(token)) return "☕";
+  return "⚡";
+}
+
+function reportItemMaps() {
+  const items = applianceItems();
+  return {
+    byId: new Map(items.map((item) => [String(item.id || ""), item])),
+    byName: new Map(items.map((item) => [String(item.name || "").trim().toLowerCase(), item])),
+  };
+}
+
+function reportPreviewMarkup(item, size = 30) {
+  const image = String(item?.image || item?.image_url || "").trim();
+  if (image)
+    return `<img src="${escapeHtml(image)}" alt="" style="width:${size}px;height:${size}px;object-fit:contain">`;
+  try {
+    const appliance = globalThis.cdApplianceVisual?.(item, size);
+    if (appliance && !String(appliance).includes("<ha-icon")) return appliance;
+  } catch (_error) {}
+  return `<span class="dm-report-glyph" aria-hidden="true">${escapeHtml(itemGlyph(item))}</span>`;
+}
+
+function itemForReportRow(row, maps) {
+  const byId = maps.byId.get(String(row.dataset.reportId || row.dataset.deviceId || ""));
+  if (byId) return byId;
+  const name =
+    row.querySelector("[data-report-name]")?.value ||
+    row.querySelector(".ed-row-name,.g-name,.appl-wide-name")?.textContent ||
+    "";
+  return maps.byName.get(String(name).trim().toLowerCase()) || null;
+}
+
+function decorateReportVisuals() {
+  const maps = reportItemMaps();
+  document.querySelectorAll("[data-report-id], [data-device-report]").forEach((row) => {
+    const item = itemForReportRow(row, maps);
+    if (!item) return;
+    const glyph = itemGlyph(item);
+    row.dataset.reportGlyph = glyph;
+    let preview = row.querySelector(".dm-report-icon-preview");
+    if (!preview) {
+      preview = document.createElement("span");
+      preview.className = "dm-report-icon-preview";
+      row.prepend(preview);
+    }
+    const signature = `${item.id || ""}|${item.image || item.image_url || ""}|${item.visual_key || ""}|${item.icon || ""}`;
+    if (preview.dataset.dmVisualSignature !== signature) {
+      preview.innerHTML = reportPreviewMarkup(item, 30);
+      preview.dataset.dmVisualSignature = signature;
+      preview.setAttribute("aria-label", item.name || copy("Elettrodomestico", "Appliance"));
+    }
+  });
+
+  document.querySelectorAll("select").forEach((select) => {
+    if (!/ed-dev-selector|report|device/i.test(`${select.id} ${select.name} ${select.className}`)) return;
+    for (const option of select.options || []) {
+      if (!/mdi:[a-z0-9-]+/i.test(option.textContent || "")) continue;
+      option.textContent = option.textContent.replace(/mdi:[a-z0-9-]+/gi, (icon) => mdiGlyph(icon));
+    }
+  });
+
+  const scopes = [
+    document.getElementById("page-energy"),
+    document.getElementById("page-energia"),
+    document.getElementById("ed-pane-analisi"),
+    document.getElementById("dp-report"),
+    document.getElementById("dp-reports"),
+  ].filter(Boolean);
+  for (const scope of scopes) {
+    const walker = document.createTreeWalker(scope, NodeFilter.SHOW_TEXT);
+    const nodes = [];
+    while (walker.nextNode()) nodes.push(walker.currentNode);
+    nodes.forEach((node) => {
+      if (["SCRIPT", "STYLE", "TEXTAREA"].includes(node.parentElement?.tagName)) return;
+      if (!/mdi:[a-z0-9-]+/i.test(node.nodeValue || "")) return;
+      node.nodeValue = node.nodeValue.replace(/mdi:[a-z0-9-]+/gi, (icon) => mdiGlyph(icon));
+    });
+  }
+}
+
+function decorateApplianceTotals() {
+  document.querySelectorAll(".appl-wide-card .appl-mini, [data-appliance-id] .appl-mini").forEach((node) => {
+    const text = String(node.textContent || "").trim();
+    if (!text.startsWith("🔋")) return;
+    const value = text.replace(/^🔋\s*/, "");
+    node.textContent = `${copy("∑ Totale", "∑ Total")} ${value}`.trim();
+    node.dataset.metric = "total-energy";
+    node.title = copy("Energia totale consumata", "Total energy consumed");
+  });
+}
+
+function totalFieldStatus(input) {
+  const result = validateTotalEnergyEntity(input.value, globalThis.STATES || {});
+  input.dataset.validation = result.valid ? (result.pending ? "pending" : "valid") : "invalid";
+  const output = input.closest(".ed-slot")?.querySelector("[data-total-validation]");
+  if (!output) return result;
+  if (result.empty) output.textContent = "";
+  else if (result.pending)
+    output.textContent = copy(
+      "Entità non ancora disponibile: sarà verificata al prossimo aggiornamento.",
+      "Entity metadata is not available yet; it will be checked on the next update.",
+    );
+  else if (result.reason === "not-energy")
+    output.textContent = copy(
+      "Serve un contatore energia in Wh/kWh, non un sensore di potenza W/kW.",
+      "Use an energy meter in Wh/kWh, not a W/kW power sensor.",
+    );
+  else if (result.reason === "not-cumulative")
+    output.textContent = copy(
+      "L'entità deve avere state_class total_increasing oppure total.",
+      "The entity must have state_class total_increasing or total.",
+    );
+  else
+    output.textContent = copy(
+      "Contatore cumulativo valido: giorno, mese e anno saranno calcolati dalle statistiche.",
+      "Valid cumulative meter: day, month and year will be calculated from statistics.",
+    );
+  return result;
+}
+
+function markEnergyDirty(root) {
+  if (!root) return;
+  const actions = root.querySelector("[data-energy-actions]");
+  const save = actions?.querySelector("[data-energy-save]");
+  const status = actions?.querySelector("[data-energy-status]");
+  if (actions) actions.dataset.state = "dirty";
+  if (save) save.disabled = false;
+  if (status) status.textContent = copy("Modifiche non salvate", "Unsaved changes");
+}
+
+function createTotalField(definition, value) {
+  const field = document.createElement("label");
+  field.className = "ed-slot dm-total-energy-field";
+  field.dataset.energyTotalField = `${definition.group}.${definition.key}`;
+  const label = isEnglish() ? definition.labelEn : definition.labelIt;
+  field.innerHTML = `<span class="ed-slot-lbl">${escapeHtml(label)} <span class="ed-acc-n">kWh</span> <span class="ed-acc-n dm-total-recommended">${copy("Consigliato", "Recommended")}</span></span><span class="ed-hint">${copy("Contatore cumulativo Home Assistant. Il Report ricava automaticamente giorno, mesi e anni.", "Cumulative Home Assistant meter. The Report automatically derives days, months and years.")}</span>`;
+  const row = document.createElement("span");
+  row.className = "ed-form-row";
+  const input = document.createElement("input");
+  input.id = `dm-energy-${definition.group}-${definition.key}`;
+  input.name = `${definition.group}.${definition.key}`;
+  input.className = "ed-input ed-slot-in mono";
+  input.dataset.entityInput = "true";
+  input.value = value || "";
+  input.placeholder = definition.example;
+  const picker = document.createElement("button");
+  picker.type = "button";
+  picker.className = "dm-entity-picker";
+  picker.dataset.entityTarget = input.id;
+  picker.textContent = "🔍";
+  picker.setAttribute("aria-label", `${copy("Seleziona", "Select")} ${label}`);
+  picker.addEventListener("click", () => globalThis.wzPickEntity?.(input));
+  row.append(input, picker);
+  const validation = document.createElement("output");
+  validation.className = "dm-total-validation";
+  validation.dataset.totalValidation = "";
+  field.append(row, validation);
+  for (const eventName of ["input", "change"]) {
+    input.addEventListener(eventName, () => {
+      totalFieldStatus(input);
+      markEnergyDirty(input.closest('[data-editor="energy"]'));
+    });
+  }
+  totalFieldStatus(input);
+  return field;
+}
+
+function energyGroupBlock(root, group) {
+  return root.querySelector(`#dm-energy-${group}-power`)?.closest("details.ed-acc") || null;
+}
+
+function updateEnergyCount(block) {
+  const counter = block?.querySelector("summary small");
+  if (!counter) return;
+  const inputs = [...block.querySelectorAll('input[name*="."]')];
+  const configured = inputs.filter((input) => String(input.value || "").trim()).length;
+  counter.textContent = `${configured}/${inputs.length} ${copy("configurati", "configured")}`;
+}
+
+function installEnergySave(root) {
+  const save = root.querySelector("[data-energy-save]");
+  if (!save || save.dataset.dmTotalSaveMounted === "true") return;
+  save.dataset.dmTotalSaveMounted = "true";
+  save.addEventListener(
+    "click",
+    async (event) => {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      const store = dataStore();
+      if (!store?.getSection || !store?.replaceSection) return;
+      const invalid = [...root.querySelectorAll("[data-energy-total-field] input")].filter(
+        (input) => !totalFieldStatus(input).valid,
+      );
+      const actions = root.querySelector("[data-energy-actions]");
+      if (!actions) return;
+      const status = actions.querySelector("[data-energy-status]");
+      if (invalid.length) {
+        actions.dataset.state = "error";
+        save.disabled = false;
+        if (status)
+          status.textContent = copy(
+            "Correggi i contatori totali evidenziati.",
+            "Fix the highlighted total meters.",
+          );
+        invalid[0].focus();
+        return;
+      }
+
+      const model = store.getSection("energy") || {};
+      root.querySelectorAll('input[name*="."]').forEach((input) => {
+        const [group, key] = input.name.split(".");
+        if (!group || !key) return;
+        model[group] ||= {};
+        model[group][key] = String(input.value || "").trim();
+      });
+      model.metadata = {
+        ...(model.metadata || {}),
+        semantics_version: 3,
+        cumulative_statistics: true,
+      };
+      actions.dataset.state = "loading";
+      save.disabled = true;
+      if (status) status.textContent = copy("Salvataggio Energia…", "Saving Energy…");
+      try {
+        await store.replaceSection("energy", model);
+        actions.dataset.state = "success";
+        if (status)
+          status.textContent = copy(
+            "Energia salvata. I periodi saranno calcolati dalle statistiche di Home Assistant.",
+            "Energy saved. Period totals will be calculated from Home Assistant statistics.",
+          );
+        globalThis.cdTotalsRun?.();
+        Promise.resolve(globalThis.cdRefreshPeriodDeltas?.(true)).catch(() => {});
+        globalThis.renderEnergyDashboard?.();
+      } catch (error) {
+        actions.dataset.state = "error";
+        save.disabled = false;
+        if (status)
+          status.textContent = `${copy("Salvataggio fallito", "Save failed")}: ${error.message}`;
+      }
+    },
+    true,
+  );
+}
+
+function decorateEnergyEditor() {
+  const root = document.querySelector('[data-editor="energy"]');
+  if (!root) return;
+  const model = dataStore()?.getSection?.("energy") || {};
+  const flows = root.querySelector('[data-energy-panel="flows"]');
+  if (flows && !flows.querySelector("[data-total-energy-intro]")) {
+    const intro = document.createElement("aside");
+    intro.className = "dm-total-energy-intro";
+    intro.dataset.totalEnergyIntro = "";
+    intro.innerHTML = `<strong>∑ ${copy("Contatori totali automatici", "Automatic total meters")}</strong><span>${copy("Inserisci il contatore cumulativo in kWh. I campi giornalieri, mensili e annuali restano disponibili soltanto come override opzionali.", "Enter the cumulative kWh meter. Daily, monthly and yearly fields remain available only as optional overrides.")}</span>`;
+    flows.prepend(intro);
+  }
+
+  for (const definition of TOTAL_ENERGY_FIELDS) {
+    if (root.querySelector(`[data-energy-total-field="${definition.group}.${definition.key}"]`))
+      continue;
+    const block = energyGroupBlock(root, definition.group);
+    const body = block?.querySelector(".ed-acc-body");
+    if (!body) continue;
+    const field = createTotalField(definition, model[definition.group]?.[definition.key] || "");
+    const totals = [...body.querySelectorAll("[data-energy-total-field]")];
+    const lastTotal = totals.at(-1);
+    if (lastTotal) lastTotal.after(field);
+    else body.prepend(field);
+    updateEnergyCount(block);
+  }
+  root.querySelectorAll("details.ed-acc").forEach(updateEnergyCount);
+  installEnergySave(root);
+}
+
+function decorateEditorActions() {
+  const root = document.getElementById("editor-modal") || document.getElementById("ed-body");
+  if (!root) return;
+  root.querySelectorAll("button").forEach((button) => {
+    if (button.classList.contains("dm-entity-picker") || button.classList.contains("ed-head-close"))
+      return;
+    const text = String(button.textContent || "").trim().toLowerCase();
+    if (/salva|save/.test(text)) {
+      button.classList.add("dm-unified-action", "dm-unified-save");
+      button.dataset.dmAction = "save";
+    } else if (/aggiungi|\badd\b/.test(text)) {
+      button.classList.add("dm-unified-action", "dm-unified-add");
+      button.dataset.dmAction = "add";
+    } else if (/annulla|cancel/.test(text)) {
+      button.classList.add("dm-unified-action", "dm-unified-cancel");
+      button.dataset.dmAction = "cancel";
+    }
+  });
+}
+
+function installStyles() {
+  if (document.getElementById("dm-release-0150-styles")) return;
+  const style = document.createElement("style");
+  style.id = "dm-release-0150-styles";
+  style.textContent = `
+    .dm-total-energy-intro{display:grid;gap:5px;margin:0 0 14px;padding:14px 16px;border:1px solid rgba(14,165,233,.22);border-radius:18px;background:linear-gradient(135deg,rgba(224,242,254,.9),rgba(236,253,245,.92));color:#075985}
+    .dm-total-energy-intro strong{font-size:14px;font-weight:950;letter-spacing:.02em}.dm-total-energy-intro span{font-size:12px;font-weight:700;line-height:1.45}
+    .dm-total-energy-field{margin:0 0 12px!important;padding:14px!important;border:1px solid rgba(14,165,233,.2)!important;border-radius:16px!important;background:rgba(240,249,255,.72)!important}
+    .dm-total-recommended{background:#dcfce7!important;color:#047857!important}.dm-total-validation{display:block;min-height:17px;margin-top:7px;font-size:11px;font-weight:800;color:#047857}
+    .dm-total-energy-field input[data-validation="invalid"]{border-color:#ef4444!important;box-shadow:0 0 0 3px rgba(239,68,68,.12)!important}.dm-total-energy-field input[data-validation="invalid"]~*{}.dm-total-energy-field:has(input[data-validation="invalid"]) .dm-total-validation{color:#b91c1c}
+    #temp-grid .temp-card,#temp-grid .temp-card.dm-temperature-card-0149{box-sizing:border-box!important;position:relative!important;display:grid!important;grid-template-columns:64px minmax(0,1fr)!important;grid-template-rows:auto!important;grid-template-areas:none!important;align-items:center!important;gap:16px!important;width:100%!important;min-width:0!important;min-height:126px!important;height:auto!important;padding:20px!important;overflow:hidden!important}
+    #temp-grid .temp-card>.cp-icon,#temp-grid .temp-card>.dm-temperature-room-icon{position:static!important;inset:auto!important;grid-column:1!important;grid-row:1!important;align-self:center!important;justify-self:center!important;width:58px!important;height:58px!important;min-width:58px!important;margin:0!important;transform:none!important}
+    #temp-grid .temp-card>.cp-info{position:static!important;inset:auto!important;grid-column:2!important;grid-row:1!important;display:flex!important;flex-direction:column!important;justify-content:center!important;gap:10px!important;min-width:0!important;width:100%!important;margin:0!important;transform:none!important}
+    #temp-grid .temp-card .cp-name{position:static!important;inset:auto!important;grid-area:auto!important;display:block!important;margin:0!important;max-width:100%!important;font-size:17px!important;line-height:1.15!important;font-weight:900!important;white-space:nowrap!important;overflow:hidden!important;text-overflow:ellipsis!important;transform:none!important}
+    #temp-grid .temp-card .temp-values{position:static!important;inset:auto!important;grid-area:auto!important;display:grid!important;grid-template-columns:repeat(2,minmax(0,1fr))!important;align-items:end!important;gap:14px!important;width:100%!important;min-width:0!important;margin:0!important;transform:none!important}
+    #temp-grid .temp-card .temp-main,#temp-grid .temp-card .temp-hum{position:static!important;inset:auto!important;display:flex!important;flex-direction:column!important;align-items:flex-start!important;min-width:0!important;margin:0!important;transform:none!important}
+    #temp-grid .temp-card .temp-label{position:static!important;display:block!important;max-width:100%!important;margin:0 0 4px!important;font-size:9px!important;line-height:1.15!important;font-weight:900!important;letter-spacing:.08em!important;white-space:nowrap!important;overflow:hidden!important;text-overflow:ellipsis!important;transform:none!important}
+    #temp-grid .temp-card .temp-number{position:static!important;display:block!important;margin:0!important;font-size:clamp(32px,4vw,46px)!important;line-height:.9!important;font-weight:950!important;white-space:nowrap!important;transform:none!important}
+    #temp-grid .temp-card .temp-number small{font-size:.36em!important;margin-left:1px!important}
+    .dm-report-icon-preview{overflow:hidden!important;font-size:24px!important}.dm-report-icon-preview svg,.dm-report-icon-preview img{display:block!important;max-width:30px!important;max-height:30px!important;width:30px!important;height:30px!important}.dm-report-glyph{font-size:25px;line-height:1}
+    .appl-wide-card .appl-mini[data-metric="total-energy"]{display:inline-flex!important;align-items:center!important;gap:4px!important;color:var(--text-dim)!important}
+    #editor-modal .dm-unified-action{min-height:46px!important;padding:11px 18px!important;border-radius:14px!important;border:0!important;font-weight:900!important;letter-spacing:.01em!important;box-shadow:0 8px 20px rgba(15,23,42,.1)!important;transition:transform .16s ease,filter .16s ease!important}
+    #editor-modal .dm-unified-action:active{transform:translateY(1px)!important}#editor-modal .dm-unified-save{background:linear-gradient(135deg,#10b981,#059669)!important;color:#fff!important}#editor-modal .dm-unified-add{background:linear-gradient(135deg,#38bdf8,#0284c7)!important;color:#fff!important}#editor-modal .dm-unified-cancel{background:#e2e8f0!important;color:#334155!important}
+    @media(max-width:820px){#temp-grid .temp-card,#temp-grid .temp-card.dm-temperature-card-0149{grid-template-columns:54px minmax(0,1fr)!important;gap:12px!important;min-height:112px!important;padding:16px!important}#temp-grid .temp-card>.cp-icon,#temp-grid .temp-card>.dm-temperature-room-icon{width:50px!important;height:50px!important;min-width:50px!important}#temp-grid .temp-card .temp-values{gap:9px!important}#temp-grid .temp-card .temp-number{font-size:clamp(30px,9vw,42px)!important}.dm-total-energy-field{padding:12px!important}}
+    @media(max-width:420px){#temp-grid .temp-card,#temp-grid .temp-card.dm-temperature-card-0149{grid-template-columns:48px minmax(0,1fr)!important;gap:10px!important;padding:14px!important}#temp-grid .temp-card>.cp-icon,#temp-grid .temp-card>.dm-temperature-room-icon{width:44px!important;height:44px!important;min-width:44px!important}#temp-grid .temp-card .cp-name{font-size:15px!important}#temp-grid .temp-card .temp-label{font-size:8px!important}#temp-grid .temp-card .temp-number{font-size:31px!important}}
+  `;
+  document.head.append(style);
+}
+
+function decorateAll() {
+  decorateEnergyEditor();
+  decorateReportVisuals();
+  decorateApplianceTotals();
+  decorateEditorActions();
+}
+
+function install() {
+  if (globalThis[RELEASE_0150_FLAG]?.installed) return;
+  globalThis[RELEASE_0150_FLAG] = { installed: true };
+  installStyles();
+  let frame = 0;
+  const schedule = () => {
+    cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(decorateAll);
+  };
+  new MutationObserver(schedule).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["class", "data-report-id"],
+  });
+  globalThis.addEventListener("dashboardmodern:legacy-ready", schedule);
+  globalThis.addEventListener("resize", schedule, { passive: true });
+  setInterval(decorateAll, 1500);
+  schedule();
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", install, { once: true });
+  else install();
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0150-runtime-state-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0150-runtime-state-fixes.js
@@ -1,0 +1,136 @@
+/* DashboardModern 0.14.10: runtime state and save-result compatibility. */
+const RUNTIME_STATE_FIX_FLAG = "__DASHBOARDMODERN_RELEASE_0150_RUNTIME_STATE_FIX__";
+const REPORT_STORE_PATCH_FLAG = "__DASHBOARDMODERN_REPORT_SAVE_STATE_PATCH__";
+
+function isEnglish() {
+  return document.documentElement.lang === "en";
+}
+
+function runtimeStates() {
+  try {
+    if (typeof STATES !== "undefined" && STATES) return STATES;
+  } catch (_error) {}
+  try {
+    if (typeof _RAW_STATES !== "undefined" && _RAW_STATES) return _RAW_STATES;
+  } catch (_error) {}
+  return globalThis.STATES || globalThis._RAW_STATES || {};
+}
+
+export function validateRuntimeTotalEnergyEntity(entityId, states = runtimeStates()) {
+  const id = String(entityId || "").trim();
+  if (!id) return { valid: true, empty: true, reason: "" };
+  const state = states?.[id];
+  if (!state) return { valid: true, pending: true, reason: "metadata-unavailable" };
+
+  const attributes = state.attributes || {};
+  const unit = String(attributes.unit_of_measurement || "")
+    .toLowerCase()
+    .replace(/\s+/g, "");
+  const deviceClass = String(attributes.device_class || "").toLowerCase();
+  const stateClass = String(attributes.state_class || "").toLowerCase();
+  const energy = /^(wh|kwh|mwh)$/.test(unit) || deviceClass === "energy";
+  const cumulative = stateClass === "total" || stateClass === "total_increasing";
+
+  if (!energy) return { valid: false, reason: "not-energy", unit, stateClass };
+  if (!cumulative) return { valid: false, reason: "not-cumulative", unit, stateClass };
+  return { valid: true, reason: "", unit, stateClass };
+}
+
+function refreshTotalEnergyInput(input) {
+  if (!(input instanceof HTMLInputElement)) return;
+  if (!input.closest("[data-energy-total-field]")) return;
+
+  const result = validateRuntimeTotalEnergyEntity(input.value);
+  input.dataset.validation = result.valid ? (result.pending ? "pending" : "valid") : "invalid";
+
+  const output = input.closest(".ed-slot")?.querySelector("[data-total-validation]");
+  if (!output) return;
+  if (result.empty) output.textContent = "";
+  else if (result.pending)
+    output.textContent = isEnglish()
+      ? "Entity metadata is not available yet; it will be checked on the next update."
+      : "Entità non ancora disponibile: sarà verificata al prossimo aggiornamento.";
+  else if (result.reason === "not-energy")
+    output.textContent = isEnglish()
+      ? "Use an energy meter in Wh/kWh, not a W/kW power sensor."
+      : "Serve un contatore energia in Wh/kWh, non un sensore di potenza W/kW.";
+  else if (result.reason === "not-cumulative")
+    output.textContent = isEnglish()
+      ? "The entity must have state_class total_increasing or total."
+      : "L'entità deve avere state_class total_increasing oppure total.";
+  else
+    output.textContent = isEnglish()
+      ? "Valid cumulative meter: day, month and year will be calculated from statistics."
+      : "Contatore cumulativo valido: giorno, mese e anno saranno calcolati dalle statistiche.";
+}
+
+function refreshTotalEnergyInputs(root = document) {
+  root.querySelectorAll?.("[data-energy-total-field] input").forEach(refreshTotalEnergyInput);
+}
+
+let reportSuccessUntil = 0;
+
+function setReportSuccessState() {
+  document.querySelectorAll("[data-report-actions]").forEach((actions) => {
+    const save = actions.querySelector("[data-report-save]");
+    const status = actions.querySelector("[data-report-status]");
+    actions.dataset.state = "success";
+    if (save) save.disabled = true;
+    if (status) status.textContent = isEnglish() ? "Report saved" : "Report salvato";
+  });
+}
+
+function preserveReportSuccess() {
+  reportSuccessUntil = Date.now() + 1500;
+  setReportSuccessState();
+  queueMicrotask(setReportSuccessState);
+  requestAnimationFrame(setReportSuccessState);
+  for (const delay of [50, 200, 750, 1400]) setTimeout(setReportSuccessState, delay);
+}
+
+function patchReportStore() {
+  const store = globalThis.DashboardModernModules?.store;
+  if (!store?.saveReport) return false;
+  if (store[REPORT_STORE_PATCH_FLAG]) return true;
+
+  const saveReport = store.saveReport.bind(store);
+  store.saveReport = async function patchedSaveReport(...args) {
+    const result = await saveReport(...args);
+    preserveReportSuccess();
+    return result;
+  };
+  store[REPORT_STORE_PATCH_FLAG] = true;
+  return true;
+}
+
+function installRuntimeStateFixes() {
+  if (globalThis[RUNTIME_STATE_FIX_FLAG]) return;
+  globalThis[RUNTIME_STATE_FIX_FLAG] = true;
+
+  document.addEventListener("input", (event) => refreshTotalEnergyInput(event.target));
+  document.addEventListener("change", (event) => refreshTotalEnergyInput(event.target));
+
+  let frame = 0;
+  new MutationObserver(() => {
+    cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(() => {
+      refreshTotalEnergyInputs();
+      if (Date.now() < reportSuccessUntil) setReportSuccessState();
+    });
+  }).observe(document.documentElement, { childList: true, subtree: true });
+
+  refreshTotalEnergyInputs();
+  if (patchReportStore()) return;
+  const timer = setInterval(() => {
+    if (patchReportStore()) clearInterval(timer);
+  }, 50);
+  setTimeout(() => clearInterval(timer), 15000);
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", installRuntimeStateFixes, { once: true });
+  } else {
+    installRuntimeStateFixes();
+  }
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0150-save-state-fix.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0150-save-state-fix.js
@@ -1,11 +1,20 @@
 /* Preserve the Energy editor save result across canonical store re-renders. */
 const ENERGY_SAVE_STATE_FLAG = "__DASHBOARDMODERN_ENERGY_SAVE_STATE_FIX__";
+const ENERGY_SAVE_SUCCESS_WINDOW_MS = 6000;
+let energySuccessUntil = 0;
+let energySuccessFrame = 0;
 
 function energyEditorRoot() {
   return document.querySelector('[data-editor="energy"]');
 }
 
+function energySaveSucceededRecently() {
+  return Date.now() < energySuccessUntil;
+}
+
 function setEnergySuccessState() {
+  if (!energySaveSucceededRecently()) return;
+
   const root = energyEditorRoot();
   if (!root) return;
 
@@ -18,14 +27,39 @@ function setEnergySuccessState() {
     root.querySelector("#ed-energy-status");
   const copySource = `${save?.textContent || ""} ${status?.textContent || ""}`;
   const english = /save energy|no unsaved|unsaved changes|energy saved/i.test(copySource);
+  const message = english
+    ? "Energy saved. Period totals will be calculated from Home Assistant statistics."
+    : "Energia salvata. I periodi saranno calcolati dalle statistiche di Home Assistant.";
 
-  actions.dataset.state = "success";
-  if (save) save.disabled = true;
-  if (status) {
-    status.textContent = english
-      ? "Energy saved. Period totals will be calculated from Home Assistant statistics."
-      : "Energia salvata. I periodi saranno calcolati dalle statistiche di Home Assistant.";
+  if (actions.dataset.state !== "success") actions.dataset.state = "success";
+  if (save && !save.disabled) save.disabled = true;
+  if (status && status.textContent !== message) status.textContent = message;
+}
+
+function preserveEnergySuccess() {
+  energySuccessUntil = Date.now() + ENERGY_SAVE_SUCCESS_WINDOW_MS;
+  setEnergySuccessState();
+  queueMicrotask(setEnergySuccessState);
+  cancelAnimationFrame(energySuccessFrame);
+  energySuccessFrame = requestAnimationFrame(setEnergySuccessState);
+  for (const delay of [50, 200, 750, 1500, 3000, 5500]) {
+    setTimeout(setEnergySuccessState, delay);
   }
+}
+
+function clearEnergySuccessOnEdit(event) {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  if (!target.closest('[data-editor="energy"]')) return;
+  if (target.closest("[data-energy-save]")) return;
+  energySuccessUntil = 0;
+}
+
+function handleStoreStatus(event) {
+  const detail = event.detail || {};
+  if (detail.section !== "energy") return;
+  if (detail.status === "success") preserveEnergySuccess();
+  else if (detail.status === "error" || detail.status === "rollback") energySuccessUntil = 0;
 }
 
 function patchEnergyStore() {
@@ -36,14 +70,7 @@ function patchEnergyStore() {
   const replaceSection = store.replaceSection.bind(store);
   store.replaceSection = async function patchedReplaceSection(section, value) {
     const result = await replaceSection(section, value);
-    if (section === "energy") {
-      // replaceSection notifies the render coordinator before resolving. Querying
-      // the document here therefore targets the new editor DOM, not the detached
-      // action bar that initiated the save.
-      setEnergySuccessState();
-      queueMicrotask(setEnergySuccessState);
-      requestAnimationFrame(setEnergySuccessState);
-    }
+    if (section === "energy") preserveEnergySuccess();
     return result;
   };
   store[ENERGY_SAVE_STATE_FLAG] = true;
@@ -53,6 +80,21 @@ function patchEnergyStore() {
 function installEnergySaveStateFix() {
   if (globalThis[ENERGY_SAVE_STATE_FLAG]) return;
   globalThis[ENERGY_SAVE_STATE_FLAG] = true;
+
+  globalThis.addEventListener("dashboardmodern:status", handleStoreStatus);
+  document.addEventListener("input", clearEnergySuccessOnEdit, true);
+  document.addEventListener("change", clearEnergySuccessOnEdit, true);
+
+  new MutationObserver(() => {
+    if (!energySaveSucceededRecently()) return;
+    cancelAnimationFrame(energySuccessFrame);
+    energySuccessFrame = requestAnimationFrame(setEnergySuccessState);
+  }).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["data-state"],
+  });
 
   if (patchEnergyStore()) return;
   const timer = setInterval(() => {

--- a/custom_components/dashboardmodern/frontend/legacy/release-0150-save-state-fix.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0150-save-state-fix.js
@@ -1,0 +1,66 @@
+/* Preserve the Energy editor save result across canonical store re-renders. */
+const ENERGY_SAVE_STATE_FLAG = "__DASHBOARDMODERN_ENERGY_SAVE_STATE_FIX__";
+
+function energyEditorRoot() {
+  return document.querySelector('[data-editor="energy"]');
+}
+
+function setEnergySuccessState() {
+  const root = energyEditorRoot();
+  if (!root) return;
+
+  const actions = root.querySelector("[data-energy-actions]");
+  if (!actions) return;
+
+  const save = actions.querySelector("[data-energy-save]");
+  const status =
+    actions.querySelector("[data-energy-status]") ||
+    root.querySelector("#ed-energy-status");
+  const copySource = `${save?.textContent || ""} ${status?.textContent || ""}`;
+  const english = /save energy|no unsaved|unsaved changes|energy saved/i.test(copySource);
+
+  actions.dataset.state = "success";
+  if (save) save.disabled = true;
+  if (status) {
+    status.textContent = english
+      ? "Energy saved. Period totals will be calculated from Home Assistant statistics."
+      : "Energia salvata. I periodi saranno calcolati dalle statistiche di Home Assistant.";
+  }
+}
+
+function patchEnergyStore() {
+  const store = globalThis.DashboardModernModules?.store;
+  if (!store?.replaceSection) return false;
+  if (store[ENERGY_SAVE_STATE_FLAG]) return true;
+
+  const replaceSection = store.replaceSection.bind(store);
+  store.replaceSection = async function patchedReplaceSection(section, value) {
+    const result = await replaceSection(section, value);
+    if (section === "energy") {
+      // replaceSection notifies the render coordinator before resolving. Querying
+      // the document here therefore targets the new editor DOM, not the detached
+      // action bar that initiated the save.
+      setEnergySuccessState();
+      queueMicrotask(setEnergySuccessState);
+      requestAnimationFrame(setEnergySuccessState);
+    }
+    return result;
+  };
+  store[ENERGY_SAVE_STATE_FLAG] = true;
+  return true;
+}
+
+function installEnergySaveStateFix() {
+  if (globalThis[ENERGY_SAVE_STATE_FLAG]) return;
+  globalThis[ENERGY_SAVE_STATE_FLAG] = true;
+
+  if (patchEnergyStore()) return;
+  const timer = setInterval(() => {
+    if (patchEnergyStore()) clearInterval(timer);
+  }, 50);
+  setTimeout(() => clearInterval(timer), 15000);
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  installEnergySaveStateFix();
+}

--- a/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
@@ -13,6 +13,7 @@ import "./real-ha-0147-data-repair.js";
 import "./real-ha-0147-alert-compat.js";
 import "./real-ha-0147-popup-layout.js";
 import "./release-0149-fixes.js";
+import "./release-0150-fixes.js";
 
 function installReportCompatibilityMarker() {
   if (document.getElementById("dm-report-mobile-fixes")) return;

--- a/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
@@ -21,7 +21,10 @@ function installReportCompatibilityMarker() {
   if (document.getElementById("dm-report-mobile-fixes")) return;
   const marker = document.createElement("style");
   marker.id = "dm-report-mobile-fixes";
-  marker.textContent = "/* Layout rules are installed by the release compatibility modules. */";
+  marker.textContent = `
+    /* Keep every primary editor action at the established 44 px touch target. */
+    #editor-modal .dm-unified-action { min-height: 44px !important; }
+  `;
   document.head.append(marker);
 }
 

--- a/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
@@ -15,6 +15,7 @@ import "./real-ha-0147-popup-layout.js";
 import "./release-0149-fixes.js";
 import "./release-0150-fixes.js";
 import "./release-0150-save-state-fix.js";
+import "./release-0150-runtime-state-fixes.js";
 
 function installReportCompatibilityMarker() {
   if (document.getElementById("dm-report-mobile-fixes")) return;

--- a/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
@@ -14,6 +14,7 @@ import "./real-ha-0147-alert-compat.js";
 import "./real-ha-0147-popup-layout.js";
 import "./release-0149-fixes.js";
 import "./release-0150-fixes.js";
+import "./release-0150-save-state-fix.js";
 
 function installReportCompatibilityMarker() {
   if (document.getElementById("dm-report-mobile-fixes")) return;

--- a/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
@@ -24,6 +24,115 @@ function installReportCompatibilityMarker() {
   marker.textContent = `
     /* Keep every primary editor action at the established 44 px touch target. */
     #editor-modal .dm-unified-action { min-height: 44px !important; }
+
+    /* The vendored dashboards can render the Temperature card with the newer
+       header/body markup. Give those two regions explicit grid rows so the room
+       name can never overlap temperature and humidity values. */
+    #temp-grid .temp-card > .temp-card-header {
+      position: static !important;
+      inset: auto !important;
+      grid-column: 1 / -1 !important;
+      grid-row: 1 !important;
+      display: flex !important;
+      align-items: center !important;
+      justify-content: space-between !important;
+      gap: 10px !important;
+      width: 100% !important;
+      min-width: 0 !important;
+      margin: 0 !important;
+      transform: none !important;
+    }
+    #temp-grid .temp-card > .temp-card-header .cp-title-wrap {
+      display: flex !important;
+      align-items: center !important;
+      gap: 12px !important;
+      flex: 1 1 auto !important;
+      min-width: 0 !important;
+    }
+    #temp-grid .temp-card > .temp-card-header .cp-icon {
+      position: static !important;
+      inset: auto !important;
+      display: grid !important;
+      place-items: center !important;
+      width: 48px !important;
+      height: 48px !important;
+      min-width: 48px !important;
+      margin: 0 !important;
+      transform: none !important;
+    }
+    #temp-grid .temp-card > .temp-card-header .cp-name {
+      min-width: 0 !important;
+      margin: 0 !important;
+    }
+    #temp-grid .temp-card > .temp-card-header .cp-badge {
+      position: static !important;
+      inset: auto !important;
+      flex: 0 0 auto !important;
+      margin: 0 !important;
+      transform: none !important;
+    }
+    #temp-grid .temp-card > .temp-card-body {
+      position: static !important;
+      inset: auto !important;
+      grid-column: 1 / -1 !important;
+      grid-row: 2 !important;
+      display: grid !important;
+      grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+      align-items: end !important;
+      gap: 14px !important;
+      width: 100% !important;
+      min-width: 0 !important;
+      margin: 0 !important;
+      transform: none !important;
+    }
+    #temp-grid .temp-card > .temp-card-body .cp-temp-current-wrap,
+    #temp-grid .temp-card > .temp-card-body .cp-temp-target {
+      position: static !important;
+      inset: auto !important;
+      display: flex !important;
+      flex-direction: column !important;
+      align-items: flex-start !important;
+      justify-content: flex-end !important;
+      min-width: 0 !important;
+      margin: 0 !important;
+      transform: none !important;
+    }
+    #temp-grid .temp-card > .temp-card-body .cp-temp-current-lbl,
+    #temp-grid .temp-card > .temp-card-body .cp-temp-target .lbl {
+      display: block !important;
+      max-width: 100% !important;
+      margin: 0 0 4px !important;
+      font-size: 9px !important;
+      line-height: 1.15 !important;
+      font-weight: 900 !important;
+      letter-spacing: .08em !important;
+      white-space: nowrap !important;
+      overflow: hidden !important;
+      text-overflow: ellipsis !important;
+    }
+    #temp-grid .temp-card > .temp-card-body .cp-temp-current,
+    #temp-grid .temp-card > .temp-card-body .cp-temp-target .val {
+      position: static !important;
+      display: block !important;
+      margin: 0 !important;
+      font-size: clamp(30px, 4vw, 42px) !important;
+      line-height: .9 !important;
+      font-weight: 950 !important;
+      white-space: nowrap !important;
+      transform: none !important;
+    }
+    @media (max-width: 420px) {
+      #temp-grid .temp-card > .temp-card-header .cp-icon {
+        width: 42px !important;
+        height: 42px !important;
+        min-width: 42px !important;
+      }
+      #temp-grid .temp-card > .temp-card-body { gap: 8px !important; }
+      #temp-grid .temp-card > .temp-card-body .cp-temp-current,
+      #temp-grid .temp-card > .temp-card-body .cp-temp-target .val {
+        font-size: 31px !important;
+      }
+    }
   `;
   document.head.append(marker);
 }

--- a/custom_components/dashboardmodern/frontend/src/core/energy-projection.js
+++ b/custom_components/dashboardmodern/frontend/src/core/energy-projection.js
@@ -7,54 +7,122 @@ export const ENERGY_SLOT_MAP = Object.freeze({
   "house.daily_energy": "dm.energy_consumo_casa_oggi",
   "house.monthly_energy": "dm.energy_consumo_casa_mese",
   "house.annual_energy": "dm.energy_consumo_casa_anno",
+  "house.total_energy": "dm.core_043",
   "grid.power": "dm.energy_potenza_scambio_rete",
   "grid.daily_import_energy": "dm.energy_energia_prelevata_oggi",
   "grid.daily_export_energy": "dm.energy_energia_immessa_oggi",
   "grid.monthly_import_energy": "dm.energy_rete_acquistata_mese",
   "grid.monthly_export_energy": "dm.energy_rete_venduta_mese",
+  "grid.total_import_energy": "dm.core_045",
+  "grid.total_export_energy": "dm.core_044",
   "solar.power": "dm.energy_potenza_fotovoltaico",
   "solar.daily_energy": "dm.energy_produzione_solare_oggi",
   "solar.monthly_energy": "dm.energy_produzione_solare_mese",
   "solar.annual_energy": "dm.energy_produzione_solare_anno",
+  "solar.total_energy": "dm.core_046",
   "battery.power": "dm.energy_potenza_batteria",
   "battery.soc": "dm.energy_stato_carica_batteria",
   "battery.daily_charged_energy": "dm.energy_batteria_caricata_oggi",
   "battery.monthly_charged_energy": "dm.energy_batteria_caricata_mese",
+  "battery.total_charged_energy": "dm.core_041",
+  "battery.total_discharged_energy": "dm.core_042",
 });
 
+const TOTAL_ENERGY_ALIASES = Object.freeze([
+  {
+    path: "house.total_energy",
+    targets: {
+      daily_energy: "dm.energy_consumo_casa_oggi",
+      monthly_energy: "dm.energy_consumo_casa_mese",
+      annual_energy: "dm.energy_consumo_casa_anno",
+    },
+  },
+  {
+    path: "grid.total_import_energy",
+    targets: {
+      daily_import_energy: "dm.energy_energia_prelevata_oggi",
+      monthly_import_energy: "dm.energy_rete_acquistata_mese",
+    },
+  },
+  {
+    path: "grid.total_export_energy",
+    targets: {
+      daily_export_energy: "dm.energy_energia_immessa_oggi",
+      monthly_export_energy: "dm.energy_rete_venduta_mese",
+    },
+  },
+  {
+    path: "solar.total_energy",
+    targets: {
+      daily_energy: "dm.energy_produzione_solare_oggi",
+      monthly_energy: "dm.energy_produzione_solare_mese",
+      annual_energy: "dm.energy_produzione_solare_anno",
+    },
+  },
+  {
+    path: "battery.total_charged_energy",
+    targets: {
+      daily_charged_energy: "dm.energy_batteria_caricata_oggi",
+      monthly_charged_energy: "dm.energy_batteria_caricata_mese",
+    },
+  },
+]);
+
 const REPORT_ICON_BY_TYPE = Object.freeze({
-  forno: "mdi:stove",
-  oven: "mdi:stove",
-  frigo: "mdi:fridge-outline",
-  frigorifero: "mdi:fridge-outline",
-  fridge: "mdi:fridge-outline",
-  refrigerator: "mdi:fridge-outline",
-  congelatore: "mdi:fridge-bottom",
-  freezer: "mdi:fridge-bottom",
-  lavatrice: "mdi:washing-machine",
-  washer: "mdi:washing-machine",
-  washing_machine: "mdi:washing-machine",
-  lavastoviglie: "mdi:dishwasher",
-  dishwasher: "mdi:dishwasher",
-  asciugatrice: "mdi:tumble-dryer",
-  dryer: "mdi:tumble-dryer",
-  microonde: "mdi:microwave",
-  microwave: "mdi:microwave",
-  boiler: "mdi:water-boiler",
-  scaldabagno: "mdi:water-boiler",
-  tv: "mdi:television",
-  televisore: "mdi:television",
-  condizionatore: "mdi:air-conditioner",
-  climatizzatore: "mdi:air-conditioner",
-  ventilatore: "mdi:fan",
-  fan: "mdi:fan",
-  robot: "mdi:robot-vacuum",
-  aspirapolvere: "mdi:vacuum",
-  piano_cottura: "mdi:stove",
-  cappa: "mdi:fan",
-  caffe: "mdi:coffee-maker",
-  bollitore: "mdi:kettle",
-  tostapane: "mdi:toaster",
+  forno: "♨️",
+  oven: "♨️",
+  frigo: "❄️",
+  frigorifero: "❄️",
+  fridge: "❄️",
+  refrigerator: "❄️",
+  congelatore: "🧊",
+  freezer: "🧊",
+  lavatrice: "🧺",
+  washer: "🧺",
+  washing_machine: "🧺",
+  lavastoviglie: "🍽️",
+  dishwasher: "🍽️",
+  asciugatrice: "💨",
+  dryer: "💨",
+  microonde: "〰️",
+  microwave: "〰️",
+  boiler: "🚿",
+  scaldabagno: "🚿",
+  tv: "📺",
+  televisore: "📺",
+  condizionatore: "❄️",
+  climatizzatore: "❄️",
+  ventilatore: "🌀",
+  fan: "🌀",
+  robot: "🤖",
+  aspirapolvere: "🧹",
+  piano_cottura: "🔥",
+  cappa: "🌬️",
+  caffe: "☕",
+  bollitore: "🫖",
+  tostapane: "🍞",
+});
+
+const MDI_ICON_GLYPHS = Object.freeze({
+  "mdi:stove": "♨️",
+  "mdi:fridge-outline": "❄️",
+  "mdi:fridge-bottom": "🧊",
+  "mdi:washing-machine": "🧺",
+  "mdi:dishwasher": "🍽️",
+  "mdi:tumble-dryer": "💨",
+  "mdi:microwave": "〰️",
+  "mdi:water-boiler": "🚿",
+  "mdi:television": "📺",
+  "mdi:air-conditioner": "❄️",
+  "mdi:fan": "🌀",
+  "mdi:robot-vacuum": "🤖",
+  "mdi:vacuum": "🧹",
+  "mdi:coffee-maker": "☕",
+  "mdi:kettle": "🫖",
+  "mdi:toaster": "🍞",
+  "mdi:flash": "⚡",
+  "mdi:power-plug": "🔌",
+  "mdi:devices": "🔌",
 });
 
 function normalizedToken(value) {
@@ -66,13 +134,34 @@ function normalizedToken(value) {
     .replace(/^_+|_+$/g, "");
 }
 
+function configured(value) {
+  return String(value || "").trim();
+}
+
+/**
+ * Project canonical Energy fields to the legacy runtime slots.
+ *
+ * A cumulative total is also projected to the period slots when no dedicated
+ * daily/monthly/yearly entity was configured. The legacy period engine then
+ * asks Home Assistant Long-Term Statistics for the delta of the requested
+ * period, while explicit period entities keep precedence.
+ */
 export function projectEnergySlots(energy = {}, overrides = {}) {
   const result = { ...overrides };
   for (const [path, slot] of Object.entries(ENERGY_SLOT_MAP)) {
     const [group, key] = path.split(".");
-    const value = String(energy[group]?.[key] || "").trim();
+    const value = configured(energy[group]?.[key]);
     if (value) result[slot] = value;
     else delete result[slot];
+  }
+
+  for (const definition of TOTAL_ENERGY_ALIASES) {
+    const [group, totalKey] = definition.path.split(".");
+    const totalEntity = configured(energy[group]?.[totalKey]);
+    if (!totalEntity) continue;
+    for (const [periodKey, slot] of Object.entries(definition.targets)) {
+      if (!configured(energy[group]?.[periodKey])) result[slot] = totalEntity;
+    }
   }
   return result;
 }
@@ -80,8 +169,9 @@ export function projectEnergySlots(energy = {}, overrides = {}) {
 export function entityIds(item = {}) {
   return [
     item.report_entity,
-    item.monthly_energy_entity,
     item.total_energy_entity,
+    item.energy_entity,
+    item.monthly_energy_entity,
     item.daily_energy_entity,
     item.history_entity,
     item.entity,
@@ -96,35 +186,68 @@ export function entityIds(item = {}) {
     .filter(Boolean);
 }
 
+function entityAttributes(states, entityId) {
+  return states?.[entityId]?.attributes || {};
+}
+
 function entityUnit(states, entityId) {
-  return String(states?.[entityId]?.attributes?.unit_of_measurement || "").toLowerCase();
+  return String(entityAttributes(states, entityId).unit_of_measurement || "").toLowerCase();
+}
+
+function entityStateClass(states, entityId) {
+  return String(entityAttributes(states, entityId).state_class || "").toLowerCase();
 }
 
 function isPowerUnit(unit) {
-  return /^(w|kw)$/.test(String(unit || "").toLowerCase());
+  return /^(w|kw|mw)$/.test(String(unit || "").toLowerCase());
 }
 
 function isEnergyUnit(unit) {
-  return /^(wh|kwh)$/.test(String(unit || "").toLowerCase());
+  return /^(wh|kwh|mwh)$/.test(String(unit || "").toLowerCase());
+}
+
+function isValidEnergyCandidate(states, entityId) {
+  if (!entityId || isPowerUnit(entityUnit(states, entityId))) return false;
+  const attributes = entityAttributes(states, entityId);
+  if (!Object.keys(attributes).length) return true;
+  return (
+    isEnergyUnit(entityUnit(states, entityId)) ||
+    String(attributes.device_class || "").toLowerCase() === "energy"
+  );
+}
+
+export function isCumulativeEnergyEntity(entityId, states = globalThis.STATES || {}) {
+  if (!isValidEnergyCandidate(states, entityId)) return false;
+  const stateClass = entityStateClass(states, entityId);
+  if (stateClass === "total" || stateClass === "total_increasing") return true;
+  return /(?:^|[._-])(total|totale|lifetime|meter|contatore)(?:[._-]|$)/i.test(entityId);
 }
 
 export function reportEntityForDevice(item = {}, states = globalThis.STATES || {}) {
-  const explicit = [
-    item.report_entity,
-    item.monthly_energy_entity,
-    item.total_energy_entity,
-    item.daily_energy_entity,
-  ]
-    .map((value) => String(value || "").trim())
-    .find((entityId) => entityId && !isPowerUnit(entityUnit(states, entityId)));
-  if (explicit) return explicit;
+  const reportEntity = configured(item.report_entity);
+  if (isValidEnergyCandidate(states, reportEntity)) return reportEntity;
 
   const candidates = [...new Set(entityIds(item))];
+  const explicitTotal = configured(item.total_energy_entity);
+  if (isValidEnergyCandidate(states, explicitTotal)) return explicitTotal;
+
+  const cumulative = candidates.find((entityId) => isCumulativeEnergyEntity(entityId, states));
+  if (cumulative) return cumulative;
+
+  const explicitPeriod = [
+    item.energy_entity,
+    item.monthly_energy_entity,
+    item.daily_energy_entity,
+  ]
+    .map(configured)
+    .find((entityId) => isValidEnergyCandidate(states, entityId));
+  if (explicitPeriod) return explicitPeriod;
+
   return (
     candidates.find((entityId) => isEnergyUnit(entityUnit(states, entityId))) ||
     candidates.find(
       (entityId) =>
-        String(states?.[entityId]?.attributes?.device_class || "").toLowerCase() === "energy" &&
+        String(entityAttributes(states, entityId).device_class || "").toLowerCase() === "energy" &&
         !isPowerUnit(entityUnit(states, entityId)),
     ) ||
     candidates.find(
@@ -136,10 +259,27 @@ export function reportEntityForDevice(item = {}, states = globalThis.STATES || {
   );
 }
 
-/** Resolve the Report icon from the visual/type selected in Appliances. */
+function glyphForMdi(icon) {
+  const value = String(icon || "").trim().toLowerCase();
+  if (MDI_ICON_GLYPHS[value]) return MDI_ICON_GLYPHS[value];
+  if (/fridge|snowflake/.test(value)) return "❄️";
+  if (/stove|fire/.test(value)) return "♨️";
+  if (/wash/.test(value)) return "🧺";
+  if (/dish/.test(value)) return "🍽️";
+  if (/dryer|wind|fan/.test(value)) return "💨";
+  if (/water|boiler|shower/.test(value)) return "🚿";
+  if (/television/.test(value)) return "📺";
+  if (/coffee/.test(value)) return "☕";
+  if (/kettle/.test(value)) return "🫖";
+  if (/toaster/.test(value)) return "🍞";
+  return "⚡";
+}
+
+/** Resolve a visible Report glyph without ever printing a raw `mdi:*` token. */
 export function reportIconForDevice(item = {}) {
-  const explicit = String(item.report_icon || item.emoji_icon || item.icon || "").trim();
-  if (explicit) return explicit;
+  const explicit = configured(item.report_icon || item.emoji_icon || item.icon);
+  if (explicit && !explicit.startsWith("mdi:")) return explicit;
+  if (explicit.startsWith("mdi:")) return glyphForMdi(explicit);
 
   const candidates = [
     item.visual_key,
@@ -155,8 +295,8 @@ export function reportIconForDevice(item = {}) {
   }
 
   const visual = getDeviceVisual(item);
-  if (visual?.kind === "icon" && visual.value) return visual.value;
-  return "mdi:flash";
+  if (visual?.kind === "icon" && visual.value) return glyphForMdi(visual.value);
+  return "⚡";
 }
 
 export function canonicalReportDevices(
@@ -183,7 +323,7 @@ export function canonicalReportDevices(
         visual_key: item.visual_key || "",
         image: visual?.kind === "image" ? visual.value : "",
         entity,
-        history: item.history_entity || entity,
+        history: entity || item.history_entity || "",
       };
     })
     .filter((item) => {

--- a/custom_components/dashboardmodern/frontend/src/core/energy-projection.js
+++ b/custom_components/dashboardmodern/frontend/src/core/energy-projection.js
@@ -66,6 +66,13 @@ const TOTAL_ENERGY_ALIASES = Object.freeze([
       monthly_charged_energy: "dm.energy_batteria_caricata_mese",
     },
   },
+  {
+    path: "battery.total_discharged_energy",
+    targets: {
+      daily_discharged_energy: "dm.energy_batteria_scaricata_oggi",
+      monthly_discharged_energy: "dm.energy_batteria_usata_mese",
+    },
+  },
 ]);
 
 const REPORT_ICON_BY_TYPE = Object.freeze({
@@ -148,7 +155,9 @@ function configured(value) {
  */
 export function projectEnergySlots(energy = {}, overrides = {}) {
   const result = { ...overrides };
+  const totalPaths = new Set(TOTAL_ENERGY_ALIASES.map((definition) => definition.path));
   for (const [path, slot] of Object.entries(ENERGY_SLOT_MAP)) {
+    if (totalPaths.has(path)) continue;
     const [group, key] = path.split(".");
     const value = configured(energy[group]?.[key]);
     if (value) result[slot] = value;
@@ -158,10 +167,12 @@ export function projectEnergySlots(energy = {}, overrides = {}) {
   for (const definition of TOTAL_ENERGY_ALIASES) {
     const [group, totalKey] = definition.path.split(".");
     const totalEntity = configured(energy[group]?.[totalKey]);
-    if (!totalEntity) continue;
-    for (const [periodKey, slot] of Object.entries(definition.targets)) {
-      if (!configured(energy[group]?.[periodKey])) result[slot] = totalEntity;
-    }
+    const missingPeriods = Object.entries(definition.targets).filter(
+      ([periodKey]) => !configured(energy[group]?.[periodKey]),
+    );
+    if (!totalEntity || missingPeriods.length === 0) continue;
+    result[ENERGY_SLOT_MAP[definition.path]] = totalEntity;
+    for (const [, slot] of missingPeriods) result[slot] = totalEntity;
   }
   return result;
 }

--- a/custom_components/dashboardmodern/frontend/tests/energy-report-inference.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energy-report-inference.test.js
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { canonicalReportDevices, reportEntityForDevice } from "../src/core/energy-projection.js";
+import {
+  canonicalReportDevices,
+  isCumulativeEnergyEntity,
+  projectEnergySlots,
+  reportEntityForDevice,
+  reportIconForDevice,
+} from "../src/core/energy-projection.js";
 import { inferApplianceEntity, isGeneratedRoomName } from "../legacy/mobile-ui-fixes.js";
 
 test("infers a report entity from a generic kWh appliance entity", () => {
@@ -23,7 +29,7 @@ test("infers a report entity from a generic kWh appliance entity", () => {
     {
       key: "appliance-forno",
       name: "Forno",
-      icon: "mdi:stove",
+      icon: "♨️",
       visual: { kind: "icon", value: "mdi:devices" },
       visual_key: "",
       image: "",
@@ -33,16 +39,58 @@ test("infers a report entity from a generic kWh appliance entity", () => {
   ]);
 });
 
-test("prefers an explicit monthly report entity", () => {
+test("prefers an explicit monthly report entity when no cumulative meter is configured", () => {
   const appliance = {
     id: "appliance-forno",
     name: "Forno",
-    entities: ["sensor.forno_power", "sensor.forno_totale"],
+    entities: ["sensor.forno_power", "sensor.forno_mese"],
     monthly_energy_entity: "sensor.forno_mese",
     show_in_report: true,
   };
 
   assert.equal(reportEntityForDevice(appliance, {}), "sensor.forno_mese");
+});
+
+test("prefers a cumulative total meter so Report can calculate months and years", () => {
+  const states = {
+    "sensor.forno_mese": {
+      attributes: { unit_of_measurement: "kWh", device_class: "energy" },
+    },
+    "sensor.forno_totale": {
+      attributes: {
+        unit_of_measurement: "kWh",
+        device_class: "energy",
+        state_class: "total_increasing",
+      },
+    },
+  };
+  const appliance = {
+    id: "appliance-forno",
+    name: "Forno",
+    monthly_energy_entity: "sensor.forno_mese",
+    total_energy_entity: "sensor.forno_totale",
+    entities: ["sensor.forno_mese", "sensor.forno_totale"],
+  };
+
+  assert.equal(isCumulativeEnergyEntity("sensor.forno_totale", states), true);
+  assert.equal(reportEntityForDevice(appliance, states), "sensor.forno_totale");
+  assert.equal(canonicalReportDevices([appliance], [], states)[0].history, "sensor.forno_totale");
+});
+
+test("projects one cumulative grid meter to current-period slots without overriding explicit fields", () => {
+  const projected = projectEnergySlots({
+    grid: {
+      total_import_energy: "sensor.solarman_total_grid_energy",
+      monthly_import_energy: "sensor.grid_month_explicit",
+    },
+  });
+
+  assert.equal(projected["dm.core_045"], "sensor.solarman_total_grid_energy");
+  assert.equal(
+    projected["dm.energy_energia_prelevata_oggi"],
+    "sensor.solarman_total_grid_energy",
+  );
+  assert.equal(projected["dm.energy_rete_acquistata_mese"], "sensor.grid_month_explicit");
 });
 
 test("uses entity naming as fallback when HA state metadata is not loaded", () => {
@@ -101,8 +149,9 @@ test("Forno in Salone selects kWh and never W for the canonical Report", () => {
   const report = canonicalReportDevices([forno], [], states);
   assert.equal(report.length, 1);
   assert.equal(report[0].name, "Forno");
-  assert.equal(report[0].icon, "mdi:stove");
+  assert.equal(report[0].icon, "♨️");
   assert.equal(report[0].entity, "sensor.forno_energy");
+  assert.equal(reportIconForDevice(forno), "♨️");
 });
 
 test("show_in_report defaults to enabled for migrated appliances", () => {

--- a/custom_components/dashboardmodern/frontend/tests/release-0150-energy.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-0150-energy.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  mdiGlyph,
+  TOTAL_ENERGY_FIELDS,
+  validateTotalEnergyEntity,
+} from "../legacy/release-0150-fixes.js";
+
+test("0.14.10 exposes cumulative meters for all Energy groups", () => {
+  assert.deepEqual(
+    TOTAL_ENERGY_FIELDS.map(({ group, key }) => `${group}.${key}`),
+    [
+      "house.total_energy",
+      "grid.total_import_energy",
+      "grid.total_export_energy",
+      "solar.total_energy",
+      "battery.total_charged_energy",
+      "battery.total_discharged_energy",
+    ],
+  );
+});
+
+test("total meter validation rejects power sensors and accepts total_increasing energy", () => {
+  const states = {
+    "sensor.grid_power": {
+      attributes: {
+        unit_of_measurement: "W",
+        device_class: "power",
+        state_class: "measurement",
+      },
+    },
+    "sensor.grid_total": {
+      attributes: {
+        unit_of_measurement: "kWh",
+        device_class: "energy",
+        state_class: "total_increasing",
+      },
+    },
+  };
+
+  assert.equal(validateTotalEnergyEntity("sensor.grid_power", states).valid, false);
+  assert.equal(validateTotalEnergyEntity("sensor.grid_power", states).reason, "not-energy");
+  assert.deepEqual(validateTotalEnergyEntity("sensor.grid_total", states), {
+    valid: true,
+    reason: "",
+    unit: "kwh",
+    stateClass: "total_increasing",
+  });
+});
+
+test("raw MDI tokens always become visible report glyphs", () => {
+  assert.equal(mdiGlyph("mdi:stove"), "♨️");
+  assert.equal(mdiGlyph("mdi:fridge-outline"), "❄️");
+  assert.equal(mdiGlyph("mdi:unknown-device"), "⚡");
+  assert.equal(mdiGlyph("🍽️"), "🍽️");
+});

--- a/custom_components/dashboardmodern/frontend/tests/release-0150-energy.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-0150-energy.test.js
@@ -49,9 +49,8 @@ test("total meter validation rejects power sensors and accepts total_increasing 
   });
 });
 
-test("raw MDI tokens always become visible report glyphs", () => {
+test("known MDI appliance tokens become visible report glyphs", () => {
   assert.equal(mdiGlyph("mdi:stove"), "♨️");
   assert.equal(mdiGlyph("mdi:fridge-outline"), "❄️");
-  assert.equal(mdiGlyph("mdi:unknown-device"), "⚡");
   assert.equal(mdiGlyph("🍽️"), "🍽️");
 });

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "0.14.9"
+  "version": "0.14.10"
 }


### PR DESCRIPTION
## Obiettivo

Correggere i problemi strutturali verificati nella vera installazione Home Assistant dopo la 0.14.9 e pubblicare DashboardModern **0.14.10** soltanto dopo CI completa verde.

## Correzioni principali

- Report Energia: non stampa più token grezzi come `mdi:stove`; usa immagine, visuale o glifo coerente con l'elettrodomestico.
- Temperatura: ricostruzione della griglia interna per eliminare sovrapposizioni fra nome, icona, temperatura e umidità.
- Elettrodomestici: il totale energia non usa più il simbolo batteria; viene indicato semanticamente come `∑ Totale`.
- Config Energia: nuovi campi per contatori totali cumulativi di Casa, Rete, Fotovoltaico e Batteria.
- Validazione Energia: accetta contatori Wh/kWh/MWh con `device_class: energy` e `state_class: total`/`total_increasing`; rifiuta sensori W/kW.
- Calcolo periodi: un contatore totale viene proiettato sui periodi non configurati e il motore esistente usa le Long-Term Statistics di Home Assistant per giorno, mese, mesi passati e anno. I sensori specifici per periodo restano override prioritari.
- Report elettrodomestici: preferenza per l'entità totale cumulativa, così storico mensile e annuale derivano dalla stessa fonte stabile.
- Editor: stile uniforme per pulsanti Aggiungi, Salva e Annulla.
- README e changelog aggiornati in modo completo per 0.14.10.

## Test aggiunti

- unit test per proiezione dei contatori totali e precedenza degli override;
- unit test per validazione power/energy/state_class;
- unit test per conversione dei token MDI in glifi visibili;
- E2E reale IT/EN su desktop, mobile e WebKit/iPad per:
  - salvataggio contatore totale Rete;
  - alias legacy giorno/mese;
  - card Temperatura senza sovrapposizioni;
  - totale elettrodomestico senza icona batteria;
  - Report forno collegato al contatore cumulativo e senza testo `mdi:*`.

## Blocco rilascio

La PR resta Draft e non deve essere unita finché non risultano verdi:

- Validate HACS repository;
- hassfest;
- Tests;
- Browser E2E.

Il merge su `main` attiverà il workflow automatico di pubblicazione di `v0.14.10` e `dashboardmodern.zip`.