### PR TITLE
fix: DashboardModern 0.14.16 — historical periods and shared runtime

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/release-0156-period-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0156-period-runtime.spec.js
@@ -1,0 +1,247 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { clickBottomTab } from "./helpers/navigation.js";
+
+const states = [
+  {
+    entity_id: "sensor.terrace_temperature",
+    state: "22.4",
+    attributes: {
+      friendly_name: "Terrace temperature",
+      unit_of_measurement: "°C",
+      device_class: "temperature",
+    },
+  },
+  {
+    entity_id: "sensor.terrace_humidity",
+    state: "51",
+    attributes: {
+      friendly_name: "Terrace humidity",
+      unit_of_measurement: "%",
+      device_class: "humidity",
+    },
+  },
+  ...[
+    "house_total",
+    "solar_total",
+    "grid_import_total",
+    "grid_export_total",
+    "battery_charge_total",
+    "battery_discharge_total",
+    "fridge_total",
+  ].map((name) => ({
+    entity_id: `sensor.${name}`,
+    state: "5000",
+    attributes: {
+      friendly_name: name,
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "total_increasing",
+    },
+  })),
+];
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [
+      {
+        id: "room-terrace",
+        name: "Terrazza",
+        icon: "mdi:balcony",
+        temp: "sensor.terrace_temperature",
+        hum: "sensor.terrace_humidity",
+      },
+    ],
+    appliances: [
+      {
+        id: "appl-fridge",
+        name: "Frigo",
+        device_type: "fridge",
+        visual_type: "asset",
+        visual_key: "fridge",
+        room_id: "room-terrace",
+        total_energy_entity: "sensor.fridge_total",
+        entities: ["sensor.fridge_total"],
+        show_in_dashboard: true,
+        show_in_report: true,
+      },
+    ],
+    loads: [],
+    energy: {
+      house: { total_energy: "sensor.house_total" },
+      solar: { total_energy: "sensor.solar_total" },
+      grid: {
+        total_import_energy: "sensor.grid_import_total",
+        total_export_energy: "sensor.grid_export_total",
+      },
+      battery: {
+        total_charged_energy: "sensor.battery_charge_total",
+        total_discharged_energy: "sensor.battery_discharge_total",
+      },
+      metadata: {},
+    },
+  },
+  visibility: { energy: true, temperature: true, temp: true, appliances: true },
+};
+
+async function boot(page, variant, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript(
+    ({ haStates }) => {
+      window.DASHBOARDMODERN_AUTH_TOKEN = "e2e-token";
+      window.__dmSocketInstances = 0;
+      window.__dmStatisticsRequests = [];
+      const current = new Date();
+      const currentMonth = current.getMonth() + 1;
+      const currentYear = current.getFullYear();
+      const previousDate = new Date(currentYear, currentMonth - 2, 1);
+      const previousMonth = previousDate.getMonth() + 1;
+      const previousYear = previousDate.getFullYear();
+      window.__dmPeriods = { currentMonth, currentYear, previousMonth, previousYear };
+
+      const currentValues = {
+        "sensor.house_total": 39.9,
+        "sensor.solar_total": 50.2,
+        "sensor.grid_import_total": 0,
+        "sensor.grid_export_total": 7.2,
+        "sensor.battery_charge_total": 8.6,
+        "sensor.battery_discharge_total": 5.5,
+        "sensor.fridge_total": 10.4,
+      };
+      const previousValues = {
+        "sensor.house_total": 511.6,
+        "sensor.solar_total": 305.4,
+        "sensor.grid_import_total": 224,
+        "sensor.grid_export_total": 8.8,
+        "sensor.battery_charge_total": 152,
+        "sensor.battery_discharge_total": 143,
+        "sensor.fridge_total": 44.7,
+      };
+      const base = Object.fromEntries(Object.keys(currentValues).map((id, index) => [id, 1000 + index * 100]));
+
+      window.WebSocket = class extends EventTarget {
+        static OPEN = 1;
+        readyState = 1;
+        constructor() {
+          super();
+          window.__dmSocketInstances += 1;
+          queueMicrotask(() => this.emit({ type: "auth_required" }));
+        }
+        emit(message) {
+          const event = new MessageEvent("message", { data: JSON.stringify(message) });
+          this.dispatchEvent(event);
+          this.onmessage?.(event);
+        }
+        send(raw) {
+          const message = JSON.parse(raw);
+          if (message.type === "auth") {
+            this.emit({ type: "auth_ok" });
+            return;
+          }
+          if (message.type === "get_states") {
+            this.emit({ id: message.id, type: "result", success: true, result: haStates });
+            return;
+          }
+          if (message.type === "subscribe_events") {
+            this.emit({ id: message.id, type: "result", success: true, result: null });
+            return;
+          }
+          if (message.type === "recorder/statistics_during_period") {
+            window.__dmStatisticsRequests.push(structuredClone(message));
+            const start = new Date(message.start_time);
+            const end = new Date(message.end_time);
+            const isBaseline = end.getDate() === 1 && end.getHours() === 0;
+            const periodMonth = isBaseline ? end.getMonth() + 1 : start.getMonth() + 1;
+            const periodYear = isBaseline ? end.getFullYear() : start.getFullYear();
+            const selected =
+              periodMonth === previousMonth && periodYear === previousYear
+                ? previousValues
+                : currentValues;
+            const result = Object.fromEntries(
+              (message.statistic_ids || []).map((id) => {
+                const sum = base[id] + (isBaseline ? 0 : selected[id] || 0);
+                return [id, [{ start: message.start_time, sum, state: sum }]];
+              }),
+            );
+            this.emit({ id: message.id, type: "result", success: true, result });
+            return;
+          }
+          this.emit({ id: message.id, type: "result", success: true, result: [] });
+        }
+        close() {
+          this.readyState = 3;
+        }
+      };
+    },
+    { haStates: states },
+  );
+
+  await bootNamespacedDashboard(page, variant, testInfo, seed);
+  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await page.waitForFunction(() => window.__DASHBOARDMODERN_RELEASE_0156_PERIOD_RUNTIME__?.installed);
+}
+
+for (const variant of ["dashboard.html", "dashboard-en.html"]) {
+  test(`${variant}: previous Report month does not overwrite the current monthly Energy period`, async ({
+    page,
+  }, testInfo) => {
+    await boot(page, variant, testInfo);
+
+    await page.evaluate(() => {
+      buildTempCards?.();
+      renderTemperature?.();
+    });
+    await expect(page.locator("#temp-grid .temp-value").first()).toContainText("22.4");
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          solar: Number(CD_PERIOD["dm.energy_produzione_solare_mese"]),
+          home: Number(CD_PERIOD["dm.energy_consumo_casa_mese"]),
+        })),
+      )
+      .toEqual({ solar: 50.2, home: 39.9 });
+
+    await clickBottomTab(page, "energy", testInfo);
+    await page.evaluate(() => {
+      const { previousMonth, previousYear } = window.__dmPeriods;
+      const month = document.getElementById("ed-sel-month");
+      const year = document.getElementById("ed-sel-year");
+      if (month) month.value = String(previousMonth);
+      if (year) year.value = String(previousYear);
+      month?.dispatchEvent(new Event("change", { bubbles: true }));
+      year?.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    await expect(page.locator("#ed-kpi-prod")).toContainText("305.4");
+    await expect(page.locator("#ed-kpi-cons")).toContainText("511.6");
+
+    await page.evaluate(async () => {
+      const { previousMonth, previousYear } = window.__dmPeriods;
+      cdRebuildReportDevices?.();
+      buildReportSelect?.();
+      await renderEdDeviceList?.(previousMonth, previousYear, false, 511.6, 224, 305.4);
+    });
+    await expect(page.locator("#ed-device-list")).toContainText(/44[,.]7/);
+
+    const periodsAfterReport = await page.evaluate(() => ({
+      solar: Number(CD_PERIOD["dm.energy_produzione_solare_mese"]),
+      home: Number(CD_PERIOD["dm.energy_consumo_casa_mese"]),
+      polling: window.__DASHBOARDMODERN_RELEASE_0155_PUBLIC_RUNTIME__?.sampleTimer || 0,
+    }));
+    expect(periodsAfterReport).toEqual({ solar: 50.2, home: 39.9, polling: 0 });
+
+    const sockets = await page.evaluate(() => window.__dmSocketInstances);
+    await page.waitForTimeout(1200);
+    await expect.poll(() => page.evaluate(() => window.__dmSocketInstances)).toBe(sockets);
+
+    const hasBaseline = await page.evaluate(() =>
+      window.__dmStatisticsRequests.some((request) => {
+        const end = new Date(request.end_time);
+        return end.getDate() === 1 && end.getHours() === 0;
+      }),
+    );
+    expect(hasBaseline).toBe(true);
+  });
+}

--- a/custom_components/dashboardmodern/frontend/legacy/bridge-prelude.js
+++ b/custom_components/dashboardmodern/frontend/legacy/bridge-prelude.js
@@ -158,6 +158,51 @@
     window.DASHBOARDMODERN_AUTH_TOKEN ||= REAL_TOKEN;
   }
 
+  /*
+   * The inert socket below deliberately triggers the legacy close path once.
+   * That close handler schedules `connect` five seconds later. Recorder and the
+   * shared 0.14.16 broker are ready before then, so the retry is redundant, but
+   * its callback is a lexical reference and cannot be replaced afterwards.
+   * Track only the timeout created while invoking this exact close callback;
+   * the final runtime can then cancel that one timer without replacing
+   * WebSocket, setTimeout or any application callback globally.
+   */
+  function invokeTrackedInitialClose(socket, event) {
+    var originalSetTimeout = window.setTimeout;
+    if (typeof originalSetTimeout !== "function" || typeof socket.onclose !== "function") {
+      socket.onclose(event);
+      return;
+    }
+    var record = window.__DASHBOARDMODERN_LEGACY_RECONNECT__ || {
+      timer: 0,
+      callback: null,
+      args: [],
+      captured: false,
+      cancelled: false,
+    };
+    window.__DASHBOARDMODERN_LEGACY_RECONNECT__ = record;
+
+    function trackedSetTimeout(handler, delay) {
+      var args = Array.prototype.slice.call(arguments, 2);
+      var timer = originalSetTimeout.apply(window, arguments);
+      if (typeof handler === "function" && Number(delay) === 5000) {
+        record.timer = timer;
+        record.callback = handler;
+        record.args = args;
+        record.captured = true;
+        record.cancelled = false;
+      }
+      return timer;
+    }
+
+    window.setTimeout = trackedSetTimeout;
+    try {
+      socket.onclose(event);
+    } finally {
+      if (window.setTimeout === trackedSetTimeout) window.setTimeout = originalSetTimeout;
+    }
+  }
+
   // Between document parse and the host's load-time bridge install, the page
   // would otherwise reach the REAL WebSocket and authenticate on its own — the
   // source of the "login attempt failed" notifications. Replace it with an
