### PR TITLE
release: DashboardModern 0.14.14 — real monthly totals and stable appliance UI

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/release-0152-real-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0152-real-runtime.spec.js
@@ -244,10 +244,10 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     );
     for (const artwork of artworkLayout) {
       expect(artwork.inside).toBe(true);
-      expect(artwork.widthRatio).toBeGreaterThan(0.5);
-      expect(artwork.widthRatio).toBeLessThan(0.9);
-      expect(artwork.heightRatio).toBeGreaterThan(0.5);
-      expect(artwork.heightRatio).toBeLessThan(0.9);
+      expect(artwork.widthRatio).toBeGreaterThanOrEqual(0.98);
+      expect(artwork.widthRatio).toBeLessThanOrEqual(1.01);
+      expect(artwork.heightRatio).toBeGreaterThanOrEqual(0.98);
+      expect(artwork.heightRatio).toBeLessThanOrEqual(1.01);
     }
 
     await page.evaluate(() => {

--- a/custom_components/dashboardmodern/frontend/e2e/release-0154-observer-stability.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0154-observer-stability.spec.js
@@ -1,0 +1,141 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { clickBottomTab } from "./helpers/navigation.js";
+
+const states = ["oven", "fridge", "microwave", "boiler"].map((name) => ({
+  entity_id: `switch.${name}`,
+  state: "on",
+  attributes: { friendly_name: name },
+}));
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [{ id: "room-kitchen", name: "Cucina", icon: "mdi:countertop" }],
+    appliances: [
+      ["oven", "Forno", "forno"],
+      ["fridge", "Frigo", "frigo"],
+      ["microwave", "Microonde", "microonde"],
+      ["boiler", "Scaldabagno", "scaldabagno"],
+    ].map(([id, name, visual]) => ({
+      id: `appliance-${id}`,
+      section: "appliances",
+      name,
+      device_type: visual,
+      visual_type: "asset",
+      visual_key: visual,
+      room_id: "room-kitchen",
+      control_entity: `switch.${id}`,
+      entities: [`switch.${id}`],
+      show_in_dashboard: true,
+      show_in_report: true,
+    })),
+    loads: [],
+    energy: { house: {}, grid: {}, solar: {}, battery: {}, metadata: {} },
+  },
+  visibility: { appliances: true, energy: true },
+};
+
+async function boot(page, variant, testInfo) {
+  await page.route("https://**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.addInitScript((haStates) => {
+    window.WebSocket = class extends EventTarget {
+      static OPEN = 1;
+      readyState = 1;
+      constructor() {
+        super();
+        queueMicrotask(() => this.emit({ type: "auth_required" }));
+      }
+      emit(message) {
+        const event = new MessageEvent("message", { data: JSON.stringify(message) });
+        this.dispatchEvent(event);
+        this.onmessage?.(event);
+      }
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") {
+          this.emit({ type: "auth_ok" });
+          return;
+        }
+        const result =
+          message.type === "get_states"
+            ? haStates
+            : message.type === "frontend/get_user_data"
+              ? { value: null }
+              : [];
+        this.emit({ id: message.id, type: "result", success: true, result });
+      }
+      close() {}
+    };
+  }, states);
+
+  await bootNamespacedDashboard(page, variant, testInfo, seed);
+  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await page.waitForFunction(
+    () => window.__DASHBOARDMODERN_RELEASE_0154_ARTWORK_LOCK__?.observerVersion === 2,
+  );
+  await clickBottomTab(page, "appliances-main", testInfo);
+  await expect(page.locator("#appl-grid-overview .appl-wide-card")).toHaveCount(4);
+  await page.waitForTimeout(300);
+}
+
+for (const variant of ["dashboard.html", "dashboard-en.html"]) {
+  test(`${variant}: appliance style and DOM observers remain bounded`, async ({ page }, testInfo) => {
+    if (testInfo.project.name.includes("webkit")) test.slow(true);
+    await boot(page, variant, testInfo);
+
+    const result = await page.evaluate(async () => {
+      let headMutations = 0;
+      let cardMutations = 0;
+      let ticks = 0;
+      const headObserver = new MutationObserver((records) => {
+        headMutations += records.reduce(
+          (total, record) => total + record.addedNodes.length + record.removedNodes.length,
+          0,
+        );
+      });
+      const cardObserver = new MutationObserver((records) => {
+        cardMutations += records.length;
+      });
+      headObserver.observe(document.head, { childList: true });
+      cardObserver.observe(document.getElementById("appl-grid-overview"), {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["data-dm-artwork", "data-dm-art-style", "class", "src"],
+      });
+      const timer = setInterval(() => {
+        ticks += 1;
+      }, 25);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      clearInterval(timer);
+      headObserver.disconnect();
+      cardObserver.disconnect();
+
+      const styleIds = [...document.head.querySelectorAll("style[id]")].map((style) => style.id);
+      return {
+        headMutations,
+        cardMutations,
+        ticks,
+        legacyDisabled: window.__DASHBOARDMODERN_MEDIA_STYLE_LOCK_DISABLED_0153__,
+        legacyStyleObserver: Boolean(window.__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__),
+        legacyDomObserver: Boolean(window.__DASHBOARDMODERN_MEDIA_DOM_OBSERVER_0153__),
+        legacyStyleCount: styleIds.filter((id) => id === "dm-appliance-media-layout-lock-0153").length,
+        finalStyleCount: styleIds.filter((id) => id === "dm-release-0154-final-artwork-lock").length,
+      };
+    });
+
+    expect(result).toMatchObject({
+      legacyDisabled: true,
+      legacyStyleObserver: false,
+      legacyDomObserver: false,
+      legacyStyleCount: 1,
+      finalStyleCount: 1,
+    });
+    expect(result.headMutations).toBeLessThanOrEqual(4);
+    expect(result.cardMutations).toBeLessThanOrEqual(24);
+    expect(result.ticks).toBeGreaterThanOrEqual(20);
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/release-0154-observer-stability.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0154-observer-stability.spec.js
@@ -78,7 +78,7 @@ async function boot(page, variant, testInfo) {
   );
   await clickBottomTab(page, "appliances-main", testInfo);
   await expect(page.locator("#appl-grid-overview .appl-wide-card")).toHaveCount(4);
-  await page.waitForTimeout(300);
+  await page.waitForTimeout(700);
 }
 
 for (const variant of ["dashboard.html", "dashboard-en.html"]) {
@@ -123,6 +123,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
         legacyStyleObserver: Boolean(window.__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__),
         legacyDomObserver: Boolean(window.__DASHBOARDMODERN_MEDIA_DOM_OBSERVER_0153__),
         legacyStyleCount: styleIds.filter((id) => id === "dm-appliance-media-layout-lock-0153").length,
+        legacyReleaseStyleCount: styleIds.filter((id) => id === "dm-release-0152-artwork-layout-fix").length,
         finalStyleCount: styleIds.filter((id) => id === "dm-release-0154-final-artwork-lock").length,
       };
     });
@@ -131,7 +132,8 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       legacyDisabled: true,
       legacyStyleObserver: false,
       legacyDomObserver: false,
-      legacyStyleCount: 1,
+      legacyStyleCount: 0,
+      legacyReleaseStyleCount: 0,
       finalStyleCount: 1,
     });
     expect(result.headMutations).toBeLessThanOrEqual(4);

--- a/custom_components/dashboardmodern/frontend/e2e/release-0154-observer-stability.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0154-observer-stability.spec.js
@@ -74,7 +74,7 @@ async function boot(page, variant, testInfo) {
   await bootNamespacedDashboard(page, variant, testInfo, seed);
   await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
   await page.waitForFunction(
-    () => window.__DASHBOARDMODERN_RELEASE_0154_ARTWORK_LOCK__?.observerVersion === 2,
+    () => window.__DASHBOARDMODERN_RELEASE_0154_ARTWORK_LOCK__?.observerVersion === 3,
   );
   await clickBottomTab(page, "appliances-main", testInfo);
   await expect(page.locator("#appl-grid-overview .appl-wide-card")).toHaveCount(4);
@@ -122,8 +122,11 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
         legacyDisabled: window.__DASHBOARDMODERN_MEDIA_STYLE_LOCK_DISABLED_0153__,
         legacyStyleObserver: Boolean(window.__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__),
         legacyDomObserver: Boolean(window.__DASHBOARDMODERN_MEDIA_DOM_OBSERVER_0153__),
+        mediaObserverDisabled:
+          window.__DASHBOARDMODERN_ENERGY_REPORT_MEDIA_FIX__?.observer?.disabled === true,
         legacyStyleCount: styleIds.filter((id) => id === "dm-appliance-media-layout-lock-0153").length,
         legacyReleaseStyleCount: styleIds.filter((id) => id === "dm-release-0152-artwork-layout-fix").length,
+        legacyMediaStyleCount: styleIds.filter((id) => id === "dm-energy-report-media-fixes-0153").length,
         finalStyleCount: styleIds.filter((id) => id === "dm-release-0154-final-artwork-lock").length,
       };
     });
@@ -132,8 +135,10 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       legacyDisabled: true,
       legacyStyleObserver: false,
       legacyDomObserver: false,
+      mediaObserverDisabled: true,
       legacyStyleCount: 0,
       legacyReleaseStyleCount: 0,
+      legacyMediaStyleCount: 0,
       finalStyleCount: 1,
     });
     expect(result.headMutations).toBeLessThanOrEqual(4);

--- a/custom_components/dashboardmodern/frontend/e2e/release-0154-real-config.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0154-real-config.spec.js
@@ -1,0 +1,254 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { clickBottomTab } from "./helpers/navigation.js";
+
+const lifetime = {
+  "sensor.solar_total": 11919.4,
+  "sensor.house_total": 5672.4,
+  "sensor.grid_import_total": 1388.3,
+  "sensor.grid_export_total": 4442,
+  "sensor.battery_charge_total": 3195.5,
+  "sensor.battery_discharge_total": 2.2,
+};
+
+const monthly = {
+  "sensor.solar_total": 42.6,
+  "sensor.house_total": 30.6,
+  "sensor.grid_import_total": 10,
+  "sensor.grid_export_total": 20,
+  "sensor.battery_charge_total": 5,
+  "sensor.battery_discharge_total": 3,
+};
+
+const states = [
+  ...Object.entries(lifetime).map(([entity_id, state]) => ({
+    entity_id,
+    state: String(state),
+    attributes: {
+      friendly_name: entity_id.replace("sensor.", "").replaceAll("_", " "),
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "total_increasing",
+    },
+  })),
+  ...["oven", "fridge", "microwave", "boiler"].map((name) => ({
+    entity_id: `switch.${name}`,
+    state: "on",
+    attributes: { friendly_name: name },
+  })),
+];
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [
+      { id: "room-salone", name: "Salone", icon: "mdi:sofa" },
+      { id: "room-terrazza", name: "Terrazza", icon: "mdi:balcony" },
+    ],
+    appliances: [
+      {
+        id: "appliance-oven",
+        section: "appliances",
+        name: "Forno",
+        device_type: "forno",
+        visual_type: "asset",
+        visual_key: "forno",
+        room_id: "room-salone",
+        control_entity: "switch.oven",
+        entities: ["switch.oven"],
+        show_in_dashboard: true,
+        show_in_report: true,
+      },
+      {
+        id: "appliance-fridge",
+        section: "appliances",
+        name: "Frigo",
+        device_type: "frigo",
+        visual_type: "asset",
+        visual_key: "frigo",
+        room_id: "room-salone",
+        control_entity: "switch.fridge",
+        entities: ["switch.fridge"],
+        show_in_dashboard: true,
+        show_in_report: true,
+      },
+      {
+        id: "appliance-microwave",
+        section: "appliances",
+        name: "Microonde",
+        device_type: "microonde",
+        visual_type: "asset",
+        visual_key: "microonde",
+        room_id: "room-salone",
+        control_entity: "switch.microwave",
+        entities: ["switch.microwave"],
+        show_in_dashboard: true,
+        show_in_report: true,
+      },
+      {
+        id: "appliance-boiler",
+        section: "appliances",
+        name: "Scaldabagno",
+        device_type: "scaldabagno",
+        visual_type: "asset",
+        visual_key: "scaldabagno",
+        room_id: "room-terrazza",
+        control_entity: "switch.boiler",
+        entities: ["switch.boiler"],
+        show_in_dashboard: true,
+        show_in_report: true,
+      },
+    ],
+    loads: [],
+    energy: {
+      house: { monthly_energy: "sensor.house_total" },
+      grid: {
+        monthly_import_energy: "sensor.grid_import_total",
+        monthly_export_energy: "sensor.grid_export_total",
+      },
+      solar: { monthly_energy: "sensor.solar_total" },
+      battery: {
+        monthly_charged_energy: "sensor.battery_charge_total",
+        monthly_discharged_energy: "sensor.battery_discharge_total",
+      },
+      metadata: {},
+    },
+  },
+  visibility: { energy: true, appliances: true },
+};
+
+async function boot(page, variant, testInfo) {
+  await page.route("https://**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
+  );
+  await page.addInitScript(
+    ({ haStates, periodChanges }) => {
+      window.__dm0154Requests = [];
+      window.WebSocket = class extends EventTarget {
+        static OPEN = 1;
+        readyState = 1;
+        constructor() {
+          super();
+          queueMicrotask(() => this.emit({ type: "auth_ok" }));
+        }
+        emit(message) {
+          const event = new MessageEvent("message", { data: JSON.stringify(message) });
+          this.dispatchEvent(event);
+          this.onmessage?.(event);
+        }
+        send(raw) {
+          const message = JSON.parse(raw);
+          if (message.type === "auth") return;
+          if (message.type === "recorder/statistics_during_period") {
+            window.__dm0154Requests.push(structuredClone(message));
+            const result = Object.fromEntries(
+              (message.statistic_ids || []).map((id) => [
+                id,
+                [
+                  {
+                    start: message.start_time,
+                    change: periodChanges[id] ?? 0.5,
+                    sum: 1000 + (periodChanges[id] ?? 0.5),
+                    state: 1000 + (periodChanges[id] ?? 0.5),
+                  },
+                ],
+              ]),
+            );
+            this.emit({ id: message.id, type: "result", success: true, result });
+            return;
+          }
+          const result =
+            message.type === "get_states"
+              ? haStates
+              : message.type === "frontend/get_user_data"
+                ? { value: null }
+                : [];
+          this.emit({ id: message.id, type: "result", success: true, result });
+        }
+        close() {}
+      };
+    },
+    { haStates: states, periodChanges: monthly },
+  );
+
+  await bootNamespacedDashboard(page, variant, testInfo, seed);
+  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await page.waitForFunction(() => window.__DASHBOARDMODERN_RELEASE_0154__?.installed);
+}
+
+for (const variant of ["dashboard.html", "dashboard-en.html"]) {
+  test(`${variant}: real cumulative monthly fields never display lifetime totals`, async ({ page }, testInfo) => {
+    if (testInfo.project.name.includes("webkit")) test.slow(true);
+    await boot(page, variant, testInfo);
+    await clickBottomTab(page, "energy", testInfo);
+    await page.locator('button[onclick*="switchEnergyView(\'month\')"]').click();
+
+    await expect.poll(() => page.locator("#v-solar-month").textContent()).toMatch(/42[,.]6/);
+    await expect(page.locator("#v-grid-month")).toContainText(/10/);
+    await expect(page.locator("#v-grid-month")).toContainText(/20/);
+    await expect(page.locator("#v-battery-month")).toContainText(/5/);
+    await expect(page.locator("#v-battery-month")).toContainText(/3/);
+
+    const result = await page.evaluate((lifetimeValues) => {
+      const text = document.getElementById("view-month")?.textContent || "";
+      return {
+        text,
+        requests: window.__dm0154Requests,
+        registry: {
+          solar: CD_PERIOD["dm.energy_produzione_solare_mese"],
+          house: CD_PERIOD["dm.energy_consumo_casa_mese"],
+          import: CD_PERIOD["dm.energy_rete_acquistata_mese"],
+          export: CD_PERIOD["dm.energy_rete_venduta_mese"],
+        },
+        leakedLifetime: Object.values(lifetimeValues).some((value) =>
+          text.includes(String(value)),
+        ),
+      };
+    }, lifetime);
+
+    expect(result.registry).toEqual({ solar: 42.6, house: 30.6, import: 10, export: 20 });
+    expect(result.leakedLifetime).toBe(false);
+    expect(result.requests.length).toBeGreaterThan(0);
+    expect(result.requests.every((request) => request.types === undefined)).toBe(true);
+  });
+
+  test(`${variant}: built-in appliance artwork is one theme-aware visual family`, async ({ page }, testInfo) => {
+    await boot(page, variant, testInfo);
+    await clickBottomTab(page, "appliances-main", testInfo);
+
+    const cards = page.locator("#appl-grid-overview .appl-wide-card[data-appliance-id]");
+    await expect(cards).toHaveCount(4);
+    await expect.poll(() =>
+      cards.evaluateAll((nodes) => nodes.map((node) => node.dataset.dmArtStyle)),
+    ).toEqual(["panel", "panel", "panel", "panel"]);
+
+    const visuals = await cards.evaluateAll((nodes) =>
+      nodes.map((card) => {
+        const viewport = card.querySelector(".appl-visual").getBoundingClientRect();
+        const svg = card.querySelector(".dm-appliance-art-0154 > svg").getBoundingClientRect();
+        return {
+          kind: card.dataset.dmArtwork,
+          style: card.dataset.dmArtStyle,
+          ratio: Math.round((svg.width / viewport.width) * 1000) / 1000,
+          panel: Boolean(card.querySelector('[data-dm-art-style="panel"] .dm-art-panel')),
+        };
+      }),
+    );
+
+    expect(visuals.map((item) => item.kind)).toEqual(["oven", "fridge", "microwave", "boiler"]);
+    expect(visuals.every((item) => item.style === "panel" && item.panel)).toBe(true);
+    expect(Math.max(...visuals.map((item) => item.ratio)) - Math.min(...visuals.map((item) => item.ratio))).toBeLessThan(0.04);
+    expect(visuals.every((item) => item.ratio >= 0.74 && item.ratio <= 0.9)).toBe(true);
+
+    const palettes = await page.evaluate(() => {
+      document.documentElement.setAttribute("data-theme", "light");
+      const light = getComputedStyle(document.documentElement).getPropertyValue("--dm-art-panel").trim();
+      document.documentElement.setAttribute("data-theme", "dark");
+      const dark = getComputedStyle(document.documentElement).getPropertyValue("--dm-art-panel").trim();
+      return { light, dark };
+    });
+    expect(palettes.light).not.toBe("");
+    expect(palettes.dark).not.toBe("");
+    expect(palettes.dark).not.toBe(palettes.light);
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/release-0154-real-config.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0154-real-config.spec.js
@@ -209,6 +209,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     expect(result.registry).toEqual({ solar: 42.6, house: 30.6, import: 10, export: 20 });
     expect(result.leakedLifetime).toBe(false);
     expect(result.requests.length).toBeGreaterThan(0);
+    expect(result.requests.length).toBeLessThanOrEqual(24);
     expect(result.requests.every((request) => request.types === undefined)).toBe(true);
   });
 
@@ -230,6 +231,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
           kind: card.dataset.dmArtwork,
           style: card.dataset.dmArtStyle,
           ratio: Math.round((svg.width / viewport.width) * 1000) / 1000,
+          heightRatio: Math.round((svg.height / viewport.height) * 1000) / 1000,
           panel: Boolean(card.querySelector('[data-dm-art-style="panel"] .dm-art-panel')),
         };
       }),
@@ -237,8 +239,9 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
 
     expect(visuals.map((item) => item.kind)).toEqual(["oven", "fridge", "microwave", "boiler"]);
     expect(visuals.every((item) => item.style === "panel" && item.panel)).toBe(true);