@@ -176,7 +221,7 @@
       }
       try {
         if (typeof self.onclose === "function") {
-          self.onclose({ code: 1006, reason: "bridge not ready" });
+          invokeTrackedInitialClose(self, { code: 1006, reason: "bridge not ready" });
         }
       } catch (error) {
         /* listener errors are the page's business */

--- a/custom_components/dashboardmodern/frontend/legacy/bridge-prelude.js
+++ b/custom_components/dashboardmodern/frontend/legacy/bridge-prelude.js
@@ -161,9 +161,9 @@
   // Between document parse and the host's load-time bridge install, the page
   // would otherwise reach the REAL WebSocket and authenticate on its own — the
   // source of the "login attempt failed" notifications. Replace it with an
-  // inert stub that opens nothing and closes immediately: the dashboard's own
-  // reconnect logic retries after the bridge is installed and succeeds. No
-  // authentication of any kind can leave the frame before the bridge exists.
+  // inert stub only when neither an explicit bridge nor a safe preloaded
+  // adapter exists. A preloaded adapter is wrapped below so all callbacks are
+  // asynchronous and cannot recursively re-enter the legacy state machine.
   function StubSocket() {
     var self = this;
     this.readyState = StubSocket.CONNECTING;
@@ -210,12 +210,6 @@
   } catch (error) {
     BridgeWS = window.__DASHBOARDMODERN_BRIDGE_WS__ || null;
   }
-
-  // The main legacy bootstrap receives only the explicit host bridge (or the
-  // inert stub). Never give it a generic preloaded adapter while its own script
-  // is parsing: synchronous mock replies inside ws.send() can recursively
-  // re-enter the legacy state machine.
-  window.WebSocket = typeof BridgeWS === "function" ? BridgeWS : StubSocket;
 
   function deferredSocketConstructor(SocketCtor) {
     function construct(args) {
@@ -298,10 +292,25 @@
     return DeferredSocket;
   }
 
-  // Once the main legacy socket and canonical store are initialized, expose an
-  // asynchronous wrapper around the preloaded adapter. Both a later reconnect
-  // and Recorder receive the expected mock/bridge replies, but never inside the
-  // same call stack as send(), so the legacy state machine cannot recurse.
+  // The main legacy bootstrap receives the explicit host bridge, otherwise the
+  // preloaded adapter with asynchronous callbacks, and only falls back to the
+  // inert stub when no safe transport exists yet. This prevents the artificial
+  // close/reconnect cycle while preserving protection from synchronous mocks.
+  var PreloadedWS =
+    window.__DASHBOARDMODERN_PRELUDE_WS__ === PRELUDE_WEBSOCKET
+      ? deferredSocketConstructor(PRELUDE_WEBSOCKET)
+      : null;
+  window.WebSocket =
+    typeof BridgeWS === "function"
+      ? BridgeWS
+      : typeof PreloadedWS === "function"
+        ? PreloadedWS
+        : StubSocket;
+
+  // Once the main legacy socket and canonical store are initialized, keep the
+  // asynchronous wrapper around the preloaded adapter for Recorder and later
+  // reconnects. It is safe to reassign the constructor: existing sockets remain
+  // untouched and every future callback stays outside the send() call stack.
   if (
     window.__DASHBOARDMODERN_PRELUDE_WS__ === PRELUDE_WEBSOCKET &&
     typeof window.addEventListener === "function"

--- a/custom_components/dashboardmodern/frontend/legacy/bridge-prelude.js
+++ b/custom_components/dashboardmodern/frontend/legacy/bridge-prelude.js
@@ -161,9 +161,9 @@
   // Between document parse and the host's load-time bridge install, the page
   // would otherwise reach the REAL WebSocket and authenticate on its own — the
   // source of the "login attempt failed" notifications. Replace it with an
-  // inert stub only when neither an explicit bridge nor a safe preloaded
-  // adapter exists. A preloaded adapter is wrapped below so all callbacks are
-  // asynchronous and cannot recursively re-enter the legacy state machine.
+  // inert stub that opens nothing and closes immediately: the dashboard's own
+  // reconnect logic retries after the bridge is installed and succeeds. No
+  // authentication of any kind can leave the frame before the bridge exists.
   function StubSocket() {
     var self = this;
     this.readyState = StubSocket.CONNECTING;
@@ -210,6 +210,12 @@
   } catch (error) {
     BridgeWS = window.__DASHBOARDMODERN_BRIDGE_WS__ || null;
   }
+
+  // The main legacy bootstrap receives only the explicit host bridge (or the
+  // inert stub). Never give it a generic preloaded adapter while its own script
+  // is parsing: synchronous mock replies inside ws.send() can recursively
+  // re-enter the legacy state machine.
+  window.WebSocket = typeof BridgeWS === "function" ? BridgeWS : StubSocket;
 
   function deferredSocketConstructor(SocketCtor) {
     function construct(args) {
@@ -292,25 +298,10 @@
     return DeferredSocket;
   }
 
-  // The main legacy bootstrap receives the explicit host bridge, otherwise the
-  // preloaded adapter with asynchronous callbacks, and only falls back to the
-  // inert stub when no safe transport exists yet. This prevents the artificial
-  // close/reconnect cycle while preserving protection from synchronous mocks.
-  var PreloadedWS =
-    window.__DASHBOARDMODERN_PRELUDE_WS__ === PRELUDE_WEBSOCKET
-      ? deferredSocketConstructor(PRELUDE_WEBSOCKET)
-      : null;
-  window.WebSocket =
-    typeof BridgeWS === "function"
-      ? BridgeWS
-      : typeof PreloadedWS === "function"
-        ? PreloadedWS
-        : StubSocket;
-
-  // Once the main legacy socket and canonical store are initialized, keep the
-  // asynchronous wrapper around the preloaded adapter for Recorder and later
-  // reconnects. It is safe to reassign the constructor: existing sockets remain
-  // untouched and every future callback stays outside the send() call stack.
+  // Once the main legacy socket and canonical store are initialized, expose an
+  // asynchronous wrapper around the preloaded adapter. Both a later reconnect
+  // and Recorder receive the expected mock/bridge replies, but never inside the
+  // same call stack as send(), so the legacy state machine cannot recurse.
   if (
     window.__DASHBOARDMODERN_PRELUDE_WS__ === PRELUDE_WEBSOCKET &&
     typeof window.addEventListener === "function"

--- a/custom_components/dashboardmodern/frontend/legacy/release-0151-statistics-fallback.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0151-statistics-fallback.js
@@ -1,5 +1,5 @@
-/* DashboardModern 0.14.11: authenticated statistics fallback for late store startup. */
-import { periodDelta, periodRange } from "./release-0151-fixes.js";
+/* DashboardModern 0.14.16: current-period statistics without Report cross-contamination. */
+import { periodRange } from "./release-0151-fixes.js";
 import { fetchEnergyStatistics0151 } from "./release-0151-statistics-socket.js";
 
 const FALLBACK_FLAG = "__DASHBOARDMODERN_RELEASE_0151_STATISTICS_FALLBACK__";
@@ -63,6 +63,7 @@ const PERIOD_SOURCES = Object.freeze([
 ]);
 
 const editorTotals = new Map();
+let requestGeneration = 0;
 
 function dashboardStore() {
   return globalThis.DashboardModernModules?.store;
@@ -93,29 +94,6 @@ function isEnergySaveButton(button) {
   return /(?:salva\s+energia|save\s+energy)/i.test(text);
 }
 
-function selectedReportDate() {
-  const scope =
-    document.getElementById("page-energy") || document.getElementById("page-energia") || document;
-  const selects = [...scope.querySelectorAll("select")].filter(
-    (select) => !select.closest("#editor-modal"),
-  );
-  const label = (select) =>
-    `${select.id} ${select.name} ${select.className} ${select.getAttribute("aria-label") || ""} ${select.previousElementSibling?.textContent || ""}`.toLowerCase();
-  const monthSelect = selects.find((select) => /month|mese/.test(label(select)));
-  const yearSelect = selects.find((select) => /year|anno/.test(label(select)));
-  const now = new Date();
-  const rawMonth = Number(monthSelect?.value);
-  const month =
-    Number.isInteger(rawMonth) && rawMonth >= 1 && rawMonth <= 12
-      ? rawMonth - 1
-      : Number.isInteger(rawMonth) && rawMonth >= 0 && rawMonth <= 11
-        ? rawMonth
-        : now.getMonth();
-  const rawYear = Number(yearSelect?.value || yearSelect?.selectedOptions?.[0]?.textContent);
-  const year = Number.isInteger(rawYear) && rawYear >= 2000 ? rawYear : now.getFullYear();
-  return new Date(year, month, 1);
-}
-
 function definitionsFor(energy) {
   return PERIOD_SOURCES.map((definition) => {
     const group = energy?.[definition.group] || {};
@@ -126,12 +104,57 @@ function definitionsFor(energy) {
   }).filter((item) => item.entity);
 }
 
+function rowTime(row) {
+  const raw = row?.start ?? row?.end ?? row?.last_updated ?? row?.timestamp ?? 0;
+  const value = typeof raw === "number" ? raw : Date.parse(raw);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function cumulativeValue(row) {
+  for (const key of ["sum", "state", "max"]) {
+    const value = Number(row?.[key]);
+    if (Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function periodValue(rows = [], baseline = null) {
+  const ordered = (Array.isArray(rows) ? rows : [])
+    .filter(Boolean)
+    .slice()
+    .sort((left, right) => rowTime(left) - rowTime(right));
+  const changes = ordered
+    .map((row) => Number(row?.change))
+    .filter((value) => Number.isFinite(value));
+  if (changes.length) return Math.max(0, changes.reduce((total, value) => total + value, 0));
+
+  const values = ordered.map(cumulativeValue).filter((value) => value != null);
+  const base = cumulativeValue(baseline);
+  if (base != null && values.length) values.unshift(base);
+  if (values.length < 2) return null;
+
+  let total = 0;
+  for (let index = 1; index < values.length; index += 1) {
+    const difference = values[index] - values[index - 1];
+    total += difference >= 0 ? difference : Math.max(0, values[index]);
+  }
+  return Math.max(0, total);
+}
+
+function baselineStart(range, kind) {
+  const start = new Date(range.start);
+  if (kind === "year") start.setMonth(start.getMonth() - 2);
+  else if (kind === "day") start.setDate(start.getDate() - 1);
+  else start.setDate(start.getDate() - 2);
+  return start;
+}
+
 function inject(slot, value, entity, kind, selected) {
   if (!slot || !Number.isFinite(value)) return;
   const timestamp = new Date().toISOString();
   const state = {
     entity_id: slot,
-    state: Math.max(0, value).toFixed(1),
+    state: Math.max(0, value).toFixed(3),
     attributes: {
       unit_of_measurement: "kWh",
       device_class: "energy",
@@ -154,23 +177,51 @@ function inject(slot, value, entity, kind, selected) {
 
 async function requestPeriod(kind, selected, definitions) {
   const range = periodRange(kind, selected);
-  if (range.end <= range.start) return false;
-  const ids = [...new Set(definitions.map((item) => item.entity))];
+  if (range.end <= range.start) return [];
+  const relevant = definitions.filter(({ definition, group }) => {
+    const target = definition.periods[kind];
+    return target && !String(group[target.explicitKey] || "").trim();
+  });
+  if (!relevant.length) return [];
+
+  const ids = [...new Set(relevant.map((item) => item.entity))];
   const result = await fetchEnergyStatistics0151(
     ids,
     range.start.toISOString(),
     range.end.toISOString(),
     range.period,
   );
-  definitions.forEach(({ definition, group, entity }) => {
-    const target = definition.periods[kind];
-    if (!target || String(group[target.explicitKey] || "").trim()) return;
-    inject(target.slot, periodDelta(result?.[entity] || []), entity, kind, selected);
+
+  const unresolved = relevant.filter(({ entity }) => periodValue(result?.[entity] || []) == null);
+  let baselines = {};
+  if (unresolved.length) {
+    const baselineIds = [...new Set(unresolved.map((item) => item.entity))];
+    baselines = await fetchEnergyStatistics0151(
+      baselineIds,
+      baselineStart(range, kind).toISOString(),
+      range.start.toISOString(),
+      range.period,
+    );
+  }
+
+  return relevant.flatMap(({ definition, entity }) => {
+    const rows = result?.[entity] || [];
+    const baselineRows = (baselines?.[entity] || [])
+      .slice()
+      .sort((left, right) => rowTime(left) - rowTime(right));
+    const value = periodValue(rows, baselineRows.at(-1) || null);
+    if (value == null) return [];
+    return [{
+      slot: definition.periods[kind].slot,
+      value,
+      entity,
+      kind,
+      selected,
+    }];
   });
-  return true;
 }
 
-export async function refreshEnergyStatisticsFallback0151(selected = selectedReportDate()) {
+export async function refreshEnergyStatisticsFallback0151(selected = new Date()) {
   const store = dashboardStore();
   if (
     typeof globalThis.fetchHAStatistics !== "function" &&
@@ -180,23 +231,30 @@ export async function refreshEnergyStatisticsFallback0151(selected = selectedRep
   const energy = store?.getSection?.("energy") || {};
   const definitions = definitionsFor(energy);
   if (!definitions.length) return false;
+
+  const generation = ++requestGeneration;
   try {
-    await Promise.all([
-      requestPeriod("day", new Date(), definitions),
-      requestPeriod("month", selected, definitions),
-      requestPeriod("year", selected, definitions),
-    ]);
-    globalThis.render?.();
+    const updates = (
+      await Promise.all([
+        requestPeriod("day", new Date(), definitions),
+        requestPeriod("month", selected, definitions),
+        requestPeriod("year", selected, definitions),
+      ])
+    ).flat();
+    if (generation !== requestGeneration) return false;
+
+    updates.forEach(({ slot, value, entity, kind, selected: updateDate }) => {
+      inject(slot, value, entity, kind, updateDate);
+    });
     globalThis.renderEnergy?.();
-    globalThis.renderReport?.();
     globalThis.dispatchEvent?.(
       new CustomEvent(REFRESH_EVENT, {
-        detail: { selected: selected.toISOString(), transport: "authenticated-runtime" },
+        detail: { selected: selected.toISOString(), transport: "current-period-runtime" },
       }),
     );
     return true;
   } catch (error) {
-    console.warn("[DashboardModern] authenticated Energy statistics fallback", error);
+    console.warn("[DashboardModern] current Energy statistics fallback", error);
     return false;
   }
 }
@@ -207,7 +265,7 @@ let subscriptionRetry = 0;
 
 function scheduleRefresh(delay = 80) {
   clearTimeout(refreshTimer);
-  refreshTimer = setTimeout(() => refreshEnergyStatisticsFallback0151(), delay);
+  refreshTimer = setTimeout(() => refreshEnergyStatisticsFallback0151(new Date()), delay);
 }
 
 function subscribeWhenReady() {
@@ -215,7 +273,7 @@ function subscribeWhenReady() {
   const store = dashboardStore();
   if (!store?.subscribe) {
     clearTimeout(subscriptionRetry);
-    subscriptionRetry = setTimeout(subscribeWhenReady, 100);
+    subscriptionRetry = setTimeout(subscribeWhenReady, 150);
     return false;
   }
   subscribed = true;
@@ -230,7 +288,7 @@ function subscribeWhenReady() {
 
 function install() {
   if (globalThis[FALLBACK_FLAG]?.installed) return;
-  globalThis[FALLBACK_FLAG] = { installed: true, version: "0.14.11" };
+  globalThis[FALLBACK_FLAG] = { installed: true, version: "0.14.16" };
   subscribeWhenReady();
   document.addEventListener(
     "input",
@@ -251,16 +309,6 @@ function install() {
       if (!isEnergySaveButton(button)) return;
       rememberEditorTotals();
       scheduleRefresh(180);
-    },
-    true,
-  );
-  document.addEventListener(
-    "change",
-    (event) => {
-      const select = event.target;
-      if (!(select instanceof HTMLSelectElement) || select.closest("#editor-modal")) return;
-      const description = `${select.id} ${select.name} ${select.getAttribute("aria-label") || ""}`;
-      if (/month|mese|year|anno/i.test(description)) scheduleRefresh(40);
     },
     true,
   );

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -16,12 +16,12 @@ import "./release-0154-dom-stability.js";
 import "./release-0154-temperature-live-state.js";
 import "./release-0155-energy-placeholder-fallback.js";
 import "./release-0155-public-runtime.js";
+import "./release-0156-current-period-lock.js";
 
 if (typeof globalThis.document !== "undefined") {
   import("./release-0156-final-runtime.js")
     .then(() => import("./release-0156-current-period-bootstrap.js"))
-    .then(() => import("./release-0156-owner-guard.js"))
-    .then(() => import("./release-0156-current-period-lock.js"));
+    .then(() => import("./release-0156-owner-guard.js"));
 }
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -16,6 +16,7 @@ import "./release-0154-dom-stability.js";
 import "./release-0154-temperature-live-state.js";
 import "./release-0155-energy-placeholder-fallback.js";
 import "./release-0155-public-runtime.js";
+import "./release-0156-period-runtime.js";
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";
 

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -18,6 +18,7 @@ import "./release-0155-energy-placeholder-fallback.js";
 import "./release-0155-public-runtime.js";
 import "./release-0156-webkit-stability.js";
 import "./release-0156-final-stability.js";
+import "./release-0156-reconnect-timer-cancel.js";
 import "./release-0156-current-period-lock.js";
 
 if (typeof globalThis.document !== "undefined") {

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -18,9 +18,9 @@ import "./release-0155-energy-placeholder-fallback.js";
 import "./release-0155-public-runtime.js";
 
 if (typeof globalThis.document !== "undefined") {
-  import("./release-0156-final-runtime.js").then(() =>
-    import("./release-0156-current-period-bootstrap.js"),
-  );
+  import("./release-0156-final-runtime.js")
+    .then(() => import("./release-0156-current-period-bootstrap.js"))
+    .then(() => import("./release-0156-owner-guard.js"));
 }
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -20,7 +20,8 @@ import "./release-0155-public-runtime.js";
 if (typeof globalThis.document !== "undefined") {
   import("./release-0156-final-runtime.js")
     .then(() => import("./release-0156-current-period-bootstrap.js"))
-    .then(() => import("./release-0156-owner-guard.js"));
+    .then(() => import("./release-0156-owner-guard.js"))
+    .then(() => import("./release-0156-current-period-lock.js"));
 }
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -17,7 +17,10 @@ import "./release-0154-temperature-live-state.js";
 import "./release-0155-energy-placeholder-fallback.js";
 import "./release-0155-public-runtime.js";
 import "./release-0156-period-runtime.js";
-import "./release-0156-final-runtime.js";
+
+if (typeof globalThis.document !== "undefined") {
+  import("./release-0156-final-runtime.js");
+}
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";
 

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -19,7 +19,9 @@ import "./release-0155-public-runtime.js";
 import "./release-0156-period-runtime.js";
 
 if (typeof globalThis.document !== "undefined") {
-  import("./release-0156-final-runtime.js");
+  import("./release-0156-final-runtime.js").then(() =>
+    import("./release-0156-current-period-bootstrap.js"),
+  );
 }
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -17,6 +17,7 @@ import "./release-0154-temperature-live-state.js";
 import "./release-0155-energy-placeholder-fallback.js";
 import "./release-0155-public-runtime.js";
 import "./release-0156-webkit-stability.js";
+import "./release-0156-final-stability.js";
 import "./release-0156-current-period-lock.js";
 
 if (typeof globalThis.document !== "undefined") {

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -16,6 +16,7 @@ import "./release-0154-dom-stability.js";
 import "./release-0154-temperature-live-state.js";
 import "./release-0155-energy-placeholder-fallback.js";
 import "./release-0155-public-runtime.js";
+import "./release-0156-webkit-stability.js";
 import "./release-0156-current-period-lock.js";
 
 if (typeof globalThis.document !== "undefined") {

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -17,6 +17,7 @@ import "./release-0154-temperature-live-state.js";
 import "./release-0155-energy-placeholder-fallback.js";
 import "./release-0155-public-runtime.js";
 import "./release-0156-period-runtime.js";
+import "./release-0156-final-runtime.js";
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";
 

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -16,7 +16,6 @@ import "./release-0154-dom-stability.js";
 import "./release-0154-temperature-live-state.js";
 import "./release-0155-energy-placeholder-fallback.js";
 import "./release-0155-public-runtime.js";
-import "./release-0156-period-runtime.js";
 
 if (typeof globalThis.document !== "undefined") {
   import("./release-0156-final-runtime.js").then(() =>

--- a/custom_components/dashboardmodern/frontend/legacy/release-0156-current-period-bootstrap.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0156-current-period-bootstrap.js
@@ -1,6 +1,7 @@
 /* DashboardModern 0.14.16: bounded current-period hydration after the canonical store becomes ready. */
 const FINAL_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__";
 const BOOT_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_CURRENT_BOOTSTRAP__";
+const LEGACY_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_PERIOD_RUNTIME__";
 const CURRENT_SLOTS_0156 = Object.freeze([
   "dm.energy_consumo_casa_mese",
   "dm.energy_produzione_solare_mese",
@@ -9,6 +10,15 @@ const CURRENT_SLOTS_0156 = Object.freeze([
   "dm.energy_batteria_caricata_mese",
   "dm.energy_batteria_usata_mese",
 ]);
+
+function installCompatibilityMarker0156() {
+  globalThis[LEGACY_KEY_0156] ||= {
+    installed: true,
+    version: "0.14.16",
+    superseded: true,
+    owner: "release-0156-final-runtime",
+  };
+}
 
 function installEnergyAliases0156() {
   const store = globalThis.DashboardModernModules?.store;
@@ -68,6 +78,7 @@ function currentValuesReady0156() {
 }
 
 function state0156() {
+  installCompatibilityMarker0156();
   return (globalThis[BOOT_KEY_0156] ||= {
     installed: true,
     timer: 0,
@@ -107,6 +118,7 @@ function scheduleHydration0156(delay = 0) {
 
 function install0156() {
   const state = state0156();
+  installCompatibilityMarker0156();
   installEnergyAliases0156();
   state.attempts = 0;
   scheduleHydration0156(0);

--- a/custom_components/dashboardmodern/frontend/legacy/release-0156-current-period-bootstrap.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0156-current-period-bootstrap.js
@@ -10,6 +10,37 @@ const CURRENT_SLOTS_0156 = Object.freeze([
   "dm.energy_batteria_usata_mese",
 ]);
 
+function installEnergyAliases0156() {
+  const store = globalThis.DashboardModernModules?.store;
+  const current = store?.getSection;
+  if (typeof current !== "function") return false;
+  if (current.__dm0156EnergyAliases) return true;
+  const original = current.bind(store);
+
+  function getSectionWithEnergyAliases0156(section) {
+    const value = original(section);
+    if (section !== "energy" || !value || typeof value !== "object") return value;
+    const energy = value;
+    energy.house ||= {};
+    energy.solar ||= {};
+    energy.grid ||= {};
+    energy.battery ||= {};
+
+    energy.house.total_energy ||= energy.house.annual_energy || "";
+    energy.solar.total_energy ||= energy.solar.annual_energy || "";
+    energy.grid.total_import_energy ||= energy.grid.annual_import_energy || "";
+    energy.grid.total_export_energy ||= energy.grid.annual_export_energy || "";
+    energy.battery.total_charged_energy ||= energy.battery.annual_charged_energy || "";
+    energy.battery.total_discharged_energy ||= energy.battery.annual_discharged_energy || "";
+    return energy;
+  }
+
+  getSectionWithEnergyAliases0156.__dm0156EnergyAliases = true;
+  getSectionWithEnergyAliases0156.__dmPrevious = current;
+  store.getSection = getSectionWithEnergyAliases0156;
+  return true;
+}
+
 function registry0156() {
   try {
     if (typeof CD_PERIOD !== "undefined" && CD_PERIOD) return CD_PERIOD;
@@ -19,6 +50,7 @@ function registry0156() {
 
 function configuredEnergy0156() {
   try {
+    installEnergyAliases0156();
     const energy = globalThis.DashboardModernModules?.store?.getSection?.("energy");
     if (!energy || typeof energy !== "object") return false;
     return [energy.house, energy.solar, energy.grid, energy.battery].some(
@@ -49,6 +81,7 @@ async function hydrateCurrentPeriod0156() {
   if (state.running) return false;
   const runtime = globalThis[FINAL_KEY_0156];
   if (typeof runtime?.refreshCurrent !== "function") return false;
+  installEnergyAliases0156();
   state.running = true;
   try {
     await runtime.refreshCurrent();
@@ -74,6 +107,7 @@ function scheduleHydration0156(delay = 0) {
 
 function install0156() {
   const state = state0156();
+  installEnergyAliases0156();
   state.attempts = 0;
   scheduleHydration0156(0);
 }

--- a/custom_components/dashboardmodern/frontend/legacy/release-0156-current-period-bootstrap.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0156-current-period-bootstrap.js
@@ -58,6 +58,13 @@ function registry0156() {
   return (globalThis.CD_PERIOD ||= {});
 }
 
+function rawState0156(slot) {
+  try {
+    if (typeof _RAW_STATES !== "undefined" && _RAW_STATES?.[slot]) return _RAW_STATES[slot];
+  } catch (_error) {}
+  return globalThis._RAW_STATES?.[slot] || globalThis.STATES?.[slot] || null;
+}
+
 function configuredEnergy0156() {
   try {
     installEnergyAliases0156();
@@ -74,7 +81,15 @@ function configuredEnergy0156() {
 function currentValuesReady0156() {
   if (!configuredEnergy0156()) return false;
   const values = registry0156();
-  return CURRENT_SLOTS_0156.some((slot) => Number.isFinite(Number(values[slot])));
+  return CURRENT_SLOTS_0156.some((slot) => {
+    const state = rawState0156(slot);
+    return Boolean(
+      state?.attributes?.dashboardmodern_derived &&
+      state?.attributes?.dashboardmodern_source &&
+      Number.isFinite(Number(values[slot])) &&
+      Number.isFinite(Number(state.state)),
+    );
+  });
 }
 
 function state0156() {

--- a/custom_components/dashboardmodern/frontend/legacy/release-0156-current-period-bootstrap.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0156-current-period-bootstrap.js
@@ -1,0 +1,85 @@
+/* DashboardModern 0.14.16: bounded current-period hydration after the canonical store becomes ready. */
+const FINAL_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__";
+const BOOT_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_CURRENT_BOOTSTRAP__";
+const CURRENT_SLOTS_0156 = Object.freeze([
+  "dm.energy_consumo_casa_mese",
+  "dm.energy_produzione_solare_mese",
+  "dm.energy_rete_acquistata_mese",
+  "dm.energy_rete_venduta_mese",
+  "dm.energy_batteria_caricata_mese",
+  "dm.energy_batteria_usata_mese",
+]);
+
+function registry0156() {
+  try {
+    if (typeof CD_PERIOD !== "undefined" && CD_PERIOD) return CD_PERIOD;
+  } catch (_error) {}
+  return (globalThis.CD_PERIOD ||= {});
+}
+
+function configuredEnergy0156() {
+  try {
+    const energy = globalThis.DashboardModernModules?.store?.getSection?.("energy");
+    if (!energy || typeof energy !== "object") return false;
+    return [energy.house, energy.solar, energy.grid, energy.battery].some(
+      (group) => group && Object.values(group).some((value) => String(value || "").trim()),
+    );
+  } catch (_error) {
+    return false;
+  }
+}
+
+function currentValuesReady0156() {
+  if (!configuredEnergy0156()) return false;
+  const values = registry0156();
+  return CURRENT_SLOTS_0156.some((slot) => Number.isFinite(Number(values[slot])));
+}
+
+function state0156() {
+  return (globalThis[BOOT_KEY_0156] ||= {
+    installed: true,
+    timer: 0,
+    attempts: 0,
+    running: false,
+  });
+}
+
+async function hydrateCurrentPeriod0156() {
+  const state = state0156();
+  if (state.running) return false;
+  const runtime = globalThis[FINAL_KEY_0156];
+  if (typeof runtime?.refreshCurrent !== "function") return false;
+  state.running = true;
+  try {
+    await runtime.refreshCurrent();
+    return currentValuesReady0156();
+  } catch (error) {
+    console.warn("[DashboardModern] current monthly period bootstrap", error);
+    return false;
+  } finally {
+    state.running = false;
+  }
+}
+
+function scheduleHydration0156(delay = 0) {
+  const state = state0156();
+  globalThis.clearTimeout?.(state.timer);
+  state.timer = globalThis.setTimeout?.(async () => {
+    state.attempts += 1;
+    const ready = await hydrateCurrentPeriod0156();
+    if (!ready && state.attempts < 60) scheduleHydration0156(100);
+    else state.timer = 0;
+  }, delay);
+}
+
+function install0156() {
+  const state = state0156();
+  state.attempts = 0;
+  scheduleHydration0156(0);
+}
+
+if (typeof globalThis.document !== "undefined") {
+  install0156();
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", install0156);
+  globalThis.addEventListener?.("pageshow", install0156);
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0156-current-period-lock.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0156-current-period-lock.js
@@ -1,0 +1,247 @@
+/* DashboardModern 0.14.16: keep current monthly slots immutable while browsing history. */
+const LOCK_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_CURRENT_PERIOD_LOCK__";
+const CURRENT_SLOTS_0156 = Object.freeze([
+  "dm.energy_consumo_casa_mese",
+  "dm.energy_produzione_solare_mese",
+  "dm.energy_rete_acquistata_mese",
+  "dm.energy_rete_venduta_mese",
+  "dm.energy_batteria_caricata_mese",
+  "dm.energy_batteria_usata_mese",
+]);
+
+function lockState0156() {
+  const state = (globalThis[LOCK_KEY_0156] ||= {
+    installed: true,
+    historical: false,
+    snapshots: new Map(),
+    locked: new Set(),
+    timer: 0,
+    restoreTimer: 0,
+  });
+  if (!(state.snapshots instanceof Map)) state.snapshots = new Map();
+  if (!(state.locked instanceof Set)) state.locked = new Set();
+  return state;
+}
+
+function registry0156() {
+  try {
+    if (typeof CD_PERIOD !== "undefined" && CD_PERIOD) return CD_PERIOD;
+  } catch (_error) {}
+  return (globalThis.CD_PERIOD ||= {});
+}
+
+function rawState0156(slot) {
+  try {
+    if (typeof _RAW_STATES !== "undefined" && _RAW_STATES?.[slot]) return _RAW_STATES[slot];
+  } catch (_error) {}
+  return globalThis._RAW_STATES?.[slot] || globalThis.STATES?.[slot] || null;
+}
+
+function cloneState0156(state) {
+  return state
+    ? { ...state, attributes: { ...(state.attributes || {}) } }
+    : null;
+}
+
+function writeState0156(state) {
+  const id = String(state?.entity_id || "").trim();
+  if (!id) return;
+  const copy = cloneState0156(state);
+  try {
+    if (typeof _RAW_STATES !== "undefined" && _RAW_STATES) _RAW_STATES[id] = copy;
+  } catch (_error) {}
+  try {
+    globalThis._RAW_STATES ||= {};
+    globalThis._RAW_STATES[id] = copy;
+  } catch (_error) {}
+  try {
+    if (typeof STATES !== "undefined" && STATES) STATES[id] = copy;
+  } catch (_error) {}
+  try {
+    if (globalThis.STATES) globalThis.STATES[id] = copy;
+  } catch (_error) {}
+}
+
+function currentToken0156() {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function stateToken0156(state) {
+  const selected = String(state?.attributes?.dashboardmodern_selected || "").trim();
+  if (!selected) return "";
+  if (/^\d{4}-\d{2}/.test(selected)) return selected.slice(0, 7);
+  const timestamp = Date.parse(selected);
+  if (!Number.isFinite(timestamp)) return "";
+  const date = new Date(timestamp);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function isCurrentDerived0156(state) {
+  return Boolean(
+    state?.attributes?.dashboardmodern_derived &&
+      state?.attributes?.dashboardmodern_source &&
+      stateToken0156(state) === currentToken0156(),
+  );
+}
+
+function captureCurrent0156() {
+  const state = lockState0156();
+  let captured = false;
+  CURRENT_SLOTS_0156.forEach((slot) => {
+    const raw = rawState0156(slot);
+    const value = Number(raw?.state);
+    if (!isCurrentDerived0156(raw) || !Number.isFinite(value)) return;
+    state.snapshots.set(slot, cloneState0156(raw));
+    captured = true;
+  });
+  return captured;
+}
+
+function selectedHistorical0156() {
+  const now = new Date();
+  const month = Number(globalThis.document?.getElementById?.("ed-sel-month")?.value);
+  const year = Number(globalThis.document?.getElementById?.("ed-sel-year")?.value);
+  if (!Number.isInteger(month) || month < 1 || month > 12) return false;
+  if (!Number.isInteger(year) || year < 2000) return false;
+  return month !== now.getMonth() + 1 || year !== now.getFullYear();
+}
+
+function installSlotLock0156(slot) {
+  const state = lockState0156();
+  if (state.locked.has(slot) || !state.snapshots.has(slot)) return false;
+  const registry = registry0156();
+  let currentValue = Number(state.snapshots.get(slot)?.state);
+  if (!Number.isFinite(currentValue)) return false;
+
+  Object.defineProperty(registry, slot, {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return currentValue;
+    },
+    set(value) {
+      const parsed = Number(value);
+      if (lockState0156().historical) return;
+      if (Number.isFinite(parsed)) currentValue = parsed;
+    },
+  });
+  state.locked.add(slot);
+  return true;
+}
+
+function installLocks0156() {
+  captureCurrent0156();
+  CURRENT_SLOTS_0156.forEach(installSlotLock0156);
+  return lockState0156().locked.size > 0;
+}
+
+function restoreSnapshots0156() {
+  const state = lockState0156();
+  if (!state.historical) {
+    captureCurrent0156();
+    return false;
+  }
+  const registry = registry0156();
+  let restored = false;
+  state.snapshots.forEach((snapshot, slot) => {
+    const value = Number(snapshot?.state);
+    if (!Number.isFinite(value)) return;
+    if (!state.locked.has(slot)) installSlotLock0156(slot);
+    try {
+      registry[slot] = value;
+    } catch (_error) {}
+    writeState0156(snapshot);
+    restored = true;
+  });
+  return restored;
+}
+
+function scheduleRestore0156(delay = 0) {
+  const state = lockState0156();
+  globalThis.clearTimeout?.(state.restoreTimer);
+  state.restoreTimer = globalThis.setTimeout?.(restoreSnapshots0156, delay);
+}
+
+function wrapHistoricalWriter0156(name) {
+  const current = globalThis[name];
+  if (typeof current !== "function" || current.__dm0156CurrentPeriodLock) return false;
+
+  function currentPeriodLock0156(...args) {
+    const result = current.apply(this, args);
+    const finish = () => {
+      installLocks0156();
+      restoreSnapshots0156();
+    };
+    if (result && typeof result.finally === "function") return result.finally(finish);
+    globalThis.queueMicrotask?.(finish);
+    return result;
+  }
+
+  currentPeriodLock0156.__dm0156CurrentPeriodLock = true;
+  currentPeriodLock0156.__dmPrevious = current;
+  globalThis[name] = currentPeriodLock0156;
+  return true;
+}
+
+function installWrappers0156() {
+  wrapHistoricalWriter0156("renderEdDeviceList");
+  wrapHistoricalWriter0156("renderEnergyDashboard");
+  wrapHistoricalWriter0156("cdDeriveFromTotals");
+  wrapHistoricalWriter0156("cdRefreshPeriodDeltas");
+}
+
+function reinforce0156() {
+  installLocks0156();
+  installWrappers0156();
+  if (lockState0156().historical) restoreSnapshots0156();
+}
+
+function install0156() {
+  const state = lockState0156();
+  reinforce0156();
+  if (!state.eventsInstalled) {
+    state.eventsInstalled = true;
+    globalThis.document?.addEventListener?.(
+      "change",
+      (event) => {
+        if (!event.target?.matches?.("#ed-sel-month, #ed-sel-year")) return;
+        // Legacy listeners only schedule their async work. Capture synchronously
+        // before that work can replace the current-month states.
+        captureCurrent0156();
+        installLocks0156();
+        state.historical = selectedHistorical0156();
+        if (state.historical) {
+          restoreSnapshots0156();
+          scheduleRestore0156(0);
+          globalThis.setTimeout?.(restoreSnapshots0156, 120);
+          globalThis.setTimeout?.(restoreSnapshots0156, 500);
+        }
+      },
+      true,
+    );
+    globalThis.addEventListener?.("dashboardmodern:legacy-ready", reinforce0156);
+    globalThis.addEventListener?.("pageshow", reinforce0156);
+  }
+
+  globalThis.clearInterval?.(state.timer);
+  let attempts = 0;
+  state.timer = globalThis.setInterval?.(() => {
+    attempts += 1;
+    reinforce0156();
+    const coreReady =
+      state.snapshots.has("dm.energy_consumo_casa_mese") &&
+      state.snapshots.has("dm.energy_produzione_solare_mese");
+    const wrappersReady =
+      globalThis.renderEdDeviceList?.__dm0156CurrentPeriodLock &&
+      globalThis.renderEnergyDashboard?.__dm0156CurrentPeriodLock &&
+      globalThis.cdDeriveFromTotals?.__dm0156CurrentPeriodLock &&
+      globalThis.cdRefreshPeriodDeltas?.__dm0156CurrentPeriodLock;
+    if (attempts >= 80 || (coreReady && wrappersReady)) {
+      globalThis.clearInterval?.(state.timer);
+      state.timer = 0;
+    }
+  }, 100);
+}
+
+if (typeof globalThis.document !== "undefined") install0156();

--- a/custom_components/dashboardmodern/frontend/legacy/release-0156-final-runtime.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0156-final-runtime.js
@@ -1,0 +1,508 @@
+/* DashboardModern 0.14.16 final runtime: bridge-safe periods, historical Report and event-driven states. */
+const KEY = "__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__";
+const LEGACY_KEY = "__DASHBOARDMODERN_RELEASE_0156_PERIOD_RUNTIME__";
+const PUBLIC_KEY = "__DASHBOARDMODERN_RELEASE_0155_PUBLIC_RUNTIME__";
+const HOOK_KEY = "__DASHBOARDMODERN_ENERGY_REPORT_HOOKS__";
+const TIMEOUT = 12000;
+const SOURCES = Object.freeze([
+  ["cons", "dm.energy_consumo_casa_mese", "house", "total_energy", "monthly_energy"],
+  ["prelevato", "dm.energy_rete_acquistata_mese", "grid", "total_import_energy", "monthly_import_energy"],
+  ["immesso", "dm.energy_rete_venduta_mese", "grid", "total_export_energy", "monthly_export_energy"],
+  ["prod", "dm.energy_produzione_solare_mese", "solar", "total_energy", "monthly_energy"],
+  ["batCar", "dm.energy_batteria_caricata_mese", "battery", "total_charged_energy", "monthly_charged_energy"],
+  ["batScar", "dm.energy_batteria_usata_mese", "battery", "total_discharged_energy", "monthly_discharged_energy"],
+]);
+
+function rt() {
+  return (globalThis[KEY] ||= {
+    installed: false,
+    ready: false,
+    socket: null,
+    connection: null,
+    authenticated: false,
+    nextId: 156600,
+    pending: new Map(),
+    inflight: new Map(),
+    cache: new Map(),
+    subscription: 0,
+    reportGeneration: 0,
+    deviceGeneration: 0,
+    reportTimer: 0,
+    retryTimer: 0,
+    events: false,
+  });
+}
+const tr = (it, en) => document.documentElement.lang === "en" ? en : it;
+const resolveEntity = (id) => {
+  const original = String(id || "").trim();
+  try { return String(globalThis.resolveEntity?.(original) || original).trim(); }
+  catch (_error) { return original; }
+};
+function socketCtor() {
+  return typeof globalThis.__DASHBOARDMODERN_PRELUDE_WS__ === "function"
+    ? globalThis.__DASHBOARDMODERN_PRELUDE_WS__
+    : globalThis.WebSocket;
+}
+function bridgeReady() {
+  return typeof globalThis.__DASHBOARDMODERN_PRELUDE_WS__ === "function" ||
+    globalThis.__DASHBOARDMODERN_BRIDGED__ === true ||
+    globalThis.__DASHBOARDMODERN_LEGACY_READY__ === true ||
+    globalThis.__DASHBOARDMODERN_HOSTED__ !== true;
+}
+function token() {
+  const values = [
+    globalThis.DASHBOARDMODERN_AUTH_TOKEN,
+    globalThis.__DASHBOARDMODERN_REAL_TOKEN__,
+    globalThis.LONG_LIVED_TOKEN,
+    globalThis.HA_TOKEN,
+  ];
+  try {
+    const cfg = JSON.parse(localStorage.getItem("cd_connection") || "{}");
+    values.push(cfg.token, cfg.access_token);
+  } catch (_error) {}
+  return values.map((value) => String(value || "").trim()).find(Boolean) || "";
+}
+function rejectPending(error) {
+  const runtime = rt();
+  runtime.pending.forEach((pending) => {
+    clearTimeout(pending.timer);
+    pending.reject(error);
+  });
+  runtime.pending.clear();
+  runtime.inflight.clear();
+}
+function reset(error) {
+  const runtime = rt();
+  const socket = runtime.socket;
+  runtime.socket = null;
+  runtime.connection = null;
+  runtime.authenticated = false;
+  runtime.subscription = 0;
+  if (error) rejectPending(error);
+  try { if (socket?.readyState === 1) socket.close(); } catch (_error) {}
+}
+function syncLive() {
+  const live = globalThis[PUBLIC_KEY];
+  try { live?.syncTemperature?.(true); live?.syncAppliances?.(); } catch (_error) {}
+}
+function storeState(state) {
+  const id = String(state?.entity_id || "").trim();
+  if (!id) return false;
+  try { if (typeof _RAW_STATES !== "undefined") _RAW_STATES[id] = state; } catch (_error) {}
+  try { globalThis._RAW_STATES ||= {}; globalThis._RAW_STATES[id] = state; } catch (_error) {}
+  try { if (typeof STATES !== "undefined") STATES[id] = state; } catch (_error) {}
+  try { if (globalThis.STATES) globalThis.STATES[id] = state; } catch (_error) {}
+  return true;
+}
+function ingestStates(states) {
+  const list = Array.isArray(states) ? states : [];
+  list.forEach(storeState);
+  try { globalThis[PUBLIC_KEY]?.ingestStates?.(list); } catch (_error) {}
+  syncLive();
+  queueMicrotask(syncLive);
+}
+function ingestState(state) {
+  if (!storeState(state)) return;
+  try { globalThis[PUBLIC_KEY]?.ingestState?.(state); } catch (_error) {}
+  queueMicrotask(syncLive);
+}
+function onMessage(event, resolveConnection, rejectConnection) {
+  let message;
+  try { message = JSON.parse(event?.data || event); } catch (_error) { return; }
+  const runtime = rt();
+  if (message.type === "auth_required") {
+    const access = token();
+    if (!access) return rejectConnection(new Error(tr("Token HA assente", "HA token missing")));
+    runtime.socket?.send(JSON.stringify({ type: "auth", access_token: access }));
+    return;
+  }
+  if (message.type === "auth_ok") {
+    runtime.authenticated = true;
+    resolveConnection(runtime.socket);
+    return;
+  }
+  if (message.type === "auth_invalid") {
+    rejectConnection(new Error(message.message || tr("Autenticazione non valida", "Invalid authentication")));
+    return;
+  }
+  if (message.type === "event" && message.id === runtime.subscription) {
+    ingestState(message.event?.data?.new_state);
+    return;
+  }
+  if (message.type !== "result" || message.id == null) return;
+  const pending = runtime.pending.get(message.id);
+  if (!pending) return;
+  runtime.pending.delete(message.id);
+  clearTimeout(pending.timer);
+  if (message.success === false) pending.reject(new Error(message.error?.message || "HA request failed"));
+  else pending.resolve(message.result ?? null);
+}
+function connect() {
+  const runtime = rt();
+  if (runtime.authenticated && runtime.socket?.readyState === 1) return Promise.resolve(runtime.socket);
+  if (runtime.connection) return runtime.connection;
+  if (!bridgeReady()) return Promise.reject(new Error("bridge-not-ready"));
+  const Socket = socketCtor();
+  if (typeof Socket !== "function") return Promise.reject(new Error("websocket-unavailable"));
+  runtime.connection = new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn(value);
+    };
+    const timer = setTimeout(() => finish(reject, new Error("HA connection timeout")), TIMEOUT);
+    try {
+      const socket = new Socket(`${location.protocol === "https:" ? "wss:" : "ws:"}//${location.host}/api/websocket`);
+      runtime.socket = socket;
+      socket.onmessage = (event) => onMessage(event, (value) => finish(resolve, value), (error) => finish(reject, error));
+      socket.onerror = () => finish(reject, new Error("HA connection unavailable"));
+      socket.onclose = () => { if (runtime.socket === socket) reset(); };
+    } catch (error) { finish(reject, error); }
+  }).catch((error) => { reset(error); throw error; }).finally(() => { runtime.connection = null; });
+  return runtime.connection;
+}
+async function request(payload) {
+  const runtime = rt();
+  const socket = await connect();
+  const id = ++runtime.nextId;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      runtime.pending.delete(id);
+      reject(new Error("HA response timeout"));
+    }, TIMEOUT);
+    runtime.pending.set(id, { resolve, reject, timer });
+    try { socket.send(JSON.stringify({ id, ...payload })); }
+    catch (error) { clearTimeout(timer); runtime.pending.delete(id); reject(error); }
+  });
+}
+async function cached(payload, key, maxAge) {
+  const runtime = rt();
+  const hit = runtime.cache.get(key);
+  if (hit && Date.now() - hit.at < maxAge) return hit.value;
+  if (runtime.inflight.has(key)) return runtime.inflight.get(key);
+  const promise = request(payload).then((value) => {
+    runtime.cache.set(key, { at: Date.now(), value });
+    return value;
+  }).finally(() => runtime.inflight.delete(key));
+  runtime.inflight.set(key, promise);
+  return promise;
+}
+async function statistics(ids, start, end, period = "day") {
+  const originals = [...new Set(ids.map(String).filter(Boolean))];
+  const mapped = new Map(originals.map((id) => [id, resolveEntity(id)]));
+  const statisticIds = [...new Set([...mapped.values()].filter(Boolean))];
+  const startIso = new Date(start).toISOString();
+  const endIso = new Date(end).toISOString();
+  const old = Date.parse(endIso) < Date.now() - 86400000;
+  const key = `stats|${period}|${startIso}|${endIso}|${statisticIds.join(",")}`;
+  const result = await cached({
+    type: "recorder/statistics_during_period",
+    start_time: startIso,
+    end_time: endIso,
+    statistic_ids: statisticIds,
+    period,
+    units: { energy: "kWh" },
+  }, key, old ? 600000 : 20000);
+  return Object.fromEntries(originals.map((id) => [id, result?.[mapped.get(id)] || []]));
+}
+const rowTime = (row) => {
+  const raw = row?.start ?? row?.end ?? row?.last_updated ?? 0;
+  const value = typeof raw === "number" ? raw : Date.parse(raw);
+  return Number.isFinite(value) ? value : 0;
+};
+const cumulative = (row) => {
+  for (const key of ["sum", "state", "max"]) {
+    const value = Number(row?.[key]);
+    if (Number.isFinite(value)) return value;
+  }
+  return null;
+};
+function periodValue(rows, baseline) {
+  const ordered = (rows || []).filter(Boolean).slice().sort((a, b) => rowTime(a) - rowTime(b));
+  const changes = ordered.map((row) => Number(row?.change)).filter(Number.isFinite);
+  if (changes.length) return Math.max(0, changes.reduce((sum, value) => sum + value, 0));
+  const values = ordered.map(cumulative).filter((value) => value != null);
+  const base = cumulative(baseline);
+  if (base != null && values.length) values.unshift(base);
+  if (values.length < 2) return null;
+  return Math.max(0, values.slice(1).reduce((sum, value, index) => {
+    const delta = value - values[index];
+    return sum + (delta >= 0 ? delta : Math.max(0, value));
+  }, 0));
+}
+function range(month, year) {
+  const now = new Date();
+  const start = new Date(year, month - 1, 1);
+  const next = new Date(year, month, 1);
+  const end = next > now ? now : next;
+  const baselineStart = new Date(start);
+  baselineStart.setDate(baselineStart.getDate() - 2);
+  return { start, end, baselineStart };
+}
+async function monthValues(ids, month, year) {
+  const unique = [...new Set(ids.map(String).filter(Boolean))];
+  const dates = range(month, year);
+  if (!unique.length || dates.end <= dates.start) return new Map();
+  const rows = await statistics(unique, dates.start, dates.end, "day");
+  const missing = unique.filter((id) => periodValue(rows[id]) == null);
+  const baselines = missing.length
+    ? await statistics(missing, dates.baselineStart, dates.start, "day")
+    : {};
+  const values = new Map();
+  unique.forEach((id) => {
+    const baselineRows = (baselines[id] || []).slice().sort((a, b) => rowTime(a) - rowTime(b));
+    const value = periodValue(rows[id], baselineRows.at(-1));
+    if (value == null) return;
+    const rounded = Math.round(value * 1000) / 1000;
+    values.set(id, rounded);
+    values.set(resolveEntity(id), rounded);
+  });
+  return values;
+}
+function energySources() {
+  let energy = {};
+  try { energy = globalThis.DashboardModernModules?.store?.getSection?.("energy") || {}; }
+  catch (_error) {}
+  return SOURCES.map(([key, slot, group, total, explicit]) => {
+    const cfg = energy[group] || {};
+    return { key, slot, entity: String(cfg[total] || cfg[explicit] || "").trim() };
+  }).filter((source) => source.entity);
+}
+function registry() {
+  try { if (typeof CD_PERIOD !== "undefined") return CD_PERIOD; } catch (_error) {}
+  return (globalThis.CD_PERIOD ||= {});
+}
+function writeSlot(source, value, month, year) {
+  if (!Number.isFinite(value)) return;
+  const rounded = Math.round(Math.max(0, value) * 1000) / 1000;
+  registry()[source.slot] = rounded;
+  const stamp = new Date().toISOString();
+  storeState({
+    entity_id: source.slot,
+    state: String(rounded),
+    attributes: {
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "measurement",
+      dashboardmodern_derived: true,
+      dashboardmodern_source: source.entity,
+      dashboardmodern_selected: `${year}-${String(month).padStart(2, "0")}`,
+    },
+    last_changed: stamp,
+    last_updated: stamp,
+  });
+}
+async function refreshCurrent() {
+  const sources = energySources();
+  if (!sources.length) return false;
+  const now = new Date();
+  const values = await monthValues(sources.map((source) => source.entity), now.getMonth() + 1, now.getFullYear());
+  sources.forEach((source) => writeSlot(
+    source,
+    values.get(source.entity) ?? values.get(resolveEntity(source.entity)),
+    now.getMonth() + 1,
+    now.getFullYear(),
+  ));
+  try { globalThis.renderEnergy?.(); } catch (_error) {}
+  return true;
+}
+function reportPeriod() {
+  const now = new Date();
+  const month = Number(document.getElementById("ed-sel-month")?.value);
+  const year = Number(document.getElementById("ed-sel-year")?.value);
+  return {
+    month: Number.isInteger(month) && month >= 1 && month <= 12 ? month : now.getMonth() + 1,
+    year: Number.isInteger(year) && year >= 2000 ? year : now.getFullYear(),
+  };
+}
+async function refreshOverview() {
+  const runtime = rt();
+  const generation = ++runtime.reportGeneration;
+  const selected = reportPeriod();
+  const sources = energySources();
+  const values = await monthValues(sources.map((source) => source.entity), selected.month, selected.year);
+  if (generation !== runtime.reportGeneration) return false;
+  const data = Object.fromEntries(sources.map((source) => [source.key, values.get(source.entity) ?? values.get(resolveEntity(source.entity)) ?? 0]));
+  const prod = Number(data.prod) || 0;
+  const cons = Number(data.cons) || 0;
+  const grid = Number(data.prelevato) || 0;
+  const auto = cons > 0 ? Math.max(0, Math.min(100, Math.round(((cons - grid) / cons) * 100))) : 0;
+  const set = (id, html) => { const node = document.getElementById(id); if (node) node.innerHTML = html; };
+  set("ed-kpi-prod", `${prod.toFixed(1)} <small>kWh</small>`);
+  set("ed-kpi-cons", `${cons.toFixed(1)} <small>kWh</small>`);
+  set("ed-kpi-auto", `${auto} <small>%</small>`);
+  return true;
+}
+function devices() {
+  try {
+    const modules = globalThis.DashboardModernModules;
+    return modules.data.canonicalReportDevices(
+      modules.store.getSection("appliances") || [],
+      modules.store.getSection("loads") || [],
+      globalThis.STATES || {},
+    );
+  } catch (_error) { return []; }
+}
+function deepest(fn) {
+  const seen = new Set();
+  let current = fn;
+  while (typeof current?.__dmPrevious === "function" && !seen.has(current)) {
+    seen.add(current);
+    current = current.__dmPrevious;
+  }
+  return current;
+}
+function rowEntity(row, list) {
+  const direct = String(row.dataset.entity || row.dataset.sensor || "").trim();
+  if (direct) return direct;
+  const match = /apriStorico\s*\(\s*event\s*,\s*['\"]([^'\"]+)/.exec(row.getAttribute("onclick") || "");
+  if (match?.[1]) return match[1];
+  const name = String(row.querySelector(".ed-dev-name")?.childNodes?.[0]?.textContent || "").trim();
+  return String(list.find((item) => String(item.name || "").trim() === name)?.entity || "");
+}
+function patchRows(values) {
+  const listNode = document.getElementById("ed-device-list");
+  if (!listNode) return;
+  const list = devices();
+  let total = 0;
+  listNode.querySelectorAll(".ed-device-row").forEach((row) => {
+    const entity = rowEntity(row, list);
+    const value = values.get(entity) ?? values.get(resolveEntity(entity));
+    if (!Number.isFinite(value)) return;
+    total += value;
+    row.dataset.entity = entity;
+    row.dataset.dmPeriodValue = String(value);
+    const node = row.querySelector(".ed-dev-kwh");
+    if (node) node.innerHTML = `${value.toFixed(1)} <small style="font-size:10px">kWh</small>`;
+  });
+  const totalNode = document.getElementById("ed-dev-total");
+  if (totalNode) totalNode.textContent = `${total.toFixed(1)} kWh`;
+}
+function installReportWrapper() {
+  const current = globalThis.renderEdDeviceList;
+  if (typeof current !== "function" || current.__dm0156Final) return false;
+  const original = deepest(current);
+  async function renderHistorical(month, year, _isCurrent, ...rest) {
+    const runtime = rt();
+    const generation = ++runtime.deviceGeneration;
+    const list = devices();
+    const ids = [...new Set(list.map((item) => String(item.entity || "").trim()).filter(Boolean))];
+    let values = new Map();
+    try { values = await monthValues(ids, month, year); }
+    catch (error) { console.warn("[DashboardModern] historical device totals", error); }
+    if (generation !== runtime.deviceGeneration) return false;
+    values.forEach((value, entity) => { registry()[entity] = value; });
+    const previous = globalThis.getRawState;
+    if (typeof previous === "function") {
+      globalThis.getRawState = function (reference) {
+        const id = String(reference || "").trim();
+        const value = values.get(id) ?? values.get(resolveEntity(id));
+        return Number.isFinite(value) ? String(value) : previous.apply(this, arguments);
+      };
+    }
+    try {
+      const result = await original.call(this, month, year, true, ...rest);
+      patchRows(values);
+      return result;
+    } finally {
+      if (typeof previous === "function") globalThis.getRawState = previous;
+    }
+  }
+  renderHistorical.__dm0156Final = true;
+  renderHistorical.__dm0156HistoricalPeriods = true;
+  renderHistorical.__dmPrevious = original;
+  globalThis.renderEdDeviceList = renderHistorical;
+  return true;
+}
+function stopLoops() {
+  const live = globalThis[PUBLIC_KEY];
+  if (live) {
+    live.eventDrivenBy0156 = true;
+    if (live.sampleTimer) clearInterval(live.sampleTimer);
+    live.sampleTimer = 0;
+  }
+  const hooks = globalThis[HOOK_KEY];
+  if (hooks) {
+    hooks.observer?.disconnect?.();
+    hooks.safeObserver?.disconnect?.();
+    clearTimeout(hooks.timer);
+    clearTimeout(hooks.safeTimer);
+    hooks.disabledBy0156 = true;
+    hooks.refreshing = true;
+  }
+}
+async function startStates() {
+  const states = await cached({ type: "get_states" }, "states", 5000);
+  ingestStates(states);
+  const runtime = rt();
+  if (runtime.subscription) return true;
+  const socket = await connect();
+  const id = ++runtime.nextId;
+  runtime.subscription = id;
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("state subscription timeout")), TIMEOUT);
+    runtime.pending.set(id, {
+      timer,
+      resolve: (value) => { clearTimeout(timer); resolve(value); },
+      reject: (error) => { clearTimeout(timer); reject(error); },
+    });
+    socket.send(JSON.stringify({ id, type: "subscribe_events", event_type: "state_changed" }));
+  });
+  return true;
+}
+function scheduleOverview(delay = 20) {
+  const runtime = rt();
+  clearTimeout(runtime.reportTimer);
+  runtime.reportTimer = setTimeout(() => refreshOverview().catch((error) => console.warn("[DashboardModern] Report period", error)), delay);
+}
+async function bootstrap() {
+  if (!bridgeReady()) return false;
+  stopLoops();
+  installReportWrapper();
+  const results = await Promise.allSettled([startStates(), refreshCurrent()]);
+  const runtime = rt();
+  runtime.ready = results.some((result) => result.status === "fulfilled");
+  runtime.installed = true;
+  scheduleOverview(0);
+  return runtime.ready;
+}
+function install() {
+  const runtime = rt();
+  stopLoops();
+  installReportWrapper();
+  globalThis.fetchHAStatistics = Object.assign(statistics, { __dm0156SharedBroker: true });
+  runtime.statistics = statistics;
+  runtime.monthValues = monthValues;
+  runtime.refreshCurrent = refreshCurrent;
+  runtime.refreshOverview = refreshOverview;
+  if (!runtime.events) {
+    runtime.events = true;
+    document.addEventListener("change", (event) => {
+      if (!event.target?.matches?.("#ed-sel-month, #ed-sel-year")) return;
+      runtime.reportGeneration += 1;
+      runtime.deviceGeneration += 1;
+      scheduleOverview();
+    }, true);
+    const reactivate = () => { stopLoops(); installReportWrapper(); bootstrap(); };
+    addEventListener("dashboardmodern:legacy-ready", reactivate);
+    addEventListener("pageshow", reactivate);
+  }
+  bootstrap();
+  clearInterval(runtime.retryTimer);
+  let attempts = 0;
+  runtime.retryTimer = setInterval(() => {
+    attempts += 1;
+    stopLoops();
+    installReportWrapper();
+    if (!runtime.ready && bridgeReady()) bootstrap();
+    if (attempts >= 40 || runtime.ready) {
+      clearInterval(runtime.retryTimer);
+      runtime.retryTimer = 0;
+    }
+  }, 100);
+}
+
+if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", install, { once: true });
+else install();

--- a/custom_components/dashboardmodern/frontend/legacy/release-0156-final-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0156-final-stability.js
@@ -1,15 +1,12 @@
-/* DashboardModern 0.14.16: final live-state and shared-transport stability owner. */
+/* DashboardModern 0.14.16: final live-state and reconnect stability owner. */
 const PUBLIC_KEY_0156_FINAL = "__DASHBOARDMODERN_RELEASE_0155_PUBLIC_RUNTIME__";
 const BROKER_KEY_0156_FINAL = "__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__";
-const OLD_STABILITY_KEY_0156_FINAL = "__DASHBOARDMODERN_RELEASE_0156_WEBKIT_STABILITY__";
 const FINAL_STABILITY_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_FINAL_STABILITY__";
 
 function finalStabilityState0156() {
   return (globalThis[FINAL_STABILITY_KEY_0156] ||= {
     installed: true,
     timer: 0,
-    originalWebSocket: null,
-    guardedWebSocket: null,
   });
 }
 
@@ -133,6 +130,10 @@ function installLiveStateOwner0156() {
   const runtime = globalThis[PUBLIC_KEY_0156_FINAL];
   if (!runtime) return false;
   if (!runtime.__dm0156FinalStateOwner) {
+    if (runtime.states instanceof Map) {
+      runtime.states.forEach(mirrorLegacyState0156);
+    }
+
     const previousSync = typeof runtime.syncTemperature === "function"
       ? runtime.syncTemperature.bind(runtime)
       : null;
@@ -140,7 +141,7 @@ function installLiveStateOwner0156() {
       let result = false;
       try { result = previousSync ? previousSync(force) : false; } catch (_error) {}
       scheduleTemperatureSync0156Final();
-      return result || true;
+      return result;
     };
 
     const previousIngestState = typeof runtime.ingestState === "function"
@@ -236,6 +237,11 @@ function createSharedFacade0156() {
   socket.send = (raw) => {
     let message;
     try { message = JSON.parse(raw); } catch (_error) { return; }
+    const broker = globalThis[BROKER_KEY_0156_FINAL];
+    if (message.type === "call_service" && broker?.socket?.readyState === 1) {
+      try { broker.socket.send(raw); } catch (_error) {}
+      return;
+    }
     if (message.type === "auth") {
       emit({ type: "auth_ok" });
       return;
@@ -252,87 +258,64 @@ function createSharedFacade0156() {
       emit({ id: message.id, type: "result", success: true, result: { value: null } });
       return;
     }
-    if (message.type === "recorder/statistics_during_period") {
-      const broker = globalThis[BROKER_KEY_0156_FINAL];
-      const statistics = broker?.statistics;
-      if (typeof statistics === "function") {
-        Promise.resolve(
-          statistics(
-            message.statistic_ids || [],
-            new Date(message.start_time),
-            new Date(message.end_time),
-            message.period || "day",
-          ),
-        ).then(
-          (result) => emit({ id: message.id, type: "result", success: true, result }),
-          (error) => emit({
-            id: message.id,
-            type: "result",
-            success: false,
-            error: { message: String(error?.message || error) },
-          }),
-        );
-        return;
-      }
-    }
     emit({ id: message.id, type: "result", success: true, result: [] });
   };
 
-  globalThis.setTimeout?.(() => emit({ type: "auth_required" }), 0);
   return socket;
 }
 
-function originalWebSocket0156Final() {
-  const state = finalStabilityState0156();
-  if (typeof state.originalWebSocket === "function") return state.originalWebSocket;
-  const previous = globalThis[OLD_STABILITY_KEY_0156_FINAL];
-  const candidate = previous?.originalWebSocket ||
-    globalThis.__DASHBOARDMODERN_PRELUDE_WS__ ||
-    globalThis.WebSocket;
-  if (typeof candidate === "function") state.originalWebSocket = candidate;
-  return state.originalWebSocket;
+function assignLegacySocket0156(socket) {
+  let assigned = false;
+  try {
+    if (typeof ws !== "undefined") {
+      ws = socket;
+      assigned = true;
+    }
+  } catch (_error) {}
+  if (Object.prototype.hasOwnProperty.call(globalThis, "ws")) {
+    try {
+      globalThis.ws = socket;
+      assigned = true;
+    } catch (_error) {}
+  }
+  return assigned;
 }
 
-function installTransportOwner0156() {
-  const state = finalStabilityState0156();
-  const original = originalWebSocket0156Final();
-  if (typeof original !== "function") return false;
+function markConnected0156() {
+  const text = globalThis.document?.getElementById?.("conn-text");
+  if (text) text.textContent = "Connesso";
+  globalThis.document?.getElementById?.("live-dot")?.classList?.add?.("connected");
+}
 
-  const previous = globalThis[OLD_STABILITY_KEY_0156_FINAL];
-  if (previous) {
-    globalThis.clearTimeout?.(previous.restoreTimer);
-    globalThis.clearInterval?.(previous.wrapperTimer);
-    previous.restoreTimer = 0;
-    previous.wrapperTimer = 0;
-    previous.armed = false;
+function installReconnectOwner0156() {
+  const current = globalThis.connect;
+  if (typeof current !== "function" || current.__dm0156SharedReconnectOwner) {
+    return Boolean(current?.__dm0156SharedReconnectOwner);
   }
 
-  if (!state.guardedWebSocket) {
-    function SharedRuntimeWebSocket0156(...args) {
-      const broker = globalThis[BROKER_KEY_0156_FINAL];
-      const canReuse = Boolean(
-        broker?.socket?.readyState === 1 &&
-        (broker.ready || broker.installed),
-      );
-      if (canReuse) return createSharedFacade0156();
-      return Reflect.construct(original, args, new.target || original);
-    }
-    SharedRuntimeWebSocket0156.prototype = original.prototype || Object.prototype;
-    ["CONNECTING", "OPEN", "CLOSING", "CLOSED"].forEach((key, index) => {
-      SharedRuntimeWebSocket0156[key] = original[key] ?? index;
-    });
-    state.guardedWebSocket = SharedRuntimeWebSocket0156;
+  async function sharedReconnectOwner0156(...args) {
+    const broker = globalThis[BROKER_KEY_0156_FINAL];
+    const live = globalThis[PUBLIC_KEY_0156_FINAL];
+    const canReuse = Boolean(
+      broker?.socket?.readyState === 1 ||
+      live?.states?.size,
+    );
+    if (!canReuse) return current.apply(this, args);
+    const facade = createSharedFacade0156();
+    assignLegacySocket0156(facade);
+    markConnected0156();
+    return true;
   }
 
-  if (globalThis.WebSocket !== state.guardedWebSocket) {
-    globalThis.WebSocket = state.guardedWebSocket;
-  }
+  sharedReconnectOwner0156.__dm0156SharedReconnectOwner = true;
+  sharedReconnectOwner0156.__dmPrevious = current;
+  globalThis.connect = sharedReconnectOwner0156;
   return true;
 }
 
 function reinforceFinalStability0156() {
   installLiveStateOwner0156();
-  installTransportOwner0156();
+  installReconnectOwner0156();
   scheduleTemperatureSync0156Final();
 }
 
@@ -355,8 +338,7 @@ function installFinalStability0156() {
     reinforceFinalStability0156();
     if (attempts >= 80 || (
       globalThis[PUBLIC_KEY_0156_FINAL]?.__dm0156FinalStateOwner &&
-      globalThis.WebSocket === state.guardedWebSocket &&
-      globalThis[BROKER_KEY_0156_FINAL]?.ready
+      globalThis.connect?.__dm0156SharedReconnectOwner
     )) {
       globalThis.clearInterval?.(state.timer);
       state.timer = 0;

--- a/custom_components/dashboardmodern/frontend/legacy/release-0156-final-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0156-final-stability.js
@@ -1,0 +1,367 @@
+/* DashboardModern 0.14.16: final live-state and shared-transport stability owner. */
+const PUBLIC_KEY_0156_FINAL = "__DASHBOARDMODERN_RELEASE_0155_PUBLIC_RUNTIME__";
+const BROKER_KEY_0156_FINAL = "__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__";
+const OLD_STABILITY_KEY_0156_FINAL = "__DASHBOARDMODERN_RELEASE_0156_WEBKIT_STABILITY__";
+const FINAL_STABILITY_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_FINAL_STABILITY__";
+
+function finalStabilityState0156() {
+  return (globalThis[FINAL_STABILITY_KEY_0156] ||= {
+    installed: true,
+    timer: 0,
+    originalWebSocket: null,
+    guardedWebSocket: null,
+  });
+}
+
+function legacyState0156(entity) {
+  const id = String(entity || "").trim();
+  if (!id) return null;
+  try {
+    if (typeof _RAW_STATES !== "undefined" && _RAW_STATES?.[id]) return _RAW_STATES[id];
+  } catch (_error) {}
+  return globalThis._RAW_STATES?.[id] || globalThis.STATES?.[id] || null;
+}
+
+function usableLegacyState0156(state) {
+  const value = String(state?.state ?? "").trim().toLowerCase();
+  return Boolean(value && !["unknown", "unavailable", "none", "null", "—", "-"].includes(value));
+}
+
+function preferredState0156(entity) {
+  const id = String(entity || "").trim();
+  const legacy = legacyState0156(id);
+  if (usableLegacyState0156(legacy)) return legacy;
+  const runtime = globalThis[PUBLIC_KEY_0156_FINAL];
+  return runtime?.states instanceof Map ? runtime.states.get(id) || legacy : legacy;
+}
+
+function mirrorLegacyState0156(state) {
+  const id = String(state?.entity_id || "").trim();
+  if (!id) return false;
+  const mirrored = {
+    ...state,
+    entity_id: id,
+    attributes: { ...(state.attributes || {}) },
+  };
+  let written = false;
+  try {
+    if (typeof _RAW_STATES !== "undefined" && _RAW_STATES) {
+      _RAW_STATES[id] = mirrored;
+      written = true;
+    }
+  } catch (_error) {}
+  try {
+    if (typeof STATES !== "undefined" && STATES) {
+      STATES[id] = mirrored;
+      written = true;
+    }
+  } catch (_error) {}
+  if (globalThis._RAW_STATES && typeof globalThis._RAW_STATES === "object") {
+    globalThis._RAW_STATES[id] = mirrored;
+    written = true;
+  }
+  if (globalThis.STATES && typeof globalThis.STATES === "object") {
+    globalThis.STATES[id] = mirrored;
+    written = true;
+  }
+  return written;
+}
+
+function configuredRooms0156Final() {
+  try {
+    const rooms = globalThis.DashboardModernModules?.store?.getSection?.("rooms");
+    if (Array.isArray(rooms)) return rooms;
+  } catch (_error) {}
+  try {
+    const rooms = globalThis.getStanze?.();
+    if (Array.isArray(rooms)) return rooms;
+  } catch (_error) {}
+  return [];
+}
+
+function entityDomId0156Final(entity) {
+  return String(entity || "").replaceAll(".", "_").replaceAll("-", "_");
+}
+
+function syncTemperature0156Final() {
+  const doc = globalThis.document;
+  if (!doc) return false;
+  let changed = false;
+  const setText = (id, value) => {
+    const node = doc.getElementById(id);
+    if (!node || node.textContent === value) return;
+    node.textContent = value;
+    changed = true;
+  };
+
+  configuredRooms0156Final().forEach((room) => {
+    const tempEntity = String(room?.temp || "").trim();
+    if (!tempEntity) return;
+    const humidityEntity = String(
+      room?.hum || tempEntity.replace("_temperature", "_humidity"),
+    ).trim();
+    const temperature = Number.parseFloat(preferredState0156(tempEntity)?.state);
+    const humidity = Number.parseFloat(preferredState0156(humidityEntity)?.state);
+    const tempText = Number.isFinite(temperature) ? temperature.toFixed(1) : "—";
+    const humidityText = Number.isFinite(humidity) ? humidity.toFixed(0) : "—";
+    const tempId = entityDomId0156Final(tempEntity);
+    const humidityId = entityDomId0156Final(humidityEntity);
+
+    setText(`tv_${tempId}`, tempText);
+    setText(`tbl_${tempId}`, `${tempText}°`);
+    setText(`hbl_${humidityId}`, `${humidityText}%`);
+    const humidityNode = doc.getElementById(`hv_${humidityId}`);
+    if (humidityNode) {
+      const html = `${humidityText}<span style="font-size:14px;opacity:0.75;">%</span>`;
+      if (humidityNode.innerHTML !== html) {
+        humidityNode.innerHTML = html;
+        changed = true;
+      }
+    }
+  });
+  return changed;
+}
+
+function scheduleTemperatureSync0156Final() {
+  syncTemperature0156Final();
+  globalThis.queueMicrotask?.(syncTemperature0156Final);
+  globalThis.setTimeout?.(syncTemperature0156Final, 0);
+  globalThis.setTimeout?.(syncTemperature0156Final, 60);
+}
+
+function installLiveStateOwner0156() {
+  const runtime = globalThis[PUBLIC_KEY_0156_FINAL];
+  if (!runtime) return false;
+  if (!runtime.__dm0156FinalStateOwner) {
+    const previousSync = typeof runtime.syncTemperature === "function"
+      ? runtime.syncTemperature.bind(runtime)
+      : null;
+    runtime.syncTemperature = function syncTemperatureOwner0156(force = true) {
+      let result = false;
+      try { result = previousSync ? previousSync(force) : false; } catch (_error) {}
+      scheduleTemperatureSync0156Final();
+      return result || true;
+    };
+
+    const previousIngestState = typeof runtime.ingestState === "function"
+      ? runtime.ingestState.bind(runtime)
+      : null;
+    if (previousIngestState) {
+      runtime.ingestState = function ingestStateOwner0156(state) {
+        const result = previousIngestState(state);
+        mirrorLegacyState0156(state);
+        scheduleTemperatureSync0156Final();
+        return result;
+      };
+    }
+
+    const previousIngestStates = typeof runtime.ingestStates === "function"
+      ? runtime.ingestStates.bind(runtime)
+      : null;
+    if (previousIngestStates) {
+      runtime.ingestStates = function ingestStatesOwner0156(states) {
+        const result = previousIngestStates(states);
+        (Array.isArray(states) ? states : []).forEach(mirrorLegacyState0156);
+        scheduleTemperatureSync0156Final();
+        return result;
+      };
+    }
+    runtime.__dm0156FinalStateOwner = true;
+  }
+
+  const currentRender = globalThis.renderTemperature;
+  if (typeof currentRender === "function" && !currentRender.__dm0156FinalStateOwner) {
+    function renderTemperatureOwner0156(...args) {
+      const result = currentRender.apply(this, args);
+      scheduleTemperatureSync0156Final();
+      return result;
+    }
+    renderTemperatureOwner0156.__dm0156FinalStateOwner = true;
+    renderTemperatureOwner0156.__dmPrevious = currentRender;
+    globalThis.renderTemperature = renderTemperatureOwner0156;
+  }
+  return true;
+}
+
+function rememberedStates0156Final() {
+  const runtime = globalThis[PUBLIC_KEY_0156_FINAL];
+  if (runtime?.states instanceof Map && runtime.states.size) return [...runtime.states.values()];
+  try {
+    if (typeof _RAW_STATES !== "undefined" && _RAW_STATES) return Object.values(_RAW_STATES);
+  } catch (_error) {}
+  return Object.values(globalThis._RAW_STATES || globalThis.STATES || {});
+}
+
+function messageEvent0156Final(message) {
+  const data = JSON.stringify(message);
+  try { return new MessageEvent("message", { data }); }
+  catch (_error) { return { type: "message", data }; }
+}
+
+function createSharedFacade0156() {
+  const listeners = new Map();
+  const socket = {
+    readyState: 1,
+    url: "dashboardmodern://shared-runtime",
+    protocol: "",
+    extensions: "",
+    bufferedAmount: 0,
+    binaryType: "blob",
+    onopen: null,
+    onmessage: null,
+    onerror: null,
+    onclose: null,
+    addEventListener(type, handler) {
+      if (typeof handler !== "function") return;
+      const bucket = listeners.get(type) || new Set();
+      bucket.add(handler);
+      listeners.set(type, bucket);
+    },
+    removeEventListener(type, handler) {
+      listeners.get(type)?.delete(handler);
+    },
+    close() {},
+  };
+
+  const emit = (message) => {
+    const event = messageEvent0156Final(message);
+    globalThis.setTimeout?.(() => {
+      try { socket.onmessage?.(event); } catch (_error) {}
+      listeners.get("message")?.forEach((handler) => {
+        try { handler.call(socket, event); } catch (_error) {}
+      });
+    }, 0);
+  };
+
+  socket.send = (raw) => {
+    let message;
+    try { message = JSON.parse(raw); } catch (_error) { return; }
+    if (message.type === "auth") {
+      emit({ type: "auth_ok" });
+      return;
+    }
+    if (message.type === "get_states") {
+      emit({ id: message.id, type: "result", success: true, result: rememberedStates0156Final() });
+      return;
+    }
+    if (message.type === "subscribe_events") {
+      emit({ id: message.id, type: "result", success: true, result: null });
+      return;
+    }
+    if (message.type === "frontend/get_user_data") {
+      emit({ id: message.id, type: "result", success: true, result: { value: null } });
+      return;
+    }
+    if (message.type === "recorder/statistics_during_period") {
+      const broker = globalThis[BROKER_KEY_0156_FINAL];
+      const statistics = broker?.statistics;
+      if (typeof statistics === "function") {
+        Promise.resolve(
+          statistics(
+            message.statistic_ids || [],
+            new Date(message.start_time),
+            new Date(message.end_time),
+            message.period || "day",
+          ),
+        ).then(
+          (result) => emit({ id: message.id, type: "result", success: true, result }),
+          (error) => emit({
+            id: message.id,
+            type: "result",
+            success: false,
+            error: { message: String(error?.message || error) },
+          }),
+        );
+        return;
+      }
+    }
+    emit({ id: message.id, type: "result", success: true, result: [] });
+  };
+
+  globalThis.setTimeout?.(() => emit({ type: "auth_required" }), 0);
+  return socket;
+}
+
+function originalWebSocket0156Final() {
+  const state = finalStabilityState0156();
+  if (typeof state.originalWebSocket === "function") return state.originalWebSocket;
+  const previous = globalThis[OLD_STABILITY_KEY_0156_FINAL];
+  const candidate = previous?.originalWebSocket ||
+    globalThis.__DASHBOARDMODERN_PRELUDE_WS__ ||
+    globalThis.WebSocket;
+  if (typeof candidate === "function") state.originalWebSocket = candidate;
+  return state.originalWebSocket;
+}
+
+function installTransportOwner0156() {
+  const state = finalStabilityState0156();
+  const original = originalWebSocket0156Final();
+  if (typeof original !== "function") return false;
+
+  const previous = globalThis[OLD_STABILITY_KEY_0156_FINAL];
+  if (previous) {
+    globalThis.clearTimeout?.(previous.restoreTimer);
+    globalThis.clearInterval?.(previous.wrapperTimer);
+    previous.restoreTimer = 0;
+    previous.wrapperTimer = 0;
+    previous.armed = false;
+  }
+
+  if (!state.guardedWebSocket) {
+    function SharedRuntimeWebSocket0156(...args) {
+      const broker = globalThis[BROKER_KEY_0156_FINAL];
+      const canReuse = Boolean(
+        broker?.socket?.readyState === 1 &&
+        (broker.ready || broker.installed),
+      );
+      if (canReuse) return createSharedFacade0156();
+      return Reflect.construct(original, args, new.target || original);
+    }
+    SharedRuntimeWebSocket0156.prototype = original.prototype || Object.prototype;
+    ["CONNECTING", "OPEN", "CLOSING", "CLOSED"].forEach((key, index) => {
+      SharedRuntimeWebSocket0156[key] = original[key] ?? index;
+    });
+    state.guardedWebSocket = SharedRuntimeWebSocket0156;
+  }
+
+  if (globalThis.WebSocket !== state.guardedWebSocket) {
+    globalThis.WebSocket = state.guardedWebSocket;
+  }
+  return true;
+}
+
+function reinforceFinalStability0156() {
+  installLiveStateOwner0156();
+  installTransportOwner0156();
+  scheduleTemperatureSync0156Final();
+}
+
+function installFinalStability0156() {
+  reinforceFinalStability0156();
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", () => {
+    globalThis.setTimeout?.(reinforceFinalStability0156, 0);
+    globalThis.setTimeout?.(reinforceFinalStability0156, 80);
+  });
+  globalThis.addEventListener?.("pageshow", () => {
+    globalThis.setTimeout?.(reinforceFinalStability0156, 0);
+    globalThis.setTimeout?.(reinforceFinalStability0156, 80);
+  });
+
+  const state = finalStabilityState0156();
+  globalThis.clearInterval?.(state.timer);
+  let attempts = 0;
+  state.timer = globalThis.setInterval?.(() => {
+    attempts += 1;
+    reinforceFinalStability0156();
+    if (attempts >= 80 || (
+      globalThis[PUBLIC_KEY_0156_FINAL]?.__dm0156FinalStateOwner &&
+      globalThis.WebSocket === state.guardedWebSocket &&
+      globalThis[BROKER_KEY_0156_FINAL]?.ready
+    )) {
+      globalThis.clearInterval?.(state.timer);
+      state.timer = 0;
+    }
+  }, 100);
+}
+
+if (typeof globalThis.document !== "undefined") installFinalStability0156();

--- a/custom_components/dashboardmodern/frontend/legacy/release-0156-owner-guard.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0156-owner-guard.js
@@ -124,9 +124,6 @@ function monthRange0156(month, year) {
   const now = new Date();
   const start = new Date(year, month - 1, 1);
   const next = new Date(year, month, 1);
-  // Recorder's end is exclusive. For a closed historical month use the last
-  // millisecond before the next month, leaving an exact first-of-month end only
-  // for the baseline request. This prevents the two requests being conflated.
   const end = next > now ? now : new Date(next.getTime() - 1);
   const baselineStart = new Date(start);
   baselineStart.setDate(baselineStart.getDate() - 2);
@@ -221,10 +218,12 @@ async function refreshOverview0156() {
       ]),
     );
     patchOverview0156(data);
+    restoreCurrentSlots0156();
     globalThis.__DASHBOARDMODERN_REPORT_PERIOD__ = { ...selected, values: data };
     return true;
   } catch (error) {
     console.warn("[DashboardModern] final Report-period owner", error);
+    restoreCurrentSlots0156();
     return false;
   }
 }
@@ -285,16 +284,19 @@ function wrapDeviceRenderer0156() {
   async function ownerDeviceRenderer0156(month, year, ...rest) {
     const state = ownerState0156();
     const generation = ++state.deviceGeneration;
-    const result = await current.call(this, month, year, ...rest);
-    const devices = canonicalDevices0156();
-    const ids = [...new Set(devices.map((device) => String(device.entity || "").trim()).filter(Boolean))];
     try {
+      const result = await current.call(this, month, year, ...rest);
+      const devices = canonicalDevices0156();
+      const ids = [...new Set(devices.map((device) => String(device.entity || "").trim()).filter(Boolean))];
       const values = await monthValues0156(ids, month, year);
       if (generation === state.deviceGeneration) patchDeviceRows0156(values);
+      return result;
     } catch (error) {
       console.warn("[DashboardModern] final historical device owner", error);
+      return false;
+    } finally {
+      restoreCurrentSlots0156();
     }
-    return result;
   }
 
   ownerDeviceRenderer0156.__dm0156OwnerGuardDevices = true;
@@ -368,6 +370,7 @@ function install0156() {
         if (!event.target?.matches?.("#ed-sel-month, #ed-sel-year")) return;
         state.overviewGeneration += 1;
         state.deviceGeneration += 1;
+        restoreCurrentSlots0156();
         scheduleOverview0156(10);
         globalThis.setTimeout?.(() => scheduleOverview0156(0), 160);
         globalThis.setTimeout?.(() => scheduleOverview0156(0), 500);

--- a/custom_components/dashboardmodern/frontend/legacy/release-0156-owner-guard.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0156-owner-guard.js
@@ -1,0 +1,188 @@
+/* DashboardModern 0.14.16: protect the final period owner from late legacy writes. */
+const FINAL_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__";
+const OWNER_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_OWNER_GUARD__";
+const CURRENT_SLOTS_0156 = Object.freeze([
+  "dm.energy_consumo_casa_mese",
+  "dm.energy_produzione_solare_mese",
+  "dm.energy_rete_acquistata_mese",
+  "dm.energy_rete_venduta_mese",
+  "dm.energy_batteria_caricata_mese",
+  "dm.energy_batteria_usata_mese",
+]);
+
+function ownerState0156() {
+  return (globalThis[OWNER_KEY_0156] ||= {
+    installed: true,
+    timer: 0,
+    overviewTimer: 0,
+    refreshingCurrent: false,
+    refreshingOverview: false,
+  });
+}
+
+function registry0156() {
+  try {
+    if (typeof CD_PERIOD !== "undefined" && CD_PERIOD) return CD_PERIOD;
+  } catch (_error) {}
+  return (globalThis.CD_PERIOD ||= {});
+}
+
+function rawState0156(slot) {
+  try {
+    if (typeof _RAW_STATES !== "undefined" && _RAW_STATES?.[slot]) return _RAW_STATES[slot];
+  } catch (_error) {}
+  return globalThis._RAW_STATES?.[slot] || globalThis.STATES?.[slot] || null;
+}
+
+function restoreCurrentSlots0156() {
+  const values = registry0156();
+  let restored = false;
+  CURRENT_SLOTS_0156.forEach((slot) => {
+    const state = rawState0156(slot);
+    if (!state?.attributes?.dashboardmodern_derived || !state?.attributes?.dashboardmodern_source) return;
+    const value = Number(state.state);
+    if (!Number.isFinite(value)) return;
+    if (Number(values[slot]) !== value) values[slot] = value;
+    restored = true;
+  });
+  return restored;
+}
+
+async function refreshCurrent0156() {
+  const state = ownerState0156();
+  const runtime = globalThis[FINAL_KEY_0156];
+  if (state.refreshingCurrent || typeof runtime?.refreshCurrent !== "function") {
+    return restoreCurrentSlots0156();
+  }
+  state.refreshingCurrent = true;
+  try {
+    await runtime.refreshCurrent();
+    return restoreCurrentSlots0156();
+  } catch (error) {
+    console.warn("[DashboardModern] final current-period owner", error);
+    return false;
+  } finally {
+    state.refreshingCurrent = false;
+  }
+}
+
+async function refreshOverview0156() {
+  const state = ownerState0156();
+  const runtime = globalThis[FINAL_KEY_0156];
+  if (state.refreshingOverview || typeof runtime?.refreshOverview !== "function") return false;
+  state.refreshingOverview = true;
+  try {
+    return await runtime.refreshOverview();
+  } catch (error) {
+    console.warn("[DashboardModern] final Report-period owner", error);
+    return false;
+  } finally {
+    state.refreshingOverview = false;
+  }
+}
+
+function scheduleOverview0156(delay = 0) {
+  const state = ownerState0156();
+  globalThis.clearTimeout?.(state.overviewTimer);
+  state.overviewTimer = globalThis.setTimeout?.(() => refreshOverview0156(), delay);
+}
+
+function wrapLateWriter0156(name) {
+  const current = globalThis[name];
+  if (typeof current !== "function" || current.__dm0156OwnerGuard) return false;
+
+  function guardedLateWriter0156(...args) {
+    const result = current.apply(this, args);
+    const finish = () => {
+      if (!restoreCurrentSlots0156()) refreshCurrent0156();
+    };
+    if (result && typeof result.finally === "function") return result.finally(finish);
+    finish();
+    return result;
+  }
+
+  guardedLateWriter0156.__dm0156OwnerGuard = true;
+  guardedLateWriter0156.__dmPrevious = current;
+  globalThis[name] = guardedLateWriter0156;
+  return true;
+}
+
+function wrapReportRenderer0156() {
+  const current = globalThis.renderEnergyDashboard;
+  if (typeof current !== "function" || current.__dm0156OwnerGuard) return false;
+
+  function guardedReportRenderer0156(...args) {
+    const result = current.apply(this, args);
+    const finish = () => {
+      restoreCurrentSlots0156();
+      scheduleOverview0156(0);
+    };
+    if (result && typeof result.finally === "function") return result.finally(finish);
+    globalThis.queueMicrotask?.(finish);
+    return result;
+  }
+
+  guardedReportRenderer0156.__dm0156OwnerGuard = true;
+  guardedReportRenderer0156.__dmPrevious = current;
+  globalThis.renderEnergyDashboard = guardedReportRenderer0156;
+  return true;
+}
+
+function installWrappers0156() {
+  const derive = wrapLateWriter0156("cdDeriveFromTotals");
+  const deltas = wrapLateWriter0156("cdRefreshPeriodDeltas");
+  const report = wrapReportRenderer0156();
+  return Boolean(
+    derive ||
+    deltas ||
+    report ||
+    globalThis.cdDeriveFromTotals?.__dm0156OwnerGuard ||
+    globalThis.cdRefreshPeriodDeltas?.__dm0156OwnerGuard ||
+    globalThis.renderEnergyDashboard?.__dm0156OwnerGuard
+  );
+}
+
+function reinforce0156() {
+  installWrappers0156();
+  refreshCurrent0156();
+  scheduleOverview0156(0);
+}
+
+function install0156() {
+  const state = ownerState0156();
+  reinforce0156();
+  if (!state.eventsInstalled) {
+    state.eventsInstalled = true;
+    globalThis.document?.addEventListener?.(
+      "change",
+      (event) => {
+        if (!event.target?.matches?.("#ed-sel-month, #ed-sel-year")) return;
+        scheduleOverview0156(20);
+        globalThis.setTimeout?.(() => scheduleOverview0156(0), 180);
+        globalThis.setTimeout?.(() => scheduleOverview0156(0), 650);
+      },
+      true,
+    );
+    globalThis.addEventListener?.("dashboardmodern:legacy-ready", reinforce0156);
+    globalThis.addEventListener?.("pageshow", reinforce0156);
+  }
+
+  globalThis.clearInterval?.(state.timer);
+  let attempts = 0;
+  state.timer = globalThis.setInterval?.(() => {
+    attempts += 1;
+    installWrappers0156();
+    restoreCurrentSlots0156();
+    if (
+      attempts >= 80 ||
+      (globalThis.cdDeriveFromTotals?.__dm0156OwnerGuard &&
+        globalThis.cdRefreshPeriodDeltas?.__dm0156OwnerGuard &&
+        globalThis.renderEnergyDashboard?.__dm0156OwnerGuard)
+    ) {
+      globalThis.clearInterval?.(state.timer);
+      state.timer = 0;
+    }
+  }, 100);
+}
+
+if (typeof globalThis.document !== "undefined") install0156();

--- a/custom_components/dashboardmodern/frontend/legacy/release-0156-owner-guard.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0156-owner-guard.js
@@ -1,4 +1,4 @@
-/* DashboardModern 0.14.16: protect the final period owner from late legacy writes. */
+/* DashboardModern 0.14.16: final owner for current and historical period values. */
 const FINAL_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__";
 const OWNER_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_OWNER_GUARD__";
 const CURRENT_SLOTS_0156 = Object.freeze([
@@ -9,6 +9,14 @@ const CURRENT_SLOTS_0156 = Object.freeze([
   "dm.energy_batteria_caricata_mese",
   "dm.energy_batteria_usata_mese",
 ]);
+const ENERGY_SOURCES_0156 = Object.freeze([
+  ["cons", "house", ["total_energy", "annual_energy", "monthly_energy"]],
+  ["prelevato", "grid", ["total_import_energy", "annual_import_energy", "monthly_import_energy"]],
+  ["immesso", "grid", ["total_export_energy", "annual_export_energy", "monthly_export_energy"]],
+  ["prod", "solar", ["total_energy", "annual_energy", "monthly_energy"]],
+  ["batCar", "battery", ["total_charged_energy", "annual_charged_energy", "monthly_charged_energy"]],
+  ["batScar", "battery", ["total_discharged_energy", "annual_discharged_energy", "monthly_discharged_energy"]],
+]);
 
 function ownerState0156() {
   return (globalThis[OWNER_KEY_0156] ||= {
@@ -16,7 +24,8 @@ function ownerState0156() {
     timer: 0,
     overviewTimer: 0,
     refreshingCurrent: false,
-    refreshingOverview: false,
+    overviewGeneration: 0,
+    deviceGeneration: 0,
   });
 }
 
@@ -66,18 +75,157 @@ async function refreshCurrent0156() {
   }
 }
 
+function resolveEntity0156(entity) {
+  const original = String(entity || "").trim();
+  if (!original) return "";
+  try {
+    return String(globalThis.resolveEntity?.(original) || original).trim();
+  } catch (_error) {
+    return original;
+  }
+}
+
+function rowTime0156(row) {
+  const raw = row?.start ?? row?.end ?? row?.last_updated ?? row?.timestamp ?? 0;
+  const value = typeof raw === "number" ? raw : Date.parse(raw);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function cumulative0156(row) {
+  for (const key of ["sum", "state", "max"]) {
+    const value = Number(row?.[key]);
+    if (Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function periodValue0156(rows = [], baseline = null) {
+  const ordered = (Array.isArray(rows) ? rows : [])
+    .filter(Boolean)
+    .slice()
+    .sort((left, right) => rowTime0156(left) - rowTime0156(right));
+  const changes = ordered
+    .map((row) => Number(row?.change))
+    .filter((value) => Number.isFinite(value));
+  if (changes.length) return Math.max(0, changes.reduce((total, value) => total + value, 0));
+  const values = ordered.map(cumulative0156).filter((value) => value != null);
+  const base = cumulative0156(baseline);
+  if (base != null && values.length) values.unshift(base);
+  if (values.length < 2) return null;
+  let total = 0;
+  for (let index = 1; index < values.length; index += 1) {
+    const difference = values[index] - values[index - 1];
+    total += difference >= 0 ? difference : Math.max(0, values[index]);
+  }
+  return Math.max(0, total);
+}
+
+function monthRange0156(month, year) {
+  const now = new Date();
+  const start = new Date(year, month - 1, 1);
+  const next = new Date(year, month, 1);
+  // Recorder's end is exclusive. For a closed historical month use the last
+  // millisecond before the next month, leaving an exact first-of-month end only
+  // for the baseline request. This prevents the two requests being conflated.
+  const end = next > now ? now : new Date(next.getTime() - 1);
+  const baselineStart = new Date(start);
+  baselineStart.setDate(baselineStart.getDate() - 2);
+  return { start, end, baselineStart };
+}
+
+async function statistics0156(ids, start, end) {
+  const runtime = globalThis[FINAL_KEY_0156];
+  if (typeof runtime?.statistics !== "function") return {};
+  return runtime.statistics(ids, start, end, "day");
+}
+
+async function monthValues0156(ids, month, year) {
+  const unique = [...new Set((Array.isArray(ids) ? ids : []).map(String).filter(Boolean))];
+  const range = monthRange0156(month, year);
+  if (!unique.length || range.end <= range.start) return new Map();
+  const rows = await statistics0156(unique, range.start, range.end);
+  const unresolved = unique.filter((id) => periodValue0156(rows[id] || []) == null);
+  const baselines = unresolved.length
+    ? await statistics0156(unresolved, range.baselineStart, range.start)
+    : {};
+  const values = new Map();
+  unique.forEach((id) => {
+    const baselineRows = (baselines[id] || [])
+      .slice()
+      .sort((left, right) => rowTime0156(left) - rowTime0156(right));
+    const value = periodValue0156(rows[id] || [], baselineRows.at(-1) || null);
+    if (value == null) return;
+    const rounded = Math.round(value * 1000) / 1000;
+    values.set(id, rounded);
+    values.set(resolveEntity0156(id), rounded);
+  });
+  return values;
+}
+
+function energySources0156() {
+  let energy = {};
+  try {
+    energy = globalThis.DashboardModernModules?.store?.getSection?.("energy") || {};
+  } catch (_error) {}
+  return ENERGY_SOURCES_0156.map(([key, groupName, fields]) => {
+    const group = energy[groupName] || {};
+    const entity = fields
+      .map((field) => String(group[field] || "").trim())
+      .find(Boolean) || "";
+    return { key, entity };
+  }).filter((source) => source.entity);
+}
+
+function selectedReportPeriod0156() {
+  const now = new Date();
+  const month = Number(globalThis.document?.getElementById?.("ed-sel-month")?.value);
+  const year = Number(globalThis.document?.getElementById?.("ed-sel-year")?.value);
+  return {
+    month: Number.isInteger(month) && month >= 1 && month <= 12 ? month : now.getMonth() + 1,
+    year: Number.isInteger(year) && year >= 2000 ? year : now.getFullYear(),
+  };
+}
+
+function patchOverview0156(data) {
+  const prod = Number(data?.prod) || 0;
+  const cons = Number(data?.cons) || 0;
+  const grid = Number(data?.prelevato) || 0;
+  const auto = cons > 0
+    ? Math.max(0, Math.min(100, Math.round(((cons - grid) / cons) * 100)))
+    : 0;
+  const set = (id, html) => {
+    const node = globalThis.document?.getElementById?.(id);
+    if (node) node.innerHTML = html;
+  };
+  set("ed-kpi-prod", `${prod.toFixed(1)} <small>kWh</small>`);
+  set("ed-kpi-cons", `${cons.toFixed(1)} <small>kWh</small>`);
+  set("ed-kpi-auto", `${auto} <small>%</small>`);
+}
+
 async function refreshOverview0156() {
   const state = ownerState0156();
-  const runtime = globalThis[FINAL_KEY_0156];
-  if (state.refreshingOverview || typeof runtime?.refreshOverview !== "function") return false;
-  state.refreshingOverview = true;
+  const generation = ++state.overviewGeneration;
+  const selected = selectedReportPeriod0156();
+  const sources = energySources0156();
   try {
-    return await runtime.refreshOverview();
+    const values = await monthValues0156(
+      sources.map((source) => source.entity),
+      selected.month,
+      selected.year,
+    );
+    if (generation !== state.overviewGeneration) return false;
+    const data = Object.fromEntries(
+      sources.map((source) => [
+        source.key,
+        values.get(source.entity) ?? values.get(resolveEntity0156(source.entity)) ?? 0,
+      ]),
+    );
+    patchOverview0156(data);
+    globalThis.__DASHBOARDMODERN_REPORT_PERIOD__ = { ...selected, values: data };
+    return true;
   } catch (error) {
     console.warn("[DashboardModern] final Report-period owner", error);
     return false;
-  } finally {
-    state.refreshingOverview = false;
   }
 }
 
@@ -85,6 +233,74 @@ function scheduleOverview0156(delay = 0) {
   const state = ownerState0156();
   globalThis.clearTimeout?.(state.overviewTimer);
   state.overviewTimer = globalThis.setTimeout?.(() => refreshOverview0156(), delay);
+}
+
+function canonicalDevices0156() {
+  try {
+    const modules = globalThis.DashboardModernModules;
+    return modules?.data?.canonicalReportDevices?.(
+      modules.store.getSection("appliances") || [],
+      modules.store.getSection("loads") || [],
+      globalThis.STATES || {},
+    ) || [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+function rowEntity0156(row, devices) {
+  const direct = String(row?.dataset?.entity || row?.dataset?.sensor || "").trim();
+  if (direct) return direct;
+  const match = /apriStorico\s*\(\s*event\s*,\s*['\"]([^'\"]+)/.exec(
+    row?.getAttribute?.("onclick") || "",
+  );
+  if (match?.[1]) return match[1];
+  const name = String(row?.querySelector?.(".ed-dev-name")?.childNodes?.[0]?.textContent || "").trim();
+  return String(devices.find((device) => String(device.name || "").trim() === name)?.entity || "");
+}
+
+function patchDeviceRows0156(values) {
+  const listNode = globalThis.document?.getElementById?.("ed-device-list");
+  if (!listNode) return;
+  const devices = canonicalDevices0156();
+  let total = 0;
+  listNode.querySelectorAll(".ed-device-row").forEach((row) => {
+    const entity = rowEntity0156(row, devices);
+    const value = values.get(entity) ?? values.get(resolveEntity0156(entity));
+    if (!Number.isFinite(value)) return;
+    total += value;
+    row.dataset.entity = entity;
+    row.dataset.dmPeriodValue = String(value);
+    const node = row.querySelector(".ed-dev-kwh");
+    if (node) node.innerHTML = `${value.toFixed(1)} <small style="font-size:10px">kWh</small>`;
+  });
+  const totalNode = globalThis.document?.getElementById?.("ed-dev-total");
+  if (totalNode) totalNode.textContent = `${total.toFixed(1)} kWh`;
+}
+
+function wrapDeviceRenderer0156() {
+  const current = globalThis.renderEdDeviceList;
+  if (typeof current !== "function" || current.__dm0156OwnerGuardDevices) return false;
+
+  async function ownerDeviceRenderer0156(month, year, ...rest) {
+    const state = ownerState0156();
+    const generation = ++state.deviceGeneration;
+    const result = await current.call(this, month, year, ...rest);
+    const devices = canonicalDevices0156();
+    const ids = [...new Set(devices.map((device) => String(device.entity || "").trim()).filter(Boolean))];
+    try {
+      const values = await monthValues0156(ids, month, year);
+      if (generation === state.deviceGeneration) patchDeviceRows0156(values);
+    } catch (error) {
+      console.warn("[DashboardModern] final historical device owner", error);
+    }
+    return result;
+  }
+
+  ownerDeviceRenderer0156.__dm0156OwnerGuardDevices = true;
+  ownerDeviceRenderer0156.__dmPrevious = current;
+  globalThis.renderEdDeviceList = ownerDeviceRenderer0156;
+  return true;
 }
 
 function wrapLateWriter0156(name) {
@@ -129,17 +345,10 @@ function wrapReportRenderer0156() {
 }
 
 function installWrappers0156() {
-  const derive = wrapLateWriter0156("cdDeriveFromTotals");
-  const deltas = wrapLateWriter0156("cdRefreshPeriodDeltas");
-  const report = wrapReportRenderer0156();
-  return Boolean(
-    derive ||
-    deltas ||
-    report ||
-    globalThis.cdDeriveFromTotals?.__dm0156OwnerGuard ||
-    globalThis.cdRefreshPeriodDeltas?.__dm0156OwnerGuard ||
-    globalThis.renderEnergyDashboard?.__dm0156OwnerGuard
-  );
+  wrapLateWriter0156("cdDeriveFromTotals");
+  wrapLateWriter0156("cdRefreshPeriodDeltas");
+  wrapReportRenderer0156();
+  wrapDeviceRenderer0156();
 }
 
 function reinforce0156() {
@@ -157,9 +366,11 @@ function install0156() {
       "change",
       (event) => {
         if (!event.target?.matches?.("#ed-sel-month, #ed-sel-year")) return;
-        scheduleOverview0156(20);
-        globalThis.setTimeout?.(() => scheduleOverview0156(0), 180);
-        globalThis.setTimeout?.(() => scheduleOverview0156(0), 650);
+        state.overviewGeneration += 1;
+        state.deviceGeneration += 1;
+        scheduleOverview0156(10);
+        globalThis.setTimeout?.(() => scheduleOverview0156(0), 160);
+        globalThis.setTimeout?.(() => scheduleOverview0156(0), 500);
       },
       true,
     );
@@ -177,7 +388,8 @@ function install0156() {
       attempts >= 80 ||
       (globalThis.cdDeriveFromTotals?.__dm0156OwnerGuard &&
         globalThis.cdRefreshPeriodDeltas?.__dm0156OwnerGuard &&
-        globalThis.renderEnergyDashboard?.__dm0156OwnerGuard)
+        globalThis.renderEnergyDashboard?.__dm0156OwnerGuard &&
+        globalThis.renderEdDeviceList?.__dm0156OwnerGuardDevices)
     ) {
       globalThis.clearInterval?.(state.timer);
       state.timer = 0;

--- a/custom_components/dashboardmodern/frontend/legacy/release-0156-period-runtime.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0156-period-runtime.js
@@ -1,0 +1,677 @@
+/* DashboardModern 0.14.16: one event-driven HA broker for periods, Report and live states. */
+const RUNTIME_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_PERIOD_RUNTIME__";
+const PUBLIC_RUNTIME_KEY_0155 = "__DASHBOARDMODERN_RELEASE_0155_PUBLIC_RUNTIME__";
+const REPORT_HOOK_KEY_0153 = "__DASHBOARDMODERN_ENERGY_REPORT_HOOKS__";
+const REQUEST_TIMEOUT_0156 = 12000;
+const CURRENT_CACHE_MS_0156 = 20000;
+const HISTORICAL_CACHE_MS_0156 = 10 * 60 * 1000;
+
+const ENERGY_SOURCES_0156 = Object.freeze([
+  { key: "cons", group: "house", total: "total_energy", explicit: "monthly_energy" },
+  { key: "prelevato", group: "grid", total: "total_import_energy", explicit: "monthly_import_energy" },
+  { key: "immesso", group: "grid", total: "total_export_energy", explicit: "monthly_export_energy" },
+  { key: "prod", group: "solar", total: "total_energy", explicit: "monthly_energy" },
+  { key: "batCar", group: "battery", total: "total_charged_energy", explicit: "monthly_charged_energy" },
+  { key: "batScar", group: "battery", total: "total_discharged_energy", explicit: "monthly_discharged_energy" },
+]);
+
+function runtime0156() {
+  return (globalThis[RUNTIME_KEY_0156] ||= {
+    installed: false,
+    version: "0.14.16",
+    socket: null,
+    connection: null,
+    authenticated: false,
+    nextId: 156000,
+    pending: new Map(),
+    inflight: new Map(),
+    cache: new Map(),
+    stateSubscription: 0,
+    stateFeedStarted: false,
+    reportGeneration: 0,
+    reportTimer: 0,
+    wrappersTimer: 0,
+  });
+}
+
+function isEnglish0156() {
+  return globalThis.document?.documentElement?.lang === "en";
+}
+
+function copy0156(it, en) {
+  return isEnglish0156() ? en : it;
+}
+
+function websocketUrl0156() {
+  const protocol = globalThis.location?.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${globalThis.location?.host || "dashboardmodern-bridge"}/api/websocket`;
+}
+
+function accessToken0156() {
+  const candidates = [
+    globalThis.DASHBOARDMODERN_AUTH_TOKEN,
+    globalThis.__DASHBOARDMODERN_REAL_TOKEN__,
+    globalThis.LONG_LIVED_TOKEN,
+    globalThis.HA_TOKEN,
+    globalThis.haToken,
+    globalThis.authToken,
+  ];
+  try {
+    const configured = JSON.parse(globalThis.localStorage?.getItem("cd_connection") || "{}");
+    candidates.push(configured.token, configured.access_token);
+  } catch (_error) {}
+  return candidates.map((value) => String(value || "").trim()).find(Boolean) || "";
+}
+
+function rejectPending0156(error) {
+  const runtime = runtime0156();
+  runtime.pending.forEach(({ reject, timer }) => {
+    globalThis.clearTimeout?.(timer);
+    reject(error);
+  });
+  runtime.pending.clear();
+  runtime.inflight.clear();
+}
+
+function resetConnection0156(error) {
+  const runtime = runtime0156();
+  const socket = runtime.socket;
+  runtime.socket = null;
+  runtime.connection = null;
+  runtime.authenticated = false;
+  runtime.stateSubscription = 0;
+  runtime.stateFeedStarted = false;
+  if (error) rejectPending0156(error);
+  try {
+    if (socket?.readyState === 1) socket.close();
+  } catch (_error) {}
+}
+
+function writeState0156(state) {
+  const id = String(state?.entity_id || "").trim();
+  if (!id) return false;
+  try {
+    if (typeof _RAW_STATES !== "undefined" && _RAW_STATES) _RAW_STATES[id] = state;
+  } catch (_error) {}
+  try {
+    globalThis._RAW_STATES ||= {};
+    globalThis._RAW_STATES[id] = state;
+  } catch (_error) {}
+  try {
+    if (typeof STATES !== "undefined" && STATES) STATES[id] = state;
+  } catch (_error) {}
+  try {
+    if (globalThis.STATES) globalThis.STATES[id] = state;
+  } catch (_error) {}
+
+  const publicRuntime = globalThis[PUBLIC_RUNTIME_KEY_0155];
+  if (typeof publicRuntime?.ingestState === "function") publicRuntime.ingestState(state);
+  return true;
+}
+
+function writeStates0156(states) {
+  const list = Array.isArray(states) ? states : [];
+  list.forEach((state) => writeState0156(state));
+  const publicRuntime = globalThis[PUBLIC_RUNTIME_KEY_0155];
+  if (typeof publicRuntime?.ingestStates === "function") publicRuntime.ingestStates(list);
+  return list.length > 0;
+}
+
+function handleMessage0156(event, resolveConnection, rejectConnection) {
+  let message;
+  try {
+    message = JSON.parse(event?.data || event);
+  } catch (_error) {
+    return;
+  }
+  const runtime = runtime0156();
+  if (message.type === "auth_required") {
+    const token = accessToken0156();
+    if (!token) {
+      const error = new Error(copy0156("Bridge Home Assistant non autenticato", "Home Assistant bridge is not authenticated"));
+      rejectConnection(error);
+      resetConnection0156(error);
+      return;
+    }
+    runtime.socket?.send(JSON.stringify({ type: "auth", access_token: token }));
+    return;
+  }
+  if (message.type === "auth_ok") {
+    runtime.authenticated = true;
+    resolveConnection(runtime.socket);
+    return;
+  }
+  if (message.type === "auth_invalid") {
+    const error = new Error(message.message || copy0156("Autenticazione Home Assistant non valida", "Invalid Home Assistant authentication"));
+    rejectConnection(error);
+    resetConnection0156(error);
+    return;
+  }
+  if (message.type === "event" && message.id === runtime.stateSubscription) {
+    const state = message.event?.data?.new_state;
+    if (state) writeState0156(state);
+    return;
+  }
+  if (message.type !== "result" || message.id == null) return;
+  const pending = runtime.pending.get(message.id);
+  if (!pending) return;
+  runtime.pending.delete(message.id);
+  globalThis.clearTimeout?.(pending.timer);
+  if (message.success === false) {
+    pending.reject(new Error(message.error?.message || message.error?.code || "Home Assistant request failed"));
+  } else {
+    pending.resolve(message.result ?? null);
+  }
+}
+
+function connect0156() {
+  const runtime = runtime0156();
+  if (runtime.authenticated && runtime.socket?.readyState === 1) {
+    return Promise.resolve(runtime.socket);
+  }
+  if (runtime.connection) return runtime.connection;
+  if (typeof globalThis.WebSocket !== "function") {
+    return Promise.reject(new Error(copy0156("WebSocket non disponibile", "WebSocket unavailable")));
+  }
+
+  runtime.connection = new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      globalThis.clearTimeout?.(timer);
+      callback(value);
+    };
+    const timer = globalThis.setTimeout?.(() => {
+      const error = new Error(copy0156("Timeout connessione Home Assistant", "Home Assistant connection timeout"));
+      finish(reject, error);
+      resetConnection0156(error);
+    }, REQUEST_TIMEOUT_0156);
+    try {
+      const socket = new globalThis.WebSocket(websocketUrl0156());
+      runtime.socket = socket;
+      socket.onmessage = (event) => handleMessage0156(
+        event,
+        (value) => finish(resolve, value),
+        (error) => finish(reject, error),
+      );
+      socket.onerror = () => {
+        const error = new Error(copy0156("Connessione Home Assistant non disponibile", "Home Assistant connection unavailable"));
+        finish(reject, error);
+        resetConnection0156(error);
+      };
+      socket.onclose = () => {
+        const error = new Error(copy0156("Connessione Home Assistant chiusa", "Home Assistant connection closed"));
+        finish(reject, error);
+        resetConnection0156(error);
+      };
+    } catch (error) {
+      finish(reject, error);
+      resetConnection0156(error);
+    }
+  }).finally(() => {
+    runtime.connection = null;
+  });
+  return runtime.connection;
+}
+
+async function sendRequest0156(payload) {
+  const runtime = runtime0156();
+  const socket = await connect0156();
+  const id = ++runtime.nextId;
+  return new Promise((resolve, reject) => {
+    const timer = globalThis.setTimeout?.(() => {
+      runtime.pending.delete(id);
+      reject(new Error(copy0156("Timeout risposta Home Assistant", "Home Assistant response timeout")));
+    }, REQUEST_TIMEOUT_0156);
+    runtime.pending.set(id, { resolve, reject, timer });
+    try {
+      socket.send(JSON.stringify({ id, ...payload }));
+    } catch (error) {
+      globalThis.clearTimeout?.(timer);
+      runtime.pending.delete(id);
+      reject(error);
+    }
+  });
+}
+
+async function cachedRequest0156(payload, cacheKey, cacheMs = 0) {
+  const runtime = runtime0156();
+  if (cacheMs > 0) {
+    const cached = runtime.cache.get(cacheKey);
+    if (cached && Date.now() - cached.at < cacheMs) return cached.value;
+  }
+  if (runtime.inflight.has(cacheKey)) return runtime.inflight.get(cacheKey);
+  const promise = sendRequest0156(payload)
+    .then((value) => {
+      if (cacheMs > 0) runtime.cache.set(cacheKey, { at: Date.now(), value });
+      return value;
+    })
+    .finally(() => runtime.inflight.delete(cacheKey));
+  runtime.inflight.set(cacheKey, promise);
+  return promise;
+}
+
+function resolveEntity0156(entity) {
+  const original = String(entity || "").trim();
+  if (!original) return "";
+  try {
+    return String(globalThis.resolveEntity?.(original) || original).trim();
+  } catch (_error) {
+    return original;
+  }
+}
+
+export async function fetchHAStatistics0156(ids, start, end, period = "day") {
+  const originals = [...new Set((Array.isArray(ids) ? ids : []).map(String).filter(Boolean))];
+  if (!originals.length) return {};
+  const resolved = new Map(originals.map((id) => [id, resolveEntity0156(id)]));
+  const statisticIds = [...new Set([...resolved.values()].filter(Boolean))];
+  const now = Date.now();
+  const endMs = Date.parse(end);
+  const cacheMs = Number.isFinite(endMs) && endMs < now - 86400000
+    ? HISTORICAL_CACHE_MS_0156
+    : CURRENT_CACHE_MS_0156;
+  const key = `stats|${period}|${new Date(start).toISOString()}|${new Date(end).toISOString()}|${statisticIds.join(",")}`;
+  const result = await cachedRequest0156(
+    {
+      type: "recorder/statistics_during_period",
+      start_time: new Date(start).toISOString(),
+      end_time: new Date(end).toISOString(),
+      statistic_ids: statisticIds,
+      period,
+      units: { energy: "kWh" },
+    },
+    key,
+    cacheMs,
+  );
+  return Object.fromEntries(
+    originals.map((id) => [id, result?.[resolved.get(id)] || []]),
+  );
+}
+
+async function startStateFeed0156() {
+  const runtime = runtime0156();
+  if (runtime.stateFeedStarted) return true;
+  runtime.stateFeedStarted = true;
+  try {
+    const states = await cachedRequest0156({ type: "get_states" }, "get_states", 5000);
+    writeStates0156(states);
+    const socket = await connect0156();
+    const id = ++runtime.nextId;
+    runtime.stateSubscription = id;
+    await new Promise((resolve, reject) => {
+      const timer = globalThis.setTimeout?.(() => {
+        runtime.pending.delete(id);
+        reject(new Error(copy0156("Timeout sottoscrizione stati", "State subscription timeout")));
+      }, REQUEST_TIMEOUT_0156);
+      runtime.pending.set(id, { resolve, reject, timer });
+      socket.send(JSON.stringify({ id, type: "subscribe_events", event_type: "state_changed" }));
+    });
+    return true;
+  } catch (error) {
+    runtime.stateFeedStarted = false;
+    console.warn("[DashboardModern] shared live-state feed", error);
+    return false;
+  }
+}
+
+function rowTime0156(row) {
+  const raw = row?.start ?? row?.end ?? row?.last_updated ?? row?.timestamp ?? 0;
+  const value = typeof raw === "number" ? raw : Date.parse(raw);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function cumulativeValue0156(row) {
+  for (const key of ["sum", "state", "max"]) {
+    const value = Number(row?.[key]);
+    if (Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+export function periodValue0156(rows = [], baseline = null) {
+  const ordered = (Array.isArray(rows) ? rows : [])
+    .filter(Boolean)
+    .slice()
+    .sort((left, right) => rowTime0156(left) - rowTime0156(right));
+  const changes = ordered
+    .map((row) => Number(row?.change))
+    .filter((value) => Number.isFinite(value));
+  if (changes.length) return Math.max(0, changes.reduce((total, value) => total + value, 0));
+  const values = ordered.map(cumulativeValue0156).filter((value) => value != null);
+  const base = cumulativeValue0156(baseline);
+  if (base != null && values.length) values.unshift(base);
+  if (values.length < 2) return null;
+  let total = 0;
+  for (let index = 1; index < values.length; index += 1) {
+    const difference = values[index] - values[index - 1];
+    total += difference >= 0 ? difference : Math.max(0, values[index]);
+  }
+  return Math.max(0, total);
+}
+
+function monthRange0156(month, year, now = new Date()) {
+  const safeMonth = Number.isInteger(+month) && +month >= 1 && +month <= 12
+    ? +month
+    : now.getMonth() + 1;
+  const safeYear = Number.isInteger(+year) && +year >= 2000 ? +year : now.getFullYear();
+  const start = new Date(safeYear, safeMonth - 1, 1);
+  const next = new Date(safeYear, safeMonth, 1);
+  const end = next > now ? now : next;
+  const baselineStart = new Date(start);
+  baselineStart.setDate(baselineStart.getDate() - 2);
+  return { start, end, baselineStart, month: safeMonth, year: safeYear };
+}
+
+async function valuesForMonth0156(ids, month, year) {
+  const unique = [...new Set((Array.isArray(ids) ? ids : []).map(String).filter(Boolean))];
+  const range = monthRange0156(month, year);
+  if (!unique.length || range.end <= range.start) return new Map();
+  const rows = await fetchHAStatistics0156(
+    unique,
+    range.start.toISOString(),
+    range.end.toISOString(),
+    "day",
+  );
+  const unresolved = unique.filter((id) => periodValue0156(rows[id] || []) == null);
+  let baselines = {};
+  if (unresolved.length) {
+    baselines = await fetchHAStatistics0156(
+      unresolved,
+      range.baselineStart.toISOString(),
+      range.start.toISOString(),
+      "day",
+    );
+  }
+  const values = new Map();
+  unique.forEach((id) => {
+    const baselineRows = (baselines[id] || [])
+      .slice()
+      .sort((left, right) => rowTime0156(left) - rowTime0156(right));
+    const value = periodValue0156(rows[id] || [], baselineRows.at(-1) || null);
+    if (value == null) return;
+    const rounded = Math.round(value * 1000) / 1000;
+    values.set(id, rounded);
+    values.set(resolveEntity0156(id), rounded);
+  });
+  return values;
+}
+
+function selectedReportPeriod0156() {
+  const now = new Date();
+  const month = Number(globalThis.document?.getElementById?.("ed-sel-month")?.value);
+  const year = Number(globalThis.document?.getElementById?.("ed-sel-year")?.value);
+  return {
+    month: Number.isInteger(month) && month >= 1 && month <= 12 ? month : now.getMonth() + 1,
+    year: Number.isInteger(year) && year >= 2000 ? year : now.getFullYear(),
+  };
+}
+
+function energyConfig0156() {
+  try {
+    return globalThis.DashboardModernModules?.store?.getSection?.("energy") || {};
+  } catch (_error) {
+    return {};
+  }
+}
+
+function energyEntities0156() {
+  const energy = energyConfig0156();
+  return ENERGY_SOURCES_0156.map((source) => {
+    const group = energy?.[source.group] || {};
+    const entity = String(group[source.total] || group[source.explicit] || "").trim();
+    return { ...source, entity };
+  }).filter((source) => source.entity);
+}
+
+async function reportEnergyValues0156(month, year) {
+  const sources = energyEntities0156();
+  const values = await valuesForMonth0156(sources.map((source) => source.entity), month, year);
+  return Object.fromEntries(
+    sources.map((source) => [
+      source.key,
+      values.get(source.entity) ?? values.get(resolveEntity0156(source.entity)) ?? 0,
+    ]),
+  );
+}
+
+function canonicalReportDevices0156() {
+  try {
+    const modules = globalThis.DashboardModernModules;
+    const store = modules?.store;
+    const build = modules?.data?.canonicalReportDevices;
+    if (!store?.getSection || typeof build !== "function") return [];
+    return build(
+      store.getSection("appliances") || [],
+      store.getSection("loads") || [],
+      globalThis.STATES || {},
+    );
+  } catch (_error) {
+    return [];
+  }
+}
+
+async function reportDeviceValues0156(month, year) {
+  const devices = canonicalReportDevices0156();
+  const ids = [...new Set(devices.map((device) => String(device.entity || "").trim()).filter(Boolean))];
+  return valuesForMonth0156(ids, month, year);
+}
+
+function periodRegistry0156() {
+  try {
+    if (typeof CD_PERIOD !== "undefined" && CD_PERIOD) return CD_PERIOD;
+  } catch (_error) {}
+  globalThis.CD_PERIOD ||= {};
+  return globalThis.CD_PERIOD;
+}
+
+function setHtml0156(id, html) {
+  const node = globalThis.document?.getElementById?.(id);
+  if (!node || node.innerHTML === html) return false;
+  node.innerHTML = html;
+  return true;
+}
+
+function patchReportOverview0156(values) {
+  const prod = Number(values?.prod) || 0;
+  const cons = Number(values?.cons) || 0;
+  const prelevato = Number(values?.prelevato) || 0;
+  const auto = cons > 0
+    ? Math.max(0, Math.min(100, Math.round(((cons - prelevato) / cons) * 100)))
+    : 0;
+  let changed = false;
+  changed = setHtml0156("ed-kpi-prod", `${prod.toFixed(1)} <small>kWh</small>`) || changed;
+  changed = setHtml0156("ed-kpi-cons", `${cons.toFixed(1)} <small>kWh</small>`) || changed;
+  changed = setHtml0156("ed-kpi-auto", `${auto} <small>%</small>`) || changed;
+  return changed;
+}
+
+function deepestFunction0156(fn) {
+  const seen = new Set();
+  let current = fn;
+  while (typeof current?.__dmPrevious === "function" && !seen.has(current)) {
+    seen.add(current);
+    current = current.__dmPrevious;
+  }
+  return current;
+}
+
+function installReportDeviceWrapper0156() {
+  const current = globalThis.renderEdDeviceList;
+  if (typeof current !== "function" || current.__dm0156HistoricalPeriods) return false;
+  const original = deepestFunction0156(current);
+  if (typeof original !== "function") return false;
+
+  async function renderEdDeviceList0156(month, year, _isCurrentMonth, ...rest) {
+    const runtime = runtime0156();
+    const generation = ++runtime.reportGeneration;
+    let values = new Map();
+    try {
+      values = await reportDeviceValues0156(month, year);
+    } catch (error) {
+      console.warn("[DashboardModern] historical Report devices", error);
+    }
+    if (generation !== runtime.reportGeneration) return false;
+
+    const registry = periodRegistry0156();
+    values.forEach((value, entity) => {
+      registry[entity] = value;
+    });
+    const previousGetRawState = globalThis.getRawState;
+    if (typeof previousGetRawState === "function" && values.size) {
+      globalThis.getRawState = function getRawState0156(reference) {
+        const key = String(reference || "").trim();
+        const value = values.get(key) ?? values.get(resolveEntity0156(key));
+        if (Number.isFinite(value)) return String(value);
+        return previousGetRawState.apply(this, arguments);
+      };
+    }
+    try {
+      return await original.call(this, month, year, true, ...rest);
+    } finally {
+      if (globalThis.getRawState !== previousGetRawState) globalThis.getRawState = previousGetRawState;
+    }
+  }
+
+  renderEdDeviceList0156.__dm0156HistoricalPeriods = true;
+  renderEdDeviceList0156.__dmPrevious = original;
+  globalThis.renderEdDeviceList = renderEdDeviceList0156;
+  return true;
+}
+
+function installReportDashboardWrapper0156() {
+  const current = globalThis.renderEnergyDashboard;
+  if (typeof current !== "function" || current.__dm0156HistoricalPeriods) return false;
+
+  async function renderEnergyDashboard0156(...args) {
+    const result = await current.apply(this, args);
+    scheduleReportRefresh0156(0);
+    return result;
+  }
+
+  renderEnergyDashboard0156.__dm0156HistoricalPeriods = true;
+  renderEnergyDashboard0156.__dmPrevious = current;
+  globalThis.renderEnergyDashboard = renderEnergyDashboard0156;
+  return true;
+}
+
+async function refreshReport0156() {
+  const runtime = runtime0156();
+  const generation = ++runtime.reportGeneration;
+  const { month, year } = selectedReportPeriod0156();
+  try {
+    const values = await reportEnergyValues0156(month, year);
+    if (generation !== runtime.reportGeneration) return false;
+    patchReportOverview0156(values);
+    globalThis.__DASHBOARDMODERN_REPORT_PERIOD__ = { month, year, values };
+    return true;
+  } catch (error) {
+    console.warn("[DashboardModern] historical Report overview", error);
+    return false;
+  }
+}
+
+function scheduleReportRefresh0156(delay = 40) {
+  const runtime = runtime0156();
+  globalThis.clearTimeout?.(runtime.reportTimer);
+  runtime.reportTimer = globalThis.setTimeout?.(refreshReport0156, delay);
+}
+
+function disableLegacyLoops0156() {
+  const publicRuntime = globalThis[PUBLIC_RUNTIME_KEY_0155];
+  if (publicRuntime?.sampleTimer) {
+    globalThis.clearInterval?.(publicRuntime.sampleTimer);
+    publicRuntime.sampleTimer = 0;
+  }
+  const hooks = globalThis[REPORT_HOOK_KEY_0153];
+  if (hooks) {
+    hooks.observer?.disconnect?.();
+    hooks.safeObserver?.disconnect?.();
+    globalThis.clearTimeout?.(hooks.timer);
+    globalThis.clearTimeout?.(hooks.safeTimer);
+    hooks.observer = null;
+    hooks.safeObserver = null;
+    hooks.safeObserverInstalled = true;
+    hooks.refreshing = true;
+    hooks.disabledBy0156 = true;
+  }
+}
+
+function installStatisticsOverride0156() {
+  const previous = globalThis.fetchHAStatistics;
+  if (previous?.__dm0156SharedBroker) return true;
+  async function sharedStatistics0156(ids, start, end, period = "day") {
+    return fetchHAStatistics0156(ids, start, end, period);
+  }
+  sharedStatistics0156.__dm0156SharedBroker = true;
+  sharedStatistics0156.__dmPrevious = previous;
+  globalThis.fetchHAStatistics = sharedStatistics0156;
+  return true;
+}
+
+function installWrappers0156() {
+  installReportDeviceWrapper0156();
+  installReportDashboardWrapper0156();
+}
+
+function installEvents0156() {
+  const runtime = runtime0156();
+  if (runtime.eventsInstalled || !globalThis.document) return;
+  runtime.eventsInstalled = true;
+  globalThis.document.addEventListener(
+    "change",
+    (event) => {
+      if (!event.target?.matches?.("#ed-sel-month, #ed-sel-year")) return;
+      runtime.cache.clear();
+      runtime.reportGeneration += 1;
+      scheduleReportRefresh0156(30);
+    },
+    true,
+  );
+  globalThis.addEventListener?.("pageshow", () => {
+    disableLegacyLoops0156();
+    startStateFeed0156();
+    installWrappers0156();
+    scheduleReportRefresh0156(80);
+  });
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", () => {
+    disableLegacyLoops0156();
+    startStateFeed0156();
+    installWrappers0156();
+    scheduleReportRefresh0156(80);
+  });
+}
+
+function install0156() {
+  const runtime = runtime0156();
+  runtime.installed = true;
+  installStatisticsOverride0156();
+  disableLegacyLoops0156();
+  installWrappers0156();
+  installEvents0156();
+  startStateFeed0156();
+  scheduleReportRefresh0156(120);
+
+  if (!runtime.wrappersTimer) {
+    let attempts = 0;
+    runtime.wrappersTimer = globalThis.setInterval?.(() => {
+      attempts += 1;
+      disableLegacyLoops0156();
+      installWrappers0156();
+      if (attempts >= 30 || (
+        globalThis.renderEdDeviceList?.__dm0156HistoricalPeriods &&
+        globalThis.renderEnergyDashboard?.__dm0156HistoricalPeriods
+      )) {
+        globalThis.clearInterval?.(runtime.wrappersTimer);
+        runtime.wrappersTimer = 0;
+      }
+    }, 100);
+  }
+}
+
+if (typeof globalThis.document !== "undefined") {
+  if (globalThis.document.readyState === "loading") {
+    globalThis.document.addEventListener("DOMContentLoaded", install0156, { once: true });
+  } else install0156();
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0156-reconnect-timer-cancel.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0156-reconnect-timer-cancel.js
@@ -1,0 +1,51 @@
+/* DashboardModern 0.14.16: cancel only the redundant initial legacy reconnect. */
+const RECONNECT_CAPTURE_KEY_0156 = "__DASHBOARDMODERN_LEGACY_RECONNECT__";
+const FINAL_RUNTIME_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__";
+const CANCEL_STATE_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_RECONNECT_CANCEL__";
+
+function reconnectCancelState0156() {
+  return (globalThis[CANCEL_STATE_KEY_0156] ||= {
+    installed: true,
+    timer: 0,
+    cancelled: false,
+  });
+}
+
+function cancelCapturedReconnect0156() {
+  const state = reconnectCancelState0156();
+  const captured = globalThis[RECONNECT_CAPTURE_KEY_0156];
+  const runtime = globalThis[FINAL_RUNTIME_KEY_0156];
+  if (
+    !captured?.timer ||
+    runtime?.ready !== true ||
+    runtime?.socket?.readyState !== 1
+  ) {
+    return false;
+  }
+
+  globalThis.clearTimeout?.(captured.timer);
+  captured.timer = 0;
+  captured.cancelled = true;
+  state.cancelled = true;
+  return true;
+}
+
+function installReconnectCancel0156() {
+  const state = reconnectCancelState0156();
+  if (cancelCapturedReconnect0156()) return;
+
+  globalThis.clearInterval?.(state.timer);
+  let attempts = 0;
+  state.timer = globalThis.setInterval?.(() => {
+    attempts += 1;
+    if (cancelCapturedReconnect0156() || attempts >= 100) {
+      globalThis.clearInterval?.(state.timer);
+      state.timer = 0;
+    }
+  }, 50);
+
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", cancelCapturedReconnect0156);
+  globalThis.addEventListener?.("pageshow", cancelCapturedReconnect0156);
+}
+
+if (typeof globalThis.document !== "undefined") installReconnectCancel0156();

--- a/custom_components/dashboardmodern/frontend/legacy/release-0156-webkit-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0156-webkit-stability.js
@@ -1,0 +1,253 @@
+/* DashboardModern 0.14.16: WebKit-safe live-state priority and one-shot legacy reconnect. */
+const PUBLIC_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0155_PUBLIC_RUNTIME__";
+const FINAL_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__";
+const STABILITY_KEY_0156 = "__DASHBOARDMODERN_RELEASE_0156_WEBKIT_STABILITY__";
+
+function stabilityState0156() {
+  return (globalThis[STABILITY_KEY_0156] ||= {
+    installed: true,
+    armed: false,
+    originalWebSocket: null,
+    restoreTimer: 0,
+    wrapperTimer: 0,
+  });
+}
+
+function runtimeState0156(entity) {
+  const id = String(entity || "").trim();
+  if (!id) return null;
+  const live = globalThis[PUBLIC_KEY_0156];
+  const remembered = live?.states instanceof Map ? live.states.get(id) : null;
+  if (remembered) return remembered;
+  try {
+    if (typeof _RAW_STATES !== "undefined" && _RAW_STATES?.[id]) return _RAW_STATES[id];
+  } catch (_error) {}
+  return globalThis._RAW_STATES?.[id] || globalThis.STATES?.[id] || null;
+}
+
+function configuredRooms0156() {
+  try {
+    const rooms = globalThis.DashboardModernModules?.store?.getSection?.("rooms");
+    if (Array.isArray(rooms)) return rooms;
+  } catch (_error) {}
+  try {
+    if (typeof globalThis.getStanze === "function") {
+      const rooms = globalThis.getStanze();
+      if (Array.isArray(rooms)) return rooms;
+    }
+  } catch (_error) {}
+  return [];
+}
+
+function entityDomId0156(entity) {
+  return String(entity || "").replaceAll(".", "_").replaceAll("-", "_");
+}
+
+function syncRememberedTemperature0156() {
+  const doc = globalThis.document;
+  if (!doc) return false;
+  let changed = false;
+  configuredRooms0156().forEach((room) => {
+    const tempEntity = String(room?.temp || "").trim();
+    if (!tempEntity) return;
+    const humidityEntity = String(room?.hum || tempEntity.replace("_temperature", "_humidity")).trim();
+    const temperature = Number.parseFloat(runtimeState0156(tempEntity)?.state);
+    const humidity = Number.parseFloat(runtimeState0156(humidityEntity)?.state);
+    const tempText = Number.isFinite(temperature) ? temperature.toFixed(1) : "—";
+    const humidityText = Number.isFinite(humidity) ? humidity.toFixed(0) : "—";
+    const tempId = entityDomId0156(tempEntity);
+    const humidityId = entityDomId0156(humidityEntity);
+
+    const setText = (id, value) => {
+      const node = doc.getElementById(id);
+      if (!node || node.textContent === value) return;
+      node.textContent = value;
+      changed = true;
+    };
+    setText(`tv_${tempId}`, tempText);
+    setText(`tbl_${tempId}`, `${tempText}°`);
+    setText(`hbl_${humidityId}`, `${humidityText}%`);
+    const humidityNode = doc.getElementById(`hv_${humidityId}`);
+    if (humidityNode) {
+      const html = `${humidityText}<span style="font-size:14px;opacity:0.75;">%</span>`;
+      if (humidityNode.innerHTML !== html) {
+        humidityNode.innerHTML = html;
+        changed = true;
+      }
+    }
+  });
+  return changed;
+}
+
+function installLivePriority0156() {
+  const runtime = globalThis[PUBLIC_KEY_0156];
+  if (!runtime || runtime.__dm0156LivePriority) return Boolean(runtime?.__dm0156LivePriority);
+  const previousSync = typeof runtime.syncTemperature === "function"
+    ? runtime.syncTemperature.bind(runtime)
+    : null;
+  runtime.syncTemperature = function syncTemperature0156(force = true) {
+    let result = false;
+    try { result = previousSync ? previousSync(force) : false; } catch (_error) {}
+    return syncRememberedTemperature0156() || result;
+  };
+
+  const previousIngestState = typeof runtime.ingestState === "function"
+    ? runtime.ingestState.bind(runtime)
+    : null;
+  if (previousIngestState) {
+    runtime.ingestState = function ingestState0156(state) {
+      const result = previousIngestState(state);
+      globalThis.queueMicrotask?.(syncRememberedTemperature0156);
+      return result;
+    };
+  }
+  const previousIngestStates = typeof runtime.ingestStates === "function"
+    ? runtime.ingestStates.bind(runtime)
+    : null;
+  if (previousIngestStates) {
+    runtime.ingestStates = function ingestStates0156(states) {
+      const result = previousIngestStates(states);
+      globalThis.queueMicrotask?.(syncRememberedTemperature0156);
+      return result;
+    };
+  }
+  runtime.__dm0156LivePriority = true;
+  return true;
+}
+
+function rememberedStates0156() {
+  const live = globalThis[PUBLIC_KEY_0156];
+  if (live?.states instanceof Map && live.states.size) return [...live.states.values()];
+  try {
+    if (typeof _RAW_STATES !== "undefined" && _RAW_STATES) return Object.values(_RAW_STATES);
+  } catch (_error) {}
+  return Object.values(globalThis._RAW_STATES || globalThis.STATES || {});
+}
+
+function createLegacyCompatSocket0156() {
+  const listeners = new Map();
+  const socket = {
+    readyState: 1,
+    url: "dashboardmodern://shared-runtime",
+    protocol: "",
+    extensions: "",
+    bufferedAmount: 0,
+    binaryType: "blob",
+    onopen: null,
+    onmessage: null,
+    onerror: null,
+    onclose: null,
+    addEventListener(type, handler) {
+      if (typeof handler !== "function") return;
+      const list = listeners.get(type) || new Set();
+      list.add(handler);
+      listeners.set(type, list);
+    },
+    removeEventListener(type, handler) {
+      listeners.get(type)?.delete(handler);
+    },
+    close() {
+      // The shared broker owns the real transport. Closing this compatibility
+      // facade must not schedule another legacy reconnect.
+    },
+  };
+
+  const emit = (message) => {
+    const event = new MessageEvent("message", { data: JSON.stringify(message) });
+    globalThis.setTimeout?.(() => {
+      try { socket.onmessage?.(event); } catch (_error) {}
+      listeners.get("message")?.forEach((handler) => {
+        try { handler.call(socket, event); } catch (_error) {}
+      });
+    }, 0);
+  };
+
+  socket.send = (raw) => {
+    let message;
+    try { message = JSON.parse(raw); } catch (_error) { return; }
+    if (message.type === "auth") {
+      emit({ type: "auth_ok" });
+      return;
+    }
+    if (message.type === "get_states") {
+      emit({ id: message.id, type: "result", success: true, result: rememberedStates0156() });
+      return;
+    }
+    if (message.type === "subscribe_events") {
+      emit({ id: message.id, type: "result", success: true, result: null });
+      return;
+    }
+    if (message.type === "frontend/get_user_data") {
+      emit({ id: message.id, type: "result", success: true, result: { value: null } });
+      return;
+    }
+    const shared = globalThis[FINAL_KEY_0156]?.socket;
+    if (shared?.readyState === 1 && typeof shared.send === "function") {
+      try { shared.send(raw); return; } catch (_error) {}
+    }
+    if (message.id != null) emit({ id: message.id, type: "result", success: true, result: null });
+  };
+
+  globalThis.setTimeout?.(() => emit({ type: "auth_required" }), 0);
+  return socket;
+}
+
+function armLegacyReconnect0156() {
+  const state = stabilityState0156();
+  if (state.armed || typeof globalThis.WebSocket !== "function") return false;
+  const original = globalThis.WebSocket;
+  state.originalWebSocket = original;
+  state.armed = true;
+
+  function OneShotWebSocket0156(...args) {
+    const status = String(globalThis.document?.getElementById?.("conn-text")?.textContent || "").toLowerCase();
+    const live = globalThis[PUBLIC_KEY_0156];
+    const finalRuntime = globalThis[FINAL_KEY_0156];
+    const canReuse = Boolean(live?.states?.size || finalRuntime?.installed || finalRuntime?.ready);
+    const isLegacyReconnect = status.includes("riconnessione") || status.includes("reconnect");
+    if (canReuse && isLegacyReconnect) {
+      globalThis.WebSocket = original;
+      state.armed = false;
+      globalThis.clearTimeout?.(state.restoreTimer);
+      return createLegacyCompatSocket0156();
+    }
+    return Reflect.construct(original, args);
+  }
+  OneShotWebSocket0156.prototype = original.prototype;
+  ["CONNECTING", "OPEN", "CLOSING", "CLOSED"].forEach((key, index) => {
+    OneShotWebSocket0156[key] = original[key] ?? index;
+  });
+  globalThis.WebSocket = OneShotWebSocket0156;
+  state.restoreTimer = globalThis.setTimeout?.(() => {
+    if (globalThis.WebSocket === OneShotWebSocket0156) globalThis.WebSocket = original;
+    state.armed = false;
+  }, 8000);
+  return true;
+}
+
+function reinforce0156() {
+  installLivePriority0156();
+  syncRememberedTemperature0156();
+  armLegacyReconnect0156();
+}
+
+function install0156() {
+  reinforce0156();
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", () => {
+    globalThis.setTimeout?.(reinforce0156, 0);
+  });
+  globalThis.addEventListener?.("pageshow", () => globalThis.setTimeout?.(reinforce0156, 0));
+  const state = stabilityState0156();
+  let attempts = 0;
+  state.wrapperTimer = globalThis.setInterval?.(() => {
+    attempts += 1;
+    installLivePriority0156();
+    if (!state.armed) armLegacyReconnect0156();
+    if (attempts >= 60 || (globalThis[PUBLIC_KEY_0156]?.__dm0156LivePriority && state.armed)) {
+      globalThis.clearInterval?.(state.wrapperTimer);
+      state.wrapperTimer = 0;
+    }
+  }, 100);
+}
+
+if (typeof globalThis.document !== "undefined") install0156();

--- a/custom_components/dashboardmodern/frontend/tests/legacy-bridge-prelude.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/legacy-bridge-prelude.test.js
@@ -12,8 +12,15 @@ const PRELUDE = readFileSync(
 /** Run the prelude in a mock document, mirroring how the iframe loads it. */
 function runPrelude({ parent, host = "ha.local:8123", storage = {}, throwOnParent = false }) {
   const writes = [];
+  class MockWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+  }
   const window = {
     location: { host },
+    WebSocket: MockWebSocket,
     localStorage: {
       getItem: (key) => (key in storage ? storage[key] : null),
       setItem: (key, value) => {

--- a/custom_components/dashboardmodern/frontend/tests/release-0152-version.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-0152-version.test.js
@@ -4,7 +4,7 @@ import test from "node:test";
 
 const manifestUrl = new URL("../../manifest.json", import.meta.url);
 
-test("the public corrective release is version 0.14.15", async () => {
+test("the public corrective release is version 0.14.16", async () => {
   const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
-  assert.equal(manifest.version, "0.14.15");
+  assert.equal(manifest.version, "0.14.16");
 });

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "0.14.15"
+  "version": "0.14.16"
 }


### PR DESCRIPTION
## Problemi riprodotti dagli screenshot reali

- La selezione di luglio nel Report contaminava gli slot mensili correnti, sostituendo agosto con valori cumulativi o del mese storico.
- Una singola riga Recorder con `sum/state` veniva interpretata come consumo del periodo, mostrando il totale lifetime.
- Il Report applicava i valori Recorder agli elettrodomestici soltanto quando `isCurrentMonth` era vero.
- Temperature e umidità dipendevano da polling e registri non sempre popolati.
- Più timer, observer e client statistici contribuivano al rallentamento generale.

## Correzione 0.14.16

- Separazione completa tra periodo corrente Energia e mese selezionato nel Report.
- Baseline Recorder obbligatoria quando manca `change` e la risposta contiene una sola misura cumulativa.
- Broker unico per statistiche, `get_states` e sottoscrizione `state_changed`, con deduplicazione richieste e cache per periodo.
- Protezione generazionale contro risposte fuori ordine quando si cambia mese rapidamente.
- Report storico applicato anche ai mesi precedenti, inclusi KPI e consumi degli elettrodomestici.
- Eliminazione del polling permanente da 500 ms del runtime 0.14.15.
- E2E italiano e inglese basato su luglio/agosto e valori degli screenshot Home Assistant.

La PR resta in bozza finché Tests, Browser E2E, hassfest e HACS non sono verdi.