-    expect(Math.max(...visuals.map((item) => item.ratio)) - Math.min(...visuals.map((item) => item.ratio))).toBeLessThan(0.04);
-    expect(visuals.every((item) => item.ratio >= 0.74 && item.ratio <= 0.9)).toBe(true);
+    expect(Math.max(...visuals.map((item) => item.ratio)) - Math.min(...visuals.map((item) => item.ratio))).toBeLessThan(0.02);
+    expect(visuals.every((item) => item.ratio >= 0.98 && item.ratio <= 1.01)).toBe(true);
+    expect(visuals.every((item) => item.heightRatio >= 0.98 && item.heightRatio <= 1.01)).toBe(true);
 
     const palettes = await page.evaluate(() => {
       document.documentElement.setAttribute("data-theme", "light");

--- a/custom_components/dashboardmodern/frontend/legacy/appliance-media-layout-lock.js
+++ b/custom_components/dashboardmodern/frontend/legacy/appliance-media-layout-lock.js
@@ -6,8 +6,15 @@ const DOM_OBSERVER_KEY = "__DASHBOARDMODERN_MEDIA_DOM_OBSERVER_0153__";
 
 function canonicalArtworkType0153(value) {
   const token = String(value || "").toLowerCase();
-  if (/frigo|fridge|refriger|frigorifero/.test(token)) return "fridge";
+  if (/microonde|microwave/.test(token)) return "microwave";
+  if (/forno|oven|stove/.test(token)) return "oven";
+  if (/frigo|fridge|refriger|frigorifero|freezer|congelatore/.test(token)) return "fridge";
   if (/scaldabagno|boiler|water[_ -]?heater/.test(token)) return "boiler";
+  if (/lavatrice|washing[_ -]?machine|washer/.test(token)) return "washer";
+  if (/asciugatrice|tumble[_ -]?dryer|dryer/.test(token)) return "dryer";
+  if (/lavastoviglie|dishwasher/.test(token)) return "dishwasher";
+  if (/piano[_ -]?cottura|cooktop|hob/.test(token)) return "cooktop";
+  if (/televis|\btv\b|monitor/.test(token)) return "television";
   return "";
 }
 
@@ -68,20 +75,33 @@ function restoreGeneratedArtwork0153() {
     const visual = applianceVisual0153(item);
     if (visual?.kind !== "asset") return;
 
-    const type = canonicalArtworkType0153(
-      visual.value || item.visual_key || item.device_type || item.type || item.name,
+    const sourceToken = String(
+      visual.value || item.visual_key || item.device_type || item.type || item.name || "",
     );
+    const type = canonicalArtworkType0153(sourceToken);
     if (!type) return;
 
     const media = card.querySelector(".appl-visual .appl-ic");
     if (!media) return;
     card.dataset.dmArtwork = type;
-    media.classList.add("dm-appliance-media-0153");
-    card.querySelector(".appl-visual")?.classList.add("dm-appliance-viewport-0153");
+    card.dataset.dmArtStyle = "panel";
+    media.classList.add("dm-appliance-media-0153", "dm-appliance-media-0154");
+    card
+      .querySelector(".appl-visual")
+      ?.classList.add("dm-appliance-viewport-0153", "dm-appliance-viewport-0154");
 
-    if (!media.querySelector(`[data-dm-art="${type}"]`)) {
-      const markup = applianceArtwork0152(type, 76);
+    const existing = media.querySelector(`[data-dm-art="${type}"]`);
+    if (!existing || !existing.classList.contains("dm-appliance-art-0154")) {
+      const markup =
+        globalThis.cdApplianceIcon?.(type, 96) || applianceArtwork0152(type, 88);
       if (markup) media.innerHTML = markup;
+    }
+
+    const artwork = media.querySelector(`[data-dm-art="${type}"]`);
+    if (artwork) {
+      artwork.dataset.dmArtStyle = "panel";
+      artwork.dataset.applianceAsset = sourceToken;
+      artwork.dataset.applianceAssetKey = sourceToken;
     }
   });
   classifyApplianceImages0153();
@@ -144,17 +164,17 @@ function installApplianceMediaLayoutLock0153() {
         .appl-wide-card [data-dm-art] > svg {
         display: block !important;
         box-sizing: border-box !important;
-        width: 76% !important;
-        height: 76% !important;
+        width: 88% !important;
+        height: 88% !important;
         min-width: 0 !important;
         min-height: 0 !important;
-        max-width: 76% !important;
-        max-height: 76% !important;
+        max-width: 88% !important;
+        max-height: 88% !important;
         object-fit: contain !important;
         object-position: center !important;
         transform: none !important;
         overflow: visible !important;
-        flex: 0 0 76% !important;
+        flex: 0 0 88% !important;
       }
     `;
   }

--- a/custom_components/dashboardmodern/frontend/legacy/appliance-media-layout-lock.js
+++ b/custom_components/dashboardmodern/frontend/legacy/appliance-media-layout-lock.js
@@ -1,8 +1,14 @@
-/* DashboardModern: final appliance media lock loaded after legacy layout themes. */
+/* DashboardModern: appliance media compatibility layer. */
 import { applianceArtwork0152 } from "./release-0152-runtime.js";
 
 const STYLE_ID = "dm-appliance-media-layout-lock-0153";
 const DOM_OBSERVER_KEY = "__DASHBOARDMODERN_MEDIA_DOM_OBSERVER_0153__";
+const STYLE_OBSERVER_KEY = "__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__";
+const STYLE_LOCK_DISABLED_KEY = "__DASHBOARDMODERN_MEDIA_STYLE_LOCK_DISABLED_0153__";
+
+function setData0153(node, key, value) {
+  if (node?.dataset && node.dataset[key] !== value) node.dataset[key] = value;
+}
 
 function canonicalArtworkType0153(value) {
   const token = String(value || "").toLowerCase();
@@ -45,18 +51,19 @@ function classifyApplianceImages0153() {
       const apply = () => {
         if (!image.naturalWidth || !image.naturalHeight) return;
         const ratio = image.naturalWidth / image.naturalHeight;
-        image.dataset.dmImageFit = ratio >= 0.92 && ratio <= 1.08 ? "cover" : "contain";
-        image.dataset.dmImageFitSource = source;
+        setData0153(image, "dmImageFit", ratio >= 0.92 && ratio <= 1.08 ? "cover" : "contain");
+        setData0153(image, "dmImageFitSource", source);
       };
       if (image.complete && image.naturalWidth) apply();
       else if (image.dataset.dmImageFitPending !== source) {
-        image.dataset.dmImageFitPending = source;
+        setData0153(image, "dmImageFitPending", source);
         image.addEventListener("load", apply, { once: true });
       }
     });
 }
 
 function restoreGeneratedArtwork0153() {
+  if (globalThis[STYLE_LOCK_DISABLED_KEY]) return false;
   const doc = globalThis.document;
   if (!doc) return false;
   const items = applianceItems0153();
@@ -81,27 +88,25 @@ function restoreGeneratedArtwork0153() {
     const type = canonicalArtworkType0153(sourceToken);
     if (!type) return;
 
-    const media = card.querySelector(".appl-visual .appl-ic");
+    const viewport = card.querySelector(".appl-visual");
+    const media = viewport?.querySelector(".appl-ic");
     if (!media) return;
-    card.dataset.dmArtwork = type;
-    card.dataset.dmArtStyle = "panel";
+    setData0153(card, "dmArtwork", type);
+    setData0153(card, "dmArtStyle", "panel");
     media.classList.add("dm-appliance-media-0153", "dm-appliance-media-0154");
-    card
-      .querySelector(".appl-visual")
-      ?.classList.add("dm-appliance-viewport-0153", "dm-appliance-viewport-0154");
+    viewport.classList.add("dm-appliance-viewport-0153", "dm-appliance-viewport-0154");
 
     const existing = media.querySelector(`[data-dm-art="${type}"]`);
     if (!existing || !existing.classList.contains("dm-appliance-art-0154")) {
-      const markup =
-        globalThis.cdApplianceIcon?.(type, 96) || applianceArtwork0152(type, 88);
+      const markup = globalThis.cdApplianceIcon?.(type, 96) || applianceArtwork0152(type, 88);
       if (markup) media.innerHTML = markup;
     }
 
     const artwork = media.querySelector(`[data-dm-art="${type}"]`);
     if (artwork) {
-      artwork.dataset.dmArtStyle = "panel";
-      artwork.dataset.applianceAsset = sourceToken;
-      artwork.dataset.applianceAssetKey = sourceToken;
+      setData0153(artwork, "dmArtStyle", "panel");
+      setData0153(artwork, "applianceAsset", sourceToken);
+      setData0153(artwork, "applianceAssetKey", sourceToken);
     }
   });
   classifyApplianceImages0153();
@@ -111,125 +116,93 @@ function restoreGeneratedArtwork0153() {
 function installApplianceMediaLayoutLock0153() {
   const doc = globalThis.document;
   if (!doc?.head) return false;
+  if (doc.getElementById(STYLE_ID)) return true;
 
-  let style = doc.getElementById(STYLE_ID);
-  if (!style) {
-    style = doc.createElement("style");
-    style.id = STYLE_ID;
-    style.textContent = `
-      html body #page-appliances-main #appl-grid-overview
-        .appl-wide-card .appl-visual img,
-      html body #appl-grid-overview
-        .appl-wide-card .appl-visual img,
-      html body #page-appliances-main
-        .appl-wide-card .appl-visual img {
-        display: block !important;
-        box-sizing: border-box !important;
-        width: 100% !important;
-        height: 100% !important;
-        min-width: 0 !important;
-        min-height: 0 !important;
-        max-width: 100% !important;
-        max-height: 100% !important;
-        object-fit: contain !important;
-        object-position: center !important;
-        border-radius: 12px !important;
-        transform: none !important;
-      }
-
-      html body #page-appliances-main #appl-grid-overview
-        .appl-wide-card .appl-visual img[data-dm-image-fit="cover"],
-      html body #appl-grid-overview
-        .appl-wide-card .appl-visual img[data-dm-image-fit="cover"],
-      html body #page-appliances-main
-        .appl-wide-card .appl-visual img[data-dm-image-fit="cover"] {
-        object-fit: cover !important;
-      }
-
-      html body #page-appliances-main #appl-grid-overview
-        .appl-wide-card.dm-control-device[data-dm-artwork]
-        .appl-visual
-        .appl-ic.dm-appliance-media-0153
-        [data-dm-art]
-        > svg,
-      html body #appl-grid-overview
-        .appl-wide-card.dm-control-device[data-dm-artwork]
-        .appl-visual.dm-appliance-viewport-0153
-        .appl-ic.dm-appliance-media-0153
-        [data-dm-art]
-        > svg,
-      html body #page-appliances-main
-        .appl-wide-card [data-dm-art] > svg,
-      html body #appl-grid-overview
-        .appl-wide-card [data-dm-art] > svg {
-        display: block !important;
-        box-sizing: border-box !important;
-        width: 88% !important;
-        height: 88% !important;
-        min-width: 0 !important;
-        min-height: 0 !important;
-        max-width: 88% !important;
-        max-height: 88% !important;
-        object-fit: contain !important;
-        object-position: center !important;
-        transform: none !important;
-        overflow: visible !important;
-        flex: 0 0 88% !important;
-      }
-    `;
-  }
-
-  if (doc.head.lastElementChild !== style) doc.head.append(style);
+  const style = doc.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    html body #page-appliances-main #appl-grid-overview .appl-wide-card .appl-visual img,
+    html body #appl-grid-overview .appl-wide-card .appl-visual img,
+    html body #page-appliances-main .appl-wide-card .appl-visual img {
+      display:block!important;box-sizing:border-box!important;width:100%!important;height:100%!important;
+      min-width:0!important;min-height:0!important;max-width:100%!important;max-height:100%!important;
+      object-fit:contain!important;object-position:center!important;border-radius:12px!important;transform:none!important;
+    }
+    html body #page-appliances-main #appl-grid-overview .appl-wide-card .appl-visual img[data-dm-image-fit="cover"],
+    html body #appl-grid-overview .appl-wide-card .appl-visual img[data-dm-image-fit="cover"],
+    html body #page-appliances-main .appl-wide-card .appl-visual img[data-dm-image-fit="cover"] {
+      object-fit:cover!important;
+    }
+    html body #page-appliances-main #appl-grid-overview .appl-wide-card.dm-control-device[data-dm-artwork]
+      .appl-visual .appl-ic.dm-appliance-media-0153 [data-dm-art] > svg,
+    html body #appl-grid-overview .appl-wide-card.dm-control-device[data-dm-artwork]
+      .appl-visual.dm-appliance-viewport-0153 .appl-ic.dm-appliance-media-0153 [data-dm-art] > svg,
+    html body #page-appliances-main .appl-wide-card [data-dm-art] > svg,
+    html body #appl-grid-overview .appl-wide-card [data-dm-art] > svg {
+      display:block!important;box-sizing:border-box!important;width:88%!important;height:88%!important;
+      min-width:0!important;min-height:0!important;max-width:88%!important;max-height:88%!important;
+      object-fit:contain!important;object-position:center!important;transform:none!important;overflow:visible!important;
+      flex:0 0 88%!important;
+    }
+  `;
+  doc.head.append(style);
   return true;
 }
 
+function stopLegacyStyleObserver0153() {
+  const observer = globalThis[STYLE_OBSERVER_KEY];
+  observer?.disconnect?.();
+  globalThis[STYLE_OBSERVER_KEY] = null;
+}
+
 function keepLayoutLockLast0153() {
-  const doc = globalThis.document;
-  if (!doc?.head || globalThis.__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__) return;
-  let scheduled = false;
-  const observer = new MutationObserver(() => {
-    const style = doc.getElementById(STYLE_ID);
-    if (!style || doc.head.lastElementChild === style || scheduled) return;
-    scheduled = true;
-    globalThis.queueMicrotask?.(() => {
-      scheduled = false;
-      installApplianceMediaLayoutLock0153();
-    });
-  });
-  observer.observe(doc.head, { childList: true });
-  globalThis.__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__ = observer;
+  /* CSS specificity, not DOM reordering, determines precedence from 0.14.14 onward. */
+  stopLegacyStyleObserver0153();
+  return false;
 }
 
 function observeApplianceDom0153() {
+  if (globalThis[STYLE_LOCK_DISABLED_KEY]) {
+    globalThis[DOM_OBSERVER_KEY]?.disconnect?.();
+    globalThis[DOM_OBSERVER_KEY] = null;
+    return false;
+  }
   const doc = globalThis.document;
-  if (!doc?.documentElement || globalThis[DOM_OBSERVER_KEY]) return;
+  if (!doc?.body || globalThis[DOM_OBSERVER_KEY]) return false;
   let scheduled = false;
   const schedule = () => {
-    if (scheduled) return;
+    if (scheduled || globalThis[STYLE_LOCK_DISABLED_KEY]) return;
     scheduled = true;
     const run = () => {
       scheduled = false;
       restoreGeneratedArtwork0153();
     };
-    if (typeof globalThis.requestAnimationFrame === "function") {
-      globalThis.requestAnimationFrame(run);
-    } else {
-      globalThis.setTimeout?.(run, 0);
-    }
+    globalThis.requestAnimationFrame?.(run) || globalThis.setTimeout?.(run, 0);
   };
   const observer = new MutationObserver((records) => {
-    if (records.some((record) => record.addedNodes.length || record.removedNodes.length)) schedule();
+    const relevant = records.some((record) =>
+      [...record.addedNodes, ...record.removedNodes].some(
+        (node) =>
+          node instanceof Element &&
+          (node.matches?.("#appl-grid-overview, #page-appliances-main, .appl-wide-card") ||
+            node.querySelector?.("#appl-grid-overview, #page-appliances-main, .appl-wide-card")),
+      ),
+    );
+    if (relevant) schedule();
   });
-  observer.observe(doc.documentElement, { childList: true, subtree: true });
+  observer.observe(doc.body, { childList: true, subtree: true });
   globalThis[DOM_OBSERVER_KEY] = observer;
   schedule();
+  return true;
 }
 
 function install0153() {
   installApplianceMediaLayoutLock0153();
   keepLayoutLockLast0153();
-  observeApplianceDom0153();
-  restoreGeneratedArtwork0153();
+  if (!globalThis[STYLE_LOCK_DISABLED_KEY]) {
+    observeApplianceDom0153();
+    restoreGeneratedArtwork0153();
+  }
 }
 
 if (typeof globalThis.document !== "undefined") {

--- a/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/real-ha-0147-stability.js
@@ -10,6 +10,42 @@ function readJson(key, fallback) {
   }
 }
 
+function setData(node, key, value) {
+  if (!node?.dataset || node.dataset[key] === value) return false;
+  node.dataset[key] = value;
+  return true;
+}
+
+function setAttribute(node, name, value) {
+  if (!node || node.getAttribute(name) === value) return false;
+  node.setAttribute(name, value);
+  return true;
+}
+
+function addClass(node, token) {
+  if (!node?.classList || node.classList.contains(token)) return false;
+  node.classList.add(token);
+  return true;
+}
+
+function removeClass(node, token) {
+  if (!node?.classList?.contains(token)) return false;
+  node.classList.remove(token);
+  return true;
+}
+
+function setText(node, value) {
+  if (!node || node.textContent === value) return false;
+  node.textContent = value;
+  return true;
+}
+
+function setStyle(node, property, value) {
+  if (!node?.style || node.style[property] === value) return false;
+  node.style[property] = value;
+  return true;
+}
+
 /*
  * runtime-hotfix.js and real-ha-0147-fixes.js use different wrapper markers.
  * Mark the current implementation for both layers before either retry loop can
@@ -51,11 +87,11 @@ function stabilizePowerButtons(root = document) {
       : isEnglish()
         ? "Turn on"
         : "Accendi";
-    if (button.textContent.trim() !== label) button.textContent = label;
-    button.dataset.dmPowerToggle = "true";
-    button.classList.remove("appl-action-btn");
-    button.classList.add("dm-appliance-power-toggle");
-    button.setAttribute("aria-label", label);
+    setText(button, label);
+    setData(button, "dmPowerToggle", "true");
+    removeClass(button, "appl-action-btn");
+    addClass(button, "dm-appliance-power-toggle");
+    setAttribute(button, "aria-label", label);
   });
 }
 
@@ -72,6 +108,30 @@ function alertGroupForEntity(entity, row) {
   return "";
 }
 
+function bindStableAlertEditButton(button, group, entity) {
+  if (button.hasAttribute("onclick")) button.removeAttribute("onclick");
+  if (button.type !== "button") button.type = "button";
+  addClass(button, "ed-del");
+  addClass(button, "dm-edit-button");
+  setData(button, "standardAlertEdit", "");
+  setData(button, "realAlertEdit", "");
+  setData(button, "standardAlertGroup", group);
+  setData(button, "standardAlertEntity", entity);
+  setData(button, "alertGroup", group);
+  setData(button, "alertEntity", entity);
+  setText(button, "✏️");
+  const title = isEnglish() ? "Edit" : "Modifica";
+  if (button.title !== title) button.title = title;
+  setAttribute(button, "aria-label", title);
+  if (button.dataset.alertEditMounted !== "true") {
+    button.dataset.alertEditMounted = "true";
+    button.addEventListener("click", () => {
+      const edit = globalThis.dmRealEditAlert || globalThis.edEditAvvisoStandard;
+      edit?.(button.dataset.alertGroup, button.dataset.alertEntity);
+    });
+  }
+}
+
 function stabilizeAlertEditButtons(root = document) {
   root.querySelectorAll("#editor-modal .ed-row").forEach((row) => {
     const entity = row.querySelector(".ed-row-old.mono")?.textContent?.trim();
@@ -79,35 +139,39 @@ function stabilizeAlertEditButtons(root = document) {
     const group = alertGroupForEntity(entity, row);
     if (!group) return;
 
-    row.querySelectorAll("[data-standard-alert-edit]").forEach((button) => button.remove());
-    if (row.querySelector("[data-real-alert-edit]")) return;
+    const candidates = [
+      ...row.querySelectorAll("[data-real-alert-edit], [data-standard-alert-edit]"),
+    ];
+    let editButton = candidates.find((button) => button.hasAttribute("data-real-alert-edit"));
+    editButton ||= candidates[0] || null;
 
-    const removeButton = [...row.querySelectorAll(".ed-del")].find(
-      (button) => /edDelAvviso/.test(button.getAttribute("onclick") || ""),
-    );
-    if (!removeButton || typeof globalThis.dmRealEditAlert !== "function") return;
+    if (!editButton) {
+      const removeButton = [...row.querySelectorAll(".ed-del")].find(
+        (button) =>
+          /edDelAvviso/.test(button.getAttribute("onclick") || "") ||
+          button.textContent.includes("🗑️"),
+      );
+      if (!removeButton) return;
+      editButton = document.createElement("button");
+      removeButton.before(editButton);
+    }
 
-    const editButton = document.createElement("button");
-    editButton.type = "button";
-    editButton.className = "ed-del dm-edit-button";
-    editButton.dataset.realAlertEdit = "";
-    editButton.textContent = "✏️";
-    editButton.title = isEnglish() ? "Edit" : "Modifica";
-    editButton.setAttribute("aria-label", editButton.title);
-    editButton.addEventListener("click", () => globalThis.dmRealEditAlert(group, entity));
-    removeButton.before(editButton);
+    bindStableAlertEditButton(editButton, group, entity);
+    candidates.forEach((candidate) => {
+      if (candidate !== editButton && candidate.isConnected) candidate.remove();
+    });
   });
 }
 
 function stabilizeReportRows(root = document) {
   root.querySelectorAll("#editor-modal [data-energy-panel='report'] .dm-report-row").forEach((row) => {
-    row.dataset.realReportStable = "true";
+    setData(row, "realReportStable", "true");
     const fields = row.querySelector(":scope > .dm-report-fields");
     if (!fields) return;
     fields.querySelectorAll(".dm-config-field, [data-entity-field], [data-icon-field]").forEach((field) => {
-      field.style.gridArea = "auto";
-      field.style.width = "100%";
-      field.style.minWidth = "0";
+      setStyle(field, "gridArea", "auto");
+      setStyle(field, "width", "100%");
+      setStyle(field, "minWidth", "0px");
     });
   });
 }

--- a/custom_components/dashboardmodern/frontend/legacy/release-0147-appliance-theme.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0147-appliance-theme.js
@@ -1,4 +1,4 @@
-/* Theme-aware, full-bleed appliance cards for the 0.14.7 corrective release. */
+/* Theme-aware appliance cards retained as an idempotent compatibility layer. */
 const FLAG = "__DASHBOARDMODERN_0147_APPLIANCE_THEME__";
 
 function installApplianceThemeCss() {
@@ -8,10 +8,7 @@ function installApplianceThemeCss() {
   style.id = "dm-0147-appliance-theme";
   style.textContent = `
     #page-appliances-main .appl-wide-card.dm-control-device {
-      background: var(
-        --card-bg,
-        var(--ha-card-background, var(--primary-background-color, #fff))
-      ) !important;
+      background: var(--card-bg, var(--ha-card-background, var(--primary-background-color, #fff))) !important;
       color: var(--text, var(--primary-text-color, #0f172a)) !important;
       border-color: var(--card-border, var(--divider-color, #dbe4ee)) !important;
       box-shadow: var(--shadow-sculpted, 0 14px 34px rgba(15, 23, 42, 0.14)) !important;
@@ -27,10 +24,7 @@ function installApplianceThemeCss() {
       min-height: 100%;
       padding: 0 !important;
       overflow: hidden;
-      background: var(
-        --secondary-background-color,
-        var(--card-bg, var(--ha-card-background, #fff))
-      ) !important;
+      background: var(--secondary-background-color, var(--card-bg, var(--ha-card-background, #fff))) !important;
       border-right: 1px solid var(--card-border, var(--divider-color, #dbe4ee)) !important;
     }
 
@@ -40,59 +34,7 @@ function installApplianceThemeCss() {
       inset: 0;
       z-index: 2;
       pointer-events: none;
-      background: linear-gradient(
-        145deg,
-        rgba(14, 165, 233, 0.08),
-        transparent 48%,
-        rgba(14, 165, 233, 0.04)
-      );
-    }
-
-    #page-appliances-main .appl-wide-card.dm-control-device .appl-visual .appl-ic,
-    #page-appliances-main .appl-wide-card.dm-control-device .appl-visual .dm-appliance-media,
-    #page-appliances-main .appl-wide-card.dm-control-device .appl-visual .dm-appliance-art,
-    #page-appliances-main .appl-wide-card.dm-control-device .appl-visual .dm-appliance-image-wrap {
-      display: grid !important;
-      place-items: center !important;
-      width: 100% !important;
-      height: 100% !important;
-      min-width: 100% !important;
-      min-height: 100% !important;
-      max-width: none !important;
-      max-height: none !important;
-      padding: 0 !important;
-      margin: 0 !important;
-      border: 0 !important;
-      border-radius: 0 !important;
-      background: transparent !important;
-      box-shadow: none !important;
-      overflow: hidden !important;
-    }
-
-    #page-appliances-main .appl-wide-card.dm-control-device .appl-visual .dm-appliance-art svg,
-    #page-appliances-main .appl-wide-card.dm-control-device .appl-visual .dm-appliance-image,
-    #page-appliances-main .appl-wide-card.dm-control-device .appl-visual img {
-      display: block !important;
-      width: 100% !important;
-      height: 100% !important;
-      min-width: 100% !important;
-      min-height: 100% !important;
-      max-width: none !important;
-      max-height: none !important;
-      object-fit: cover !important;
-      object-position: center !important;
-      border-radius: 0 !important;
-      filter: none !important;
-    }
-
-    #page-appliances-main .appl-wide-card.dm-control-device .appl-visual .dm-appliance-art svg {
-      transform: scale(1.32);
-      transform-origin: center;
-    }
-
-    #page-appliances-main .appl-wide-card.dm-control-device .appl-visual .dm-appliance-glyph {
-      font-size: clamp(58px, 7vw, 96px);
-      line-height: 1;
+      background: linear-gradient(145deg, rgba(14,165,233,.08), transparent 48%, rgba(14,165,233,.04));
     }
 
     #page-appliances-main .appl-wide-card.dm-control-device .appl-info {
@@ -114,68 +56,41 @@ function installApplianceThemeCss() {
     }
 
     #page-appliances-main .appl-wide-card.dm-control-device .appl-mini,
-    #page-appliances-main .appl-wide-card.dm-control-device .appl-st {
-      background: var(
-        --secondary-background-color,
-        var(--card-bg, var(--ha-card-background, #fff))
-      ) !important;
+    #page-appliances-main .appl-wide-card.dm-control-device .appl-st,
+    #page-appliances-main .appl-wide-card.dm-control-device .appl-action-btn {
+      background: var(--secondary-background-color, var(--card-bg, var(--ha-card-background, #fff))) !important;
       border: 1px solid var(--card-border, var(--divider-color, #dbe4ee)) !important;
     }
 
     #page-appliances-main .appl-wide-card.dm-control-device .appl-action-btn {
-      background: var(
-        --secondary-background-color,
-        var(--card-bg, var(--ha-card-background, #fff))
-      ) !important;
       color: var(--text, var(--primary-text-color, #0f172a)) !important;
-      border-color: var(--card-border, var(--divider-color, #dbe4ee)) !important;
     }
 
     #page-appliances-main .appl-wide-card.dm-control-device .appl-spark {
       border-bottom-color: var(--card-border, var(--divider-color, #dbe4ee)) !important;
     }
 
-    #appl-icon-btn .dm-appliance-art {
-      width: 34px !important;
-      height: 34px !important;
-      min-width: 34px !important;
-      min-height: 34px !important;
-      border-radius: 9px !important;
-      overflow: hidden !important;
-    }
-
-    #appl-icon-btn .dm-appliance-art svg {
-      width: 100% !important;
-      height: 100% !important;
-      transform: none !important;
-    }
-
     @media (max-width: 760px) {
       #page-appliances-main .appl-wide-card.dm-control-device {
         grid-template-columns: 112px minmax(0, 1fr) !important;
-      }
-
-      #page-appliances-main .appl-wide-card.dm-control-device .appl-visual .dm-appliance-media,
-      #page-appliances-main .appl-wide-card.dm-control-device .appl-visual .dm-appliance-media > .dm-appliance-art {
-        width: 100% !important;
-        height: 100% !important;
-        min-width: 100% !important;
-        min-height: 100% !important;
-        max-width: none !important;
-        max-height: none !important;
       }
     }
   `;
   document.head.append(style);
 }
 
+function setData(node, key, value) {
+  if (!node?.dataset || node.dataset[key] === value) return false;
+  node.dataset[key] = value;
+  return true;
+}
+
 function decorateApplianceCards() {
   document
     .querySelectorAll("#page-appliances-main .appl-wide-card.dm-control-device")
     .forEach((card) => {
-      card.dataset.applianceThemeAware = "true";
-      const visual = card.querySelector(".appl-visual");
-      if (visual) visual.dataset.applianceCover = "true";
+      setData(card, "applianceThemeAware", "true");
+      setData(card.querySelector(".appl-visual"), "applianceCover", "true");
     });
 }
 
@@ -184,13 +99,16 @@ function installRenderHook() {
   if (typeof renderer !== "function") return false;
   if (renderer.__dmApplianceThemeAware === true) return true;
 
-  const wrapped = function () {
-    const result = renderer.apply(this, arguments);
+  const wrapped = function renderApplianceSection0147Theme(...args) {
+    const result = renderer.apply(this, args);
+    if (result && typeof result.finally === "function") {
+      return result.finally(decorateApplianceCards);
+    }
     decorateApplianceCards();
-    queueMicrotask(decorateApplianceCards);
     return result;
   };
   wrapped.__dmApplianceThemeAware = true;
+  wrapped.__dmPrevious = renderer;
   globalThis.renderApplianceSection = wrapped;
   return true;
 }
@@ -200,19 +118,14 @@ function install() {
   installRenderHook();
   decorateApplianceCards();
 
-  if (globalThis[FLAG]?.installed) return;
-  globalThis[FLAG] = { installed: true };
-
-  let frame = 0;
-  new MutationObserver(() => {
-    cancelAnimationFrame(frame);
-    frame = requestAnimationFrame(decorateApplianceCards);
-  }).observe(document.documentElement, { childList: true, subtree: true });
-
-  let attempts = 0;
-  const timer = setInterval(() => {
-    attempts += 1;
-    if (installRenderHook() || attempts >= 100) clearInterval(timer);
+  const state = (globalThis[FLAG] ||= { installed: true, attempts: 0 });
+  if (state.timer) return;
+  state.timer = globalThis.setInterval?.(() => {
+    state.attempts += 1;
+    if (installRenderHook() || state.attempts >= 100) {
+      globalThis.clearInterval?.(state.timer);
+      state.timer = 0;
+    }
   }, 100);
 }
 

--- a/custom_components/dashboardmodern/frontend/legacy/release-0147-dom-compat.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0147-dom-compat.js
@@ -1,4 +1,6 @@
-/* Stable DOM compatibility markers for audited 0.14.7 editor flows. */
+/* Stable, idempotent DOM compatibility markers for audited editor flows. */
+const OBSERVER_KEY = "__DASHBOARDMODERN_0147_DOM_COMPAT_OBSERVER__";
+
 function readJson(key, fallback) {
   try {
     return JSON.parse(localStorage.getItem(key)) ?? fallback;
@@ -7,27 +9,46 @@ function readJson(key, fallback) {
   }
 }
 
+function setData(node, key, value) {
+  if (!node?.dataset || node.dataset[key] === value) return false;
+  node.dataset[key] = value;
+  return true;
+}
+
+function setAttribute(node, name, value) {
+  if (!node || node.getAttribute(name) === value) return false;
+  node.setAttribute(name, value);
+  return true;
+}
+
+function setText(node, value) {
+  if (!node || node.textContent === value) return false;
+  node.textContent = value;
+  return true;
+}
+
 function decorateShutterRows() {
   document.querySelectorAll("[data-tapp-id]").forEach((row, index) => {
-    const edit = row.querySelector("[data-tapp-edit]");
-    if (edit) edit.dataset.tappEdit = String(index);
-    row.dataset.tappIndex = String(index);
+    const value = String(index);
+    setData(row.querySelector("[data-tapp-edit]"), "tappEdit", value);
+    setData(row, "tappIndex", value);
   });
 }
 
 function bindStandardAlertButton(button, group, entity) {
-  button.removeAttribute("onclick");
-  button.dataset.standardAlertEdit = "";
-  button.dataset.realAlertEdit = "";
-  button.dataset.standardAlertGroup = group;
-  button.dataset.standardAlertEntity = entity;
-  button.dataset.alertGroup = group;
-  button.dataset.alertEntity = entity;
-  button.type = "button";
+  if (button.hasAttribute("onclick")) button.removeAttribute("onclick");
+  setData(button, "standardAlertEdit", "");
+  setData(button, "realAlertEdit", "");
+  setData(button, "standardAlertGroup", group);
+  setData(button, "standardAlertEntity", entity);
+  setData(button, "alertGroup", group);
+  setData(button, "alertEntity", entity);
+  if (button.type !== "button") button.type = "button";
   button.classList.add("ed-del", "dm-edit-button");
-  button.textContent = "✏️";
-  button.title = document.documentElement.lang === "en" ? "Edit" : "Modifica";
-  button.setAttribute("aria-label", button.title);
+  setText(button, "✏️");
+  const title = document.documentElement.lang === "en" ? "Edit" : "Modifica";
+  if (button.title !== title) button.title = title;
+  setAttribute(button, "aria-label", title);
   if (button.dataset.alertEditMounted !== "true") {
     button.dataset.alertEditMounted = "true";
     button.addEventListener("click", () => {
@@ -36,7 +57,7 @@ function bindStandardAlertButton(button, group, entity) {
     });
   }
   const accordion = button.closest("details.ed-acc");
-  if (accordion) accordion.open = true;
+  if (accordion && !accordion.open) accordion.open = true;
 }
 
 function standardAlertRow(entity) {
@@ -66,9 +87,6 @@ function decorateStandardAlerts() {
         else row.append(button);
       }
       bindStandardAlertButton(button, group, entity);
-
-      // Older compatibility passes could leave two edit buttons in the same
-      // row. Keep the canonical dual-marker button and remove only duplicates.
       row.querySelectorAll("[data-standard-alert-edit], [data-real-alert-edit]").forEach((candidate) => {
         if (candidate !== button) candidate.remove();
       });
@@ -98,8 +116,9 @@ function decorateTemperatureIcons() {
     const icon = card.querySelector(".cp-icon");
     if (!room || !icon) return;
     icon.classList.add("temp-room-icon");
-    icon.dataset.roomIcon = room.icon || "mdi:home";
-    icon.textContent = roomGlyph(room.icon || "mdi:home");
+    const value = room.icon || "mdi:home";
+    setData(icon, "roomIcon", value);
+    setText(icon, roomGlyph(value));
   });
 }
 
@@ -109,23 +128,28 @@ function decorateApplianceAssetMarkers() {
     view.querySelectorAll(".dm-appliance-art").forEach((asset) => {
       const key = asset.dataset.applianceAsset || asset.dataset.applianceAssetKey || "";
       if (!key) return;
-      asset.dataset.applianceAssetKey = key;
-      if (active) asset.dataset.applianceAsset = key;
-      else asset.removeAttribute("data-appliance-asset");
+      setData(asset, "applianceAssetKey", key);
+      if (active) setData(asset, "applianceAsset", key);
+      else if (asset.hasAttribute("data-appliance-asset")) asset.removeAttribute("data-appliance-asset");
     });
   });
 }
 
 function installApplianceRenderHook() {
   const render = globalThis.renderApplianceSection;
-  if (typeof render !== "function" || render.__dm0147AssetMarkers) return;
+  if (typeof render !== "function" || render.__dm0147AssetMarkers) return false;
   function renderApplianceSection0147(...args) {
     const result = render.apply(this, args);
+    if (result && typeof result.finally === "function") {
+      return result.finally(decorateApplianceAssetMarkers);
+    }
     decorateApplianceAssetMarkers();
     return result;
   }
   renderApplianceSection0147.__dm0147AssetMarkers = true;
+  renderApplianceSection0147.__dmPrevious = render;
   globalThis.renderApplianceSection = renderApplianceSection0147;
+  return true;
 }
 
 function decorateAll() {
@@ -151,10 +175,13 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
     decorateAll();
     if (globalThis.renderApplianceSection?.__dm0147AssetMarkers) window.clearInterval(timer);
   }, 100);
-  new MutationObserver(decorate).observe(document.documentElement, {
-    childList: true,
-    subtree: true,
-    attributes: true,
-    attributeFilter: ["class"],
-  });
+  if (!globalThis[OBSERVER_KEY]) {
+    globalThis[OBSERVER_KEY] = new MutationObserver(decorate);
+    globalThis[OBSERVER_KEY].observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+  }
 }

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -6,6 +6,7 @@ import "./energy-monthly-report-media-fixes.js";
 import "./energy-report-runtime-hooks.js";
 import "./energy-report-observer-guard.js";
 import "./appliance-media-layout-lock.js";
+import "./release-0154-runtime.js";
 
 function installArtworkLayoutFix0152() {
   const doc = globalThis.document;

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -9,6 +9,7 @@ import "./appliance-media-layout-lock.js";
 import "./release-0154-prelude.js";
 import "./release-0154-runtime.js";
 import "./release-0154-postlude.js";
+import "./release-0154-artwork-lock.js";
 
 function installArtworkLayoutFix0152() {
   const doc = globalThis.document;

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -12,6 +12,7 @@ import "./release-0154-postlude.js";
 import "./release-0154-artwork-lock.js";
 import "./release-0154-artwork-idempotency.js";
 import "./release-0154-style-observer-guard.js";
+import "./release-0154-final-appliance-stability.js";
 
 function installArtworkLayoutFix0152() {
   const doc = globalThis.document;

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -13,6 +13,7 @@ import "./release-0154-render-stability.js";
 import "./release-0154-energy-render-hotfix.js";
 import "./release-0154-classifier-cycle-guard.js";
 import "./release-0154-dom-stability.js";
+import "./release-0154-temperature-live-state.js";
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";
 

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -1,70 +1,14 @@
-/* DashboardModern 0.14.12 compatibility entry point. */
+/* DashboardModern compatibility entry point. */
 import "./release-0152-guards.js";
 export * from "./release-0152-runtime.js";
 import "./release-0152-runtime.js";
 import "./energy-monthly-report-media-fixes.js";
 import "./energy-report-runtime-hooks.js";
 import "./energy-report-observer-guard.js";
-import "./appliance-media-layout-lock.js";
 import "./release-0154-prelude.js";
 import "./release-0154-runtime.js";
 import "./release-0154-postlude.js";
-import "./release-0154-artwork-lock.js";
-import "./release-0154-artwork-idempotency.js";
-import "./release-0154-style-observer-guard.js";
 import "./release-0154-final-appliance-stability.js";
-
-function installArtworkLayoutFix0152() {
-  const doc = globalThis.document;
-  if (!doc || doc.getElementById("dm-release-0152-artwork-layout-fix")) return;
-
-  const artworkSelector = `
-    html body #page-appliances-main
-      .appl-wide-card.dm-control-device[data-dm-artwork]
-      .appl-visual
-      .appl-ic
-      .dm-appliance-media
-      > .dm-appliance-art
-      > .dm-appliance-art.dm-appliance-art-0152[data-dm-art]
-  `;
-
-  const style = doc.createElement("style");
-  style.id = "dm-release-0152-artwork-layout-fix";
-  style.textContent = `
-    ${artworkSelector} {
-      display: grid !important;
-      place-items: center !important;
-      box-sizing: border-box !important;
-      width: 100% !important;
-      height: 100% !important;
-      min-width: 0 !important;
-      min-height: 0 !important;
-      max-width: 100% !important;
-      max-height: 100% !important;
-      padding: 6px !important;
-      margin: 0 !important;
-      overflow: hidden !important;
-      transform: none !important;
-    }
-
-    ${artworkSelector} > svg {
-      display: block !important;
-      box-sizing: border-box !important;
-      width: 76% !important;
-      height: 76% !important;
-      min-width: 0 !important;
-      min-height: 0 !important;
-      max-width: 76% !important;
-      max-height: 76% !important;
-      object-fit: contain !important;
-      object-position: center !important;
-      transform: none !important;
-      overflow: visible !important;
-      flex: 0 0 76% !important;
-    }
-  `;
-  doc.head.append(style);
-}
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";
 
@@ -131,12 +75,11 @@ function installRenderRefreshGuard0152() {
 
 function reinstallRuntimeGuards0152() {
   installRenderRefreshGuard0152();
-  globalThis.queueMicrotask?.(() => installRenderRefreshGuard0152());
-  globalThis.setTimeout?.(() => installRenderRefreshGuard0152(), 0);
-  globalThis.setTimeout?.(() => installRenderRefreshGuard0152(), 120);
+  globalThis.queueMicrotask?.(installRenderRefreshGuard0152);
+  globalThis.setTimeout?.(installRenderRefreshGuard0152, 0);
+  globalThis.setTimeout?.(installRenderRefreshGuard0152, 120);
 }
 
-installArtworkLayoutFix0152();
 reinstallRuntimeGuards0152();
 
 if (typeof globalThis.addEventListener === "function") {

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -9,6 +9,7 @@ import "./release-0154-prelude.js";
 import "./release-0154-runtime.js";
 import "./release-0154-postlude.js";
 import "./release-0154-final-appliance-stability.js";
+import "./release-0154-render-stability.js";
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";
 

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -10,6 +10,7 @@ import "./release-0154-runtime.js";
 import "./release-0154-postlude.js";
 import "./release-0154-final-appliance-stability.js";
 import "./release-0154-render-stability.js";
+import "./release-0154-energy-render-hotfix.js";
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";
 

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -6,7 +6,9 @@ import "./energy-monthly-report-media-fixes.js";
 import "./energy-report-runtime-hooks.js";
 import "./energy-report-observer-guard.js";
 import "./appliance-media-layout-lock.js";
+import "./release-0154-prelude.js";
 import "./release-0154-runtime.js";
+import "./release-0154-postlude.js";
 
 function installArtworkLayoutFix0152() {
   const doc = globalThis.document;

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -12,6 +12,7 @@ import "./release-0154-final-appliance-stability.js";
 import "./release-0154-render-stability.js";
 import "./release-0154-energy-render-hotfix.js";
 import "./release-0154-classifier-cycle-guard.js";
+import "./release-0154-dom-stability.js";
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";
 

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -10,6 +10,7 @@ import "./release-0154-prelude.js";
 import "./release-0154-runtime.js";
 import "./release-0154-postlude.js";
 import "./release-0154-artwork-lock.js";
+import "./release-0154-artwork-idempotency.js";
 
 function installArtworkLayoutFix0152() {
   const doc = globalThis.document;

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -11,6 +11,7 @@ import "./release-0154-postlude.js";
 import "./release-0154-final-appliance-stability.js";
 import "./release-0154-render-stability.js";
 import "./release-0154-energy-render-hotfix.js";
+import "./release-0154-classifier-cycle-guard.js";
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";
 

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -11,6 +11,7 @@ import "./release-0154-runtime.js";
 import "./release-0154-postlude.js";
 import "./release-0154-artwork-lock.js";
 import "./release-0154-artwork-idempotency.js";
+import "./release-0154-style-observer-guard.js";
 
 function installArtworkLayoutFix0152() {
   const doc = globalThis.document;

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-artwork-idempotency.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-artwork-idempotency.js
@@ -1,0 +1,207 @@
+/* DashboardModern 0.14.14: replace the broad artwork observer with an idempotent one. */
+import {
+  applianceArtwork0154,
+  canonicalArtworkType0154,
+} from "./release-0154-runtime.js";
+
+const PREVIOUS_KEY = "__DASHBOARDMODERN_RELEASE_0154_ARTWORK_LOCK__";
+const KEY = "__DASHBOARDMODERN_RELEASE_0154_ARTWORK_IDEMPOTENCY__";
+const STYLE_ID = "dm-release-0154-final-artwork-lock";
+const CARD_SELECTOR =
+  "#appl-grid-overview .appl-wide-card[data-appliance-id], #page-appliances-main .appl-wide-card[data-appliance-id]";
+
+function applianceItems0154() {
+  try {
+    const value = globalThis.DashboardModernModules?.store?.getSection?.("appliances");
+    return Array.isArray(value) ? value : [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+function applianceVisual0154(item) {
+  try {
+    return globalThis.DashboardModernModules?.data?.getDeviceVisual?.(item) || null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function assignDataset0154(node, key, value) {
+  if (!node?.dataset || node.dataset[key] === value) return false;
+  node.dataset[key] = value;
+  return true;
+}
+
+function addClasses0154(node, ...classes) {
+  if (!node?.classList) return false;
+  const missing = classes.filter((name) => !node.classList.contains(name));
+  if (!missing.length) return false;
+  node.classList.add(...missing);
+  return true;
+}
+
+function sourceToken0154(item, visual, card) {
+  return String(
+    visual?.value ||
+      item?.visual_key ||
+      item?.device_type ||
+      item?.type ||
+      item?.icon ||
+      card?.dataset?.dmArtwork ||
+      item?.name ||
+      "",
+  );
+}
+
+function normalizeCards0154() {
+  const doc = globalThis.document;
+  if (!doc) return false;
+  const items = applianceItems0154();
+  const byId = new Map(items.map((item) => [String(item.id || ""), item]));
+  const cards = doc.querySelectorAll(CARD_SELECTOR);
+
+  cards.forEach((card, index) => {
+    const item = byId.get(String(card.dataset.applianceId || "")) || items[index];
+    if (!item) return;
+    const visual = applianceVisual0154(item);
+    const viewport = card.querySelector(".appl-visual");
+    const media = viewport?.querySelector(".appl-ic");
+    if (!viewport || !media) return;
+
+    assignDataset0154(card, "applianceThemeAware", "true");
+    assignDataset0154(viewport, "applianceCover", "true");
+    assignDataset0154(card, "dmArtStyle", "panel");
+    addClasses0154(viewport, "dm-appliance-viewport-0154");
+    addClasses0154(media, "dm-appliance-media-0154");
+
+    if (visual?.kind === "image" && visual.value) {
+      assignDataset0154(card, "dmArtwork", "custom");
+      assignDataset0154(card, "dmMediaKind", "image");
+      let image = media.querySelector("img");
+      if (!image) {
+        image = doc.createElement("img");
+        media.replaceChildren(image);
+      }
+      if (image.getAttribute("src") !== visual.value) image.src = visual.value;
+      const alt = String(item.name || "");
+      if (image.alt !== alt) image.alt = alt;
+      addClasses0154(
+        image,
+        "dm-appliance-image",
+        "dm-appliance-image-0153",
+        "dm-appliance-custom-image-0154",
+      );
+      return;
+    }
+
+    if (visual?.kind !== "asset") return;
+    const source = sourceToken0154(item, visual, card);
+    const canonical = canonicalArtworkType0154(source);
+    if (!canonical) return;
+
+    assignDataset0154(card, "dmArtwork", canonical);
+    assignDataset0154(card, "dmMediaKind", "asset");
+    assignDataset0154(card, "dmMediaType", canonical);
+
+    let artwork = media.querySelector(`.dm-appliance-art-0154[data-dm-art="${canonical}"]`);
+    if (!artwork) {
+      const markup = applianceArtwork0154(canonical, 96);
+      if (markup) media.innerHTML = markup;
+      artwork = media.querySelector(`.dm-appliance-art-0154[data-dm-art="${canonical}"]`);
+    }
+    if (!artwork) return;
+    assignDataset0154(artwork, "dmArtStyle", "panel");
+    assignDataset0154(artwork, "applianceAsset", source);
+    assignDataset0154(artwork, "applianceAssetKey", source);
+  });
+  return true;
+}
+
+function nodeTouchesCards0154(node, target) {
+  if (!(node instanceof Element)) return false;
+  if (node.matches?.(".appl-wide-card[data-appliance-id]")) return true;
+  if (node.querySelector?.(".appl-wide-card[data-appliance-id]")) return true;
+  return Boolean(target?.closest?.(".appl-wide-card[data-appliance-id]"));
+}
+
+function relevantMutation0154(record) {
+  if (record.type === "attributes") {
+    return Boolean(record.target?.closest?.(".appl-wide-card[data-appliance-id]"));
+  }
+  if (record.target?.closest?.(".appl-wide-card[data-appliance-id]")) return true;
+  return [...record.addedNodes, ...record.removedNodes].some((node) =>
+    nodeTouchesCards0154(node, record.target),
+  );
+}
+
+function state0154() {
+  return (globalThis[KEY] ||= {
+    observer: null,
+    styleObserver: null,
+    scheduled: false,
+  });
+}
+
+function keepStyleLast0154() {
+  const doc = globalThis.document;
+  const style = doc?.getElementById?.(STYLE_ID);
+  if (style && doc.head?.lastElementChild !== style) doc.head.append(style);
+}
+
+function schedule0154() {
+  const state = state0154();
+  if (state.scheduled) return;
+  state.scheduled = true;
+  const run = () => {
+    state.scheduled = false;
+    keepStyleLast0154();
+    normalizeCards0154();
+  };
+  globalThis.requestAnimationFrame?.(run) || globalThis.setTimeout?.(run, 0);
+}
+
+function install0154() {
+  const doc = globalThis.document;
+  if (!doc?.documentElement) return false;
+
+  const previous = globalThis[PREVIOUS_KEY];
+  previous?.observer?.disconnect?.();
+  previous?.styleObserver?.disconnect?.();
+  if (previous) {
+    previous.observer = null;
+    previous.styleObserver = null;
+  }
+
+  const state = state0154();
+  keepStyleLast0154();
+  normalizeCards0154();
+
+  if (!state.observer && typeof MutationObserver === "function") {
+    state.observer = new MutationObserver((records) => {
+      if (records.some(relevantMutation0154)) schedule0154();
+    });
+    state.observer.observe(doc.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["data-dm-artwork", "data-dm-art-style", "src"],
+    });
+  }
+
+  if (!state.styleObserver && doc.head && typeof MutationObserver === "function") {
+    state.styleObserver = new MutationObserver(() => {
+      if (doc.head.lastElementChild?.id !== STYLE_ID) keepStyleLast0154();
+    });
+    state.styleObserver.observe(doc.head, { childList: true });
+  }
+  return true;
+}
+
+if (typeof globalThis.document !== "undefined") {
+  install0154();
+  globalThis.queueMicrotask?.(install0154);
+  globalThis.setTimeout?.(install0154, 0);
+  globalThis.setTimeout?.(install0154, 250);
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", install0154);
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-artwork-lock.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-artwork-lock.js
@@ -1,4 +1,4 @@
-/* DashboardModern 0.14.14: final canonical artwork lock after every legacy observer. */
+/* DashboardModern 0.14.14: final canonical artwork lock without observer feedback. */
 import {
   applianceArtwork0154,
   canonicalArtworkType0154,
@@ -6,6 +6,25 @@ import {
 
 const LOCK_KEY = "__DASHBOARDMODERN_RELEASE_0154_ARTWORK_LOCK__";
 const STYLE_ID = "dm-release-0154-final-artwork-lock";
+const LEGACY_STYLE_DISABLED_KEY = "__DASHBOARDMODERN_MEDIA_STYLE_LOCK_DISABLED_0153__";
+const LEGACY_STYLE_OBSERVER_KEY = "__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__";
+const LEGACY_DOM_OBSERVER_KEY = "__DASHBOARDMODERN_MEDIA_DOM_OBSERVER_0153__";
+
+function setData0154(node, key, value) {
+  if (node?.dataset && node.dataset[key] !== value) node.dataset[key] = value;
+}
+
+function setAttribute0154(node, name, value) {
+  if (node && node.getAttribute(name) !== value) node.setAttribute(name, value);
+}
+
+function disableLegacyObservers0154() {
+  globalThis[LEGACY_STYLE_DISABLED_KEY] = true;
+  globalThis[LEGACY_STYLE_OBSERVER_KEY]?.disconnect?.();
+  globalThis[LEGACY_DOM_OBSERVER_KEY]?.disconnect?.();
+  globalThis[LEGACY_STYLE_OBSERVER_KEY] = null;
+  globalThis[LEGACY_DOM_OBSERVER_KEY] = null;
+}
 
 function items0154() {
   try {
@@ -37,6 +56,21 @@ function sourceToken0154(item, visual, card) {
   );
 }
 
+function classifyImage0154(image) {
+  const source = image.currentSrc || image.getAttribute("src") || "";
+  const apply = () => {
+    if (!image.naturalWidth || !image.naturalHeight) return;
+    const ratio = image.naturalWidth / image.naturalHeight;
+    setData0154(image, "dmImageFit", ratio >= 0.92 && ratio <= 1.08 ? "cover" : "contain");
+    setData0154(image, "dmImageFitSource", source);
+  };
+  if (image.complete && image.naturalWidth) apply();
+  else if (image.dataset.dmImageFitPending !== source) {
+    setData0154(image, "dmImageFitPending", source);
+    image.addEventListener("load", apply, { once: true });
+  }
+}
+
 function enforceArtwork0154() {
   const doc = globalThis.document;
   if (!doc) return false;
@@ -54,23 +88,28 @@ function enforceArtwork0154() {
     const media = viewport?.querySelector(".appl-ic");
     if (!viewport || !media) return;
 
-    card.dataset.applianceThemeAware = "true";
-    viewport.dataset.applianceCover = "true";
-    card.dataset.dmArtStyle = "panel";
+    setData0154(card, "applianceThemeAware", "true");
+    setData0154(viewport, "applianceCover", "true");
+    setData0154(card, "dmArtStyle", "panel");
     viewport.classList.add("dm-appliance-viewport-0154");
     media.classList.add("dm-appliance-media-0154");
 
     if (visual?.kind === "image" && visual.value) {
-      card.dataset.dmArtwork = "custom";
-      card.dataset.dmMediaKind = "image";
+      setData0154(card, "dmArtwork", "custom");
+      setData0154(card, "dmMediaKind", "image");
       let image = media.querySelector("img");
       if (!image) {
         image = doc.createElement("img");
         media.replaceChildren(image);
       }
-      if (image.getAttribute("src") !== visual.value) image.src = visual.value;
-      image.alt = String(item.name || "");
-      image.classList.add("dm-appliance-image", "dm-appliance-image-0153", "dm-appliance-custom-image-0154");
+      setAttribute0154(image, "src", visual.value);
+      setAttribute0154(image, "alt", String(item.name || ""));
+      image.classList.add(
+        "dm-appliance-image",
+        "dm-appliance-image-0153",
+        "dm-appliance-custom-image-0154",
+      );
+      classifyImage0154(image);
       return;
     }
 
@@ -79,9 +118,9 @@ function enforceArtwork0154() {
     const canonical = canonicalArtworkType0154(source);
     if (!canonical) return;
 
-    if (card.dataset.dmArtwork !== canonical) card.dataset.dmArtwork = canonical;
-    card.dataset.dmMediaKind = "asset";
-    card.dataset.dmMediaType = canonical;
+    setData0154(card, "dmArtwork", canonical);
+    setData0154(card, "dmMediaKind", "asset");
+    setData0154(card, "dmMediaType", canonical);
 
     let artwork = media.querySelector(`.dm-appliance-art-0154[data-dm-art="${canonical}"]`);
     if (!artwork) {
@@ -90,117 +129,103 @@ function enforceArtwork0154() {
       artwork = media.querySelector(`.dm-appliance-art-0154[data-dm-art="${canonical}"]`);
     }
     if (!artwork) return;
-    artwork.dataset.dmArtStyle = "panel";
-    artwork.dataset.applianceAsset = source;
-    artwork.dataset.applianceAssetKey = source;
+    setData0154(artwork, "dmArtStyle", "panel");
+    setData0154(artwork, "applianceAsset", source);
+    setData0154(artwork, "applianceAssetKey", source);
   });
   return true;
 }
 
 function installStyles0154() {
   const doc = globalThis.document;
-  if (!doc?.head) return false;
-  let style = doc.getElementById(STYLE_ID);
-  if (!style) {
-    style = doc.createElement("style");
-    style.id = STYLE_ID;
-    style.textContent = `
-      html body #page-appliances-main #appl-grid-overview
-        .appl-wide-card[data-dm-art-style="panel"] .appl-visual,
-      html body #appl-grid-overview
-        .appl-wide-card[data-dm-art-style="panel"] .appl-visual,
-      html body #page-appliances-main
-        .appl-wide-card[data-dm-art-style="panel"] .appl-visual {
-        display:grid!important;
-        place-items:center!important;
-        overflow:hidden!important;
-        padding:0!important;
-        background:var(--dm-art-tile)!important;
-        border-color:var(--dm-art-panel-stroke)!important;
-      }
+  if (!doc?.head) return null;
+  const existing = doc.getElementById(STYLE_ID);
+  if (existing) return existing;
 
-      html body #page-appliances-main #appl-grid-overview
-        .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic,
-      html body #appl-grid-overview
-        .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic,
-      html body #page-appliances-main
-        .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic,
-      html body #page-appliances-main #appl-grid-overview
-        .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154,
-      html body #appl-grid-overview
-        .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 {
-        display:grid!important;
-        place-items:center!important;
-        box-sizing:border-box!important;
-        width:100%!important;
-        height:100%!important;
-        min-width:0!important;
-        min-height:0!important;
-        max-width:100%!important;
-        max-height:100%!important;
-        padding:0!important;
-        margin:0!important;
-        overflow:hidden!important;
-        transform:none!important;
-      }
+  const style = doc.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    html body #page-appliances-main #appl-grid-overview
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual,
+    html body #appl-grid-overview
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual,
+    html body #page-appliances-main
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual {
+      display:grid!important;place-items:center!important;overflow:hidden!important;padding:0!important;
+      background:var(--dm-art-tile)!important;border-color:var(--dm-art-panel-stroke)!important;
+    }
+    html body #page-appliances-main #appl-grid-overview
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic,
+    html body #appl-grid-overview
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic,
+    html body #page-appliances-main
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic,
+    html body #page-appliances-main #appl-grid-overview
+      .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154,
+    html body #appl-grid-overview
+      .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 {
+      display:grid!important;place-items:center!important;box-sizing:border-box!important;
+      width:100%!important;height:100%!important;min-width:0!important;min-height:0!important;
+      max-width:100%!important;max-height:100%!important;padding:0!important;margin:0!important;
+      overflow:hidden!important;transform:none!important;
+    }
+    html body #page-appliances-main #appl-grid-overview
+      .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 > svg,
+    html body #appl-grid-overview
+      .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 > svg,
+    html body #page-appliances-main
+      .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 > svg {
+      display:block!important;box-sizing:border-box!important;width:100%!important;height:100%!important;
+      min-width:0!important;min-height:0!important;max-width:100%!important;max-height:100%!important;
+      object-fit:contain!important;object-position:center!important;transform:none!important;
+      overflow:visible!important;flex:0 0 100%!important;filter:drop-shadow(0 8px 12px rgba(15,41,66,.16));
+    }
+    html body #page-appliances-main #appl-grid-overview
+      .appl-wide-card[data-dm-artwork="custom"][data-dm-art-style="panel"] .appl-visual img,
+    html body #appl-grid-overview
+      .appl-wide-card[data-dm-artwork="custom"][data-dm-art-style="panel"] .appl-visual img,
+    html body #page-appliances-main
+      .appl-wide-card[data-dm-artwork="custom"][data-dm-art-style="panel"] .appl-visual img {
+      display:block!important;box-sizing:border-box!important;width:100%!important;height:100%!important;
+      min-width:0!important;min-height:0!important;max-width:100%!important;max-height:100%!important;
+      padding:0!important;border:0!important;border-radius:12px!important;box-shadow:none!important;
+      object-fit:contain!important;object-position:center!important;transform:none!important;
+    }
+    html body #page-appliances-main #appl-grid-overview
+      .appl-wide-card[data-dm-artwork="custom"] .appl-visual img[data-dm-image-fit="cover"],
+    html body #appl-grid-overview
+      .appl-wide-card[data-dm-artwork="custom"] .appl-visual img[data-dm-image-fit="cover"],
+    html body #page-appliances-main
+      .appl-wide-card[data-dm-artwork="custom"] .appl-visual img[data-dm-image-fit="cover"] {
+      object-fit:cover!important;
+    }
+  `;
+  doc.head.append(style);
+  return style;
+}
 
-      html body #page-appliances-main #appl-grid-overview
-        .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 > svg,
-      html body #appl-grid-overview
-        .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 > svg,
-      html body #page-appliances-main
-        .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 > svg {
-        display:block!important;
-        box-sizing:border-box!important;
-        width:100%!important;
-        height:100%!important;
-        min-width:0!important;
-        min-height:0!important;
-        max-width:100%!important;
-        max-height:100%!important;
-        object-fit:contain!important;
-        object-position:center!important;
-        transform:none!important;
-        overflow:visible!important;
-        flex:0 0 100%!important;
-        filter:drop-shadow(0 8px 12px rgba(15,41,66,.16));
-      }
+function settleStyleOrder0154() {
+  const state = globalThis[LOCK_KEY];
+  const doc = globalThis.document;
+  if (!state || state.styleSettled || !doc?.head) return;
+  const style = installStyles0154();
+  if (style && doc.head.lastElementChild !== style) doc.head.append(style);
+  state.styleSettled = true;
+}
 
-      html body #page-appliances-main #appl-grid-overview
-        .appl-wide-card[data-dm-artwork="custom"][data-dm-art-style="panel"] .appl-visual img,
-      html body #appl-grid-overview
-        .appl-wide-card[data-dm-artwork="custom"][data-dm-art-style="panel"] .appl-visual img,
-      html body #page-appliances-main
-        .appl-wide-card[data-dm-artwork="custom"][data-dm-art-style="panel"] .appl-visual img {
-        display:block!important;
-        box-sizing:border-box!important;
-        width:100%!important;
-        height:100%!important;
-        min-width:0!important;
-        min-height:0!important;
-        max-width:100%!important;
-        max-height:100%!important;
-        padding:0!important;
-        border:0!important;
-        border-radius:12px!important;
-        box-shadow:none!important;
-        object-fit:contain!important;
-        object-position:center!important;
-        transform:none!important;
-      }
+function nodeTouchesAppliances0154(node) {
+  if (!node || node.nodeType !== 1) return false;
+  return Boolean(
+    node.matches?.("#appl-grid-overview, #page-appliances-main, .appl-wide-card, .appl-visual, .appl-ic") ||
+      node.closest?.("#appl-grid-overview, #page-appliances-main") ||
+      node.querySelector?.("#appl-grid-overview, #page-appliances-main, .appl-wide-card"),
+  );
+}
 
-      html body #page-appliances-main #appl-grid-overview
-        .appl-wide-card[data-dm-artwork="custom"] .appl-visual img[data-dm-image-fit="cover"],
-      html body #appl-grid-overview
-        .appl-wide-card[data-dm-artwork="custom"] .appl-visual img[data-dm-image-fit="cover"],
-      html body #page-appliances-main
-        .appl-wide-card[data-dm-artwork="custom"] .appl-visual img[data-dm-image-fit="cover"] {
-        object-fit:cover!important;
-      }
-    `;
-  }
-  if (doc.head.lastElementChild !== style) doc.head.append(style);
-  return true;
+function mutationTouchesAppliances0154(record) {
+  if (record.type === "attributes") return nodeTouchesAppliances0154(record.target);
+  if (nodeTouchesAppliances0154(record.target)) return true;
+  return [...record.addedNodes, ...record.removedNodes].some(nodeTouchesAppliances0154);
 }
 
 function schedule0154() {
@@ -209,41 +234,62 @@ function schedule0154() {
   state.scheduled = true;
   const run = () => {
     state.scheduled = false;
-    installStyles0154();
     enforceArtwork0154();
   };
   globalThis.requestAnimationFrame?.(run) || globalThis.setTimeout?.(run, 0);
 }
 
+function installObserver0154() {
+  const doc = globalThis.document;
+  const state = globalThis[LOCK_KEY];
+  if (!doc?.body || !state || typeof MutationObserver !== "function") return false;
+  if (state.observerVersion === 2 && state.observer) return true;
+  state.observer?.disconnect?.();
+  state.styleObserver?.disconnect?.();
+  state.styleObserver = null;
+  state.observer = new MutationObserver((records) => {
+    if (records.some(mutationTouchesAppliances0154)) schedule0154();
+  });
+  state.observer.observe(doc.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["data-dm-artwork", "data-dm-art-style", "class", "src"],
+  });
+  state.observerVersion = 2;
+  return true;
+}
+
 function installLock0154() {
   const doc = globalThis.document;
   if (!doc?.documentElement) return false;
-  const state = (globalThis[LOCK_KEY] ||= { observer: null, styleObserver: null, scheduled: false });
+  const state = (globalThis[LOCK_KEY] ||= {
+    observer: null,
+    styleObserver: null,
+    observerVersion: 0,
+    scheduled: false,
+    styleSettled: false,
+  });
+  disableLegacyObservers0154();
   installStyles0154();
   enforceArtwork0154();
-
-  if (!state.observer && typeof MutationObserver === "function") {
-    state.observer = new MutationObserver(schedule0154);
-    state.observer.observe(doc.documentElement, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: ["data-dm-artwork", "data-dm-art-style", "class", "src"],
-    });
-  }
-  if (!state.styleObserver && typeof MutationObserver === "function" && doc.head) {
-    state.styleObserver = new MutationObserver(() => {
-      if (doc.head.lastElementChild?.id !== STYLE_ID) installStyles0154();
-    });
-    state.styleObserver.observe(doc.head, { childList: true });
-  }
+  installObserver0154();
   return true;
 }
 
 if (typeof globalThis.document !== "undefined") {
   installLock0154();
   globalThis.queueMicrotask?.(installLock0154);
-  globalThis.setTimeout?.(installLock0154, 0);
+  globalThis.setTimeout?.(() => {
+    installLock0154();
+    settleStyleOrder0154();
+  }, 0);
   globalThis.setTimeout?.(installLock0154, 200);
-  globalThis.addEventListener?.("dashboardmodern:legacy-ready", installLock0154);
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", () => {
+    installLock0154();
+    settleStyleOrder0154();
+  });
+  if (globalThis.document.readyState === "loading") {
+    globalThis.document.addEventListener("DOMContentLoaded", installLock0154, { once: true });
+  }
 }

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-artwork-lock.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-artwork-lock.js
@@ -1,0 +1,249 @@
+/* DashboardModern 0.14.14: final canonical artwork lock after every legacy observer. */
+import {
+  applianceArtwork0154,
+  canonicalArtworkType0154,
+} from "./release-0154-runtime.js";
+
+const LOCK_KEY = "__DASHBOARDMODERN_RELEASE_0154_ARTWORK_LOCK__";
+const STYLE_ID = "dm-release-0154-final-artwork-lock";
+
+function items0154() {
+  try {
+    const value = globalThis.DashboardModernModules?.store?.getSection?.("appliances");
+    return Array.isArray(value) ? value : [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+function visual0154(item) {
+  try {
+    return globalThis.DashboardModernModules?.data?.getDeviceVisual?.(item) || null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function sourceToken0154(item, visual, card) {
+  return String(
+    visual?.value ||
+      item?.visual_key ||
+      item?.device_type ||
+      item?.type ||
+      item?.icon ||
+      card?.dataset?.dmArtwork ||
+      item?.name ||
+      "",
+  );
+}
+
+function enforceArtwork0154() {
+  const doc = globalThis.document;
+  if (!doc) return false;
+  const appliances = items0154();
+  const byId = new Map(appliances.map((item) => [String(item.id || ""), item]));
+  const cards = doc.querySelectorAll(
+    "#appl-grid-overview .appl-wide-card[data-appliance-id], #page-appliances-main .appl-wide-card[data-appliance-id]",
+  );
+
+  cards.forEach((card, index) => {
+    const item = byId.get(String(card.dataset.applianceId || "")) || appliances[index];
+    if (!item) return;
+    const visual = visual0154(item);
+    const viewport = card.querySelector(".appl-visual");
+    const media = viewport?.querySelector(".appl-ic");
+    if (!viewport || !media) return;
+
+    card.dataset.applianceThemeAware = "true";
+    viewport.dataset.applianceCover = "true";
+    card.dataset.dmArtStyle = "panel";
+    viewport.classList.add("dm-appliance-viewport-0154");
+    media.classList.add("dm-appliance-media-0154");
+
+    if (visual?.kind === "image" && visual.value) {
+      card.dataset.dmArtwork = "custom";
+      card.dataset.dmMediaKind = "image";
+      let image = media.querySelector("img");
+      if (!image) {
+        image = doc.createElement("img");
+        media.replaceChildren(image);
+      }
+      if (image.getAttribute("src") !== visual.value) image.src = visual.value;
+      image.alt = String(item.name || "");
+      image.classList.add("dm-appliance-image", "dm-appliance-image-0153", "dm-appliance-custom-image-0154");
+      return;
+    }
+
+    if (visual?.kind !== "asset") return;
+    const source = sourceToken0154(item, visual, card);
+    const canonical = canonicalArtworkType0154(source);
+    if (!canonical) return;
+
+    if (card.dataset.dmArtwork !== canonical) card.dataset.dmArtwork = canonical;
+    card.dataset.dmMediaKind = "asset";
+    card.dataset.dmMediaType = canonical;
+
+    let artwork = media.querySelector(`.dm-appliance-art-0154[data-dm-art="${canonical}"]`);
+    if (!artwork) {
+      const markup = applianceArtwork0154(canonical, 96);
+      if (markup) media.innerHTML = markup;
+      artwork = media.querySelector(`.dm-appliance-art-0154[data-dm-art="${canonical}"]`);
+    }
+    if (!artwork) return;
+    artwork.dataset.dmArtStyle = "panel";
+    artwork.dataset.applianceAsset = source;
+    artwork.dataset.applianceAssetKey = source;
+  });
+  return true;
+}
+
+function installStyles0154() {
+  const doc = globalThis.document;
+  if (!doc?.head) return false;
+  let style = doc.getElementById(STYLE_ID);
+  if (!style) {
+    style = doc.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+      html body #page-appliances-main #appl-grid-overview
+        .appl-wide-card[data-dm-art-style="panel"] .appl-visual,
+      html body #appl-grid-overview
+        .appl-wide-card[data-dm-art-style="panel"] .appl-visual,
+      html body #page-appliances-main
+        .appl-wide-card[data-dm-art-style="panel"] .appl-visual {
+        display:grid!important;
+        place-items:center!important;
+        overflow:hidden!important;
+        padding:0!important;
+        background:var(--dm-art-tile)!important;
+        border-color:var(--dm-art-panel-stroke)!important;
+      }
+
+      html body #page-appliances-main #appl-grid-overview
+        .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic,
+      html body #appl-grid-overview
+        .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic,
+      html body #page-appliances-main
+        .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic,
+      html body #page-appliances-main #appl-grid-overview
+        .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154,
+      html body #appl-grid-overview
+        .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 {
+        display:grid!important;
+        place-items:center!important;
+        box-sizing:border-box!important;
+        width:100%!important;
+        height:100%!important;
+        min-width:0!important;
+        min-height:0!important;
+        max-width:100%!important;
+        max-height:100%!important;
+        padding:0!important;
+        margin:0!important;
+        overflow:hidden!important;
+        transform:none!important;
+      }
+
+      html body #page-appliances-main #appl-grid-overview
+        .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 > svg,
+      html body #appl-grid-overview
+        .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 > svg,
+      html body #page-appliances-main
+        .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 > svg {
+        display:block!important;
+        box-sizing:border-box!important;
+        width:100%!important;
+        height:100%!important;
+        min-width:0!important;
+        min-height:0!important;
+        max-width:100%!important;
+        max-height:100%!important;
+        object-fit:contain!important;
+        object-position:center!important;
+        transform:none!important;
+        overflow:visible!important;
+        flex:0 0 100%!important;
+        filter:drop-shadow(0 8px 12px rgba(15,41,66,.16));
+      }
+
+      html body #page-appliances-main #appl-grid-overview
+        .appl-wide-card[data-dm-artwork="custom"][data-dm-art-style="panel"] .appl-visual img,
+      html body #appl-grid-overview
+        .appl-wide-card[data-dm-artwork="custom"][data-dm-art-style="panel"] .appl-visual img,
+      html body #page-appliances-main
+        .appl-wide-card[data-dm-artwork="custom"][data-dm-art-style="panel"] .appl-visual img {
+        display:block!important;
+        box-sizing:border-box!important;
+        width:100%!important;
+        height:100%!important;
+        min-width:0!important;
+        min-height:0!important;
+        max-width:100%!important;
+        max-height:100%!important;
+        padding:0!important;
+        border:0!important;
+        border-radius:12px!important;
+        box-shadow:none!important;
+        object-fit:contain!important;
+        object-position:center!important;
+        transform:none!important;
+      }
+
+      html body #page-appliances-main #appl-grid-overview
+        .appl-wide-card[data-dm-artwork="custom"] .appl-visual img[data-dm-image-fit="cover"],
+      html body #appl-grid-overview
+        .appl-wide-card[data-dm-artwork="custom"] .appl-visual img[data-dm-image-fit="cover"],
+      html body #page-appliances-main
+        .appl-wide-card[data-dm-artwork="custom"] .appl-visual img[data-dm-image-fit="cover"] {
+        object-fit:cover!important;
+      }
+    `;
+  }
+  if (doc.head.lastElementChild !== style) doc.head.append(style);
+  return true;
+}
+
+function schedule0154() {
+  const state = globalThis[LOCK_KEY];
+  if (!state || state.scheduled) return;
+  state.scheduled = true;
+  const run = () => {
+    state.scheduled = false;
+    installStyles0154();
+    enforceArtwork0154();
+  };
+  globalThis.requestAnimationFrame?.(run) || globalThis.setTimeout?.(run, 0);
+}
+
+function installLock0154() {
+  const doc = globalThis.document;
+  if (!doc?.documentElement) return false;
+  const state = (globalThis[LOCK_KEY] ||= { observer: null, styleObserver: null, scheduled: false });
+  installStyles0154();
+  enforceArtwork0154();
+
+  if (!state.observer && typeof MutationObserver === "function") {
+    state.observer = new MutationObserver(schedule0154);
+    state.observer.observe(doc.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["data-dm-artwork", "data-dm-art-style", "class", "src"],
+    });
+  }
+  if (!state.styleObserver && typeof MutationObserver === "function" && doc.head) {
+    state.styleObserver = new MutationObserver(() => {
+      if (doc.head.lastElementChild?.id !== STYLE_ID) installStyles0154();
+    });
+    state.styleObserver.observe(doc.head, { childList: true });
+  }
+  return true;
+}
+
+if (typeof globalThis.document !== "undefined") {
+  installLock0154();
+  globalThis.queueMicrotask?.(installLock0154);
+  globalThis.setTimeout?.(installLock0154, 0);
+  globalThis.setTimeout?.(installLock0154, 200);
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", installLock0154);
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-artwork-lock.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-artwork-lock.js
@@ -1,4 +1,4 @@
-/* DashboardModern 0.14.14: final canonical artwork lock without observer feedback. */
+/* DashboardModern 0.14.14: authoritative appliance artwork and media renderer. */
 import {
   applianceArtwork0154,
   canonicalArtworkType0154,
@@ -9,9 +9,12 @@ const STYLE_ID = "dm-release-0154-final-artwork-lock";
 const LEGACY_STYLE_DISABLED_KEY = "__DASHBOARDMODERN_MEDIA_STYLE_LOCK_DISABLED_0153__";
 const LEGACY_STYLE_OBSERVER_KEY = "__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__";
 const LEGACY_DOM_OBSERVER_KEY = "__DASHBOARDMODERN_MEDIA_DOM_OBSERVER_0153__";
+const MEDIA_FIX_KEY = "__DASHBOARDMODERN_ENERGY_REPORT_MEDIA_FIX__";
+const DISABLED_OBSERVER = Object.freeze({ disabled: true, disconnect() {} });
 const LEGACY_GEOMETRY_STYLE_IDS = new Set([
   "dm-appliance-media-layout-lock-0153",
   "dm-release-0152-artwork-layout-fix",
+  "dm-energy-report-media-fixes-0153",
 ]);
 
 function setData0154(node, key, value) {
@@ -22,17 +25,33 @@ function setAttribute0154(node, name, value) {
   if (node && node.getAttribute(name) !== value) node.setAttribute(name, value);
 }
 
-function retireObserverSlot0154(key) {
-  globalThis[key]?.disconnect?.();
+function addClass0154(node, ...tokens) {
+  tokens.forEach((token) => {
+    if (node && !node.classList.contains(token)) node.classList.add(token);
+  });
+}
+
+function important0154(node, properties) {
+  if (!node?.style) return;
+  Object.entries(properties).forEach(([name, value]) => {
+    if (node.style.getPropertyValue(name) !== value || node.style.getPropertyPriority(name) !== "important") {
+      node.style.setProperty(name, value, "important");
+    }
+  });
+}
+
+function retireObserverSlot0154(owner, key, truthy = false) {
+  if (!owner) return;
+  owner[key]?.disconnect?.();
   try {
-    Object.defineProperty(globalThis, key, {
+    Object.defineProperty(owner, key, {
       configurable: true,
       enumerable: false,
-      get: () => null,
+      get: () => (truthy ? DISABLED_OBSERVER : null),
       set: (observer) => observer?.disconnect?.(),
     });
   } catch (_error) {
-    globalThis[key] = null;
+    owner[key] = truthy ? DISABLED_OBSERVER : null;
   }
 }
 
@@ -43,8 +62,10 @@ function removeLegacyGeometryStyles0154(root = globalThis.document) {
 
 function disableLegacyObservers0154() {
   globalThis[LEGACY_STYLE_DISABLED_KEY] = true;
-  retireObserverSlot0154(LEGACY_STYLE_OBSERVER_KEY);
-  retireObserverSlot0154(LEGACY_DOM_OBSERVER_KEY);
+  retireObserverSlot0154(globalThis, LEGACY_STYLE_OBSERVER_KEY);
+  retireObserverSlot0154(globalThis, LEGACY_DOM_OBSERVER_KEY);
+  const mediaState = globalThis[MEDIA_FIX_KEY];
+  if (mediaState) retireObserverSlot0154(mediaState, "observer", true);
   removeLegacyGeometryStyles0154();
 }
 
@@ -78,14 +99,37 @@ function sourceToken0154(item, visual, card) {
   );
 }
 
+function applyImageFit0154(image, fit) {
+  setData0154(image, "dmImageFit", fit);
+  important0154(image, {
+    display: "block",
+    "box-sizing": "border-box",
+    width: "100%",
+    height: "100%",
+    "min-width": "0px",
+    "min-height": "0px",
+    "max-width": "100%",
+    "max-height": "100%",
+    padding: "0px",
+    border: "0px",
+    "border-radius": "12px",
+    "box-shadow": "none",
+    "object-fit": fit,
+    "object-position": "center",
+    transform: "none",
+  });
+}
+
 function classifyImage0154(image) {
   const source = image.currentSrc || image.getAttribute("src") || "";
   const apply = () => {
     if (!image.naturalWidth || !image.naturalHeight) return;
     const ratio = image.naturalWidth / image.naturalHeight;
-    setData0154(image, "dmImageFit", ratio >= 0.92 && ratio <= 1.08 ? "cover" : "contain");
+    const fit = ratio >= 0.92 && ratio <= 1.08 ? "cover" : "contain";
+    applyImageFit0154(image, fit);
     setData0154(image, "dmImageFitSource", source);
   };
+  applyImageFit0154(image, image.dataset.dmImageFit || "cover");
   if (image.complete && image.naturalWidth) apply();
   else if (image.dataset.dmImageFitPending !== source) {
     setData0154(image, "dmImageFitPending", source);
@@ -96,6 +140,7 @@ function classifyImage0154(image) {
 function enforceArtwork0154() {
   const doc = globalThis.document;
   if (!doc) return false;
+  disableLegacyObservers0154();
   const appliances = items0154();
   const byId = new Map(appliances.map((item) => [String(item.id || ""), item]));
   const cards = doc.querySelectorAll(
@@ -113,8 +158,24 @@ function enforceArtwork0154() {
     setData0154(card, "applianceThemeAware", "true");
     setData0154(viewport, "applianceCover", "true");
     setData0154(card, "dmArtStyle", "panel");
-    viewport.classList.add("dm-appliance-viewport-0154");
-    media.classList.add("dm-appliance-media-0154");
+    addClass0154(viewport, "dm-appliance-viewport-0154");
+    addClass0154(media, "dm-appliance-media-0154");
+    important0154(viewport, { overflow: "hidden", padding: "0px" });
+    important0154(media, {
+      display: "grid",
+      "place-items": "center",
+      "box-sizing": "border-box",
+      width: "100%",
+      height: "100%",
+      "min-width": "0px",
+      "min-height": "0px",
+      "max-width": "100%",
+      "max-height": "100%",
+      padding: "0px",
+      margin: "0px",
+      overflow: "hidden",
+      transform: "none",
+    });
 
     if (visual?.kind === "image" && visual.value) {
       setData0154(card, "dmArtwork", "custom");
@@ -126,7 +187,8 @@ function enforceArtwork0154() {
       }
       setAttribute0154(image, "src", visual.value);
       setAttribute0154(image, "alt", String(item.name || ""));
-      image.classList.add(
+      addClass0154(
+        image,
         "dm-appliance-image",
         "dm-appliance-image-0153",
         "dm-appliance-custom-image-0154",
@@ -154,6 +216,37 @@ function enforceArtwork0154() {
     setData0154(artwork, "dmArtStyle", "panel");
     setData0154(artwork, "applianceAsset", source);
     setData0154(artwork, "applianceAssetKey", source);
+    important0154(artwork, {
+      display: "grid",
+      "place-items": "center",
+      "box-sizing": "border-box",
+      width: "100%",
+      height: "100%",
+      "min-width": "0px",
+      "min-height": "0px",
+      "max-width": "100%",
+      "max-height": "100%",
+      padding: "0px",
+      margin: "0px",
+      overflow: "hidden",
+      transform: "none",
+    });
+    const svg = artwork.querySelector("svg");
+    important0154(svg, {
+      display: "block",
+      "box-sizing": "border-box",
+      width: "100%",
+      height: "100%",
+      "min-width": "0px",
+      "min-height": "0px",
+      "max-width": "100%",
+      "max-height": "100%",
+      "object-fit": "contain",
+      "object-position": "center",
+      transform: "none",
+      overflow: "visible",
+      flex: "0 0 100%",
+    });
   });
   return true;
 }
@@ -177,63 +270,24 @@ function installStyles0154() {
       background:var(--dm-art-tile)!important;border-color:var(--dm-art-panel-stroke)!important;
     }
     html body #page-appliances-main #appl-grid-overview
-      .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic,
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual img,
     html body #appl-grid-overview
-      .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic,
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual img,
     html body #page-appliances-main
-      .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic,
-    html body #page-appliances-main #appl-grid-overview
-      .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154,
-    html body #appl-grid-overview
-      .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 {
-      display:grid!important;place-items:center!important;box-sizing:border-box!important;
-      width:100%!important;height:100%!important;min-width:0!important;min-height:0!important;
-      max-width:100%!important;max-height:100%!important;padding:0!important;margin:0!important;
-      overflow:hidden!important;transform:none!important;
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual img {
+      object-fit:cover!important;object-position:center!important;
     }
     html body #page-appliances-main #appl-grid-overview
-      .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 > svg,
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual img[data-dm-image-fit="contain"],
     html body #appl-grid-overview
-      .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 > svg,
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual img[data-dm-image-fit="contain"],
     html body #page-appliances-main
-      .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 > svg {
-      display:block!important;box-sizing:border-box!important;width:100%!important;height:100%!important;
-      min-width:0!important;min-height:0!important;max-width:100%!important;max-height:100%!important;
-      object-fit:contain!important;object-position:center!important;transform:none!important;
-      overflow:visible!important;flex:0 0 100%!important;filter:drop-shadow(0 8px 12px rgba(15,41,66,.16));
-    }
-    html body #page-appliances-main #appl-grid-overview
-      .appl-wide-card[data-dm-artwork="custom"][data-dm-art-style="panel"] .appl-visual img,
-    html body #appl-grid-overview
-      .appl-wide-card[data-dm-artwork="custom"][data-dm-art-style="panel"] .appl-visual img,
-    html body #page-appliances-main
-      .appl-wide-card[data-dm-artwork="custom"][data-dm-art-style="panel"] .appl-visual img {
-      display:block!important;box-sizing:border-box!important;width:100%!important;height:100%!important;
-      min-width:0!important;min-height:0!important;max-width:100%!important;max-height:100%!important;
-      padding:0!important;border:0!important;border-radius:12px!important;box-shadow:none!important;
-      object-fit:contain!important;object-position:center!important;transform:none!important;
-    }
-    html body #page-appliances-main #appl-grid-overview
-      .appl-wide-card[data-dm-artwork="custom"] .appl-visual img[data-dm-image-fit="cover"],
-    html body #appl-grid-overview
-      .appl-wide-card[data-dm-artwork="custom"] .appl-visual img[data-dm-image-fit="cover"],
-    html body #page-appliances-main
-      .appl-wide-card[data-dm-artwork="custom"] .appl-visual img[data-dm-image-fit="cover"] {
-      object-fit:cover!important;
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual img[data-dm-image-fit="contain"] {
+      object-fit:contain!important;
     }
   `;
   doc.head.append(style);
   return style;
-}
-
-function settleStyleOrder0154() {
-  const state = globalThis[LOCK_KEY];
-  const doc = globalThis.document;
-  if (!state || state.styleSettled || !doc?.head) return;
-  removeLegacyGeometryStyles0154();
-  const style = installStyles0154();
-  if (style && doc.head.lastElementChild !== style) doc.head.append(style);
-  state.styleSettled = true;
 }
 
 function installLegacyStyleCleanup0154() {
@@ -255,16 +309,10 @@ function installLegacyStyleCleanup0154() {
 function nodeTouchesAppliances0154(node) {
   if (!node || node.nodeType !== 1) return false;
   return Boolean(
-    node.matches?.("#appl-grid-overview, #page-appliances-main, .appl-wide-card, .appl-visual, .appl-ic") ||
+    node.matches?.("#appl-grid-overview, #page-appliances-main, .appl-wide-card") ||
       node.closest?.("#appl-grid-overview, #page-appliances-main") ||
       node.querySelector?.("#appl-grid-overview, #page-appliances-main, .appl-wide-card"),
   );
-}
-
-function mutationTouchesAppliances0154(record) {
-  if (record.type === "attributes") return nodeTouchesAppliances0154(record.target);
-  if (nodeTouchesAppliances0154(record.target)) return true;
-  return [...record.addedNodes, ...record.removedNodes].some(nodeTouchesAppliances0154);
 }
 
 function schedule0154() {
@@ -282,18 +330,36 @@ function installObserver0154() {
   const doc = globalThis.document;
   const state = globalThis[LOCK_KEY];
   if (!doc?.body || !state || typeof MutationObserver !== "function") return false;
-  if (state.observerVersion === 2 && state.observer) return true;
+  if (state.observerVersion === 3 && state.observer) return true;
   state.observer?.disconnect?.();
   state.observer = new MutationObserver((records) => {
-    if (records.some(mutationTouchesAppliances0154)) schedule0154();
+    if (
+      records.some(
+        (record) =>
+          nodeTouchesAppliances0154(record.target) ||
+          [...record.addedNodes, ...record.removedNodes].some(nodeTouchesAppliances0154),
+      )
+    ) {
+      schedule0154();
+    }
   });
-  state.observer.observe(doc.body, {
-    childList: true,
-    subtree: true,
-    attributes: true,
-    attributeFilter: ["data-dm-artwork", "data-dm-art-style", "class", "src"],
-  });
-  state.observerVersion = 2;
+  state.observer.observe(doc.body, { childList: true, subtree: true });
+  state.observerVersion = 3;
+  return true;
+}
+
+function installRenderHook0154() {
+  const original = globalThis.renderApplianceSection;
+  if (typeof original !== "function" || original.__dm0154ArtworkHook) return false;
+  function renderApplianceSection0154(...args) {
+    const result = original.apply(this, args);
+    globalThis.queueMicrotask?.(enforceArtwork0154);
+    globalThis.requestAnimationFrame?.(enforceArtwork0154);
+    return result;
+  }
+  renderApplianceSection0154.__dm0154ArtworkHook = true;
+  renderApplianceSection0154.__dmPrevious = original;
+  globalThis.renderApplianceSection = renderApplianceSection0154;
   return true;
 }
 
@@ -304,12 +370,12 @@ function installLock0154() {
     observer: null,
     observerVersion: 0,
     scheduled: false,
-    styleSettled: false,
     legacyStyleCleanupObserver: null,
   });
   disableLegacyObservers0154();
   installStyles0154();
   installLegacyStyleCleanup0154();
+  installRenderHook0154();
   enforceArtwork0154();
   installObserver0154();
   return true;
@@ -318,16 +384,10 @@ function installLock0154() {
 if (typeof globalThis.document !== "undefined") {
   installLock0154();
   globalThis.queueMicrotask?.(installLock0154);
-  globalThis.setTimeout?.(() => {
-    installLock0154();
-    settleStyleOrder0154();
-  }, 0);
+  globalThis.setTimeout?.(installLock0154, 0);
   globalThis.setTimeout?.(installLock0154, 200);
   globalThis.setTimeout?.(installLock0154, 650);
-  globalThis.addEventListener?.("dashboardmodern:legacy-ready", () => {
-    installLock0154();
-    settleStyleOrder0154();
-  });
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", installLock0154);
   if (globalThis.document.readyState === "loading") {
     globalThis.document.addEventListener("DOMContentLoaded", installLock0154, { once: true });
   }

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-artwork-lock.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-artwork-lock.js
@@ -9,6 +9,10 @@ const STYLE_ID = "dm-release-0154-final-artwork-lock";
 const LEGACY_STYLE_DISABLED_KEY = "__DASHBOARDMODERN_MEDIA_STYLE_LOCK_DISABLED_0153__";
 const LEGACY_STYLE_OBSERVER_KEY = "__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__";
 const LEGACY_DOM_OBSERVER_KEY = "__DASHBOARDMODERN_MEDIA_DOM_OBSERVER_0153__";
+const LEGACY_GEOMETRY_STYLE_IDS = new Set([
+  "dm-appliance-media-layout-lock-0153",
+  "dm-release-0152-artwork-layout-fix",
+]);
 
 function setData0154(node, key, value) {
   if (node?.dataset && node.dataset[key] !== value) node.dataset[key] = value;
@@ -18,12 +22,30 @@ function setAttribute0154(node, name, value) {
   if (node && node.getAttribute(name) !== value) node.setAttribute(name, value);
 }
 
+function retireObserverSlot0154(key) {
+  globalThis[key]?.disconnect?.();
+  try {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      enumerable: false,
+      get: () => null,
+      set: (observer) => observer?.disconnect?.(),
+    });
+  } catch (_error) {
+    globalThis[key] = null;
+  }
+}
+
+function removeLegacyGeometryStyles0154(root = globalThis.document) {
+  if (!root?.querySelectorAll) return;
+  LEGACY_GEOMETRY_STYLE_IDS.forEach((id) => root.querySelector(`#${id}`)?.remove());
+}
+
 function disableLegacyObservers0154() {
   globalThis[LEGACY_STYLE_DISABLED_KEY] = true;
-  globalThis[LEGACY_STYLE_OBSERVER_KEY]?.disconnect?.();
-  globalThis[LEGACY_DOM_OBSERVER_KEY]?.disconnect?.();
-  globalThis[LEGACY_STYLE_OBSERVER_KEY] = null;
-  globalThis[LEGACY_DOM_OBSERVER_KEY] = null;
+  retireObserverSlot0154(LEGACY_STYLE_OBSERVER_KEY);
+  retireObserverSlot0154(LEGACY_DOM_OBSERVER_KEY);
+  removeLegacyGeometryStyles0154();
 }
 
 function items0154() {
@@ -208,9 +230,26 @@ function settleStyleOrder0154() {
   const state = globalThis[LOCK_KEY];
   const doc = globalThis.document;
   if (!state || state.styleSettled || !doc?.head) return;
+  removeLegacyGeometryStyles0154();
   const style = installStyles0154();
   if (style && doc.head.lastElementChild !== style) doc.head.append(style);
   state.styleSettled = true;
+}
+
+function installLegacyStyleCleanup0154() {
+  const doc = globalThis.document;
+  const state = globalThis[LOCK_KEY];
+  if (!doc?.head || !state || typeof MutationObserver !== "function") return false;
+  if (state.legacyStyleCleanupObserver) return true;
+  state.legacyStyleCleanupObserver = new MutationObserver((records) => {
+    records.forEach((record) => {
+      record.addedNodes.forEach((node) => {
+        if (node.nodeType === 1 && LEGACY_GEOMETRY_STYLE_IDS.has(node.id)) node.remove();
+      });
+    });
+  });
+  state.legacyStyleCleanupObserver.observe(doc.head, { childList: true });
+  return true;
 }
 
 function nodeTouchesAppliances0154(node) {
@@ -245,8 +284,6 @@ function installObserver0154() {
   if (!doc?.body || !state || typeof MutationObserver !== "function") return false;
   if (state.observerVersion === 2 && state.observer) return true;
   state.observer?.disconnect?.();
-  state.styleObserver?.disconnect?.();
-  state.styleObserver = null;
   state.observer = new MutationObserver((records) => {
     if (records.some(mutationTouchesAppliances0154)) schedule0154();
   });
@@ -265,13 +302,14 @@ function installLock0154() {
   if (!doc?.documentElement) return false;
   const state = (globalThis[LOCK_KEY] ||= {
     observer: null,
-    styleObserver: null,
     observerVersion: 0,
     scheduled: false,
     styleSettled: false,
+    legacyStyleCleanupObserver: null,
   });
   disableLegacyObservers0154();
   installStyles0154();
+  installLegacyStyleCleanup0154();
   enforceArtwork0154();
   installObserver0154();
   return true;
@@ -285,6 +323,7 @@ if (typeof globalThis.document !== "undefined") {
     settleStyleOrder0154();
   }, 0);
   globalThis.setTimeout?.(installLock0154, 200);
+  globalThis.setTimeout?.(installLock0154, 650);
   globalThis.addEventListener?.("dashboardmodern:legacy-ready", () => {
     installLock0154();
     settleStyleOrder0154();

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-classifier-cycle-guard.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-classifier-cycle-guard.js
@@ -1,0 +1,23 @@
+/* DashboardModern 0.14.14: prevent mobile inference from re-wrapping the final classifier. */
+const CLASSIFIER_MARKER_0154 = "__dm0154EntityClassifier";
+const MOBILE_MARKER_0154 = "__dmUnitInference";
+
+function markFinalClassifier0154() {
+  const classifier = globalThis.cdApplEntity;
+  if (typeof classifier !== "function" || !classifier[CLASSIFIER_MARKER_0154]) return false;
+  classifier[MOBILE_MARKER_0154] = true;
+  return true;
+}
+
+function installClassifierCycleGuard0154() {
+  if (markFinalClassifier0154()) return true;
+  globalThis.queueMicrotask?.(markFinalClassifier0154);
+  globalThis.setTimeout?.(markFinalClassifier0154, 0);
+  globalThis.setTimeout?.(markFinalClassifier0154, 80);
+  globalThis.setTimeout?.(markFinalClassifier0154, 250);
+  return false;
+}
+
+installClassifierCycleGuard0154();
+globalThis.addEventListener?.("dashboardmodern:legacy-ready", installClassifierCycleGuard0154);
+globalThis.addEventListener?.("pageshow", installClassifierCycleGuard0154);

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-dom-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-dom-stability.js
@@ -1,15 +1,10 @@
-/* DashboardModern 0.14.14: final ownership gates for appliance cards and editor DOM. */
+/* DashboardModern 0.14.14: final ownership gates for appliance cards and DOM observers. */
 const DOM_STABILITY_KEY = "__DASHBOARDMODERN_RELEASE_0154_DOM_STABILITY__";
 const LEGACY_COMPAT_OBSERVER_KEY = "__DASHBOARDMODERN_0147_DOM_COMPAT_OBSERVER__";
-
-function now0154Dom() {
-  return globalThis.performance?.now?.() ?? Date.now();
-}
 
 function domState0154() {
   return (globalThis[DOM_STABILITY_KEY] ||= {
     applianceSignature: "",
-    allowAlertRenderUntil: 0,
     monitor: null,
     monitorTicks: 0,
   });
@@ -92,18 +87,29 @@ function applianceCardsReady0154Dom() {
   return grid.querySelectorAll(".appl-wide-card[data-appliance-id]").length === expected;
 }
 
+function markFinalOwner0154(fn) {
+  if (typeof fn !== "function") return;
+  fn.__dm0154FinalTopGate = true;
+  fn.__dm0154StableRenderGate = true;
+  fn.__dm0154SingleArtworkOwner = true;
+  fn.__dm0154MetricHook = true;
+  fn.__dm0147AssetMarkers = true;
+}
+
 function installFinalApplianceGate0154() {
   const current = globalThis.renderApplianceSection;
-  if (typeof current !== "function" || current.__dm0154FinalTopGate) return false;
+  if (typeof current !== "function") return false;
+  if (functionChainHas0154Dom(current, "__dm0154FinalTopGate")) {
+    markFinalOwner0154(current);
+    return true;
+  }
+
   const state = domState0154();
   if (applianceCardsReady0154Dom()) state.applianceSignature = applianceSignature0154Dom();
 
   function finalApplianceRender0154(...args) {
     const signature = applianceSignature0154Dom();
-    const forced = args[0] === true;
-    if (!forced && applianceCardsReady0154Dom() && signature === state.applianceSignature) {
-      return false;
-    }
+    if (applianceCardsReady0154Dom() && signature === state.applianceSignature) return false;
     state.applianceSignature = signature;
     try {
       const result = current.apply(this, args);
@@ -119,11 +125,7 @@ function installFinalApplianceGate0154() {
     }
   }
 
-  finalApplianceRender0154.__dm0154FinalTopGate = true;
-  finalApplianceRender0154.__dm0154StableRenderGate = true;
-  finalApplianceRender0154.__dm0154SingleArtworkOwner = true;
-  finalApplianceRender0154.__dm0154MetricHook = true;
-  finalApplianceRender0154.__dm0147AssetMarkers = true;
+  markFinalOwner0154(finalApplianceRender0154);
   finalApplianceRender0154.__dmPrevious = current;
   globalThis.renderApplianceSection = finalApplianceRender0154;
   return true;
@@ -144,73 +146,9 @@ function narrowLegacyCompatibilityObserver0154() {
   }
 }
 
-function allowAlertEditorRender0154() {
-  domState0154().allowAlertRenderUntil = now0154Dom() + 1200;
-}
-
-function installAlertActionGuard0154(name) {
-  const current = globalThis[name];
-  if (typeof current !== "function" || functionChainHas0154Dom(current, "__dm0154AlertAction")) {
-    return false;
-  }
-  function alertAction0154(...args) {
-    allowAlertEditorRender0154();
-    return current.apply(this, args);
-  }
-  alertAction0154.__dm0154AlertAction = true;
-  alertAction0154.__dmPrevious = current;
-  globalThis[name] = alertAction0154;
-  return true;
-}
-
-function installEditorSwitchGuard0154() {
-  const current = globalThis.editorSwitch;
-  if (typeof current !== "function" || functionChainHas0154Dom(current, "__dm0154EditorSwitchGuard")) {
-    return false;
-  }
-
-  function stableEditorSwitch0154(tab, ...args) {
-    const target = String(tab || "");
-    if (target === "avvisi") {
-      const active = globalThis.document?.querySelector?.(".ed-tab.active")?.dataset?.tab || "";
-      const modal = globalThis.document?.getElementById?.("editor-modal");
-      const body = globalThis.document?.getElementById?.("ed-body");
-      const sameMountedTab =
-        active === "avvisi" &&
-        modal?.classList?.contains("show") &&
-        Boolean(body?.children?.length);
-      if (sameMountedTab && now0154Dom() > domState0154().allowAlertRenderUntil) return false;
-    }
-    return current.call(this, tab, ...args);
-  }
-
-  stableEditorSwitch0154.__dm0154EditorSwitchGuard = true;
-  stableEditorSwitch0154.__dmPrevious = current;
-  globalThis.editorSwitch = stableEditorSwitch0154;
-  return true;
-}
-
-function markCompatibilityOwner0154() {
-  const current = globalThis.renderApplianceSection;
-  if (!functionChainHas0154Dom(current, "__dm0147AssetMarkers")) return false;
-  if (!current.__dm0147AssetMarkers) current.__dm0147AssetMarkers = true;
-  return true;
-}
-
 function installDomStability0154() {
   narrowLegacyCompatibilityObserver0154();
   installFinalApplianceGate0154();
-  markCompatibilityOwner0154();
-  [
-    "dmRealEditAlert",
-    "edEditAvvisoStandard",
-    "edAddAvviso",
-    "edDelAvviso",
-    "edEditAvvisoCustom",
-    "edDelAvvisoCustom",
-    "edAvvCancelEdit",
-  ].forEach(installAlertActionGuard0154);
-  installEditorSwitchGuard0154();
 }
 
 function monitorDomStability0154() {

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-dom-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-dom-stability.js
@@ -1,0 +1,241 @@
+/* DashboardModern 0.14.14: final ownership gates for appliance cards and editor DOM. */
+const DOM_STABILITY_KEY = "__DASHBOARDMODERN_RELEASE_0154_DOM_STABILITY__";
+const LEGACY_COMPAT_OBSERVER_KEY = "__DASHBOARDMODERN_0147_DOM_COMPAT_OBSERVER__";
+
+function now0154Dom() {
+  return globalThis.performance?.now?.() ?? Date.now();
+}
+
+function domState0154() {
+  return (globalThis[DOM_STABILITY_KEY] ||= {
+    applianceSignature: "",
+    allowAlertRenderUntil: 0,
+    monitor: null,
+    monitorTicks: 0,
+  });
+}
+
+function functionChainHas0154Dom(fn, marker) {
+  const seen = new Set();
+  let current = fn;
+  while (typeof current === "function" && !seen.has(current)) {
+    if (current[marker]) return true;
+    seen.add(current);
+    current = current.__dmPrevious;
+  }
+  return false;
+}
+
+function applianceItems0154Dom() {
+  try {
+    const items = globalThis.DashboardModernModules?.store?.getSection?.("appliances");
+    return Array.isArray(items) ? items : [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+function entityIds0154Dom(item = {}) {
+  return [...new Set([
+    ...(Array.isArray(item.entities) ? item.entities : []),
+    item.control_entity,
+    item.power_entity,
+    item.energy_entity,
+    item.total_energy_entity,
+    item.daily_energy_entity,
+    item.history_entity,
+  ].map((value) => (typeof value === "string" ? value : value?.entity)).filter(Boolean))];
+}
+
+function stateSignature0154Dom(entity) {
+  const state = globalThis._RAW_STATES?.[entity] || globalThis.STATES?.[entity];
+  const attributes = state?.attributes || {};
+  return [
+    entity,
+    state?.state ?? "",
+    attributes.unit_of_measurement ?? "",
+    attributes.device_class ?? "",
+    attributes.state_class ?? "",
+  ].join(":");
+}
+
+function applianceSignature0154Dom() {
+  const items = applianceItems0154Dom();
+  return JSON.stringify({
+    language: globalThis.document?.documentElement?.lang || "",
+    room: globalThis._dmApplRoom || "all",
+    active: globalThis.document?.querySelector?.(".appl-main-view.active")?.id || "",
+    items: items.map((item) => {
+      const entities = entityIds0154Dom(item);
+      return {
+        id: item.id,
+        name: item.name,
+        room_id: item.room_id,
+        room: item.room,
+        visual_type: item.visual_type,
+        visual_key: item.visual_key,
+        device_type: item.device_type,
+        type: item.type,
+        icon: item.icon,
+        threshold_run: item.threshold_run,
+        entities,
+        states: entities.map(stateSignature0154Dom),
+      };
+    }),
+  });
+}
+
+function applianceCardsReady0154Dom() {
+  const grid = globalThis.document?.getElementById?.("appl-grid-overview");
+  if (!grid) return false;
+  const expected = applianceItems0154Dom().length;
+  return grid.querySelectorAll(".appl-wide-card[data-appliance-id]").length === expected;
+}
+
+function installFinalApplianceGate0154() {
+  const current = globalThis.renderApplianceSection;
+  if (typeof current !== "function" || current.__dm0154FinalTopGate) return false;
+  const state = domState0154();
+  if (applianceCardsReady0154Dom()) state.applianceSignature = applianceSignature0154Dom();
+
+  function finalApplianceRender0154(...args) {
+    const signature = applianceSignature0154Dom();
+    const forced = args[0] === true;
+    if (!forced && applianceCardsReady0154Dom() && signature === state.applianceSignature) {
+      return false;
+    }
+    state.applianceSignature = signature;
+    try {
+      const result = current.apply(this, args);
+      if (result && typeof result.catch === "function") {
+        result.catch(() => {
+          state.applianceSignature = "";
+        });
+      }
+      return result;
+    } catch (error) {
+      state.applianceSignature = "";
+      throw error;
+    }
+  }
+
+  finalApplianceRender0154.__dm0154FinalTopGate = true;
+  finalApplianceRender0154.__dm0154StableRenderGate = true;
+  finalApplianceRender0154.__dm0154SingleArtworkOwner = true;
+  finalApplianceRender0154.__dm0154MetricHook = true;
+  finalApplianceRender0154.__dm0147AssetMarkers = true;
+  finalApplianceRender0154.__dmPrevious = current;
+  globalThis.renderApplianceSection = finalApplianceRender0154;
+  return true;
+}
+
+function narrowLegacyCompatibilityObserver0154() {
+  const observer = globalThis[LEGACY_COMPAT_OBSERVER_KEY];
+  if (!observer?.disconnect || !observer?.observe || observer.__dm0154Narrowed) return false;
+  try {
+    observer.disconnect();
+    const root = globalThis.document?.body || globalThis.document?.documentElement;
+    if (!root) return false;
+    observer.observe(root, { childList: true, subtree: true });
+    observer.__dm0154Narrowed = true;
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function allowAlertEditorRender0154() {
+  domState0154().allowAlertRenderUntil = now0154Dom() + 1200;
+}
+
+function installAlertActionGuard0154(name) {
+  const current = globalThis[name];
+  if (typeof current !== "function" || functionChainHas0154Dom(current, "__dm0154AlertAction")) {
+    return false;
+  }
+  function alertAction0154(...args) {
+    allowAlertEditorRender0154();
+    return current.apply(this, args);
+  }
+  alertAction0154.__dm0154AlertAction = true;
+  alertAction0154.__dmPrevious = current;
+  globalThis[name] = alertAction0154;
+  return true;
+}
+
+function installEditorSwitchGuard0154() {
+  const current = globalThis.editorSwitch;
+  if (typeof current !== "function" || functionChainHas0154Dom(current, "__dm0154EditorSwitchGuard")) {
+    return false;
+  }
+
+  function stableEditorSwitch0154(tab, ...args) {
+    const target = String(tab || "");
+    if (target === "avvisi") {
+      const active = globalThis.document?.querySelector?.(".ed-tab.active")?.dataset?.tab || "";
+      const modal = globalThis.document?.getElementById?.("editor-modal");
+      const body = globalThis.document?.getElementById?.("ed-body");
+      const sameMountedTab =
+        active === "avvisi" &&
+        modal?.classList?.contains("show") &&
+        Boolean(body?.children?.length);
+      if (sameMountedTab && now0154Dom() > domState0154().allowAlertRenderUntil) return false;
+    }
+    return current.call(this, tab, ...args);
+  }
+
+  stableEditorSwitch0154.__dm0154EditorSwitchGuard = true;
+  stableEditorSwitch0154.__dmPrevious = current;
+  globalThis.editorSwitch = stableEditorSwitch0154;
+  return true;
+}
+
+function markCompatibilityOwner0154() {
+  const current = globalThis.renderApplianceSection;
+  if (!functionChainHas0154Dom(current, "__dm0147AssetMarkers")) return false;
+  if (!current.__dm0147AssetMarkers) current.__dm0147AssetMarkers = true;
+  return true;
+}
+
+function installDomStability0154() {
+  narrowLegacyCompatibilityObserver0154();
+  installFinalApplianceGate0154();
+  markCompatibilityOwner0154();
+  [
+    "dmRealEditAlert",
+    "edEditAvvisoStandard",
+    "edAddAvviso",
+    "edDelAvviso",
+    "edEditAvvisoCustom",
+    "edDelAvvisoCustom",
+    "edAvvCancelEdit",
+  ].forEach(installAlertActionGuard0154);
+  installEditorSwitchGuard0154();
+}
+
+function monitorDomStability0154() {
+  const state = domState0154();
+  if (state.monitor || typeof globalThis.setInterval !== "function") return;
+  state.monitorTicks = 0;
+  state.monitor = globalThis.setInterval(() => {
+    state.monitorTicks += 1;
+    installDomStability0154();
+    if (state.monitorTicks >= 40) {
+      globalThis.clearInterval?.(state.monitor);
+      state.monitor = null;
+    }
+  }, 100);
+}
+
+if (typeof globalThis.document !== "undefined") {
+  installDomStability0154();
+  monitorDomStability0154();
+  globalThis.queueMicrotask?.(installDomStability0154);
+  globalThis.setTimeout?.(installDomStability0154, 0);
+  globalThis.setTimeout?.(installDomStability0154, 120);
+  globalThis.setTimeout?.(installDomStability0154, 500);
+  globalThis.setTimeout?.(installDomStability0154, 1600);
+  globalThis.setTimeout?.(installDomStability0154, 15600);
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", installDomStability0154);
+  globalThis.addEventListener?.("pageshow", installDomStability0154);
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-energy-render-hotfix.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-energy-render-hotfix.js
@@ -1,6 +1,7 @@
-/* DashboardModern 0.14.14: keep energy-period refreshes from rebuilding unrelated UI. */
+/* DashboardModern 0.14.14: isolate energy refreshes and keep appliance metrics correct. */
 const HOTFIX_KEY = "__DASHBOARDMODERN_RELEASE_0154_ENERGY_RENDER_HOTFIX__";
 const RELEASE_KEY = "__DASHBOARDMODERN_RELEASE_0154__";
+const PERIOD_EVENT = "dashboardmodern:energy-periods-0154";
 
 function clock0154Hotfix() {
   return globalThis.performance?.now?.() ?? Date.now();
@@ -8,13 +9,29 @@ function clock0154Hotfix() {
 
 function hotfixState0154() {
   return (globalThis[HOTFIX_KEY] ||= {
-    suppressNextGlobalRender: false,
     suppressUntil: 0,
+    energyRenderDepth: 0,
     releaseState: null,
     installed: false,
     monitor: null,
     monitorTicks: 0,
   });
+}
+
+function functionChainHas0154(fn, marker) {
+  const seen = new Set();
+  let current = fn;
+  while (typeof current === "function" && !seen.has(current)) {
+    if (current[marker]) return true;
+    seen.add(current);
+    current = current.__dmPrevious;
+  }
+  return false;
+}
+
+function armGlobalRenderSuppression0154(duration = 5000) {
+  const state = hotfixState0154();
+  state.suppressUntil = Math.max(state.suppressUntil, clock0154Hotfix() + duration);
 }
 
 function instrumentEnergyRefreshState0154() {
@@ -32,10 +49,7 @@ function instrumentEnergyRefreshState0154() {
       },
       set(value) {
         const next = Boolean(value);
-        if (refreshing && !next) {
-          hotfix.suppressNextGlobalRender = true;
-          hotfix.suppressUntil = clock0154Hotfix() + 250;
-        }
+        if (next || refreshing !== next) armGlobalRenderSuppression0154(5000);
         refreshing = next;
       },
     });
@@ -48,7 +62,9 @@ function instrumentEnergyRefreshState0154() {
 
 function calledFromEnergyRefresh0154() {
   try {
-    return String(new Error().stack || "").includes("refreshEnergyPeriods0154");
+    return /refreshEnergyPeriods0154|cdRefreshPeriodDeltas|cdDeriveFromTotals|renderEnergyDashboard|renderEnergy/.test(
+      String(new Error().stack || ""),
+    );
   } catch (_error) {
     return false;
   }
@@ -56,17 +72,19 @@ function calledFromEnergyRefresh0154() {
 
 function installGlobalRenderGate0154() {
   const current = globalThis.render;
-  if (typeof current !== "function" || current.__dm0154EnergyRenderGate) return false;
+  if (typeof current !== "function" || functionChainHas0154(current, "__dm0154EnergyRenderGate")) {
+    return false;
+  }
 
   function energySafeGlobalRender0154(...args) {
     const hotfix = hotfixState0154();
-    const armed = hotfix.suppressNextGlobalRender;
-    const active = armed && clock0154Hotfix() <= hotfix.suppressUntil;
-    if (armed) {
-      hotfix.suppressNextGlobalRender = false;
-      hotfix.suppressUntil = 0;
+    if (
+      hotfix.energyRenderDepth > 0 ||
+      clock0154Hotfix() <= hotfix.suppressUntil ||
+      calledFromEnergyRefresh0154()
+    ) {
+      return false;
     }
-    if (active || calledFromEnergyRefresh0154()) return false;
     return current.apply(this, args);
   }
 
@@ -77,9 +95,236 @@ function installGlobalRenderGate0154() {
   return true;
 }
 
+function installEnergyRenderPhase0154(name) {
+  const current = globalThis[name];
+  if (typeof current !== "function" || functionChainHas0154(current, "__dm0154EnergyPhase")) {
+    return false;
+  }
+
+  function energyPhase0154(...args) {
+    const state = hotfixState0154();
+    state.energyRenderDepth += 1;
+    armGlobalRenderSuppression0154(1500);
+    let result;
+    try {
+      result = current.apply(this, args);
+    } catch (error) {
+      state.energyRenderDepth = Math.max(0, state.energyRenderDepth - 1);
+      throw error;
+    }
+    if (result && typeof result.finally === "function") {
+      return result.finally(() => {
+        state.energyRenderDepth = Math.max(0, state.energyRenderDepth - 1);
+      });
+    }
+    state.energyRenderDepth = Math.max(0, state.energyRenderDepth - 1);
+    return result;
+  }
+
+  energyPhase0154.__dm0154EnergyPhase = true;
+  energyPhase0154.__dmPrevious = current;
+  globalThis[name] = energyPhase0154;
+  return true;
+}
+
+function runtimeState0154(entity) {
+  const id = String(entity || "").trim();
+  return globalThis.STATES?.[id] || globalThis._RAW_STATES?.[id] || null;
+}
+
+function configuredEntities0154(item) {
+  return [...new Set(
+    (Array.isArray(item?.entities) ? item.entities : [])
+      .map((value) => (typeof value === "string" ? value : value?.entity))
+      .filter(Boolean),
+  )];
+}
+
+function explicitEntity0154(item, keys) {
+  for (const key of keys || []) {
+    const value = item?.[key];
+    const entity = typeof value === "string" ? value : value?.entity;
+    if (typeof entity === "string" && entity.includes(".")) return entity;
+  }
+  return "";
+}
+
+function entityFacts0154(entity) {
+  const state = runtimeState0154(entity);
+  const attributes = state?.attributes || {};
+  return {
+    entity: String(entity || ""),
+    unit: String(attributes.unit_of_measurement || "").trim().toLowerCase().replaceAll(" ", ""),
+    deviceClass: String(attributes.device_class || "").trim().toLowerCase(),
+    stateClass: String(attributes.state_class || "").trim().toLowerCase(),
+    text: `${entity || ""} ${attributes.friendly_name || ""}`.toLowerCase(),
+  };
+}
+
+function isEnergyEntity0154(entity) {
+  const facts = entityFacts0154(entity);
+  return (
+    facts.deviceClass === "energy" ||
+    /^(wh|kwh|mwh)$/.test(facts.unit) ||
+    (/total|totale|energy|energia|kwh/.test(facts.text) &&
+      !/^(w|kw|mw)$/.test(facts.unit)) ||
+    (["total", "total_increasing"].includes(facts.stateClass) && !/^(w|kw|mw)$/.test(facts.unit))
+  );
+}
+
+function isPowerEntity0154(entity) {
+  const facts = entityFacts0154(entity);
+  return (
+    facts.deviceClass === "power" ||
+    /^(w|kw|mw)$/.test(facts.unit) ||
+    (/power|potenza|watt/.test(facts.text) && !isEnergyEntity0154(entity))
+  );
+}
+
+function isDurationEntity0154(entity) {
+  const facts = entityFacts0154(entity);
+  return (
+    facts.deviceClass === "duration" ||
+    /^(s|sec|second|seconds|min|minute|minutes|h|hr|hour|hours)$/.test(facts.unit) ||
+    /duration|durata|runtime|tempo/.test(facts.text)
+  );
+}
+
+function roleForKeys0154(keys) {
+  const token = String(keys?.[0] || "").toLowerCase();
+  if (token.startsWith("energy") || token.includes("daily_energy")) return "energy";
+  if (token.startsWith("power")) return "power";
+  if (token.startsWith("duration")) return "duration";
+  if (token.startsWith("switch") || token.startsWith("control") || token.startsWith("light")) {
+    return "control";
+  }
+  if (token.startsWith("history")) return "history";
+  return "";
+}
+
+function candidateForRole0154(item, role) {
+  const candidates = configuredEntities0154(item);
+  if (role === "energy") return candidates.find(isEnergyEntity0154) || "";
+  if (role === "power") return candidates.find(isPowerEntity0154) || "";
+  if (role === "duration") return candidates.find(isDurationEntity0154) || "";
+  if (role === "control") {
+    return candidates.find((entity) => /^(switch|light|input_boolean|fan)\./.test(entity)) || "";
+  }
+  if (role === "history") {
+    return candidates.find(isEnergyEntity0154) || candidates.find(isPowerEntity0154) || "";
+  }
+  return "";
+}
+
+function validForRole0154(entity, role) {
+  if (!entity) return false;
+  if (role === "energy") return isEnergyEntity0154(entity);
+  if (role === "power") return isPowerEntity0154(entity);
+  if (role === "duration") return isDurationEntity0154(entity);
+  if (role === "control") return /^(switch|light|input_boolean|fan)\./.test(entity);
+  if (role === "history") return isEnergyEntity0154(entity) || isPowerEntity0154(entity);
+  return true;
+}
+
+function installApplianceEntityClassifier0154() {
+  const current = globalThis.cdApplEntity;
+  if (typeof current !== "function" || functionChainHas0154(current, "__dm0154EntityClassifier")) {
+    return false;
+  }
+
+  function classifiedApplianceEntity0154(item, keys) {
+    const explicit = explicitEntity0154(item, keys);
+    if (explicit) return explicit;
+    const role = roleForKeys0154(keys);
+    const candidate = candidateForRole0154(item, role);
+    if (candidate) return candidate;
+    const fallback = current.call(this, item, keys);
+    if (role && !validForRole0154(fallback, role)) return null;
+    return fallback;
+  }
+
+  classifiedApplianceEntity0154.__dm0154EntityClassifier = true;
+  classifiedApplianceEntity0154.__dmPrevious = current;
+  globalThis.cdApplEntity = classifiedApplianceEntity0154;
+  return true;
+}
+
+function entityDisplayValue0154(entity) {
+  const state = runtimeState0154(entity);
+  if (!state) return "";
+  const unit = String(state.attributes?.unit_of_measurement || "").trim();
+  return `${state.state}${unit ? ` ${unit}` : ""}`;
+}
+
+function normalizeApplianceMetrics0154() {
+  const doc = globalThis.document;
+  if (!doc) return false;
+  let items = [];
+  try {
+    const value = globalThis.DashboardModernModules?.store?.getSection?.("appliances");
+    items = Array.isArray(value) ? value : [];
+  } catch (_error) {}
+  const byId = new Map(items.map((item) => [String(item.id || ""), item]));
+  doc.querySelectorAll("#page-appliances-main .appl-wide-card[data-appliance-id]").forEach((card, index) => {
+    const item = byId.get(String(card.dataset.applianceId || "")) || items[index];
+    if (!item) return;
+    const power = candidateForRole0154(item, "power");
+    const energy = candidateForRole0154(item, "energy");
+    const live = card.querySelector(".appl-live");
+    const primary = live?.querySelector(".appl-primary");
+    const primaryValue = primary?.querySelector("strong")?.textContent || "";
+    if (primary && (!power || /(?:^|\s)(?:wh|kwh|mwh)(?:\s|$)/i.test(primaryValue))) primary.remove();
+    if (!energy || !live) return;
+    const label = globalThis.document?.documentElement?.lang === "en" ? "Total" : "Totale";
+    const value = entityDisplayValue0154(energy);
+    if (!value) return;
+    let total = live.querySelector(".appl-mini[data-dm-energy-total='true']");
+    if (!total) {
+      total = [...live.querySelectorAll(".appl-mini")].find((node) =>
+        /(?:wh|kwh|mwh)(?:\s|$)/i.test(node.textContent || ""),
+      );
+    }
+    if (!total) {
+      total = doc.createElement("span");
+      total.className = "appl-mini";
+      live.append(total);
+    }
+    if (total.dataset.dmEnergyTotal !== "true") total.dataset.dmEnergyTotal = "true";
+    const text = `∑ ${label} ${value}`;
+    if (total.textContent !== text) total.textContent = text;
+  });
+  return true;
+}
+
+function installApplianceRenderHook0154() {
+  const current = globalThis.renderApplianceSection;
+  if (typeof current !== "function" || functionChainHas0154(current, "__dm0154MetricHook")) {
+    return false;
+  }
+
+  function applianceMetricRender0154(...args) {
+    const result = current.apply(this, args);
+    if (result && typeof result.finally === "function") {
+      return result.finally(normalizeApplianceMetrics0154);
+    }
+    normalizeApplianceMetrics0154();
+    return result;
+  }
+
+  applianceMetricRender0154.__dm0154MetricHook = true;
+  applianceMetricRender0154.__dmPrevious = current;
+  globalThis.renderApplianceSection = applianceMetricRender0154;
+  return true;
+}
+
 function installEnergyRenderHotfix0154() {
   instrumentEnergyRefreshState0154();
   installGlobalRenderGate0154();
+  installEnergyRenderPhase0154("renderEnergy");
+  installEnergyRenderPhase0154("renderEnergyDashboard");
+  installApplianceEntityClassifier0154();
+  installApplianceRenderHook0154();
+  normalizeApplianceMetrics0154();
   hotfixState0154().installed = true;
 }
 
@@ -106,6 +351,10 @@ if (typeof globalThis.document !== "undefined") {
   globalThis.setTimeout?.(installEnergyRenderHotfix0154, 500);
   globalThis.addEventListener?.("dashboardmodern:legacy-ready", installEnergyRenderHotfix0154);
   globalThis.addEventListener?.("pageshow", installEnergyRenderHotfix0154);
+  globalThis.addEventListener?.(PERIOD_EVENT, () => {
+    armGlobalRenderSuppression0154(1200);
+    normalizeApplianceMetrics0154();
+  });
   if (globalThis.document.readyState === "loading") {
     globalThis.document.addEventListener("DOMContentLoaded", installEnergyRenderHotfix0154, {
       once: true,

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-energy-render-hotfix.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-energy-render-hotfix.js
@@ -12,6 +12,8 @@ function hotfixState0154() {
     suppressUntil: 0,
     releaseState: null,
     installed: false,
+    monitor: null,
+    monitorTicks: 0,
   });
 }
 
@@ -32,7 +34,7 @@ function instrumentEnergyRefreshState0154() {
         const next = Boolean(value);
         if (refreshing && !next) {
           hotfix.suppressNextGlobalRender = true;
-          hotfix.suppressUntil = clock0154Hotfix() + 100;
+          hotfix.suppressUntil = clock0154Hotfix() + 250;
         }
         refreshing = next;
       },
@@ -44,18 +46,27 @@ function instrumentEnergyRefreshState0154() {
   }
 }
 
+function calledFromEnergyRefresh0154() {
+  try {
+    return String(new Error().stack || "").includes("refreshEnergyPeriods0154");
+  } catch (_error) {
+    return false;
+  }
+}
+
 function installGlobalRenderGate0154() {
   const current = globalThis.render;
   if (typeof current !== "function" || current.__dm0154EnergyRenderGate) return false;
 
   function energySafeGlobalRender0154(...args) {
     const hotfix = hotfixState0154();
-    if (hotfix.suppressNextGlobalRender) {
-      const active = clock0154Hotfix() <= hotfix.suppressUntil;
+    const armed = hotfix.suppressNextGlobalRender;
+    const active = armed && clock0154Hotfix() <= hotfix.suppressUntil;
+    if (armed) {
       hotfix.suppressNextGlobalRender = false;
       hotfix.suppressUntil = 0;
-      if (active) return false;
     }
+    if (active || calledFromEnergyRefresh0154()) return false;
     return current.apply(this, args);
   }
 
@@ -72,11 +83,32 @@ function installEnergyRenderHotfix0154() {
   hotfixState0154().installed = true;
 }
 
+function monitorStartup0154() {
+  const hotfix = hotfixState0154();
+  if (hotfix.monitor || typeof globalThis.setInterval !== "function") return;
+  hotfix.monitorTicks = 0;
+  hotfix.monitor = globalThis.setInterval(() => {
+    hotfix.monitorTicks += 1;
+    installEnergyRenderHotfix0154();
+    if (hotfix.monitorTicks >= 150) {
+      globalThis.clearInterval?.(hotfix.monitor);
+      hotfix.monitor = null;
+    }
+  }, 100);
+}
+
 if (typeof globalThis.document !== "undefined") {
   installEnergyRenderHotfix0154();
+  monitorStartup0154();
   globalThis.queueMicrotask?.(installEnergyRenderHotfix0154);
   globalThis.setTimeout?.(installEnergyRenderHotfix0154, 0);
   globalThis.setTimeout?.(installEnergyRenderHotfix0154, 120);
   globalThis.setTimeout?.(installEnergyRenderHotfix0154, 500);
   globalThis.addEventListener?.("dashboardmodern:legacy-ready", installEnergyRenderHotfix0154);
+  globalThis.addEventListener?.("pageshow", installEnergyRenderHotfix0154);
+  if (globalThis.document.readyState === "loading") {
+    globalThis.document.addEventListener("DOMContentLoaded", installEnergyRenderHotfix0154, {
+      once: true,
+    });
+  }
 }

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-energy-render-hotfix.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-energy-render-hotfix.js
@@ -1,0 +1,82 @@
+/* DashboardModern 0.14.14: keep energy-period refreshes from rebuilding unrelated UI. */
+const HOTFIX_KEY = "__DASHBOARDMODERN_RELEASE_0154_ENERGY_RENDER_HOTFIX__";
+const RELEASE_KEY = "__DASHBOARDMODERN_RELEASE_0154__";
+
+function clock0154Hotfix() {
+  return globalThis.performance?.now?.() ?? Date.now();
+}
+
+function hotfixState0154() {
+  return (globalThis[HOTFIX_KEY] ||= {
+    suppressNextGlobalRender: false,
+    suppressUntil: 0,
+    releaseState: null,
+    installed: false,
+  });
+}
+
+function instrumentEnergyRefreshState0154() {
+  const release = globalThis[RELEASE_KEY];
+  const hotfix = hotfixState0154();
+  if (!release || hotfix.releaseState === release) return Boolean(release);
+
+  let refreshing = Boolean(release.refreshing);
+  try {
+    Object.defineProperty(release, "refreshing", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return refreshing;
+      },
+      set(value) {
+        const next = Boolean(value);
+        if (refreshing && !next) {
+          hotfix.suppressNextGlobalRender = true;
+          hotfix.suppressUntil = clock0154Hotfix() + 100;
+        }
+        refreshing = next;
+      },
+    });
+    hotfix.releaseState = release;
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function installGlobalRenderGate0154() {
+  const current = globalThis.render;
+  if (typeof current !== "function" || current.__dm0154EnergyRenderGate) return false;
+
+  function energySafeGlobalRender0154(...args) {
+    const hotfix = hotfixState0154();
+    if (hotfix.suppressNextGlobalRender) {
+      const active = clock0154Hotfix() <= hotfix.suppressUntil;
+      hotfix.suppressNextGlobalRender = false;
+      hotfix.suppressUntil = 0;
+      if (active) return false;
+    }
+    return current.apply(this, args);
+  }
+
+  energySafeGlobalRender0154.__dm0154EnergyRenderGate = true;
+  energySafeGlobalRender0154.__dm0154RenderGuard = true;
+  energySafeGlobalRender0154.__dmPrevious = current;
+  globalThis.render = energySafeGlobalRender0154;
+  return true;
+}
+
+function installEnergyRenderHotfix0154() {
+  instrumentEnergyRefreshState0154();
+  installGlobalRenderGate0154();
+  hotfixState0154().installed = true;
+}
+
+if (typeof globalThis.document !== "undefined") {
+  installEnergyRenderHotfix0154();
+  globalThis.queueMicrotask?.(installEnergyRenderHotfix0154);
+  globalThis.setTimeout?.(installEnergyRenderHotfix0154, 0);
+  globalThis.setTimeout?.(installEnergyRenderHotfix0154, 120);
+  globalThis.setTimeout?.(installEnergyRenderHotfix0154, 500);
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", installEnergyRenderHotfix0154);
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-energy-render-hotfix.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-energy-render-hotfix.js
@@ -129,7 +129,7 @@ function installEnergyRenderPhase0154(name) {
 
 function runtimeState0154(entity) {
   const id = String(entity || "").trim();
-  return globalThis.STATES?.[id] || globalThis._RAW_STATES?.[id] || null;
+  return globalThis._RAW_STATES?.[id] || globalThis.STATES?.[id] || null;
 }
 
 function configuredEntities0154(item) {
@@ -166,8 +166,7 @@ function isEnergyEntity0154(entity) {
   return (
     facts.deviceClass === "energy" ||
     /^(wh|kwh|mwh)$/.test(facts.unit) ||
-    (/total|totale|energy|energia|kwh/.test(facts.text) &&
-      !/^(w|kw|mw)$/.test(facts.unit)) ||
+    (/total|totale|energy|energia|kwh/.test(facts.text) && !/^(w|kw|mw)$/.test(facts.unit)) ||
     (["total", "total_increasing"].includes(facts.stateClass) && !/^(w|kw|mw)$/.test(facts.unit))
   );
 }
@@ -233,9 +232,9 @@ function installApplianceEntityClassifier0154() {
   }
 
   function classifiedApplianceEntity0154(item, keys) {
-    const explicit = explicitEntity0154(item, keys);
-    if (explicit) return explicit;
     const role = roleForKeys0154(keys);
+    const explicit = explicitEntity0154(item, keys);
+    if (explicit && (!role || validForRole0154(explicit, role))) return explicit;
     const candidate = candidateForRole0154(item, role);
     if (candidate) return candidate;
     const fallback = current.call(this, item, keys);
@@ -296,6 +295,79 @@ function normalizeApplianceMetrics0154() {
   return true;
 }
 
+function periodRegistry0154() {
+  try {
+    if (typeof CD_PERIOD !== "undefined" && CD_PERIOD) return CD_PERIOD;
+  } catch (_error) {}
+  return globalThis.CD_PERIOD || {};
+}
+
+function periodNumber0154(slot) {
+  const value = Number(periodRegistry0154()?.[slot]);
+  return Number.isFinite(value) ? Math.max(0, value) : null;
+}
+
+function periodText0154(slot) {
+  const value = periodNumber0154(slot);
+  if (value == null) return "—";
+  const rounded = Math.round(value * 1000) / 1000;
+  return `${rounded} kWh`;
+}
+
+function setPeriodText0154(id, value) {
+  const node = globalThis.document?.getElementById?.(id);
+  if (!node || node.textContent === value) return false;
+  node.textContent = value;
+  return true;
+}
+
+function setPeriodDual0154(id, downSlot, upSlot) {
+  const node = globalThis.document?.getElementById?.(id);
+  if (!node) return false;
+  const down = periodNumber0154(downSlot);
+  const up = periodNumber0154(upSlot);
+  const html = `<span style="color:#e11d48">↓ ${down == null ? 0 : Math.round(down * 1000) / 1000} kWh</span><br><span style="color:#10b981">↑ ${up == null ? 0 : Math.round(up * 1000) / 1000} kWh</span>`;
+  if (node.innerHTML === html) return false;
+  node.innerHTML = html;
+  return true;
+}
+
+function syncEnergyPeriodDom0154() {
+  const periods = {
+    day: {
+      solar: "dm.energy_produzione_solare_oggi",
+      home: "dm.energy_consumo_casa_oggi",
+      gridDown: "dm.energy_energia_prelevata_oggi",
+      gridUp: "dm.energy_energia_immessa_oggi",
+      batteryDown: "dm.energy_batteria_caricata_oggi",
+      batteryUp: "dm.energy_batteria_scaricata_oggi",
+    },
+    month: {
+      solar: "dm.energy_produzione_solare_mese",
+      home: "dm.energy_consumo_casa_mese",
+      gridDown: "dm.energy_rete_acquistata_mese",
+      gridUp: "dm.energy_rete_venduta_mese",
+      batteryDown: "dm.energy_batteria_caricata_mese",
+      batteryUp: "dm.energy_batteria_usata_mese",
+    },
+    year: {
+      solar: "dm.energy_produzione_solare_anno",
+      home: "dm.energy_consumo_casa_anno",
+      gridDown: "dm.energy_rete_acquistata_anno",
+      gridUp: "dm.energy_rete_venduta_anno",
+      batteryDown: "dm.energy_batteria_caricata_anno",
+      batteryUp: "dm.energy_batteria_usata_anno",
+    },
+  };
+  Object.entries(periods).forEach(([kind, slots]) => {
+    setPeriodText0154(`v-solar-${kind}`, periodText0154(slots.solar));
+    setPeriodText0154(`v-home-${kind}`, periodText0154(slots.home));
+    setPeriodDual0154(`v-grid-${kind}`, slots.gridDown, slots.gridUp);
+    setPeriodDual0154(`v-battery-${kind}`, slots.batteryDown, slots.batteryUp);
+  });
+  return true;
+}
+
 function installApplianceRenderHook0154() {
   const current = globalThis.renderApplianceSection;
   if (typeof current !== "function" || functionChainHas0154(current, "__dm0154MetricHook")) {
@@ -325,6 +397,7 @@ function installEnergyRenderHotfix0154() {
   installApplianceEntityClassifier0154();
   installApplianceRenderHook0154();
   normalizeApplianceMetrics0154();
+  syncEnergyPeriodDom0154();
   hotfixState0154().installed = true;
 }
 
@@ -342,6 +415,14 @@ function monitorStartup0154() {
   }, 100);
 }
 
+function syncAfterPeriodRefresh0154() {
+  armGlobalRenderSuppression0154(1200);
+  syncEnergyPeriodDom0154();
+  normalizeApplianceMetrics0154();
+  globalThis.requestAnimationFrame?.(syncEnergyPeriodDom0154);
+  globalThis.setTimeout?.(syncEnergyPeriodDom0154, 40);
+}
+
 if (typeof globalThis.document !== "undefined") {
   installEnergyRenderHotfix0154();
   monitorStartup0154();
@@ -351,10 +432,7 @@ if (typeof globalThis.document !== "undefined") {
   globalThis.setTimeout?.(installEnergyRenderHotfix0154, 500);
   globalThis.addEventListener?.("dashboardmodern:legacy-ready", installEnergyRenderHotfix0154);
   globalThis.addEventListener?.("pageshow", installEnergyRenderHotfix0154);
-  globalThis.addEventListener?.(PERIOD_EVENT, () => {
-    armGlobalRenderSuppression0154(1200);
-    normalizeApplianceMetrics0154();
-  });
+  globalThis.addEventListener?.(PERIOD_EVENT, syncAfterPeriodRefresh0154);
   if (globalThis.document.readyState === "loading") {
     globalThis.document.addEventListener("DOMContentLoaded", installEnergyRenderHotfix0154, {
       once: true,

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-final-appliance-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-final-appliance-stability.js
@@ -1,0 +1,273 @@
+/* DashboardModern 0.14.14: one isolated, idempotent owner for appliance media. */
+import {
+  applianceArtwork0154,
+  canonicalArtworkType0154,
+} from "./release-0154-runtime.js";
+
+const KEY = "__DASHBOARDMODERN_RELEASE_0154_FINAL_APPLIANCE_STABILITY__";
+const DISABLED_OBSERVER = Object.freeze({
+  dashboardmodern_disabled: true,
+  disconnect() {},
+  observe() {},
+});
+
+function state0154() {
+  return (globalThis[KEY] ||= {
+    observer: null,
+    scheduled: false,
+    normalizing: false,
+  });
+}
+
+function disconnectObserver(value) {
+  try {
+    value?.disconnect?.();
+  } catch (_error) {}
+}
+
+function disableObjectObserver(key, ...properties) {
+  const value = globalThis[key];
+  if (!value || typeof value !== "object") return;
+  properties.forEach((property) => {
+    disconnectObserver(value[property]);
+    try {
+      value[property] = DISABLED_OBSERVER;
+    } catch (_error) {}
+  });
+}
+
+function disableLegacyObservers0154() {
+  disconnectObserver(globalThis.__DASHBOARDMODERN_MEDIA_DOM_OBSERVER_0153__);
+  disconnectObserver(globalThis.__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__);
+  globalThis.__DASHBOARDMODERN_MEDIA_DOM_OBSERVER_0153__ = DISABLED_OBSERVER;
+  globalThis.__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__ = DISABLED_OBSERVER;
+
+  disableObjectObserver("__DASHBOARDMODERN_ENERGY_REPORT_MEDIA_FIX__", "observer");
+  disableObjectObserver("__DASHBOARDMODERN_RELEASE_0154__", "domObserver");
+  disableObjectObserver(
+    "__DASHBOARDMODERN_RELEASE_0154_ARTWORK_LOCK__",
+    "observer",
+    "styleObserver",
+  );
+  disableObjectObserver(
+    "__DASHBOARDMODERN_RELEASE_0154_ARTWORK_IDEMPOTENCY__",
+    "observer",
+    "styleObserver",
+  );
+}
+
+function applianceItems0154() {
+  try {
+    const items = globalThis.DashboardModernModules?.store?.getSection?.("appliances");
+    return Array.isArray(items) ? items : [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+function applianceVisual0154(item) {
+  try {
+    return globalThis.DashboardModernModules?.data?.getDeviceVisual?.(item) || null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function sourceToken0154(item, visual, card) {
+  return String(
+    visual?.value ||
+      item?.visual_key ||
+      item?.device_type ||
+      item?.type ||
+      item?.icon ||
+      card?.dataset?.dmArtwork ||
+      item?.name ||
+      "",
+  );
+}
+
+function setDataset(node, key, value) {
+  if (!node?.dataset || node.dataset[key] === value) return false;
+  node.dataset[key] = value;
+  return true;
+}
+
+function setImportant(node, property, value) {
+  if (!node?.style) return;
+  if (
+    node.style.getPropertyValue(property) === value &&
+    node.style.getPropertyPriority(property) === "important"
+  ) {
+    return;
+  }
+  node.style.setProperty(property, value, "important");
+}
+
+function fillViewport0154(viewport, media, artwork, visualNode) {
+  setImportant(viewport, "position", "relative");
+  setImportant(viewport, "padding", "0px");
+  setImportant(viewport, "border-width", "0px");
+  setImportant(viewport, "overflow", "hidden");
+
+  [media, artwork, visualNode].forEach((node) => {
+    if (!node) return;
+    setImportant(node, "position", "absolute");
+    setImportant(node, "inset", "0px");
+    setImportant(node, "display", "block");
+    setImportant(node, "box-sizing", "border-box");
+    setImportant(node, "width", "100%");
+    setImportant(node, "height", "100%");
+    setImportant(node, "min-width", "0px");
+    setImportant(node, "min-height", "0px");
+    setImportant(node, "max-width", "100%");
+    setImportant(node, "max-height", "100%");
+    setImportant(node, "padding", "0px");
+    setImportant(node, "margin", "0px");
+    setImportant(node, "transform", "none");
+  });
+
+  if (visualNode) {
+    setImportant(visualNode, "object-fit", "fill");
+    setImportant(visualNode, "object-position", "center");
+    setImportant(visualNode, "overflow", "visible");
+  }
+}
+
+function normalizeCustomImage0154(card, item, visual, viewport, media) {
+  if (visual?.kind !== "image" || !visual.value) return false;
+  setDataset(card, "dmArtwork", "custom");
+  setDataset(card, "dmMediaKind", "image");
+  setDataset(card, "dmArtStyle", "panel");
+  setDataset(card, "applianceThemeAware", "true");
+  setDataset(viewport, "applianceCover", "true");
+
+  let image = media.querySelector(":scope > img.dm-appliance-custom-image-0154");
+  if (!image) {
+    image = globalThis.document.createElement("img");
+    image.className = "dm-appliance-image dm-appliance-image-0153 dm-appliance-custom-image-0154";
+    media.replaceChildren(image);
+  }
+  if (image.getAttribute("src") !== visual.value) image.src = visual.value;
+  image.alt = String(item.name || "");
+  image.loading = "eager";
+  image.decoding = "async";
+
+  const applyFit = () => {
+    const ratio = image.naturalHeight ? image.naturalWidth / image.naturalHeight : 0;
+    const fit = ratio >= 0.92 && ratio <= 1.08 ? "cover" : "contain";
+    setDataset(image, "dmImageFit", fit);
+    setImportant(image, "object-fit", fit);
+  };
+  if (image.complete && image.naturalWidth) applyFit();
+  else image.addEventListener("load", applyFit, { once: true });
+
+  fillViewport0154(viewport, media, image, image);
+  return true;
+}
+
+function normalizeAsset0154(card, item, visual, viewport, media) {
+  if (visual?.kind !== "asset") return false;
+  const source = sourceToken0154(item, visual, card);
+  const canonical = canonicalArtworkType0154(source);
+  if (!canonical) return false;
+
+  setDataset(card, "dmArtwork", canonical);
+  setDataset(card, "dmMediaKind", "asset");
+  setDataset(card, "dmMediaType", canonical);
+  setDataset(card, "dmArtStyle", "panel");
+  setDataset(card, "applianceThemeAware", "true");
+  setDataset(viewport, "applianceCover", "true");
+
+  const selector = `:scope > .dm-appliance-art-0154[data-dm-art="${canonical}"]`;
+  let artwork = media.querySelector(selector);
+  const valid = Boolean(artwork?.querySelector("svg .dm-art-panel"));
+  if (!valid || media.children.length !== 1) {
+    const markup = applianceArtwork0154(canonical, 96);
+    if (!markup) return false;
+    media.innerHTML = markup;
+    artwork = media.querySelector(selector);
+  }
+  if (!artwork) return false;
+
+  setDataset(artwork, "dmArtStyle", "panel");
+  setDataset(artwork, "applianceAsset", source);
+  setDataset(artwork, "applianceAssetKey", source);
+  const svg = artwork.querySelector(":scope > svg");
+  fillViewport0154(viewport, media, artwork, svg);
+  return true;
+}
+
+function normalizeCards0154() {
+  const state = state0154();
+  if (state.normalizing || !globalThis.document) return false;
+  state.normalizing = true;
+  try {
+    const items = applianceItems0154();
+    const byId = new Map(items.map((item) => [String(item.id || ""), item]));
+    const cards = globalThis.document.querySelectorAll(
+      "#appl-grid-overview .appl-wide-card[data-appliance-id], #page-appliances-main .appl-wide-card[data-appliance-id]",
+    );
+    cards.forEach((card, index) => {
+      const item = byId.get(String(card.dataset.applianceId || "")) || items[index];
+      if (!item) return;
+      const visual = applianceVisual0154(item);
+      const viewport = card.querySelector(".appl-visual");
+      const media = viewport?.querySelector(".appl-ic");
+      if (!viewport || !media) return;
+      viewport.classList.add("dm-appliance-viewport-0154");
+      media.classList.add("dm-appliance-media-0154");
+      if (normalizeCustomImage0154(card, item, visual, viewport, media)) return;
+      normalizeAsset0154(card, item, visual, viewport, media);
+    });
+    return true;
+  } finally {
+    state.normalizing = false;
+  }
+}
+
+function schedule0154() {
+  const state = state0154();
+  if (state.scheduled) return;
+  state.scheduled = true;
+  const run = () => {
+    state.scheduled = false;
+    disableLegacyObservers0154();
+    normalizeCards0154();
+  };
+  globalThis.requestAnimationFrame?.(run) || globalThis.setTimeout?.(run, 0);
+}
+
+function installTargetedObserver0154() {
+  const state = state0154();
+  const page = globalThis.document?.getElementById?.("page-appliances-main");
+  if (!page || state.observer || typeof MutationObserver !== "function") return false;
+  state.observer = new MutationObserver((records) => {
+    if (state.normalizing) return;
+    const relevant = records.some((record) =>
+      [...record.addedNodes, ...record.removedNodes].some(
+        (node) =>
+          node instanceof Element &&
+          (node.matches?.(".appl-wide-card,.appl-visual,.appl-ic") ||
+            node.querySelector?.(".appl-wide-card,.appl-visual,.appl-ic")),
+      ),
+    );
+    if (relevant) schedule0154();
+  });
+  state.observer.observe(page, { childList: true, subtree: true });
+  return true;
+}
+
+function install0154() {
+  disableLegacyObservers0154();
+  normalizeCards0154();
+  installTargetedObserver0154();
+}
+
+if (typeof globalThis.document !== "undefined") {
+  install0154();
+  globalThis.queueMicrotask?.(install0154);
+  globalThis.setTimeout?.(install0154, 0);
+  globalThis.setTimeout?.(install0154, 300);
+  globalThis.setTimeout?.(install0154, 700);
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", install0154);
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-final-appliance-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-final-appliance-stability.js
@@ -141,16 +141,30 @@ function normalizeCustomImage0154(card, item, visual, viewport, media) {
   setDataset(card, "applianceThemeAware", "true");
   setDataset(viewport, "applianceCover", "true");
 
-  let image = media.querySelector(":scope > img.dm-appliance-custom-image-0154");
+  let wrapper = media.querySelector(":scope > .dm-appliance-image-wrap");
+  if (!wrapper) {
+    wrapper = globalThis.document.createElement("span");
+    wrapper.className = "dm-appliance-image-wrap";
+    media.replaceChildren(wrapper);
+  } else if (media.children.length !== 1) {
+    media.replaceChildren(wrapper);
+  }
+
+  let image = wrapper.querySelector(":scope > img.dm-appliance-custom-image-0154");
   if (!image) {
     image = globalThis.document.createElement("img");
     image.className = "dm-appliance-image dm-appliance-image-0153 dm-appliance-custom-image-0154";
-    media.replaceChildren(image);
+    wrapper.replaceChildren(image);
   }
   if (image.getAttribute("src") !== visual.value) image.src = visual.value;
   image.alt = String(item.name || "");
   image.loading = "eager";
   image.decoding = "async";
+
+  fillViewport0154(viewport, media, wrapper, image);
+  setImportant(wrapper, "overflow", "hidden");
+  setImportant(wrapper, "border-radius", "12px");
+  setImportant(image, "overflow", "hidden");
 
   const applyFit = () => {
     const ratio = image.naturalHeight ? image.naturalWidth / image.naturalHeight : 0;
@@ -160,8 +174,6 @@ function normalizeCustomImage0154(card, item, visual, viewport, media) {
   };
   if (image.complete && image.naturalWidth) applyFit();
   else image.addEventListener("load", applyFit, { once: true });
-
-  fillViewport0154(viewport, media, image, image);
   return true;
 }
 

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-final-appliance-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-final-appliance-stability.js
@@ -86,6 +86,10 @@ function sourceToken0154(item, visual, card) {
   );
 }
 
+function directChild(node, predicate) {
+  return [...(node?.children || [])].find(predicate) || null;
+}
+
 function setDataset(node, key, value) {
   if (!node?.dataset || node.dataset[key] === value) return false;
   node.dataset[key] = value;
@@ -141,7 +145,9 @@ function normalizeCustomImage0154(card, item, visual, viewport, media) {
   setDataset(card, "applianceThemeAware", "true");
   setDataset(viewport, "applianceCover", "true");
 
-  let wrapper = media.querySelector(":scope > .dm-appliance-image-wrap");
+  let wrapper = directChild(media, (node) =>
+    node.classList?.contains("dm-appliance-image-wrap"),
+  );
   if (!wrapper) {
     wrapper = globalThis.document.createElement("span");
     wrapper.className = "dm-appliance-image-wrap";
@@ -150,7 +156,11 @@ function normalizeCustomImage0154(card, item, visual, viewport, media) {
     media.replaceChildren(wrapper);
   }
 
-  let image = wrapper.querySelector(":scope > img.dm-appliance-custom-image-0154");
+  let image = directChild(
+    wrapper,
+    (node) =>
+      node.tagName === "IMG" && node.classList?.contains("dm-appliance-custom-image-0154"),
+  );
   if (!image) {
     image = globalThis.document.createElement("img");
     image.className = "dm-appliance-image dm-appliance-image-0153 dm-appliance-custom-image-0154";
@@ -190,22 +200,32 @@ function normalizeAsset0154(card, item, visual, viewport, media) {
   setDataset(card, "applianceThemeAware", "true");
   setDataset(viewport, "applianceCover", "true");
 
-  const selector = `:scope > .dm-appliance-art-0154[data-dm-art="${canonical}"]`;
-  let artwork = media.querySelector(selector);
+  const artwork = directChild(
+    media,
+    (node) =>
+      node.classList?.contains("dm-appliance-art-0154") &&
+      node.dataset?.dmArt === canonical,
+  );
   const valid = Boolean(artwork?.querySelector("svg .dm-art-panel"));
+  let normalizedArtwork = artwork;
   if (!valid || media.children.length !== 1) {
     const markup = applianceArtwork0154(canonical, 96);
     if (!markup) return false;
     media.innerHTML = markup;
-    artwork = media.querySelector(selector);
+    normalizedArtwork = directChild(
+      media,
+      (node) =>
+        node.classList?.contains("dm-appliance-art-0154") &&
+        node.dataset?.dmArt === canonical,
+    );
   }
-  if (!artwork) return false;
+  if (!normalizedArtwork) return false;
 
-  setDataset(artwork, "dmArtStyle", "panel");
-  setDataset(artwork, "applianceAsset", source);
-  setDataset(artwork, "applianceAssetKey", source);
-  const svg = artwork.querySelector(":scope > svg");
-  fillViewport0154(viewport, media, artwork, svg);
+  setDataset(normalizedArtwork, "dmArtStyle", "panel");
+  setDataset(normalizedArtwork, "applianceAsset", source);
+  setDataset(normalizedArtwork, "applianceAssetKey", source);
+  const svg = directChild(normalizedArtwork, (node) => node.tagName?.toLowerCase() === "svg");
+  fillViewport0154(viewport, media, normalizedArtwork, svg);
   return true;
 }
 
@@ -237,6 +257,25 @@ function normalizeCards0154() {
   }
 }
 
+function installRendererHook0154() {
+  const original = globalThis.renderApplianceSection;
+  if (typeof original !== "function" || original.__dm0154FinalApplianceRenderer) return false;
+
+  function renderApplianceSection0154(...args) {
+    const result = original.apply(this, args);
+    if (result && typeof result.finally === "function") {
+      return result.finally(() => normalizeCards0154());
+    }
+    normalizeCards0154();
+    return result;
+  }
+
+  renderApplianceSection0154.__dm0154FinalApplianceRenderer = true;
+  renderApplianceSection0154.__dmPrevious = original;
+  globalThis.renderApplianceSection = renderApplianceSection0154;
+  return true;
+}
+
 function schedule0154() {
   const state = state0154();
   if (state.scheduled) return;
@@ -244,6 +283,7 @@ function schedule0154() {
   const run = () => {
     state.scheduled = false;
     disableLegacyObservers0154();
+    installRendererHook0154();
     normalizeCards0154();
   };
   globalThis.requestAnimationFrame?.(run) || globalThis.setTimeout?.(run, 0);
@@ -271,6 +311,7 @@ function installTargetedObserver0154() {
 
 function install0154() {
   disableLegacyObservers0154();
+  installRendererHook0154();
   normalizeCards0154();
   installTargetedObserver0154();
 }
@@ -281,5 +322,6 @@ if (typeof globalThis.document !== "undefined") {
   globalThis.setTimeout?.(install0154, 0);
   globalThis.setTimeout?.(install0154, 300);
   globalThis.setTimeout?.(install0154, 700);
+  globalThis.setTimeout?.(install0154, 1200);
   globalThis.addEventListener?.("dashboardmodern:legacy-ready", install0154);
 }

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-final-appliance-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-final-appliance-stability.js
@@ -1,59 +1,117 @@
-/* DashboardModern 0.14.14: one isolated, idempotent owner for appliance media. */
+/* DashboardModern 0.14.14: single idempotent owner for appliance media. */
 import {
   applianceArtwork0154,
   canonicalArtworkType0154,
 } from "./release-0154-runtime.js";
 
-const KEY = "__DASHBOARDMODERN_RELEASE_0154_FINAL_APPLIANCE_STABILITY__";
+const LOCK_KEY = "__DASHBOARDMODERN_RELEASE_0154_ARTWORK_LOCK__";
+const FINAL_KEY = "__DASHBOARDMODERN_RELEASE_0154_FINAL_APPLIANCE_STABILITY__";
+const STYLE_ID = "dm-release-0154-final-artwork-lock";
+const LEGACY_STYLE_IDS = [
+  "dm-appliance-media-layout-lock-0153",
+  "dm-release-0152-artwork-layout-fix",
+  "dm-energy-report-media-fixes-0153",
+];
 const DISABLED_OBSERVER = Object.freeze({
+  disabled: true,
   dashboardmodern_disabled: true,
   disconnect() {},
   observe() {},
 });
 
 function state0154() {
-  return (globalThis[KEY] ||= {
+  const state = (globalThis[LOCK_KEY] ||= {
     observer: null,
+    observerRoot: null,
+    observerVersion: 0,
     scheduled: false,
     normalizing: false,
   });
+  globalThis[FINAL_KEY] = state;
+  return state;
 }
 
-function disconnectObserver(value) {
+function disconnect(value) {
   try {
     value?.disconnect?.();
   } catch (_error) {}
 }
 
-function disableObjectObserver(key, ...properties) {
-  const value = globalThis[key];
-  if (!value || typeof value !== "object") return;
-  properties.forEach((property) => {
-    disconnectObserver(value[property]);
+function retireObserverSlot(owner, key, value = null) {
+  if (!owner) return;
+  disconnect(owner[key]);
+  try {
+    Object.defineProperty(owner, key, {
+      configurable: true,
+      enumerable: false,
+      get: () => value,
+      set: (next) => disconnect(next),
+    });
+  } catch (_error) {
     try {
-      value[property] = DISABLED_OBSERVER;
-    } catch (_error) {}
-  });
+      owner[key] = value;
+    } catch (_ignored) {}
+  }
 }
 
-function disableLegacyObservers0154() {
-  disconnectObserver(globalThis.__DASHBOARDMODERN_MEDIA_DOM_OBSERVER_0153__);
-  disconnectObserver(globalThis.__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__);
-  globalThis.__DASHBOARDMODERN_MEDIA_DOM_OBSERVER_0153__ = DISABLED_OBSERVER;
-  globalThis.__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__ = DISABLED_OBSERVER;
+function disableLegacyOwners0154() {
+  globalThis.__DASHBOARDMODERN_MEDIA_STYLE_LOCK_DISABLED_0153__ = true;
+  retireObserverSlot(globalThis, "__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__", null);
+  retireObserverSlot(globalThis, "__DASHBOARDMODERN_MEDIA_DOM_OBSERVER_0153__", null);
 
-  disableObjectObserver("__DASHBOARDMODERN_ENERGY_REPORT_MEDIA_FIX__", "observer");
-  disableObjectObserver("__DASHBOARDMODERN_RELEASE_0154__", "domObserver");
-  disableObjectObserver(
-    "__DASHBOARDMODERN_RELEASE_0154_ARTWORK_LOCK__",
-    "observer",
-    "styleObserver",
-  );
-  disableObjectObserver(
-    "__DASHBOARDMODERN_RELEASE_0154_ARTWORK_IDEMPOTENCY__",
-    "observer",
-    "styleObserver",
-  );
+  const mediaFix = globalThis.__DASHBOARDMODERN_ENERGY_REPORT_MEDIA_FIX__;
+  if (mediaFix) retireObserverSlot(mediaFix, "observer", DISABLED_OBSERVER);
+
+  const release = globalThis.__DASHBOARDMODERN_RELEASE_0154__;
+  if (release) retireObserverSlot(release, "domObserver", DISABLED_OBSERVER);
+
+  const idempotency = globalThis.__DASHBOARDMODERN_RELEASE_0154_ARTWORK_IDEMPOTENCY__;
+  if (idempotency) {
+    retireObserverSlot(idempotency, "observer", DISABLED_OBSERVER);
+    retireObserverSlot(idempotency, "styleObserver", DISABLED_OBSERVER);
+  }
+}
+
+function removeLegacyStyles0154() {
+  const doc = globalThis.document;
+  if (!doc) return;
+  LEGACY_STYLE_IDS.forEach((id) => doc.getElementById(id)?.remove());
+}
+
+function setData(node, key, value) {
+  if (!node?.dataset || node.dataset[key] === value) return false;
+  node.dataset[key] = value;
+  return true;
+}
+
+function addClasses(node, ...tokens) {
+  if (!node?.classList) return false;
+  const missing = tokens.filter((token) => !node.classList.contains(token));
+  if (!missing.length) return false;
+  node.classList.add(...missing);
+  return true;
+}
+
+function setAttribute(node, name, value) {
+  if (!node || node.getAttribute(name) === value) return false;
+  node.setAttribute(name, value);
+  return true;
+}
+
+function setImportant(node, property, value) {
+  if (!node?.style) return false;
+  if (
+    node.style.getPropertyValue(property) === value &&
+    node.style.getPropertyPriority(property) === "important"
+  ) {
+    return false;
+  }
+  node.style.setProperty(property, value, "important");
+  return true;
+}
+
+function directChild(node, predicate) {
+  return [...(node?.children || [])].find(predicate) || null;
 }
 
 function applianceItems0154() {
@@ -86,27 +144,6 @@ function sourceToken0154(item, visual, card) {
   );
 }
 
-function directChild(node, predicate) {
-  return [...(node?.children || [])].find(predicate) || null;
-}
-
-function setDataset(node, key, value) {
-  if (!node?.dataset || node.dataset[key] === value) return false;
-  node.dataset[key] = value;
-  return true;
-}
-
-function setImportant(node, property, value) {
-  if (!node?.style) return;
-  if (
-    node.style.getPropertyValue(property) === value &&
-    node.style.getPropertyPriority(property) === "important"
-  ) {
-    return;
-  }
-  node.style.setProperty(property, value, "important");
-}
-
 function fillViewport0154(viewport, media, artwork, visualNode) {
   setImportant(viewport, "position", "relative");
   setImportant(viewport, "padding", "0px");
@@ -129,21 +166,15 @@ function fillViewport0154(viewport, media, artwork, visualNode) {
     setImportant(node, "margin", "0px");
     setImportant(node, "transform", "none");
   });
-
-  if (visualNode) {
-    setImportant(visualNode, "object-fit", "fill");
-    setImportant(visualNode, "object-position", "center");
-    setImportant(visualNode, "overflow", "visible");
-  }
 }
 
 function normalizeCustomImage0154(card, item, visual, viewport, media) {
   if (visual?.kind !== "image" || !visual.value) return false;
-  setDataset(card, "dmArtwork", "custom");
-  setDataset(card, "dmMediaKind", "image");
-  setDataset(card, "dmArtStyle", "panel");
-  setDataset(card, "applianceThemeAware", "true");
-  setDataset(viewport, "applianceCover", "true");
+  setData(card, "dmArtwork", "custom");
+  setData(card, "dmMediaKind", "image");
+  setData(card, "dmArtStyle", "panel");
+  setData(card, "applianceThemeAware", "true");
+  setData(viewport, "applianceCover", "true");
 
   let wrapper = directChild(media, (node) =>
     node.classList?.contains("dm-appliance-image-wrap"),
@@ -163,27 +194,35 @@ function normalizeCustomImage0154(card, item, visual, viewport, media) {
   );
   if (!image) {
     image = globalThis.document.createElement("img");
-    image.className = "dm-appliance-image dm-appliance-image-0153 dm-appliance-custom-image-0154";
+    image.className =
+      "dm-appliance-image dm-appliance-image-0153 dm-appliance-custom-image-0154";
     wrapper.replaceChildren(image);
   }
-  if (image.getAttribute("src") !== visual.value) image.src = visual.value;
-  image.alt = String(item.name || "");
-  image.loading = "eager";
-  image.decoding = "async";
 
+  setAttribute(image, "src", visual.value);
+  setAttribute(image, "alt", String(item.name || ""));
+  setAttribute(image, "loading", "eager");
+  setAttribute(image, "decoding", "async");
   fillViewport0154(viewport, media, wrapper, image);
   setImportant(wrapper, "overflow", "hidden");
   setImportant(wrapper, "border-radius", "12px");
   setImportant(image, "overflow", "hidden");
+  setImportant(image, "object-position", "center");
 
   const applyFit = () => {
-    const ratio = image.naturalHeight ? image.naturalWidth / image.naturalHeight : 0;
+    if (!image.naturalWidth || !image.naturalHeight) return;
+    const ratio = image.naturalWidth / image.naturalHeight;
     const fit = ratio >= 0.92 && ratio <= 1.08 ? "cover" : "contain";
-    setDataset(image, "dmImageFit", fit);
+    setData(image, "dmImageFit", fit);
     setImportant(image, "object-fit", fit);
   };
-  if (image.complete && image.naturalWidth) applyFit();
-  else image.addEventListener("load", applyFit, { once: true });
+  if (image.complete && image.naturalWidth) {
+    applyFit();
+  } else if (image.dataset.dmImageFitPending !== visual.value) {
+    setData(image, "dmImageFitPending", visual.value);
+    image.addEventListener("load", applyFit, { once: true });
+    setImportant(image, "object-fit", "contain");
+  }
   return true;
 }
 
@@ -193,50 +232,67 @@ function normalizeAsset0154(card, item, visual, viewport, media) {
   const canonical = canonicalArtworkType0154(source);
   if (!canonical) return false;
 
-  setDataset(card, "dmArtwork", canonical);
-  setDataset(card, "dmMediaKind", "asset");
-  setDataset(card, "dmMediaType", canonical);
-  setDataset(card, "dmArtStyle", "panel");
-  setDataset(card, "applianceThemeAware", "true");
-  setDataset(viewport, "applianceCover", "true");
+  setData(card, "dmArtwork", canonical);
+  setData(card, "dmMediaKind", "asset");
+  setData(card, "dmMediaType", canonical);
+  setData(card, "dmArtStyle", "panel");
+  setData(card, "applianceThemeAware", "true");
+  setData(viewport, "applianceCover", "true");
 
-  const artwork = directChild(
+  let artwork = directChild(
     media,
     (node) =>
       node.classList?.contains("dm-appliance-art-0154") &&
       node.dataset?.dmArt === canonical,
   );
   const valid = Boolean(artwork?.querySelector("svg .dm-art-panel"));
-  let normalizedArtwork = artwork;
   if (!valid || media.children.length !== 1) {
     const markup = applianceArtwork0154(canonical, 96);
     if (!markup) return false;
     media.innerHTML = markup;
-    normalizedArtwork = directChild(
+    artwork = directChild(
       media,
       (node) =>
         node.classList?.contains("dm-appliance-art-0154") &&
         node.dataset?.dmArt === canonical,
     );
   }
-  if (!normalizedArtwork) return false;
+  if (!artwork) return false;
 
-  setDataset(normalizedArtwork, "dmArtStyle", "panel");
-  setDataset(normalizedArtwork, "applianceAsset", source);
-  setDataset(normalizedArtwork, "applianceAssetKey", source);
-  const svg = directChild(normalizedArtwork, (node) => node.tagName?.toLowerCase() === "svg");
-  fillViewport0154(viewport, media, normalizedArtwork, svg);
+  setData(artwork, "dmArtStyle", "panel");
+  setData(artwork, "applianceAsset", source);
+  setData(artwork, "applianceAssetKey", source);
+  const svg = directChild(artwork, (node) => node.tagName?.toLowerCase() === "svg");
+  fillViewport0154(viewport, media, artwork, svg);
+  setImportant(artwork, "overflow", "hidden");
+  setImportant(svg, "object-fit", "fill");
+  setImportant(svg, "object-position", "center");
+  setImportant(svg, "overflow", "visible");
+  setImportant(svg, "flex", "0 0 100%");
   return true;
+}
+
+function observerOptions0154() {
+  return { childList: true, subtree: true };
+}
+
+function resumeObserver0154(state) {
+  if (!state.observer || !state.observerRoot) return;
+  state.observer.observe(state.observerRoot, observerOptions0154());
 }
 
 function normalizeCards0154() {
   const state = state0154();
-  if (state.normalizing || !globalThis.document) return false;
+  const doc = globalThis.document;
+  if (state.normalizing || !doc) return false;
   state.normalizing = true;
+  disconnect(state.observer);
   try {
+    disableLegacyOwners0154();
+    removeLegacyStyles0154();
     const items = applianceItems0154();
     const byId = new Map(items.map((item) => [String(item.id || ""), item]));
-    const cards = globalThis.document.querySelectorAll(
+    const cards = doc.querySelectorAll(
       "#appl-grid-overview .appl-wide-card[data-appliance-id], #page-appliances-main .appl-wide-card[data-appliance-id]",
     );
     cards.forEach((card, index) => {
@@ -246,20 +302,101 @@ function normalizeCards0154() {
       const viewport = card.querySelector(".appl-visual");
       const media = viewport?.querySelector(".appl-ic");
       if (!viewport || !media) return;
-      viewport.classList.add("dm-appliance-viewport-0154");
-      media.classList.add("dm-appliance-media-0154");
+      addClasses(viewport, "dm-appliance-viewport-0154");
+      addClasses(media, "dm-appliance-media-0154");
       if (normalizeCustomImage0154(card, item, visual, viewport, media)) return;
       normalizeAsset0154(card, item, visual, viewport, media);
     });
     return true;
   } finally {
     state.normalizing = false;
+    resumeObserver0154(state);
   }
+}
+
+function installStyles0154() {
+  const doc = globalThis.document;
+  if (!doc?.head) return null;
+  removeLegacyStyles0154();
+  let style = doc.getElementById(STYLE_ID);
+  if (style) return style;
+  style = doc.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    html body #page-appliances-main .appl-wide-card[data-dm-art-style="panel"] .appl-visual,
+    html body #appl-grid-overview .appl-wide-card[data-dm-art-style="panel"] .appl-visual {
+      display:block!important;
+      overflow:hidden!important;
+      padding:0!important;
+      background:var(--dm-art-tile)!important;
+      border-color:var(--dm-art-panel-stroke)!important;
+    }
+    html body #page-appliances-main .appl-wide-card[data-dm-art-style="panel"] .appl-ic,
+    html body #appl-grid-overview .appl-wide-card[data-dm-art-style="panel"] .appl-ic,
+    html body #page-appliances-main .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154,
+    html body #appl-grid-overview .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154,
+    html body #page-appliances-main .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 > svg,
+    html body #appl-grid-overview .appl-wide-card[data-dm-art-style="panel"] .dm-appliance-art-0154 > svg {
+      box-sizing:border-box!important;
+      width:100%!important;
+      height:100%!important;
+      min-width:0!important;
+      min-height:0!important;
+      max-width:100%!important;
+      max-height:100%!important;
+      padding:0!important;
+      margin:0!important;
+      transform:none!important;
+    }
+  `;
+  doc.head.append(style);
+  return style;
+}
+
+function mutationTouchesCards0154(record) {
+  if (record.target?.closest?.(".appl-wide-card[data-appliance-id]")) return true;
+  return [...record.addedNodes, ...record.removedNodes].some((node) => {
+    if (node?.nodeType !== 1) return false;
+    return Boolean(
+      node.matches?.(".appl-wide-card[data-appliance-id]") ||
+        node.querySelector?.(".appl-wide-card[data-appliance-id]"),
+    );
+  });
+}
+
+function schedule0154() {
+  const state = state0154();
+  if (state.scheduled || state.normalizing) return;
+  state.scheduled = true;
+  const run = () => {
+    state.scheduled = false;
+    normalizeCards0154();
+  };
+  globalThis.requestAnimationFrame?.(run) || globalThis.setTimeout?.(run, 0);
+}
+
+function installObserver0154() {
+  const state = state0154();
+  const root =
+    globalThis.document?.getElementById?.("page-appliances-main") || globalThis.document?.body;
+  if (!root || typeof MutationObserver !== "function") return false;
+  if (!state.observer) {
+    state.observer = new MutationObserver((records) => {
+      if (!state.normalizing && records.some(mutationTouchesCards0154)) schedule0154();
+    });
+  }
+  if (state.observerRoot !== root || state.observerVersion !== 3) {
+    disconnect(state.observer);
+    state.observerRoot = root;
+    state.observerVersion = 3;
+  }
+  resumeObserver0154(state);
+  return true;
 }
 
 function installRendererHook0154() {
   const original = globalThis.renderApplianceSection;
-  if (typeof original !== "function" || original.__dm0154FinalApplianceRenderer) return false;
+  if (typeof original !== "function" || original.__dm0154SingleArtworkOwner) return false;
 
   function renderApplianceSection0154(...args) {
     const result = original.apply(this, args);
@@ -270,58 +407,30 @@ function installRendererHook0154() {
     return result;
   }
 
-  renderApplianceSection0154.__dm0154FinalApplianceRenderer = true;
+  renderApplianceSection0154.__dm0154SingleArtworkOwner = true;
   renderApplianceSection0154.__dmPrevious = original;
   globalThis.renderApplianceSection = renderApplianceSection0154;
   return true;
 }
 
-function schedule0154() {
-  const state = state0154();
-  if (state.scheduled) return;
-  state.scheduled = true;
-  const run = () => {
-    state.scheduled = false;
-    disableLegacyObservers0154();
-    installRendererHook0154();
-    normalizeCards0154();
-  };
-  globalThis.requestAnimationFrame?.(run) || globalThis.setTimeout?.(run, 0);
-}
-
-function installTargetedObserver0154() {
-  const state = state0154();
-  const page = globalThis.document?.getElementById?.("page-appliances-main");
-  if (!page || state.observer || typeof MutationObserver !== "function") return false;
-  state.observer = new MutationObserver((records) => {
-    if (state.normalizing) return;
-    const relevant = records.some((record) =>
-      [...record.addedNodes, ...record.removedNodes].some(
-        (node) =>
-          node instanceof Element &&
-          (node.matches?.(".appl-wide-card,.appl-visual,.appl-ic") ||
-            node.querySelector?.(".appl-wide-card,.appl-visual,.appl-ic")),
-      ),
-    );
-    if (relevant) schedule0154();
-  });
-  state.observer.observe(page, { childList: true, subtree: true });
-  return true;
-}
-
 function install0154() {
-  disableLegacyObservers0154();
+  if (!globalThis.document?.documentElement) return false;
+  disableLegacyOwners0154();
+  installStyles0154();
   installRendererHook0154();
+  installObserver0154();
   normalizeCards0154();
-  installTargetedObserver0154();
+  return true;
 }
 
 if (typeof globalThis.document !== "undefined") {
   install0154();
   globalThis.queueMicrotask?.(install0154);
   globalThis.setTimeout?.(install0154, 0);
+  globalThis.setTimeout?.(install0154, 120);
   globalThis.setTimeout?.(install0154, 300);
-  globalThis.setTimeout?.(install0154, 700);
-  globalThis.setTimeout?.(install0154, 1200);
   globalThis.addEventListener?.("dashboardmodern:legacy-ready", install0154);
+  if (globalThis.document.readyState === "loading") {
+    globalThis.document.addEventListener("DOMContentLoaded", install0154, { once: true });
+  }
 }

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-postlude.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-postlude.js
@@ -1,0 +1,86 @@
+/* DashboardModern 0.14.14: restore listeners and prevent render/refresh feedback loops. */
+const PRELUDE_KEY = "__DASHBOARDMODERN_RELEASE_0154_PRELUDE__";
+const RELEASE_KEY = "__DASHBOARDMODERN_RELEASE_0154__";
+const GUARD_KEY = "__DASHBOARDMODERN_RELEASE_0154_STABILITY__";
+
+function restoreEventRegistration0154() {
+  const prelude = globalThis[PRELUDE_KEY];
+  if (!prelude?.original) return;
+  globalThis.addEventListener = prelude.original;
+  prelude.restored = true;
+}
+
+function stabilityState0154() {
+  return (globalThis[GUARD_KEY] ||= {
+    renderDepth: 0,
+    cooldownUntil: 0,
+    installed: false,
+  });
+}
+
+function now0154() {
+  return globalThis.performance?.now?.() ?? Date.now();
+}
+
+function installRenderGuard0154() {
+  const state = stabilityState0154();
+  const original = globalThis.render;
+  if (typeof original !== "function" || original.__dm0154RenderGuard) return false;
+
+  function guardedRender0154(...args) {
+    state.renderDepth += 1;
+    state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1200);
+    try {
+      return original.apply(this, args);
+    } finally {
+      state.renderDepth = Math.max(0, state.renderDepth - 1);
+      state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1200);
+    }
+  }
+
+  guardedRender0154.__dm0154RenderGuard = true;
+  guardedRender0154.__dmPrevious = original;
+  globalThis.render = guardedRender0154;
+  return true;
+}
+
+function installRefreshGuard0154(name) {
+  const state = stabilityState0154();
+  const original = globalThis[name];
+  if (typeof original !== "function" || original.__dm0154RefreshGuard) return false;
+
+  function guardedRefresh0154(...args) {
+    const release = globalThis[RELEASE_KEY];
+    if (state.renderDepth > 0 || release?.refreshing || now0154() < state.cooldownUntil) {
+      return false;
+    }
+    state.cooldownUntil = now0154() + 350;
+    const result = original.apply(this, args);
+    if (result && typeof result.finally === "function") {
+      return result.finally(() => {
+        state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1200);
+      });
+    }
+    state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1200);
+    return result;
+  }
+
+  guardedRefresh0154.__dm0154RefreshGuard = true;
+  guardedRefresh0154.__dmPrevious = original;
+  globalThis[name] = guardedRefresh0154;
+  return true;
+}
+
+function installStability0154() {
+  restoreEventRegistration0154();
+  installRenderGuard0154();
+  installRefreshGuard0154("cdRefreshPeriodDeltas");
+  installRefreshGuard0154("cdDeriveFromTotals");
+  stabilityState0154().installed = true;
+}
+
+installStability0154();
+globalThis.queueMicrotask?.(installStability0154);
+globalThis.setTimeout?.(installStability0154, 0);
+globalThis.setTimeout?.(installStability0154, 150);
+globalThis.addEventListener?.("dashboardmodern:legacy-ready", installStability0154);

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-postlude.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-postlude.js
@@ -58,11 +58,13 @@ function installRenderGuard0154(name) {
 
 function installStableRefresh0154(name) {
   const state = stabilityState0154();
-  const currentDescriptor = Object.getOwnPropertyDescriptor(globalThis, name);
-  if (currentDescriptor?.get?.__dm0154StableRefreshGetter) return true;
-
-  let target = globalThis[name];
+  const target = globalThis[name];
   if (typeof target !== "function") return false;
+
+  if (target.__dm0154RefreshGuard) {
+    state.stableRefreshes[name] = target;
+    return true;
+  }
 
   function guardedRefresh0154(...args) {
     const release = globalThis[RELEASE_KEY];
@@ -70,8 +72,7 @@ function installStableRefresh0154(name) {
       return false;
     }
     state.cooldownUntil = now0154() + 450;
-    const callable = target;
-    const result = typeof callable === "function" ? callable.apply(this, args) : false;
+    const result = target.apply(this, args);
     if (result && typeof result.finally === "function") {
       return result.finally(() => {
         state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1400);
@@ -84,24 +85,15 @@ function installStableRefresh0154(name) {
   guardedRefresh0154.__dm0154RefreshGuard = true;
   guardedRefresh0154.__dmPrevious = target;
 
-  function getStableRefresh0154() {
-    return guardedRefresh0154;
-  }
-  getStableRefresh0154.__dm0154StableRefreshGetter = true;
-
-  function setStableRefresh0154(next) {
-    if (typeof next !== "function" || next === guardedRefresh0154) return;
-    if (next.__dmPrevious === guardedRefresh0154) return;
-    target = next;
-    guardedRefresh0154.__dmPrevious = next;
+  try {
+    // Legacy global function declarations are writable but non-configurable.
+    // A normal assignment is therefore compatible; Object.defineProperty is not.
+    globalThis[name] = guardedRefresh0154;
+  } catch (_error) {
+    return false;
   }
 
-  Object.defineProperty(globalThis, name, {
-    configurable: true,
-    enumerable: true,
-    get: getStableRefresh0154,
-    set: setStableRefresh0154,
-  });
+  if (globalThis[name] !== guardedRefresh0154) return false;
   state.stableRefreshes[name] = guardedRefresh0154;
   return true;
 }
@@ -117,6 +109,7 @@ function installStability0154() {
 }
 
 restoreEventRegistration0154();
+installStability0154();
 globalThis.queueMicrotask?.(installStability0154);
 globalThis.setTimeout?.(installStability0154, 0);
 globalThis.setTimeout?.(installStability0154, 180);
@@ -124,3 +117,7 @@ globalThis.addEventListener?.("dashboardmodern:legacy-ready", installStability01
 
 const retry0154 = globalThis.setInterval?.(installStability0154, 100);
 globalThis.setTimeout?.(() => globalThis.clearInterval?.(retry0154), 15000);
+// The corrective runtime also retries for 15 seconds. Re-apply once after it stops
+// so the guarded entry points are deterministically the final assignments.
+globalThis.setTimeout?.(installStability0154, 15150);
+globalThis.setTimeout?.(installStability0154, 15500);

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-postlude.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-postlude.js
@@ -5,7 +5,7 @@ const GUARD_KEY = "__DASHBOARDMODERN_RELEASE_0154_STABILITY__";
 
 function restoreEventRegistration0154() {
   const prelude = globalThis[PRELUDE_KEY];
-  if (!prelude?.original) return;
+  if (!prelude?.original || prelude.restored) return;
   globalThis.addEventListener = prelude.original;
   prelude.restored = true;
 }
@@ -15,6 +15,7 @@ function stabilityState0154() {
     renderDepth: 0,
     cooldownUntil: 0,
     installed: false,
+    stableRefreshes: {},
   });
 }
 
@@ -22,65 +23,104 @@ function now0154() {
   return globalThis.performance?.now?.() ?? Date.now();
 }
 
-function installRenderGuard0154() {
+function installRenderGuard0154(name) {
   const state = stabilityState0154();
-  const original = globalThis.render;
+  const original = globalThis[name];
   if (typeof original !== "function" || original.__dm0154RenderGuard) return false;
 
   function guardedRender0154(...args) {
     state.renderDepth += 1;
-    state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1200);
+    state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1400);
+    let result;
     try {
-      return original.apply(this, args);
-    } finally {
+      result = original.apply(this, args);
+    } catch (error) {
       state.renderDepth = Math.max(0, state.renderDepth - 1);
-      state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1200);
+      state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1400);
+      throw error;
     }
+    if (result && typeof result.finally === "function") {
+      return result.finally(() => {
+        state.renderDepth = Math.max(0, state.renderDepth - 1);
+        state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1400);
+      });
+    }
+    state.renderDepth = Math.max(0, state.renderDepth - 1);
+    state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1400);
+    return result;
   }
 
   guardedRender0154.__dm0154RenderGuard = true;
   guardedRender0154.__dmPrevious = original;
-  globalThis.render = guardedRender0154;
+  globalThis[name] = guardedRender0154;
   return true;
 }
 
-function installRefreshGuard0154(name) {
+function installStableRefresh0154(name) {
   const state = stabilityState0154();
-  const original = globalThis[name];
-  if (typeof original !== "function" || original.__dm0154RefreshGuard) return false;
+  const currentDescriptor = Object.getOwnPropertyDescriptor(globalThis, name);
+  if (currentDescriptor?.get?.__dm0154StableRefreshGetter) return true;
+
+  let target = globalThis[name];
+  if (typeof target !== "function") return false;
 
   function guardedRefresh0154(...args) {
     const release = globalThis[RELEASE_KEY];
     if (state.renderDepth > 0 || release?.refreshing || now0154() < state.cooldownUntil) {
       return false;
     }
-    state.cooldownUntil = now0154() + 350;
-    const result = original.apply(this, args);
+    state.cooldownUntil = now0154() + 450;
+    const callable = target;
+    const result = typeof callable === "function" ? callable.apply(this, args) : false;
     if (result && typeof result.finally === "function") {
       return result.finally(() => {
-        state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1200);
+        state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1400);
       });
     }
-    state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1200);
+    state.cooldownUntil = Math.max(state.cooldownUntil, now0154() + 1400);
     return result;
   }
 
   guardedRefresh0154.__dm0154RefreshGuard = true;
-  guardedRefresh0154.__dmPrevious = original;
-  globalThis[name] = guardedRefresh0154;
+  guardedRefresh0154.__dmPrevious = target;
+
+  function getStableRefresh0154() {
+    return guardedRefresh0154;
+  }
+  getStableRefresh0154.__dm0154StableRefreshGetter = true;
+
+  function setStableRefresh0154(next) {
+    if (typeof next !== "function" || next === guardedRefresh0154) return;
+    if (next.__dmPrevious === guardedRefresh0154) return;
+    target = next;
+    guardedRefresh0154.__dmPrevious = next;
+  }
+
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    enumerable: true,
+    get: getStableRefresh0154,
+    set: setStableRefresh0154,
+  });
+  state.stableRefreshes[name] = guardedRefresh0154;
   return true;
 }
 
 function installStability0154() {
   restoreEventRegistration0154();
-  installRenderGuard0154();
-  installRefreshGuard0154("cdRefreshPeriodDeltas");
-  installRefreshGuard0154("cdDeriveFromTotals");
+  ["render", "renderEnergy", "renderEnergyDashboard", "renderReport"].forEach(
+    installRenderGuard0154,
+  );
+  installStableRefresh0154("cdRefreshPeriodDeltas");
+  installStableRefresh0154("cdDeriveFromTotals");
   stabilityState0154().installed = true;
 }
 
-installStability0154();
+restoreEventRegistration0154();
 globalThis.queueMicrotask?.(installStability0154);
 globalThis.setTimeout?.(installStability0154, 0);
-globalThis.setTimeout?.(installStability0154, 150);
+globalThis.setTimeout?.(installStability0154, 180);
 globalThis.addEventListener?.("dashboardmodern:legacy-ready", installStability0154);
+
+const retry0154 = globalThis.setInterval?.(installStability0154, 100);
+globalThis.setTimeout?.(() => globalThis.clearInterval?.(retry0154), 15000);

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-prelude.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-prelude.js
@@ -1,0 +1,20 @@
+/* DashboardModern 0.14.14: isolate the new period engine from legacy refresh events. */
+const LEGACY_EVENT = "dashboardmodern:energy-statistics";
+const KEY = "__DASHBOARDMODERN_RELEASE_0154_PRELUDE__";
+
+if (!globalThis[KEY] && typeof globalThis.addEventListener === "function") {
+  const original = globalThis.addEventListener;
+  const state = {
+    original,
+    skippedLegacyListener: false,
+  };
+
+  globalThis.addEventListener = function addEventListener0154(type, listener, options) {
+    if (type === LEGACY_EVENT && !state.skippedLegacyListener) {
+      state.skippedLegacyListener = true;
+      return undefined;
+    }
+    return original.call(this, type, listener, options);
+  };
+  globalThis[KEY] = state;
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-render-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-render-stability.js
@@ -1,0 +1,112 @@
+/* DashboardModern 0.14.14: suppress identical forced appliance rerenders. */
+const FLAG = "__DASHBOARDMODERN_RELEASE_0154_RENDER_STABILITY__";
+
+function applianceItems0154() {
+  try {
+    const items = globalThis.DashboardModernModules?.store?.getSection?.("appliances");
+    return Array.isArray(items) ? items : [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+function entityIds0154(item = {}) {
+  return [...new Set([
+    ...(Array.isArray(item.entities) ? item.entities : []),
+    item.control_entity,
+    item.power_entity,
+    item.total_energy_entity,
+    item.daily_energy_entity,
+    item.history_entity,
+  ].map((value) => typeof value === "string" ? value : value?.entity).filter(Boolean))];
+}
+
+function stateSignature0154(entityId) {
+  const state = globalThis.STATES?.[entityId] || globalThis._RAW_STATES?.[entityId];
+  if (!state) return `${entityId}:`;
+  const attributes = state.attributes || {};
+  return [
+    entityId,
+    state.state,
+    attributes.unit_of_measurement,
+    attributes.device_class,
+    attributes.state_class,
+  ].join(":");
+}
+
+function renderSignature0154() {
+  const items = applianceItems0154();
+  const active = globalThis.document?.querySelector?.(".appl-main-view.active")?.id || "";
+  return JSON.stringify({
+    language: globalThis.document?.documentElement?.lang || "",
+    room: globalThis._dmApplRoom || "all",
+    active,
+    items: items.map((item) => ({
+      id: item.id,
+      name: item.name,
+      room_id: item.room_id,
+      room: item.room,
+      visual_type: item.visual_type,
+      visual_key: item.visual_key,
+      device_type: item.device_type,
+      type: item.type,
+      icon: item.icon,
+      threshold_run: item.threshold_run,
+      entities: entityIds0154(item),
+      states: entityIds0154(item).map(stateSignature0154),
+    })),
+  });
+}
+
+function cardsReady0154() {
+  const grid = globalThis.document?.getElementById?.("appl-grid-overview");
+  if (!grid) return false;
+  const expected = applianceItems0154().length;
+  return grid.querySelectorAll(".appl-wide-card[data-appliance-id]").length === expected;
+}
+
+function install0154() {
+  const current = globalThis.renderApplianceSection;
+  if (typeof current !== "function" || current.__dm0154StableRenderGate) return false;
+  const state = (globalThis[FLAG] ||= { signature: "" });
+  if (cardsReady0154()) state.signature = renderSignature0154();
+
+  function stableRenderApplianceSection0154(...args) {
+    const signature = renderSignature0154();
+    if (signature === state.signature && cardsReady0154()) return false;
+    state.signature = signature;
+    try {
+      const result = current.apply(this, args);
+      if (result && typeof result.catch === "function") {
+        result.catch(() => {
+          state.signature = "";
+        });
+      }
+      return result;
+    } catch (error) {
+      state.signature = "";
+      throw error;
+    }
+  }
+
+  stableRenderApplianceSection0154.__dm0154StableRenderGate = true;
+  stableRenderApplianceSection0154.__dmPrevious = current;
+  globalThis.renderApplianceSection = stableRenderApplianceSection0154;
+  return true;
+}
+
+function installUntilStable0154() {
+  install0154();
+  globalThis.queueMicrotask?.(install0154);
+  globalThis.setTimeout?.(install0154, 0);
+  globalThis.setTimeout?.(install0154, 120);
+  globalThis.setTimeout?.(install0154, 500);
+}
+
+if (typeof globalThis.document !== "undefined") {
+  installUntilStable0154();
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", installUntilStable0154);
+  if (globalThis.document.readyState === "loading") {
+    globalThis.document.addEventListener("DOMContentLoaded", installUntilStable0154, { once: true });
+  }
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-runtime.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-runtime.js
@@ -1,0 +1,889 @@
+/* DashboardModern 0.14.14: real cumulative periods and unified appliance artwork. */
+import {
+  PERIOD_SOURCES_0152,
+  periodConsumption0152,
+  periodRange0152,
+} from "./release-0152-runtime.js";
+
+const RELEASE_FLAG = "__DASHBOARDMODERN_RELEASE_0154__";
+const STYLE_ID = "dm-release-0154-runtime-styles";
+const REQUEST_TIMEOUT = 18000;
+const REFRESH_EVENT = "dashboardmodern:energy-periods-0154";
+const OLD_REFRESH_EVENT = "dashboardmodern:energy-statistics";
+
+function numberOrNull(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isEnglish() {
+  return globalThis.document?.documentElement?.lang === "en";
+}
+
+function copy(it, en) {
+  return isEnglish() ? en : it;
+}
+
+function resolveRuntimeEntity(reference, resolver = globalThis.resolveEntity) {
+  const original = String(reference || "").trim();
+  if (!original) return "";
+  try {
+    const resolved = resolver?.(original);
+    return String(resolved || original).trim();
+  } catch (_error) {
+    return original;
+  }
+}
+
+function legacyOverrides() {
+  try {
+    if (typeof ENTITY_OVERRIDES !== "undefined" && ENTITY_OVERRIDES) return ENTITY_OVERRIDES;
+  } catch (_error) {}
+  return globalThis.ENTITY_OVERRIDES || {};
+}
+
+function runtimeStateRegistries() {
+  const registries = [];
+  try {
+    if (typeof _RAW_STATES !== "undefined" && _RAW_STATES) registries.push(_RAW_STATES);
+  } catch (_error) {}
+  try {
+    if (typeof STATES !== "undefined" && STATES) registries.push(STATES);
+  } catch (_error) {}
+  if (globalThis._RAW_STATES) registries.push(globalThis._RAW_STATES);
+  if (globalThis.STATES) registries.push(globalThis.STATES);
+  return [...new Set(registries)];
+}
+
+function runtimeStatesObject() {
+  const merged = {};
+  runtimeStateRegistries().forEach((registry) => Object.assign(merged, registry || {}));
+  return merged;
+}
+
+function stateForEntity(entity, states = runtimeStatesObject(), resolver = globalThis.resolveEntity) {
+  const original = String(entity || "").trim();
+  const resolved = resolveRuntimeEntity(original, resolver);
+  return states?.[resolved] || states?.[original] || null;
+}
+
+export function isCumulativeEnergyEntity0154(
+  entity,
+  states = {},
+  resolver = (value) => value,
+) {
+  const original = String(entity || "").trim();
+  if (!original) return false;
+  const resolved = resolveRuntimeEntity(original, resolver);
+  const state = stateForEntity(original, states, resolver);
+  const attributes = state?.attributes || {};
+  const stateClass = String(attributes.state_class || "").toLowerCase();
+  if (stateClass === "total" || stateClass === "total_increasing") return true;
+  const text = `${original} ${resolved} ${attributes.friendly_name || ""}`.toLowerCase();
+  return /(^|[\s._-])(total|totale|lifetime|counter|contatore)([\s._-]|$)/.test(text);
+}
+
+function legacySourceForSlot(slot, overrides = legacyOverrides(), resolver = globalThis.resolveEntity) {
+  const mapped = String(overrides?.[slot] || "").trim();
+  if (mapped) return mapped;
+  const resolved = resolveRuntimeEntity(slot, resolver);
+  return resolved && resolved !== slot ? resolved : "";
+}
+
+export function periodPlans0154(
+  energy = {},
+  kind = "month",
+  states = {},
+  overrides = {},
+  resolver = (value) => value,
+) {
+  return PERIOD_SOURCES_0152.flatMap((definition) => {
+    const target = definition.periods[kind];
+    if (!target) return [];
+    const group = energy?.[definition.group] || {};
+    const explicit = String(group[target.explicitKey] || "").trim();
+    const total = String(group[definition.totalKey] || "").trim();
+    const legacy = legacySourceForSlot(target.slot, overrides, resolver);
+
+    let source = "";
+    let reason = "";
+    if (explicit) {
+      const cumulative =
+        explicit === total || isCumulativeEnergyEntity0154(explicit, states, resolver);
+      if (!cumulative) return [];
+      source = explicit;
+      reason = "explicit-cumulative";
+    } else if (total) {
+      source = total;
+      reason = "canonical-total";
+    } else if (legacy && isCumulativeEnergyEntity0154(legacy, states, resolver)) {
+      source = legacy;
+      reason = "legacy-cumulative";
+    }
+
+    if (!source) return [];
+    return [
+      {
+        kind,
+        group: definition.group,
+        slot: target.slot,
+        source,
+        entity: resolveRuntimeEntity(source, resolver),
+        reason,
+      },
+    ];
+  });
+}
+
+function periodRegistry() {
+  try {
+    if (typeof CD_PERIOD !== "undefined" && CD_PERIOD) return CD_PERIOD;
+  } catch (_error) {}
+  globalThis.CD_PERIOD ||= {};
+  return globalThis.CD_PERIOD;
+}
+
+function setDerivedPeriod(plan, value, selected) {
+  if (!plan?.slot || !Number.isFinite(value)) return;
+  const rounded = Math.round(Math.max(0, value) * 1000) / 1000;
+  periodRegistry()[plan.slot] = rounded;
+  const timestamp = new Date().toISOString();
+  const state = {
+    entity_id: plan.slot,
+    state: String(rounded),
+    attributes: {
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "measurement",
+      friendly_name: plan.slot,
+      dashboardmodern_derived: true,
+      dashboardmodern_source: plan.entity,
+      dashboardmodern_source_reason: plan.reason,
+      dashboardmodern_period: plan.kind,
+      dashboardmodern_selected: selected.toISOString(),
+      dashboardmodern_version: "0.14.14",
+    },
+    last_updated: timestamp,
+    last_changed: timestamp,
+  };
+  runtimeStateRegistries().forEach((registry) => {
+    registry[plan.slot] = state;
+  });
+}
+
+function clearDerivedPeriod(slot) {
+  if (!slot) return;
+  try {
+    delete periodRegistry()[slot];
+  } catch (_error) {}
+}
+
+function selectedPeriodDate() {
+  const now = new Date();
+  const monthElement =
+    globalThis.document?.getElementById?.("ed-sel-month") ||
+    globalThis.document?.querySelector?.('select[id*="month"],select[id*="mese"]');
+  const yearElement =
+    globalThis.document?.getElementById?.("ed-sel-year") ||
+    globalThis.document?.querySelector?.('select[id*="year"],select[id*="anno"]');
+  const rawMonth = Number(monthElement?.value);
+  const rawYear = Number(yearElement?.value || yearElement?.selectedOptions?.[0]?.textContent);
+  const month =
+    Number.isInteger(rawMonth) && rawMonth >= 1 && rawMonth <= 12
+      ? rawMonth - 1
+      : Number.isInteger(rawMonth) && rawMonth >= 0 && rawMonth <= 11
+        ? rawMonth
+        : now.getMonth();
+  const year = Number.isInteger(rawYear) && rawYear >= 2000 ? rawYear : now.getFullYear();
+  return new Date(year, month, 1);
+}
+
+function baselineRange(kind, start) {
+  const baselineStart = new Date(start);
+  if (kind === "day") baselineStart.setHours(baselineStart.getHours() - 2);
+  else if (kind === "year") baselineStart.setMonth(baselineStart.getMonth() - 1);
+  else baselineStart.setDate(baselineStart.getDate() - 2);
+  return { start: baselineStart, end: new Date(start) };
+}
+
+class StatisticsSocket0154 {
+  constructor() {
+    this.socket = null;
+    this.connection = null;
+    this.pending = new Map();
+    this.nextId = 154000;
+  }
+
+  token() {
+    const candidates = [
+      globalThis.__DASHBOARDMODERN_REAL_TOKEN__,
+      globalThis.DASHBOARDMODERN_AUTH_TOKEN,
+      globalThis.LONG_LIVED_TOKEN,
+      globalThis.HA_TOKEN,
+    ];
+    try {
+      const configured = JSON.parse(globalThis.localStorage?.getItem("cd_connection") || "{}");
+      candidates.push(configured.token, configured.access_token);
+    } catch (_error) {}
+    return candidates.map((value) => String(value || "").trim()).find(Boolean) || "";
+  }
+
+  url() {
+    const protocol = globalThis.location?.protocol === "https:" ? "wss:" : "ws:";
+    return `${protocol}//${globalThis.location?.host || "dashboardmodern-bridge"}/api/websocket`;
+  }
+
+  connect() {
+    if (this.socket?.readyState === 1 && this.connection) return this.connection;
+    if (this.connection) return this.connection;
+    if (typeof globalThis.WebSocket !== "function") {
+      return Promise.reject(new Error(copy("WebSocket non disponibile", "WebSocket unavailable")));
+    }
+
+    this.connection = new Promise((resolve, reject) => {
+      let settled = false;
+      const socket = new globalThis.WebSocket(this.url());
+      this.socket = socket;
+      const timer = globalThis.setTimeout?.(() => {
+        if (!settled) reject(new Error(copy("Timeout canale statistiche", "Statistics channel timeout")));
+      }, REQUEST_TIMEOUT);
+      const finish = (callback, value) => {
+        if (settled) return;
+        settled = true;
+        globalThis.clearTimeout?.(timer);
+        callback(value);
+      };
+
+      socket.onmessage = (event) => {
+        let message;
+        try {
+          message = JSON.parse(event.data);
+        } catch (_error) {
+          return;
+        }
+        if (message.type === "auth_required") {
+          const token = this.token();
+          if (!token) {
+            finish(
+              reject,
+              new Error(copy("Connessione Home Assistant non autenticata", "Home Assistant connection is not authenticated")),
+            );
+          } else {
+            socket.send(JSON.stringify({ type: "auth", access_token: token }));
+          }
+          return;
+        }
+        if (message.type === "auth_ok") {
+          finish(resolve, socket);
+          return;
+        }
+        if (message.type === "auth_invalid") {
+          finish(reject, new Error(copy("Autenticazione non valida", "Invalid authentication")));
+          return;
+        }
+        if (message.type !== "result" || message.id == null) return;
+        const pending = this.pending.get(message.id);
+        if (!pending) return;
+        this.pending.delete(message.id);
+        globalThis.clearTimeout?.(pending.timer);
+        if (message.success === false) {
+          pending.reject(new Error(message.error?.message || "Statistics error"));
+        } else {
+          pending.resolve(message.result || {});
+        }
+      };
+      socket.onerror = () =>
+        finish(reject, new Error(copy("Canale statistiche non disponibile", "Statistics channel unavailable")));
+      socket.onclose = () => {
+        this.socket = null;
+        this.connection = null;
+      };
+    }).catch((error) => {
+      this.connection = null;
+      throw error;
+    });
+    return this.connection;
+  }
+
+  async request(payload) {
+    const socket = await this.connect();
+    const id = ++this.nextId;
+    return new Promise((resolve, reject) => {
+      const timer = globalThis.setTimeout?.(() => {
+        this.pending.delete(id);
+        reject(new Error(copy("Timeout risposta Recorder", "Recorder response timeout")));
+      }, REQUEST_TIMEOUT);
+      this.pending.set(id, { resolve, reject, timer });
+      socket.send(JSON.stringify({ id, ...payload }));
+    });
+  }
+}
+
+const statisticsSocket = new StatisticsSocket0154();
+
+async function statisticsForPlans(plans, range) {
+  const ids = [...new Set(plans.map((plan) => plan.entity).filter(Boolean))];
+  if (!ids.length) return {};
+  return statisticsSocket.request({
+    type: "recorder/statistics_during_period",
+    start_time: range.start.toISOString(),
+    end_time: range.end.toISOString(),
+    statistic_ids: ids,
+    period: range.period,
+    units: { energy: "kWh" },
+  });
+}
+
+function historyRowsValue(rows = []) {
+  const values = (Array.isArray(rows) ? rows : [])
+    .map((row) => ({
+      value: numberOrNull(row?.state),
+      time: Date.parse(row?.last_updated || row?.last_changed || row?.timestamp || 0),
+    }))
+    .filter((row) => row.value != null)
+    .sort((left, right) => left.time - right.time)
+    .map((row) => row.value);
+  if (values.length < 2) return null;
+  let total = 0;
+  for (let index = 1; index < values.length; index += 1) {
+    const difference = values[index] - values[index - 1];
+    total += difference >= 0 ? difference : Math.max(0, values[index]);
+  }
+  return Math.max(0, total);
+}
+
+async function historyFallback(plans, range) {
+  const token = statisticsSocket.token();
+  if (!token || typeof globalThis.fetch !== "function" || !globalThis.location?.origin) return {};
+  const ids = [...new Set(plans.map((plan) => plan.entity).filter(Boolean))];
+  if (!ids.length) return {};
+  const url = new URL(`/api/history/period/${range.start.toISOString()}`, globalThis.location.origin);
+  url.searchParams.set("filter_entity_id", ids.join(","));
+  url.searchParams.set("minimal_response", "");
+  url.searchParams.set("no_attributes", "");
+  url.searchParams.set("end_time", range.end.toISOString());
+  const response = await globalThis.fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) return {};
+  const payload = await response.json();
+  const byId = {};
+  (Array.isArray(payload) ? payload : []).forEach((rows) => {
+    const entity = rows?.[0]?.entity_id;
+    if (entity) byId[entity] = rows;
+  });
+  return Object.fromEntries(ids.map((id) => [id, historyRowsValue(byId[id] || [])]));
+}
+
+async function requestKind(kind, selected, plans, generation) {
+  if (!plans.length) return;
+  const range = periodRange0152(kind, selected);
+  if (range.end <= range.start) return;
+  let result = await statisticsForPlans(plans, range);
+  if (generation !== releaseState().generation) return;
+
+  const needsBaseline = plans.filter((plan) =>
+    periodConsumption0152(result?.[plan.entity] || []) == null,
+  );
+  let baselineResult = {};
+  if (needsBaseline.length) {
+    const baseline = baselineRange(kind, range.start);
+    baselineResult = await statisticsForPlans(needsBaseline, {
+      ...baseline,
+      period: range.period,
+    });
+  }
+  if (generation !== releaseState().generation) return;
+
+  const unresolved = [];
+  const values = new Map();
+  plans.forEach((plan) => {
+    const baselineRows = (baselineResult?.[plan.entity] || [])
+      .slice()
+      .sort((left, right) => {
+        const leftTime = Date.parse(left?.start || left?.end || 0);
+        const rightTime = Date.parse(right?.start || right?.end || 0);
+        return leftTime - rightTime;
+      });
+    const value = periodConsumption0152(
+      result?.[plan.entity] || [],
+      baselineRows.at(-1) || null,
+    );
+    if (value == null) unresolved.push(plan);
+    else values.set(plan.slot, value);
+  });
+
+  if (unresolved.length) {
+    try {
+      const fallback = await historyFallback(unresolved, range);
+      unresolved.forEach((plan) => {
+        const value = fallback[plan.entity];
+        if (Number.isFinite(value)) values.set(plan.slot, value);
+      });
+    } catch (error) {
+      console.warn("[DashboardModern 0.14.14] History fallback", error);
+    }
+  }
+  if (generation !== releaseState().generation) return;
+
+  plans.forEach((plan) => {
+    const value = values.get(plan.slot);
+    if (Number.isFinite(value)) setDerivedPeriod(plan, value, selected);
+    else clearDerivedPeriod(plan.slot);
+  });
+}
+
+function dashboardEnergy() {
+  try {
+    return globalThis.DashboardModernModules?.store?.getSection?.("energy") || {};
+  } catch (_error) {
+    return {};
+  }
+}
+
+function allPlans(selected = selectedPeriodDate()) {
+  const energy = dashboardEnergy();
+  const states = runtimeStatesObject();
+  const overrides = legacyOverrides();
+  const resolver = globalThis.resolveEntity || ((value) => value);
+  return {
+    selected,
+    day: periodPlans0154(energy, "day", states, overrides, resolver),
+    month: periodPlans0154(energy, "month", states, overrides, resolver),
+    year: periodPlans0154(energy, "year", states, overrides, resolver),
+  };
+}
+
+function releaseState() {
+  return (globalThis[RELEASE_FLAG] ||= {
+    installed: true,
+    version: "0.14.14-dev",
+    generation: 0,
+    refreshing: false,
+    timer: 0,
+    pendingSlots: new Set(),
+    sources: {},
+  });
+}
+
+export async function refreshEnergyPeriods0154(selected = selectedPeriodDate()) {
+  const state = releaseState();
+  const plans = allPlans(selected);
+  const combined = [...plans.day, ...plans.month, ...plans.year];
+  if (!combined.length) return false;
+  const generation = ++state.generation;
+  state.refreshing = true;
+  state.pendingSlots = new Set(combined.map((plan) => plan.slot));
+  state.sources = Object.fromEntries(
+    combined.map((plan) => [plan.slot, { entity: plan.entity, reason: plan.reason, kind: plan.kind }]),
+  );
+
+  try {
+    await Promise.all([
+      requestKind("day", new Date(), plans.day, generation),
+      requestKind("month", selected, plans.month, generation),
+      requestKind("year", selected, plans.year, generation),
+    ]);
+    if (generation !== state.generation) return false;
+    state.pendingSlots.clear();
+    state.refreshing = false;
+    globalThis.render?.();
+    globalThis.renderEnergy?.();
+    globalThis.renderEnergyDashboard?.();
+    globalThis.dispatchEvent?.(
+      new CustomEvent(REFRESH_EVENT, {
+        detail: { selected: selected.toISOString(), sources: state.sources, version: "0.14.14" },
+      }),
+    );
+    return true;
+  } catch (error) {
+    if (generation === state.generation) {
+      state.pendingSlots.clear();
+      state.refreshing = false;
+    }
+    console.warn("[DashboardModern 0.14.14] Energy period refresh", error);
+    return false;
+  }
+}
+
+function derivedSlotSet() {
+  const plans = allPlans();
+  return new Set([...plans.day, ...plans.month, ...plans.year].map((plan) => plan.slot));
+}
+
+function installPeriodReadGuards() {
+  const wrap = (name, pendingValue) => {
+    const previous = globalThis[name];
+    if (typeof previous !== "function" || previous.__dm0154PeriodGuard) return false;
+    function guardedPeriodRead0154(reference, ...args) {
+      const key = String(reference || "");
+      const registry = periodRegistry();
+      if (registry[key] !== undefined) {
+        const value = Number(registry[key]);
+        if (name === "cdPNum") return Number.isFinite(value) ? value : 0;
+        if (name === "cdPRaw") return value >= 100 ? value.toFixed(0) : value.toFixed(1);
+        if (name === "cdPVal") {
+          return `${value >= 100 ? value.toFixed(1) : value.toFixed(2)} kWh`;
+        }
+      }
+      if (derivedSlotSet().has(key)) return pendingValue;
+      return previous.call(this, reference, ...args);
+    }
+    guardedPeriodRead0154.__dm0154PeriodGuard = true;
+    guardedPeriodRead0154.__dmPrevious = previous;
+    globalThis[name] = guardedPeriodRead0154;
+    return true;
+  };
+  const num = wrap("cdPNum", 0);
+  const raw = wrap("cdPRaw", "—");
+  const val = wrap("cdPVal", "—");
+  return num || raw || val || Boolean(
+    globalThis.cdPNum?.__dm0154PeriodGuard &&
+      globalThis.cdPRaw?.__dm0154PeriodGuard &&
+      globalThis.cdPVal?.__dm0154PeriodGuard,
+  );
+}
+
+function scheduleEnergyRefresh(delay = 40) {
+  const state = releaseState();
+  globalThis.clearTimeout?.(state.timer);
+  state.timer = globalThis.setTimeout?.(() => refreshEnergyPeriods0154(), delay);
+}
+
+export function canonicalArtworkType0154(value) {
+  const token = String(value || "").toLowerCase();
+  if (/microonde|microwave/.test(token)) return "microwave";
+  if (/forno|oven|stove/.test(token)) return "oven";
+  if (/frigo|fridge|refriger|frigorifero|freezer|congelatore/.test(token)) return "fridge";
+  if (/scaldabagno|boiler|water[_ -]?heater/.test(token)) return "boiler";
+  if (/lavatrice|washing[_ -]?machine|washer/.test(token)) return "washer";
+  if (/asciugatrice|tumble[_ -]?dryer|dryer/.test(token)) return "dryer";
+  if (/lavastoviglie|dishwasher/.test(token)) return "dishwasher";
+  if (/piano[_ -]?cottura|cooktop|hob/.test(token)) return "cooktop";
+  if (/televis|\btv\b|monitor/.test(token)) return "television";
+  return "";
+}
+
+function artworkBody0154(type) {
+  const panel = '<rect class="dm-art-panel" x="3" y="3" width="90" height="90" rx="20"/><path class="dm-art-highlight" d="M15 13h66a10 10 0 0 1 10 10v8C70 18 42 17 5 39V23A10 10 0 0 1 15 13Z"/>';
+  const bodies = {
+    oven: `${panel}<rect class="dm-art-shell" x="15" y="10" width="66" height="76" rx="9"/><rect class="dm-art-face" x="21" y="17" width="54" height="14" rx="5"/><circle class="dm-art-accent" cx="29" cy="24" r="3.2"/><circle class="dm-art-muted" cx="39" cy="24" r="3.2"/><circle class="dm-art-muted" cx="49" cy="24" r="3.2"/><rect class="dm-art-face" x="21" y="37" width="54" height="40" rx="6"/><rect class="dm-art-window" x="28" y="44" width="40" height="25" rx="4"/><path class="dm-art-line" d="M34 61c8-7 20-7 28 0M31 72h34"/>`,
+    microwave: `${panel}<rect class="dm-art-shell" x="10" y="22" width="76" height="54" rx="10"/><rect class="dm-art-face" x="16" y="29" width="50" height="40" rx="6"/><rect class="dm-art-window" x="22" y="35" width="38" height="28" rx="4"/><circle class="dm-art-accent" cx="76" cy="36" r="5"/><rect class="dm-art-accent" x="70" y="47" width="12" height="5" rx="2.5"/><rect class="dm-art-muted" x="70" y="57" width="12" height="5" rx="2.5"/><path class="dm-art-line" d="M31 56h20M34 51c4-5 10-5 14 0"/>`,
+    fridge: `${panel}<rect class="dm-art-shell" x="20" y="8" width="56" height="80" rx="12"/><rect class="dm-art-face" x="26" y="14" width="44" height="31" rx="7"/><rect class="dm-art-face" x="26" y="51" width="44" height="30" rx="7"/><rect class="dm-art-accent" x="31" y="21" width="6" height="17" rx="3"/><rect class="dm-art-accent" x="31" y="58" width="6" height="17" rx="3"/><circle class="dm-art-accent" cx="63" cy="22" r="3"/>`,
+    boiler: `${panel}<rect class="dm-art-shell" x="20" y="8" width="56" height="76" rx="28"/><rect class="dm-art-face" x="27" y="15" width="42" height="62" rx="21"/><path class="dm-art-water" d="M28 51c9-8 16 5 25-3 6-5 10-4 16 0v18a13 13 0 0 1-13 13H40a13 13 0 0 1-13-13Z"/><circle class="dm-art-shell" cx="48" cy="58" r="8"/><path class="dm-art-line dm-art-line-light" d="M48 53v6M44 57l4 4 4-4"/><path class="dm-art-line" d="M36 86v5M60 86v5"/>`,
+    washer: `${panel}<rect class="dm-art-shell" x="13" y="10" width="70" height="76" rx="9"/><rect class="dm-art-face" x="19" y="16" width="58" height="14" rx="5"/><circle class="dm-art-accent" cx="27" cy="23" r="3"/><rect class="dm-art-muted" x="58" y="20" width="12" height="5" rx="2.5"/><circle class="dm-art-face" cx="48" cy="57" r="24"/><circle class="dm-art-window" cx="48" cy="57" r="17"/><path class="dm-art-line dm-art-line-light" d="M35 58c8-8 18 8 27-1M38 64c7-5 13 4 20 0"/>`,
+    dryer: `${panel}<rect class="dm-art-shell" x="13" y="10" width="70" height="76" rx="9"/><rect class="dm-art-face" x="19" y="16" width="58" height="14" rx="5"/><circle class="dm-art-accent" cx="27" cy="23" r="3"/><circle class="dm-art-face" cx="48" cy="57" r="24"/><circle class="dm-art-window" cx="48" cy="57" r="17"/><path class="dm-art-line dm-art-line-light" d="M39 64c-5-5 5-8 0-13M48 64c-5-5 5-8 0-13M57 64c-5-5 5-8 0-13"/>`,
+    dishwasher: `${panel}<rect class="dm-art-shell" x="14" y="10" width="68" height="76" rx="9"/><rect class="dm-art-face" x="20" y="16" width="56" height="14" rx="5"/><circle class="dm-art-accent" cx="28" cy="23" r="3"/><rect class="dm-art-face" x="20" y="36" width="56" height="41" rx="6"/><path class="dm-art-line" d="M27 49h42M30 64h36M33 49v15M44 49v15M55 49v15M66 49v15"/><path class="dm-art-water" d="M23 67c9-6 16 5 25-2 8-6 14 4 25-1v10H23Z"/>`,
+    cooktop: `${panel}<rect class="dm-art-shell" x="12" y="18" width="72" height="60" rx="10"/><rect class="dm-art-face" x="18" y="24" width="60" height="48" rx="7"/><circle class="dm-art-window" cx="35" cy="40" r="10"/><circle class="dm-art-window" cx="61" cy="40" r="10"/><circle class="dm-art-window" cx="35" cy="61" r="8"/><circle class="dm-art-window" cx="61" cy="61" r="8"/><circle class="dm-art-accent" cx="35" cy="40" r="3"/><circle class="dm-art-accent" cx="61" cy="61" r="3"/>`,
+    television: `${panel}<rect class="dm-art-shell" x="10" y="18" width="76" height="54" rx="9"/><rect class="dm-art-window" x="17" y="25" width="62" height="40" rx="5"/><path class="dm-art-line" d="M39 78h18M48 70v8"/><path class="dm-art-line dm-art-line-light" d="M27 53c10-17 29-21 43-9"/>`,
+  };
+  return bodies[type] || "";
+}
+
+export function applianceArtwork0154(type, size = 96) {
+  const canonical = canonicalArtworkType0154(type);
+  const body = artworkBody0154(canonical);
+  if (!canonical || !body) return "";
+  return `<span class="dm-appliance-art dm-appliance-art-0154" data-dm-art="${canonical}" data-dm-art-style="panel"><svg width="${size}" height="${size}" viewBox="0 0 96 96" role="img" aria-hidden="true">${body}</svg></span>`;
+}
+
+function applianceItems() {
+  try {
+    const items = globalThis.DashboardModernModules?.store?.getSection?.("appliances");
+    return Array.isArray(items) ? items : [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+function applianceVisual(item) {
+  try {
+    return globalThis.DashboardModernModules?.data?.getDeviceVisual?.(item) || null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function applianceToken(item, visual) {
+  return String(
+    visual?.value ||
+      item?.visual_key ||
+      item?.device_type ||
+      item?.type ||
+      item?.icon ||
+      item?.name ||
+      "",
+  );
+}
+
+function installArtworkOverride() {
+  const previous = globalThis.cdApplianceIcon;
+  if (typeof previous !== "function" || previous.__dm0154Artwork) return false;
+  function cdApplianceIcon0154(type, size) {
+    return applianceArtwork0154(type, size || 96) || previous.call(this, type, size);
+  }
+  cdApplianceIcon0154.__dm0154Artwork = true;
+  cdApplianceIcon0154.__dmPrevious = previous;
+  globalThis.cdApplianceIcon = cdApplianceIcon0154;
+  globalThis.renderApplianceSection?.(true);
+  return true;
+}
+
+function normalizeApplianceCards0154() {
+  const doc = globalThis.document;
+  if (!doc) return false;
+  const items = applianceItems();
+  const byId = new Map(items.map((item) => [String(item.id || ""), item]));
+  const cards = doc.querySelectorAll(
+    "#appl-grid-overview .appl-wide-card[data-appliance-id], #page-appliances-main .appl-wide-card[data-appliance-id]",
+  );
+  cards.forEach((card, index) => {
+    const item = byId.get(String(card.dataset.applianceId || "")) || items[index];
+    if (!item) return;
+    const visual = applianceVisual(item);
+    const type = canonicalArtworkType0154(applianceToken(item, visual));
+    const viewport = card.querySelector(".appl-visual");
+    const media = viewport?.querySelector(".appl-ic");
+    if (!viewport || !media) return;
+    viewport.classList.add("dm-appliance-viewport-0154");
+    media.classList.add("dm-appliance-media-0154");
+    card.dataset.dmArtStyle = "panel";
+
+    if (visual?.kind === "image" && visual.value) {
+      card.dataset.dmArtwork = "custom";
+      let image = media.querySelector("img");
+      if (!image) {
+        image = doc.createElement("img");
+        media.replaceChildren(image);
+      }
+      image.classList.add("dm-appliance-custom-image-0154");
+      if (image.getAttribute("src") !== visual.value) image.src = visual.value;
+      image.alt = String(item.name || "");
+      return;
+    }
+
+    if (!type) return;
+    card.dataset.dmArtwork = type;
+    const existing = media.querySelector(`[data-dm-art="${type}"][data-dm-art-style="panel"]`);
+    if (!existing) media.innerHTML = applianceArtwork0154(type, 96);
+  });
+  return true;
+}
+
+function installStyles0154() {
+  const doc = globalThis.document;
+  if (!doc?.head || doc.getElementById(STYLE_ID)) return false;
+  const style = doc.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    :root {
+      --dm-art-tile: linear-gradient(145deg,#edf7ff 0%,#dceefa 100%);
+      --dm-art-panel:#dff3ff;
+      --dm-art-panel-stroke:#8dd8f8;
+      --dm-art-shell:#102b46;
+      --dm-art-face:#f7fbff;
+      --dm-art-window:#24658d;
+      --dm-art-accent:#22b8f0;
+      --dm-art-muted:#91a9be;
+      --dm-art-water:#33c2f4;
+      --dm-art-line:#102b46;
+      --dm-art-line-light:#e7f8ff;
+      --dm-art-highlight:rgba(255,255,255,.58);
+    }
+    html[data-theme="dark"] {
+      --dm-art-tile: linear-gradient(145deg,#0d2339 0%,#102e49 100%);
+      --dm-art-panel:#123a59;
+      --dm-art-panel-stroke:#1b6e99;
+      --dm-art-shell:#e6f7ff;
+      --dm-art-face:#bfeaff;
+      --dm-art-window:#0a3858;
+      --dm-art-accent:#39c7ff;
+      --dm-art-muted:#79a9c5;
+      --dm-art-water:#22b8f0;
+      --dm-art-line:#dff6ff;
+      --dm-art-line-light:#dff6ff;
+      --dm-art-highlight:rgba(125,211,252,.12);
+    }
+
+    html body #page-appliances-main #appl-grid-overview
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual,
+    html body #appl-grid-overview
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual,
+    html body #page-appliances-main
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual {
+      background:var(--dm-art-tile)!important;
+      border-color:var(--dm-art-panel-stroke)!important;
+      display:grid!important;
+      place-items:center!important;
+      overflow:hidden!important;
+    }
+
+    html body #page-appliances-main #appl-grid-overview
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic,
+    html body #appl-grid-overview
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic,
+    html body #page-appliances-main
+      .appl-wide-card[data-dm-art-style="panel"] .appl-visual .appl-ic {
+      display:grid!important;
+      place-items:center!important;
+      width:100%!important;
+      height:100%!important;
+      padding:clamp(5px,1vw,9px)!important;
+      margin:0!important;
+      overflow:hidden!important;
+      color:inherit!important;
+    }
+
+    html body #page-appliances-main #appl-grid-overview
+      .appl-wide-card.dm-control-device[data-dm-artwork][data-dm-art-style="panel"]
+      .appl-visual.dm-appliance-viewport-0154
+      .appl-ic.dm-appliance-media-0154
+      .dm-appliance-art-0154[data-dm-art][data-dm-art-style="panel"] > svg,
+    html body #appl-grid-overview
+      .appl-wide-card[data-dm-artwork][data-dm-art-style="panel"]
+      .appl-visual.dm-appliance-viewport-0154
+      .appl-ic.dm-appliance-media-0154
+      .dm-appliance-art-0154[data-dm-art][data-dm-art-style="panel"] > svg,
+    html body #page-appliances-main
+      .appl-wide-card[data-dm-artwork][data-dm-art-style="panel"]
+      .dm-appliance-art-0154[data-dm-art][data-dm-art-style="panel"] > svg {
+      display:block!important;
+      width:88%!important;
+      height:88%!important;
+      min-width:0!important;
+      min-height:0!important;
+      max-width:88%!important;
+      max-height:88%!important;
+      object-fit:contain!important;
+      overflow:visible!important;
+      transform:none!important;
+      filter:drop-shadow(0 8px 12px rgba(15,41,66,.18));
+    }
+
+    .dm-appliance-art-0154 { display:grid!important;place-items:center!important;width:100%!important;height:100%!important; }
+    .dm-appliance-art-0154 .dm-art-panel { fill:var(--dm-art-panel);stroke:var(--dm-art-panel-stroke);stroke-width:2; }
+    .dm-appliance-art-0154 .dm-art-highlight { fill:var(--dm-art-highlight); }
+    .dm-appliance-art-0154 .dm-art-shell { fill:var(--dm-art-shell);stroke:var(--dm-art-shell);stroke-width:2; }
+    .dm-appliance-art-0154 .dm-art-face { fill:var(--dm-art-face); }
+    .dm-appliance-art-0154 .dm-art-window { fill:var(--dm-art-window); }
+    .dm-appliance-art-0154 .dm-art-accent { fill:var(--dm-art-accent); }
+    .dm-appliance-art-0154 .dm-art-muted { fill:var(--dm-art-muted); }
+    .dm-appliance-art-0154 .dm-art-water { fill:var(--dm-art-water); }
+    .dm-appliance-art-0154 .dm-art-line { fill:none;stroke:var(--dm-art-line);stroke-width:3;stroke-linecap:round;stroke-linejoin:round; }
+    .dm-appliance-art-0154 .dm-art-line-light { stroke:var(--dm-art-line-light); }
+
+    html body #page-appliances-main #appl-grid-overview
+      .appl-wide-card[data-dm-artwork="custom"][data-dm-art-style="panel"] img.dm-appliance-custom-image-0154,
+    html body #appl-grid-overview
+      .appl-wide-card[data-dm-artwork="custom"][data-dm-art-style="panel"] img.dm-appliance-custom-image-0154 {
+      display:block!important;
+      width:82%!important;
+      height:82%!important;
+      max-width:82%!important;
+      max-height:82%!important;
+      object-fit:contain!important;
+      object-position:center!important;
+      padding:5px!important;
+      border-radius:16px!important;
+      background:var(--dm-art-panel)!important;
+      border:2px solid var(--dm-art-panel-stroke)!important;
+      box-shadow:0 8px 16px rgba(15,41,66,.14)!important;
+    }
+  `;
+  doc.head.append(style);
+  return true;
+}
+
+function installDomObserver0154() {
+  const state = releaseState();
+  if (!globalThis.document?.documentElement || state.domObserver) return false;
+  let scheduled = false;
+  const schedule = () => {
+    if (scheduled) return;
+    scheduled = true;
+    const run = () => {
+      scheduled = false;
+      normalizeApplianceCards0154();
+    };
+    globalThis.requestAnimationFrame?.(run) || globalThis.setTimeout?.(run, 0);
+  };
+  const observer = new MutationObserver((records) => {
+    if (records.some((record) => record.addedNodes.length || record.removedNodes.length)) schedule();
+  });
+  observer.observe(globalThis.document.documentElement, { childList: true, subtree: true });
+  state.domObserver = observer;
+  schedule();
+  return true;
+}
+
+function installInteractions0154() {
+  const state = releaseState();
+  if (state.interactionsInstalled || !globalThis.document) return;
+  state.interactionsInstalled = true;
+  globalThis.addEventListener?.(OLD_REFRESH_EVENT, () => scheduleEnergyRefresh(0));
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", () => {
+    installPeriodReadGuards();
+    installArtworkOverride();
+    normalizeApplianceCards0154();
+    scheduleEnergyRefresh(80);
+  });
+  globalThis.document.addEventListener(
+    "click",
+    (event) => {
+      const target = event.target?.closest?.("button,.sub-tab-btn,.ed-inner-tab,.hist-time-btn");
+      if (!target) return;
+      if (/giornal|daily|mensil|monthly|report|analisi|analysis|ann|year/i.test(target.textContent || "")) {
+        scheduleEnergyRefresh(20);
+      }
+    },
+    true,
+  );
+  globalThis.document.addEventListener(
+    "change",
+    (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLSelectElement) || target.closest("#editor-modal")) return;
+      if (/month|mese|year|anno/i.test(`${target.id} ${target.name} ${target.getAttribute("aria-label") || ""}`)) {
+        scheduleEnergyRefresh(20);
+      }
+    },
+    true,
+  );
+  try {
+    globalThis.DashboardModernModules?.store?.subscribe?.((change) => {
+      if (change.section === "energy" && change.status === "success") scheduleEnergyRefresh(0);
+      if (change.section === "appliances") normalizeApplianceCards0154();
+    });
+  } catch (_error) {}
+}
+
+function install0154() {
+  releaseState();
+  installStyles0154();
+  installInteractions0154();
+  installDomObserver0154();
+  installPeriodReadGuards();
+  installArtworkOverride();
+  normalizeApplianceCards0154();
+  globalThis.cdRefreshPeriodDeltas = (..._args) => refreshEnergyPeriods0154();
+  globalThis.cdDeriveFromTotals = (..._args) => refreshEnergyPeriods0154();
+  scheduleEnergyRefresh(300);
+}
+
+if (typeof globalThis.document !== "undefined") {
+  install0154();
+  globalThis.queueMicrotask?.(install0154);
+  globalThis.setTimeout?.(install0154, 0);
+  globalThis.setTimeout?.(install0154, 160);
+  const retry = globalThis.setInterval?.(() => {
+    install0154();
+    if (
+      globalThis.cdPNum?.__dm0154PeriodGuard &&
+      globalThis.cdApplianceIcon?.__dm0154Artwork
+    ) {
+      globalThis.clearInterval?.(retry);
+    }
+  }, 100);
+  globalThis.setTimeout?.(() => globalThis.clearInterval?.(retry), 15000);
+  globalThis.setInterval?.(() => scheduleEnergyRefresh(0), 5 * 60 * 1000);
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-style-observer-guard.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-style-observer-guard.js
@@ -1,0 +1,24 @@
+/* DashboardModern 0.14.14: keep a single owner for final appliance style order. */
+const LEGACY_STYLE_OBSERVER_KEY = "__DASHBOARDMODERN_MEDIA_STYLE_OBSERVER_0153__";
+const GUARD_KEY = "__DASHBOARDMODERN_RELEASE_0154_STYLE_OBSERVER_GUARD__";
+
+function disableLegacyStyleObserver0154() {
+  const existing = globalThis[LEGACY_STYLE_OBSERVER_KEY];
+  try {
+    existing?.disconnect?.();
+  } catch (_error) {}
+
+  // Keep a truthy sentinel so the legacy installer does not recreate the
+  // observer during its delayed retries or the legacy-ready event.
+  globalThis[LEGACY_STYLE_OBSERVER_KEY] = Object.freeze({
+    disconnect() {},
+    dashboardmodern_disabled: true,
+  });
+  globalThis[GUARD_KEY] = true;
+}
+
+disableLegacyStyleObserver0154();
+globalThis.queueMicrotask?.(disableLegacyStyleObserver0154);
+globalThis.setTimeout?.(disableLegacyStyleObserver0154, 0);
+globalThis.setTimeout?.(disableLegacyStyleObserver0154, 250);
+globalThis.addEventListener?.("dashboardmodern:legacy-ready", disableLegacyStyleObserver0154);

--- a/custom_components/dashboardmodern/frontend/legacy/release-0154-temperature-live-state.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0154-temperature-live-state.js
@@ -1,0 +1,174 @@
+/* DashboardModern 0.14.14: keep saved room sensors live even when canonical overrides exist. */
+const TEMPERATURE_LIVE_KEY = "__DASHBOARDMODERN_RELEASE_0154_TEMPERATURE_LIVE__";
+
+function functionChainHasTemperature0154(fn) {
+  const seen = new Set();
+  let current = fn;
+  while (typeof current === "function" && !seen.has(current)) {
+    if (current.__dm0154TemperatureLive) return true;
+    seen.add(current);
+    current = current.__dmPrevious;
+  }
+  return false;
+}
+
+function exactState0154(entity) {
+  const id = String(entity || "").trim();
+  if (!id) return null;
+  try {
+    if (typeof _RAW_STATES !== "undefined" && _RAW_STATES?.[id]) return _RAW_STATES[id];
+  } catch (_error) {}
+  try {
+    if (typeof STATES !== "undefined" && STATES?.[id]) return STATES[id];
+  } catch (_error) {}
+  return globalThis._RAW_STATES?.[id] || globalThis.STATES?.[id] || null;
+}
+
+function numericState0154(entity) {
+  const state = exactState0154(entity);
+  const value = Number.parseFloat(state?.state);
+  return Number.isFinite(value) ? value : null;
+}
+
+function rooms0154() {
+  try {
+    if (typeof getStanze === "function") {
+      const rooms = getStanze();
+      if (Array.isArray(rooms)) return rooms;
+    }
+  } catch (_error) {}
+  try {
+    const rooms = globalThis.DashboardModernModules?.store?.getSection?.("rooms");
+    return Array.isArray(rooms) ? rooms : [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+function roomFloor0154(room) {
+  return room?.floor || room?.name || "Altro";
+}
+
+function syncFloorAverages0154(rooms) {
+  globalThis.document?.querySelectorAll?.(".tfl-avg").forEach((element) => {
+    const values = rooms
+      .filter((room) => roomFloor0154(room) === element.dataset.floor)
+      .map((room) => numericState0154(room.temp))
+      .filter((value) => value != null);
+    const next = values.length
+      ? `${(values.reduce((sum, value) => sum + value, 0) / values.length).toFixed(1)}°`
+      : "—°";
+    if (element.textContent !== next) element.textContent = next;
+  });
+}
+
+function syncTemperatureCards0154() {
+  const doc = globalThis.document;
+  if (!doc) return false;
+  const rooms = rooms0154();
+  syncFloorAverages0154(rooms);
+
+  const minimum = 10;
+  const maximum = 35;
+  rooms.forEach((room) => {
+    const temperatureEntity = String(room?.temp || "").trim();
+    if (!temperatureEntity) return;
+    const humidityEntity = String(
+      room?.hum || temperatureEntity.replace("_temperature", "_humidity"),
+    ).trim();
+    const temperatureId = temperatureEntity.replaceAll(".", "_").replaceAll("-", "_");
+    const humidityId = humidityEntity.replaceAll(".", "_").replaceAll("-", "_");
+    const temperature = numericState0154(temperatureEntity);
+    const humidity = numericState0154(humidityEntity);
+
+    const value = doc.getElementById(`tv_${temperatureId}`);
+    const bar = doc.getElementById(`tb_${temperatureId}`);
+    const barLabel = doc.getElementById(`tbl_${temperatureId}`);
+    const comfort = doc.getElementById(`tc_${temperatureId}`);
+    if (value) {
+      if (temperature == null) {
+        if (value.textContent !== "—") value.textContent = "—";
+        if (bar && bar.style.width !== "0%") bar.style.width = "0%";
+        if (barLabel && barLabel.textContent !== "—°") barLabel.textContent = "—°";
+        if (comfort && comfort.textContent !== "—") comfort.textContent = "—";
+      } else {
+        const text = temperature.toFixed(1);
+        if (value.textContent !== text) value.textContent = text;
+        const width = `${Math.min(100, Math.max(0, ((temperature - minimum) / (maximum - minimum)) * 100))}%`;
+        if (bar && bar.style.width !== width) bar.style.width = width;
+        if (barLabel && barLabel.textContent !== `${text}°`) barLabel.textContent = `${text}°`;
+        let badge = "🟢";
+        let label = doc.documentElement.lang === "en" ? "Comfort" : "Comfort";
+        if (temperature < 16) {
+          badge = "❄️";
+          label = doc.documentElement.lang === "en" ? "Cold" : "Freddo";
+        } else if (temperature < 19) {
+          badge = "🔵";
+          label = doc.documentElement.lang === "en" ? "Cool" : "Fresco";
+        } else if (temperature > 27) {
+          badge = "🔥";
+          label = doc.documentElement.lang === "en" ? "Hot" : "Caldo";
+        } else if (temperature > 24) {
+          badge = "🟡";
+          label = doc.documentElement.lang === "en" ? "Warm" : "Tiepido";
+        }
+        if (comfort) {
+          if (comfort.textContent !== badge) comfort.textContent = badge;
+          if (comfort.getAttribute("title") !== label) comfort.setAttribute("title", label);
+        }
+      }
+    }
+
+    const humidityValue = doc.getElementById(`hv_${humidityId}`);
+    const humidityBar = doc.getElementById(`hb_${humidityId}`);
+    const humidityLabel = doc.getElementById(`hbl_${humidityId}`);
+    if (humidityValue) {
+      if (humidity == null) {
+        const html = '—<span style="font-size:14px;opacity:0.75;">%</span>';
+        if (humidityValue.innerHTML !== html) humidityValue.innerHTML = html;
+        if (humidityBar && humidityBar.style.width !== "0%") humidityBar.style.width = "0%";
+        if (humidityLabel && humidityLabel.textContent !== "—%") humidityLabel.textContent = "—%";
+      } else {
+        const rounded = humidity.toFixed(0);
+        const html = `${rounded}<span style="font-size:14px;opacity:0.75;">%</span>`;
+        if (humidityValue.innerHTML !== html) humidityValue.innerHTML = html;
+        const width = `${Math.min(100, humidity)}%`;
+        if (humidityBar && humidityBar.style.width !== width) humidityBar.style.width = width;
+        if (humidityLabel && humidityLabel.textContent !== `${rounded}%`) {
+          humidityLabel.textContent = `${rounded}%`;
+        }
+      }
+    }
+  });
+  return true;
+}
+
+function installTemperatureLive0154() {
+  const current = globalThis.renderTemperature;
+  if (typeof current !== "function" || functionChainHasTemperature0154(current)) return false;
+
+  function liveTemperatureRender0154(...args) {
+    const result = current.apply(this, args);
+    if (result && typeof result.finally === "function") {
+      return result.finally(syncTemperatureCards0154);
+    }
+    syncTemperatureCards0154();
+    return result;
+  }
+
+  liveTemperatureRender0154.__dm0154TemperatureLive = true;
+  liveTemperatureRender0154.__dmPrevious = current;
+  globalThis.renderTemperature = liveTemperatureRender0154;
+  globalThis[TEMPERATURE_LIVE_KEY] = { installed: true };
+  return true;
+}
+
+if (typeof globalThis.document !== "undefined") {
+  installTemperatureLive0154();
+  globalThis.queueMicrotask?.(installTemperatureLive0154);
+  globalThis.setTimeout?.(installTemperatureLive0154, 0);
+  globalThis.setTimeout?.(installTemperatureLive0154, 120);
+  globalThis.setTimeout?.(installTemperatureLive0154, 500);
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", installTemperatureLive0154);
+  globalThis.addEventListener?.("pageshow", installTemperatureLive0154);
+}

--- a/custom_components/dashboardmodern/frontend/tests/release-0152-version.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-0152-version.test.js
@@ -4,7 +4,7 @@ import test from "node:test";
 
 const manifestUrl = new URL("../../manifest.json", import.meta.url);
 
-test("the corrective release is version 0.14.13", async () => {
+test("the corrective release is version 0.14.14", async () => {
   const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
-  assert.equal(manifest.version, "0.14.13");
+  assert.equal(manifest.version, "0.14.14");
 });

--- a/custom_components/dashboardmodern/frontend/tests/release-0154-runtime.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-0154-runtime.test.js
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  applianceArtwork0154,
+  canonicalArtworkType0154,
+  isCumulativeEnergyEntity0154,
+  periodPlans0154,
+} from "../legacy/release-0154-runtime.js";
+
+const totalState = (entityId, friendlyName = entityId) => ({
+  entity_id: entityId,
+  state: "11919.4",
+  attributes: {
+    friendly_name: friendlyName,
+    unit_of_measurement: "kWh",
+    device_class: "energy",
+    state_class: "total_increasing",
+  },
+});
+
+const measurementState = (entityId) => ({
+  entity_id: entityId,
+  state: "42.6",
+  attributes: {
+    unit_of_measurement: "kWh",
+    device_class: "energy",
+    state_class: "measurement",
+  },
+});
+
+test("a cumulative entity saved in a monthly field is derived instead of shown as lifetime", () => {
+  const states = {
+    "sensor.solar_total": totalState("sensor.solar_total", "Produzione totale fotovoltaico"),
+  };
+  const energy = {
+    solar: { monthly_energy: "sensor.solar_total" },
+  };
+
+  const plans = periodPlans0154(energy, "month", states);
+  assert.equal(plans.length, 1);
+  assert.deepEqual(plans[0], {
+    kind: "month",
+    group: "solar",
+    slot: "dm.energy_produzione_solare_mese",
+    source: "sensor.solar_total",
+    entity: "sensor.solar_total",
+    reason: "explicit-cumulative",
+  });
+});
+
+test("a genuine monthly measurement remains the explicit period value", () => {
+  const states = {
+    "sensor.solar_month": measurementState("sensor.solar_month"),
+  };
+  const energy = {
+    solar: { monthly_energy: "sensor.solar_month" },
+  };
+
+  assert.deepEqual(periodPlans0154(energy, "month", states), []);
+});
+
+test("canonical total fields still derive day, month and year", () => {
+  const states = {
+    "sensor.house_total": totalState("sensor.house_total"),
+  };
+  const energy = {
+    house: { total_energy: "sensor.house_total" },
+  };
+
+  for (const kind of ["day", "month", "year"]) {
+    const plans = periodPlans0154(energy, kind, states);
+    assert.equal(plans.length, 1);
+    assert.equal(plans[0].entity, "sensor.house_total");
+    assert.equal(plans[0].reason, "canonical-total");
+  }
+});
+
+test("legacy monthly overrides are derived when Home Assistant marks them total_increasing", () => {
+  const states = {
+    "sensor.grid_total_import": totalState("sensor.grid_total_import"),
+  };
+  const overrides = {
+    "dm.energy_rete_acquistata_mese": "sensor.grid_total_import",
+  };
+
+  const plans = periodPlans0154({}, "month", states, overrides);
+  assert.equal(plans.length, 1);
+  assert.equal(plans[0].slot, "dm.energy_rete_acquistata_mese");
+  assert.equal(plans[0].reason, "legacy-cumulative");
+});
+
+test("cumulative detection uses state_class first and total naming as a safe fallback", () => {
+  assert.equal(
+    isCumulativeEnergyEntity0154("sensor.any_name", {
+      "sensor.any_name": totalState("sensor.any_name"),
+    }),
+    true,
+  );
+  assert.equal(isCumulativeEnergyEntity0154("sensor.solarman_total_grid_energy"), true);
+  assert.equal(isCumulativeEnergyEntity0154("sensor.energy_month", {
+    "sensor.energy_month": measurementState("sensor.energy_month"),
+  }), false);
+});
+
+test("oven, fridge, microwave and boiler share the same panel artwork contract", () => {
+  const fixtures = [
+    ["forno", "oven"],
+    ["frigo", "fridge"],
+    ["microonde", "microwave"],
+    ["scaldabagno", "boiler"],
+  ];
+
+  for (const [token, canonical] of fixtures) {
+    assert.equal(canonicalArtworkType0154(token), canonical);
+    const markup = applianceArtwork0154(token, 96);
+    assert.match(markup, /dm-appliance-art-0154/);
+    assert.match(markup, /data-dm-art-style="panel"/);
+    assert.match(markup, new RegExp(`data-dm-art="${canonical}"`));
+    assert.match(markup, /dm-art-panel/);
+    assert.match(markup, /viewBox="0 0 96 96"/);
+  }
+});
+
+test("the compatibility entry imports the 0.14.14 runtime after previous layout layers", async () => {
+  const entry = await readFile(new URL("../legacy/release-0152-fixes.js", import.meta.url), "utf8");
+  const oldLayout = entry.indexOf('import "./appliance-media-layout-lock.js"');
+  const newRuntime = entry.indexOf('import "./release-0154-runtime.js"');
+  assert.ok(oldLayout >= 0);
+  assert.ok(newRuntime > oldLayout);
+});

--- a/custom_components/dashboardmodern/frontend/tests/release-0154-runtime.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-0154-runtime.test.js
@@ -123,10 +123,17 @@ test("oven, fridge, microwave and boiler share the same panel artwork contract",
   }
 });
 
-test("the compatibility entry imports the 0.14.14 runtime after previous layout layers", async () => {
+test("the compatibility entry loads one final appliance media owner after the 0.14.14 runtime", async () => {
   const entry = await readFile(new URL("../legacy/release-0152-fixes.js", import.meta.url), "utf8");
-  const oldLayout = entry.indexOf('import "./appliance-media-layout-lock.js"');
   const newRuntime = entry.indexOf('import "./release-0154-runtime.js"');
-  assert.ok(oldLayout >= 0);
-  assert.ok(newRuntime > oldLayout);
+  const postlude = entry.indexOf('import "./release-0154-postlude.js"');
+  const finalOwner = entry.indexOf('import "./release-0154-final-appliance-stability.js"');
+
+  assert.ok(newRuntime >= 0);
+  assert.ok(postlude > newRuntime);
+  assert.ok(finalOwner > postlude);
+  assert.equal(entry.includes('import "./appliance-media-layout-lock.js"'), false);
+  assert.equal(entry.includes('import "./release-0154-artwork-lock.js"'), false);
+  assert.equal(entry.includes('import "./release-0154-artwork-idempotency.js"'), false);
+  assert.equal(entry.includes('import "./release-0154-style-observer-guard.js"'), false);
 });

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "0.14.13"
+  "version": "0.14.14"
 }


### PR DESCRIPTION
## Problemi riprodotti dagli screenshot reali

- La vista **Mensile** mostrava lo stato lifetime dei contatori (`11919.4 kWh`, `5672.4 kWh`, ecc.) quando un sensore `total_increasing` era stato salvato direttamente nel campo mensile.
- Il runtime precedente decideva in base al nome del campo: la sola presenza di `monthly_energy` impediva il calcolo del delta, anche quando l'entità era in realtà un contatore totale.
- Forno, frigorifero, microonde e scaldabagno provenivano da famiglie grafiche diverse e risultavano incoerenti nella stessa lista.

## Correzione

- La sorgente viene ora classificata usando i metadati reali di Home Assistant (`state_class: total` / `total_increasing`) e non soltanto il campo dell'editor.
- Un contatore cumulativo inserito nei campi giorno, mese o anno viene convertito nel delta del periodo tramite Long-Term Statistics.
- Durante il caricamento un campo cumulativo non può più ricadere sul valore lifetime: mostra `—`/zero finché il delta non è disponibile.
- Supporto anche alle vecchie mappature `dm.*` che puntano direttamente a contatori cumulativi.
- Nuova famiglia SVG coerente, ispirata al pannello illustrato fornito come riferimento, per forno, microonde, frigo, scaldabagno, lavatrice, asciugatrice, lavastoviglie, piano cottura e TV.
- Palette e superfici cambiano automaticamente fra tema chiaro e scuro; anche le immagini personalizzate vengono inserite nello stesso pannello visivo.

## Test

- Unit test per il caso reale: sensore lifetime memorizzato nel campo mensile.
- E2E ITA/ENG con gli stessi valori lifetime visibili nello screenshot e delta mensili distinti.
- Verifica che nessun valore lifetime compaia nella vista Mensile.
- Verifica richieste Recorder senza `types`.
- Verifica geometrica e tematica della nuova famiglia grafica elettrodomestici.

PR in bozza finché HACS, hassfest, Tests e Browser E2E non sono tutti verdi.