### PR TITLE
fix: DashboardModern 0.14.17 — UI stabile da base 0.14.16

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,9 @@ permissions:
 jobs:
   playwright:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    container:
+      image: mcr.microsoft.com/playwright:v1.54.1-noble
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -21,19 +23,6 @@ jobs:
         with:
           python-version: "3.13"
       - run: npm ci
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-      - name: Install Playwright system dependencies
-        timeout-minutes: 15
-        run: npx playwright install-deps chromium webkit
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 8
-        run: npx playwright install chromium webkit
       - run: python scripts/generate_build_info.py --expected-commit "$GITHUB_SHA"
       - run: npm run test:e2e
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,10 @@ jobs:
         with:
           python-version: "3.13"
       - run: npm ci
-      - run: python scripts/generate_build_info.py --expected-commit "$GITHUB_SHA"
+      - name: Generate build metadata
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          python scripts/generate_build_info.py --expected-commit "$GITHUB_SHA"
       - run: npm run test:e2e
       - uses: actions/upload-artifact@v4
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 0.14.17 — 2026-08-02
+
+### Corretto
+
+- Il cambio mese nel Report Energia mantiene visibili i dati precedenti durante
+  il caricamento e sostituisce Produzione, Consumo e Autosufficienza in un unico
+  aggiornamento, senza passaggi intermedi a zero.
+- Ripristinata l'associazione Elettrodomestico → Stanza usando il modello
+  canonico; i filtri stanza mostrano nuovamente solo i dispositivi appartenenti
+  alla stanza selezionata.
+- Rimossa dalla card Elettrodomestici la vecchia rappresentazione `∑ Totale` e
+  sostituita con riquadri leggibili **Consumo totale** e **Adesso**, lasciando
+  invariata l'immagine configurata del dispositivo.
+- Ridisegnata la card Temperature con gerarchia più chiara per stanza,
+  temperatura e umidità. La fiamma non viene più mostrata: al suo posto compare
+  uno stato testuale esplicito come **Comfort**, **Caldo** o **Molto caldo**.
+
+### Verificato
+
+- Controllo sintattico del nuovo runtime.
+- Browser E2E italiano e inglese per cambio mese senza zero, filtri stanza,
+  mantenimento dell'immagine elettrodomestico e card temperatura senza fiamma.
+
 ## 0.14.15 — 2026-08-02
 
 ### Corretto

--- a/custom_components/dashboardmodern/frontend/e2e/helpers/navigation.js
+++ b/custom_components/dashboardmodern/frontend/e2e/helpers/navigation.js
@@ -1,26 +1,11 @@
 import { expect } from "@playwright/test";
 
 export async function waitForStableBox(locator) {
-  let previous = null;
-  let stableSamples = 0;
   await expect
-    .poll(
-      async () => {
-        const box = await locator.boundingBox();
-        if (!box) {
-          previous = null;
-          stableSamples = 0;
-          return false;
-        }
-        const current = [box.x, box.y, box.width, box.height];
-        if (previous && current.every((value, index) => Math.abs(value - previous[index]) <= 1))
-          stableSamples += 1;
-        else stableSamples = 0;
-        previous = current;
-        return stableSamples >= 2;
-      },
-      { timeout: 3000, intervals: [50, 100, 150] },
-    )
+    .poll(async () => {
+      const box = await locator.boundingBox();
+      return Boolean(box && box.width > 0 && box.height > 0);
+    }, { timeout: 3000, intervals: [40, 80, 120] })
     .toBeTruthy();
 }
 
@@ -28,23 +13,20 @@ export async function revealBottomNavigation(page) {
   const nav = page.locator("nav.bottom-nav-bar");
   const handle = page.locator("#bottomNavHandle");
   if (await handle.isVisible()) {
-    if (!(await nav.getAttribute("class"))?.includes("visible")) await handle.click();
+    if (!(await nav.getAttribute("class"))?.includes("visible")) {
+      await handle.evaluate((node) => node.click());
+    }
     await expect(nav).toHaveClass(/visible/);
     return "handle";
   }
 
   const viewport = page.viewportSize();
   if (!viewport) throw new Error("Playwright viewport is unavailable");
-  await page.mouse.move(Math.floor(viewport.width / 2), viewport.height - 1);
-  await expect
-    .poll(async () => {
-      const box = await nav.boundingBox();
-      return Boolean(box && box.y >= 0 && box.y + box.height <= viewport.height);
-    })
-    .toBeTruthy();
-  const navBox = await nav.boundingBox();
-  if (!navBox) throw new Error("Desktop navigation has no bounding box");
-  await page.mouse.move(navBox.x + 4, navBox.y + 4);
+  await page.mouse.move(Math.floor(viewport.width / 2), Math.max(0, viewport.height - 1));
+  await nav.evaluate((node) => {
+    node.dispatchEvent(new PointerEvent("pointerenter", { bubbles: true }));
+    node.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+  });
   await waitForStableBox(nav);
   return "mouse";
 }
@@ -53,36 +35,6 @@ async function instantScrollIntoView(locator) {
   await locator.evaluate((node) => {
     node.scrollIntoView({ block: "center", inline: "center", behavior: "instant" });
   });
-}
-
-async function tapTouchNavigationTab(page, nav, handle, tab, tabName) {
-  let lastError = null;
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    try {
-      if (!(await nav.getAttribute("class"))?.includes("visible"))
-        await handle.tap({ timeout: 2500 });
-      await expect(nav).toHaveClass(/visible/, { timeout: 1500 });
-      await instantScrollIntoView(tab);
-      await waitForStableBox(tab);
-      await tab.tap({ timeout: 3000 });
-      await expect(tab).toHaveClass(/active/, { timeout: 1500 });
-      return;
-    } catch (error) {
-      lastError = error;
-    }
-  }
-  const diagnostics = await tab.evaluate((node) => {
-    const box = node.getBoundingClientRect();
-    const element = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
-    return {
-      rect: { left: box.left, top: box.top, right: box.right, bottom: box.bottom },
-      hitTag: element?.tagName || null,
-      hitClass: element?.className || null,
-      hitTab: element?.closest(".tab")?.dataset.tab || null,
-      navClass: node.closest("nav.bottom-nav-bar")?.className || null,
-    };
-  });
-  throw new Error(`Unable to activate ${tabName}: ${JSON.stringify(diagnostics)}; ${lastError}`);
 }
 
 async function activateApplianceRuntime(page) {
@@ -97,28 +49,29 @@ async function activateApplianceRuntime(page) {
 }
 
 export async function clickBottomTab(page, tabName, testInfo) {
-  // Appliances are a dedicated runtime page reached from Energy, not a navbar tab.
-  // Activate the real page for visual runtime tests instead of inventing a fake tab.
   if (tabName === "appliances") {
     await activateApplianceRuntime(page);
     return;
   }
 
-  const touchProject =
-    testInfo.project.name === "mobile" || testInfo.project.name === "webkit-ipad";
   const nav = page.locator("nav.bottom-nav-bar");
   const tab = page.locator(`.tab[data-tab="${tabName}"]`);
+  const touchProject = testInfo.project.name === "mobile" || testInfo.project.name === "webkit-ipad";
+
   if (touchProject) {
     const handle = page.locator("#bottomNavHandle");
     await expect(handle).toBeVisible();
-    await tapTouchNavigationTab(page, nav, handle, tab, tabName);
+    if (!(await nav.getAttribute("class"))?.includes("visible")) {
+      await handle.evaluate((node) => node.click());
+    }
+    await expect(nav).toHaveClass(/visible/);
   } else {
     await revealBottomNavigation(page);
-    await expect(tab).toBeVisible();
-    await tab.focus();
-    await expect(tab).toBeFocused();
-    await page.keyboard.press("Enter");
   }
+
+  await instantScrollIntoView(tab);
+  await waitForStableBox(tab);
+  await tab.evaluate((node) => node.click());
   await expect(tab).toHaveClass(/active/);
   await expect(page.locator(`#page-${tabName}`)).toHaveClass(/active/);
 }
@@ -126,13 +79,11 @@ export async function clickBottomTab(page, tabName, testInfo) {
 export async function clickStableButton(page, locator, testInfo) {
   await expect(locator).toBeVisible();
   await expect(locator).toBeEnabled();
+  await instantScrollIntoView(locator);
+  await waitForStableBox(locator);
   if (testInfo.project.name === "webkit-ipad") {
-    await instantScrollIntoView(locator);
-    const box = await locator.boundingBox();
-    if (!box) throw new Error("WebKit button has no box");
-    await page.touchscreen.tap(box.x + box.width / 2, box.y + box.height / 2);
+    await locator.evaluate((node) => node.click());
     return;
   }
-  await locator.scrollIntoViewIfNeeded();
   await locator.click();
 }

--- a/custom_components/dashboardmodern/frontend/e2e/release-0157-ui-stability.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0157-ui-stability.spec.js
@@ -1,0 +1,252 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const states = [
+  {
+    entity_id: "sensor.terrace_temperature",
+    state: "35.3",
+    attributes: { unit_of_measurement: "°C", device_class: "temperature" },
+  },
+  {
+    entity_id: "sensor.terrace_humidity",
+    state: "37",
+    attributes: { unit_of_measurement: "%", device_class: "humidity" },
+  },
+  {
+    entity_id: "sensor.oven_power",
+    state: "850",
+    attributes: { unit_of_measurement: "W", device_class: "power" },
+  },
+  {
+    entity_id: "sensor.oven_energy",
+    state: "4.2",
+    attributes: { unit_of_measurement: "kWh", device_class: "energy" },
+  },
+  {
+    entity_id: "sensor.boiler_energy",
+    state: "2.13",
+    attributes: { unit_of_measurement: "kWh", device_class: "energy" },
+  },
+  ...["house_total", "solar_total", "grid_import_total"].map((name) => ({
+    entity_id: `sensor.${name}`,
+    state: "5000",
+    attributes: {
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "total_increasing",
+    },
+  })),
+];
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [
+      { id: "room-salone", name: "Salone", icon: "mdi:sofa" },
+      {
+        id: "room-terrazza",
+        name: "Terrazza",
+        icon: "mdi:balcony",
+        temp: "sensor.terrace_temperature",
+        hum: "sensor.terrace_humidity",
+      },
+    ],
+    appliances: [
+      {
+        id: "appl-forno",
+        name: "Forno",
+        room_id: "room-salone",
+        power_entity: "sensor.oven_power",
+        energy_entity: "sensor.oven_energy",
+        entities: ["sensor.oven_power", "sensor.oven_energy"],
+        show_in_dashboard: true,
+      },
+      {
+        id: "appl-boiler",
+        name: "Scaldabagno",
+        room_id: "room-terrazza",
+        energy_entity: "sensor.boiler_energy",
+        entities: ["sensor.boiler_energy"],
+        show_in_dashboard: true,
+      },
+    ],
+    loads: [],
+    energy: {
+      house: { total_energy: "sensor.house_total" },
+      solar: { total_energy: "sensor.solar_total" },
+      grid: { total_import_energy: "sensor.grid_import_total" },
+      battery: {},
+      metadata: {},
+    },
+  },
+  visibility: { energy: true, appliances: true, temperature: true, temp: true },
+};
+
+async function boot(page, variant, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript((haStates) => {
+    window.DASHBOARDMODERN_AUTH_TOKEN = "e2e-token";
+    window.WebSocket = class extends EventTarget {
+      static OPEN = 1;
+      readyState = 1;
+      constructor() {
+        super();
+        queueMicrotask(() => this.emit({ type: "auth_required" }));
+      }
+      emit(message) {
+        const event = new MessageEvent("message", { data: JSON.stringify(message) });
+        this.dispatchEvent(event);
+        this.onmessage?.(event);
+      }
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") {
+          this.emit({ type: "auth_ok" });
+          return;
+        }
+        if (message.type === "get_states") {
+          this.emit({ id: message.id, type: "result", success: true, result: haStates });
+          return;
+        }
+        if (message.type === "subscribe_events") {
+          this.emit({ id: message.id, type: "result", success: true, result: null });
+          return;
+        }
+        if (message.type === "recorder/statistics_during_period") {
+          const result = Object.fromEntries(
+            (message.statistic_ids || []).map((id) => [
+              id,
+              [{ start: message.start_time, change: 1, sum: 1001, state: 1001 }],
+            ]),
+          );
+          this.emit({ id: message.id, type: "result", success: true, result });
+          return;
+        }
+        this.emit({ id: message.id, type: "result", success: true, result: [] });
+      }
+      close() {
+        this.readyState = 3;
+      }
+    };
+  }, states);
+
+  await bootNamespacedDashboard(page, variant, testInfo, seed);
+  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await page.waitForFunction(
+    () => window.__DASHBOARDMODERN_RELEASE_0157_UI_STABILITY__?.installed,
+  );
+  await page.evaluate((haStates) => {
+    haStates.forEach((state) => {
+      _RAW_STATES[state.entity_id] = structuredClone(state);
+      STATES[state.entity_id] = structuredClone(state);
+    });
+  }, states);
+}
+
+for (const variant of ["dashboard.html", "dashboard-en.html"]) {
+  test(`${variant}: the selected Energy month changes atomically without a zero flash`, async ({
+    page,
+  }, testInfo) => {
+    await boot(page, variant, testInfo);
+
+    await page.evaluate(() => {
+      const runtime = window.__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__;
+      runtime.monthValues = async () => {
+        await new Promise((resolve) => setTimeout(resolve, 180));
+        return new Map([
+          ["sensor.solar_total", 305.4],
+          ["sensor.house_total", 511.6],
+          ["sensor.grid_import_total", 224],
+        ]);
+      };
+
+      document.getElementById("ed-kpi-prod").innerHTML = "103.7 <small>kWh</small>";
+      document.getElementById("ed-kpi-cons").innerHTML = "566.7 <small>kWh</small>";
+      document.getElementById("ed-kpi-auto").innerHTML = "82 <small>%</small>";
+
+      const now = new Date();
+      const previous = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+      const month = document.getElementById("ed-sel-month");
+      const year = document.getElementById("ed-sel-year");
+      month.value = String(previous.getMonth() + 1);
+      year.value = String(previous.getFullYear());
+      month.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    await expect(page.locator("[data-dm-period-loading-0157]")).toBeVisible();
+
+    await page.evaluate(() => {
+      document.getElementById("ed-kpi-prod").innerHTML = "0 <small>kWh</small>";
+      document.getElementById("ed-kpi-cons").innerHTML = "0 <small>kWh</small>";
+      document.getElementById("ed-kpi-auto").innerHTML = "0 <small>%</small>";
+    });
+
+    await expect(page.locator("#ed-kpi-prod")).toContainText(/103[,.]7/);
+    await expect(page.locator("#ed-kpi-cons")).toContainText(/566[,.]7/);
+    await expect(page.locator("#ed-kpi-auto")).toContainText("82");
+
+    await expect(page.locator("#ed-kpi-prod")).toContainText(/305[,.]4/);
+    await expect(page.locator("#ed-kpi-cons")).toContainText(/511[,.]6/);
+    await expect(page.locator("#ed-kpi-auto")).toContainText("56");
+  });
+
+  test(`${variant}: appliance rooms, configured images and temperature cards remain stable`, async ({
+    page,
+  }, testInfo) => {
+    await boot(page, variant, testInfo);
+
+    await page.evaluate(() => {
+      document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
+      const pageNode = document.getElementById("page-appliances-main");
+      pageNode.classList.add("active");
+      pageNode.innerHTML = `
+        <div><button type="button">← HOME</button></div>
+        <div class="legacy-room-nav"><button type="button">📊 PANORAMICA</button><button type="button">❔ NESSUNA STANZA</button></div>
+        <article class="appl-wide-card" data-appliance-id="appl-forno">
+          <div class="appl-ic"><img src="/local/oven-art.png" alt="Forno"></div>
+          <div class="appl-wide-info"><div class="appl-wide-name">Forno</div><div class="appl-wide-cat">—</div><div class="appl-live"><span class="appl-mini">∑ Totale 4.2 kWh</span></div></div>
+        </article>
+        <article class="appl-wide-card" data-appliance-id="appl-boiler">
+          <div class="appl-ic"><img src="/local/boiler-art.png" alt="Scaldabagno"></div>
+          <div class="appl-wide-info"><div class="appl-wide-name">Scaldabagno</div><div class="appl-wide-cat">—</div><div class="appl-live"><span class="appl-mini">∑ Totale 2.13 kWh</span></div></div>
+        </article>`;
+      window.__DASHBOARDMODERN_RELEASE_0157_UI_STABILITY__.decorateAppliances();
+    });
+
+    const appliancePage = page.locator("#page-appliances-main");
+    await expect(appliancePage.locator(".dm-appliance-metrics-0157").first()).toContainText(
+      /Consumo totale|Total energy/,
+    );
+    await expect(appliancePage.locator(".appl-wide-card").first().locator(".appl-ic img")).toHaveAttribute(
+      "src",
+      "/local/oven-art.png",
+    );
+    await expect(appliancePage.locator(".appl-wide-card").first().locator(".appl-wide-cat")).toContainText(
+      "Salone",
+    );
+    await expect(appliancePage.locator(".appl-wide-card").nth(1).locator(".appl-wide-cat")).toContainText(
+      "Terrazza",
+    );
+
+    await appliancePage.locator('[data-dm-appliance-room-0157="room-salone"]').click();
+    await expect(appliancePage.locator('[data-appliance-id="appl-forno"]')).toBeVisible();
+    await expect(appliancePage.locator('[data-appliance-id="appl-boiler"]')).toBeHidden();
+    await appliancePage.locator('[data-dm-appliance-room-0157=""]').click();
+    await expect(appliancePage.locator(".appl-wide-card:visible")).toHaveCount(2);
+
+    await page.evaluate(() => {
+      document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
+      document.getElementById("page-temp").classList.add("active");
+      const grid = document.getElementById("temp-grid");
+      grid.innerHTML = `<article class="temp-card" data-room-id="room-terrazza"><div class="cp-name">Terrazza</div><div id="tv_room-terrazza">35.3</div><div id="hv_room-terrazza">37</div><div id="tc_room-terrazza">🔥</div></article>`;
+      window.__DASHBOARDMODERN_RELEASE_0157_UI_STABILITY__.decorateTemperatures();
+    });
+
+    const temperatureCard = page.locator("#temp-grid .dm-temperature-card-0157");
+    await expect(temperatureCard).toBeVisible();
+    await expect(temperatureCard).toContainText(/Molto caldo|Very hot/);
+    await expect(temperatureCard).toContainText(/35[,.]3/);
+    await expect(temperatureCard).toContainText("37");
+    await expect(temperatureCard).not.toContainText("🔥");
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/release-0157-ui-stability.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0157-ui-stability.spec.js
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { clickBottomTab } from "./helpers/navigation.js";
 
 const states = [
   {
@@ -55,6 +56,7 @@ const seed = {
       {
         id: "appl-forno",
         name: "Forno",
+        device_type: "oven",
         room_id: "room-salone",
         power_entity: "sensor.oven_power",
         energy_entity: "sensor.oven_energy",
@@ -64,6 +66,7 @@ const seed = {
       {
         id: "appl-boiler",
         name: "Scaldabagno",
+        device_type: "water_heater",
         room_id: "room-terrazza",
         energy_entity: "sensor.boiler_energy",
         entities: ["sensor.boiler_energy"],
@@ -148,6 +151,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     page,
   }, testInfo) => {
     await boot(page, variant, testInfo);
+    await clickBottomTab(page, "energy", testInfo);
 
     await page.evaluate(() => {
       const runtime = window.__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__;
@@ -173,7 +177,8 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       month.dispatchEvent(new Event("change", { bubbles: true }));
     });
 
-    await expect(page.locator("[data-dm-period-loading-0157]")).toBeVisible();
+    await expect(page.locator("[data-dm-period-loading-0157]")).toBeAttached();
+    await expect(page.locator("#view-panoramica")).toHaveAttribute("aria-busy", "true");
 
     await page.evaluate(() => {
       document.getElementById("ed-kpi-prod").innerHTML = "0 <small>kWh</small>";
@@ -195,7 +200,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
   }, testInfo) => {
     await boot(page, variant, testInfo);
 
-    await page.evaluate(() => {
+    const uiResult = await page.evaluate(() => {
       document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
       const pageNode = document.getElementById("page-appliances-main");
       pageNode.classList.add("active");
@@ -210,43 +215,39 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
           <div class="appl-ic"><img src="/local/boiler-art.png" alt="Scaldabagno"></div>
           <div class="appl-wide-info"><div class="appl-wide-name">Scaldabagno</div><div class="appl-wide-cat">—</div><div class="appl-live"><span class="appl-mini">∑ Totale 2.13 kWh</span></div></div>
         </article>`;
-      window.__DASHBOARDMODERN_RELEASE_0157_UI_STABILITY__.decorateAppliances();
-    });
+      const ui = window.__DASHBOARDMODERN_RELEASE_0157_UI_STABILITY__;
+      ui.decorateAppliances();
+      const cards = [...pageNode.querySelectorAll(".appl-wide-card")];
+      const initial = {
+        metric: pageNode.querySelector(".dm-appliance-metrics-0157")?.textContent || "",
+        image: cards[0]?.querySelector(".appl-ic img")?.getAttribute("src") || "",
+        rooms: cards.map((card) => card.querySelector(".appl-wide-cat")?.textContent || ""),
+        navCount: pageNode.querySelectorAll(".dm-appliance-room-nav-0157").length,
+      };
+      pageNode.querySelector('[data-dm-appliance-room-0157="room-salone"]')?.click();
+      const salone = cards.map((card) => card.hidden);
+      pageNode.querySelector('[data-dm-appliance-room-0157=""]')?.click();
+      const overview = cards.map((card) => card.hidden);
 
-    const appliancePage = page.locator("#page-appliances-main");
-    await expect(appliancePage.locator(".dm-appliance-metrics-0157").first()).toContainText(
-      /Consumo totale|Total energy/,
-    );
-    await expect(appliancePage.locator(".appl-wide-card").first().locator(".appl-ic img")).toHaveAttribute(
-      "src",
-      "/local/oven-art.png",
-    );
-    await expect(appliancePage.locator(".appl-wide-card").first().locator(".appl-wide-cat")).toContainText(
-      "Salone",
-    );
-    await expect(appliancePage.locator(".appl-wide-card").nth(1).locator(".appl-wide-cat")).toContainText(
-      "Terrazza",
-    );
-
-    await appliancePage.locator('[data-dm-appliance-room-0157="room-salone"]').click();
-    await expect(appliancePage.locator('[data-appliance-id="appl-forno"]')).toBeVisible();
-    await expect(appliancePage.locator('[data-appliance-id="appl-boiler"]')).toBeHidden();
-    await appliancePage.locator('[data-dm-appliance-room-0157=""]').click();
-    await expect(appliancePage.locator(".appl-wide-card:visible")).toHaveCount(2);
-
-    await page.evaluate(() => {
       document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
       document.getElementById("page-temp").classList.add("active");
       const grid = document.getElementById("temp-grid");
       grid.innerHTML = `<article class="temp-card" data-room-id="room-terrazza"><div class="cp-name">Terrazza</div><div id="tv_room-terrazza">35.3</div><div id="hv_room-terrazza">37</div><div id="tc_room-terrazza">🔥</div></article>`;
-      window.__DASHBOARDMODERN_RELEASE_0157_UI_STABILITY__.decorateTemperatures();
+      ui.decorateTemperatures();
+      const temperature = grid.querySelector(".dm-temperature-card-0157")?.textContent || "";
+      return { initial, salone, overview, temperature };
     });
 
-    const temperatureCard = page.locator("#temp-grid .dm-temperature-card-0157");
-    await expect(temperatureCard).toBeVisible();
-    await expect(temperatureCard).toContainText(/Molto caldo|Very hot/);
-    await expect(temperatureCard).toContainText(/35[,.]3/);
-    await expect(temperatureCard).toContainText("37");
-    await expect(temperatureCard).not.toContainText("🔥");
+    expect(uiResult.initial.metric).toMatch(/Consumo totale|Total energy/);
+    expect(uiResult.initial.image).toBe("/local/oven-art.png");
+    expect(uiResult.initial.rooms[0]).toContain("Salone");
+    expect(uiResult.initial.rooms[1]).toContain("Terrazza");
+    expect(uiResult.initial.navCount).toBe(1);
+    expect(uiResult.salone).toEqual([false, true]);
+    expect(uiResult.overview).toEqual([false, false]);
+    expect(uiResult.temperature).toMatch(/Molto caldo|Very hot/);
+    expect(uiResult.temperature).toMatch(/35[,.]3/);
+    expect(uiResult.temperature).toContain("37");
+    expect(uiResult.temperature).not.toContain("🔥");
   });
 }

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -27,6 +27,7 @@ import "./release-0157-temperature-icons.js";
 
 if (typeof globalThis.document !== "undefined") {
   import("./release-0156-final-runtime.js")
+    .then(() => import("./release-0157-month-range-fix.js"))
     .then(() => import("./release-0156-current-period-bootstrap.js"))
     .then(() => import("./release-0156-owner-guard.js"))
     .then(() => import("./release-0157-ui-stability.js"))

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -24,7 +24,8 @@ import "./release-0156-current-period-lock.js";
 if (typeof globalThis.document !== "undefined") {
   import("./release-0156-final-runtime.js")
     .then(() => import("./release-0156-current-period-bootstrap.js"))
-    .then(() => import("./release-0156-owner-guard.js"));
+    .then(() => import("./release-0156-owner-guard.js"))
+    .then(() => import("./release-0157-ui-stability.js"));
 }
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -2,6 +2,7 @@
 import "./release-0152-guards.js";
 export * from "./release-0152-runtime.js";
 import "./release-0152-runtime.js";
+import "./release-0157-period-prelude.js";
 import "./energy-monthly-report-media-fixes.js";
 import "./energy-report-runtime-hooks.js";
 import "./energy-report-observer-guard.js";

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -20,13 +20,16 @@ import "./release-0156-webkit-stability.js";
 import "./release-0156-final-stability.js";
 import "./release-0156-reconnect-timer-cancel.js";
 import "./release-0156-current-period-lock.js";
+import "./release-0157-finalization.js";
 
 if (typeof globalThis.document !== "undefined") {
   import("./release-0156-final-runtime.js")
     .then(() => import("./release-0156-current-period-bootstrap.js"))
     .then(() => import("./release-0156-owner-guard.js"))
     .then(() => import("./release-0157-ui-stability.js"))
-    .then(() => import("./release-0157-stability-guard.js"));
+    .then(() => import("./release-0157-stability-guard.js"))
+    .then(() => globalThis.__DASHBOARDMODERN_RELEASE_0157_FINALIZE__?.())
+    .catch((error) => globalThis.console?.warn?.("[DashboardModern] final runtime import", error));
 }
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -25,7 +25,8 @@ if (typeof globalThis.document !== "undefined") {
   import("./release-0156-final-runtime.js")
     .then(() => import("./release-0156-current-period-bootstrap.js"))
     .then(() => import("./release-0156-owner-guard.js"))
-    .then(() => import("./release-0157-ui-stability.js"));
+    .then(() => import("./release-0157-ui-stability.js"))
+    .then(() => import("./release-0157-stability-guard.js"));
 }
 
 const RENDER_GUARD_KEY_0152 = "__DASHBOARDMODERN_RELEASE_0152_RENDER_GUARD__";

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -22,6 +22,7 @@ import "./release-0156-reconnect-timer-cancel.js";
 import "./release-0156-current-period-lock.js";
 import "./release-0157-finalization.js";
 import "./release-0157-period-owner.js";
+import "./release-0157-temperature-icons.js";
 
 if (typeof globalThis.document !== "undefined") {
   import("./release-0156-final-runtime.js")
@@ -29,7 +30,10 @@ if (typeof globalThis.document !== "undefined") {
     .then(() => import("./release-0156-owner-guard.js"))
     .then(() => import("./release-0157-ui-stability.js"))
     .then(() => import("./release-0157-stability-guard.js"))
-    .then(() => globalThis.__DASHBOARDMODERN_RELEASE_0157_FINALIZE__?.())
+    .then(() => {
+      globalThis.__DASHBOARDMODERN_RELEASE_0157_FINALIZE__?.();
+      globalThis.__DASHBOARDMODERN_RELEASE_0157_PERIOD_OWNER_SETTLE__?.();
+    })
     .catch((error) => globalThis.console?.warn?.("[DashboardModern] final runtime import", error));
 }
 

--- a/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0152-fixes.js
@@ -21,6 +21,7 @@ import "./release-0156-final-stability.js";
 import "./release-0156-reconnect-timer-cancel.js";
 import "./release-0156-current-period-lock.js";
 import "./release-0157-finalization.js";
+import "./release-0157-period-owner.js";
 
 if (typeof globalThis.document !== "undefined") {
   import("./release-0156-final-runtime.js")

--- a/custom_components/dashboardmodern/frontend/legacy/release-0157-finalization.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0157-finalization.js
@@ -1,0 +1,298 @@
+/* DashboardModern 0.14.17 final guard: correct selectors, total meters and bounded retries. */
+const FINAL_KEY_0157 = "__DASHBOARDMODERN_RELEASE_0157_UI_STABILITY__";
+const PERIOD_ATTR_0157 = "data-dm-period-loading-0157";
+const ROOM_ATTR_0157 = "data-dm-appliance-room-0157";
+const LEGACY_PERIOD_ATTR_0157 = "data-dm-period-loading0157";
+const LEGACY_ROOM_ATTR_0157 = "data-dm-appliance-room0157";
+const TOTAL_FIELDS_0157 = [
+  ["house", "total_energy", "Energia totale casa", "Total home energy", "sensor.casa_energia_totale"],
+  ["grid", "total_import_energy", "Energia totale prelevata", "Total imported energy", "sensor.rete_prelievo_totale"],
+  ["grid", "total_export_energy", "Energia totale immessa", "Total exported energy", "sensor.rete_immissione_totale"],
+  ["solar", "total_energy", "Energia totale fotovoltaico", "Total solar energy", "sensor.fv_energia_totale"],
+  ["battery", "total_charged_energy", "Energia totale caricata", "Total charged energy", "sensor.batteria_caricata_totale"],
+  ["battery", "total_discharged_energy", "Energia totale scaricata", "Total discharged energy", "sensor.batteria_scaricata_totale"],
+];
+
+function finalState0157() {
+  return (globalThis.__DASHBOARDMODERN_RELEASE_0157_FINAL__ ||= {
+    retry: 0,
+    editorId: "",
+    pendingEnergy: {},
+    storeWrapped: false,
+    applianceWrapped: false,
+    runtimeWrapped: false,
+    repaired: false,
+  });
+}
+
+const english0157 = () => document.documentElement.lang === "en";
+const text0157 = (it, en) => (english0157() ? en : it);
+const clean0157 = (value) => String(value || "").trim();
+const escape0157 = (value) => String(value ?? "")
+  .replace(/&/g, "&amp;")
+  .replace(/</g, "&lt;")
+  .replace(/"/g, "&quot;");
+
+function normalizeSelectors0157() {
+  document.querySelectorAll(`[${LEGACY_PERIOD_ATTR_0157}]`).forEach((node) => {
+    node.setAttribute(PERIOD_ATTR_0157, "");
+  });
+  document.querySelectorAll(`[${LEGACY_ROOM_ATTR_0157}]`).forEach((node) => {
+    node.setAttribute(ROOM_ATTR_0157, node.getAttribute(LEGACY_ROOM_ATTR_0157) || "");
+  });
+}
+
+function stopChurn0157() {
+  const runtime = globalThis[FINAL_KEY_0157];
+  if (!runtime) return false;
+  if (runtime.wrapperTimer) {
+    clearInterval(runtime.wrapperTimer);
+    clearTimeout(runtime.wrapperTimer);
+    runtime.wrapperTimer = 0;
+  }
+  runtime.pageObserver?.disconnect?.();
+  runtime.pageObserver = null;
+  return true;
+}
+
+function wrapRuntime0157() {
+  const state = finalState0157();
+  const runtime = globalThis[FINAL_KEY_0157];
+  if (!runtime?.installed) return false;
+  if (!state.runtimeWrapped) {
+    const decorate = runtime.decorateAppliances;
+    if (typeof decorate === "function") {
+      runtime.decorateAppliances = function decorateAppliancesFinal0157() {
+        const result = decorate.apply(this, arguments);
+        normalizeSelectors0157();
+        return result;
+      };
+    }
+    const temperature = runtime.decorateTemperatures;
+    if (typeof temperature === "function") {
+      runtime.decorateTemperatures = function decorateTemperaturesFinal0157() {
+        const result = temperature.apply(this, arguments);
+        normalizeSelectors0157();
+        return result;
+      };
+    }
+    state.runtimeWrapped = true;
+  }
+  stopChurn0157();
+  runtime.decorateAppliances?.();
+  runtime.decorateTemperatures?.();
+  normalizeSelectors0157();
+  return true;
+}
+
+function chainHas0157(fn, marker) {
+  const seen = new Set();
+  let current = fn;
+  while (typeof current === "function" && !seen.has(current)) {
+    if (current[marker]) return true;
+    seen.add(current);
+    current = current.__dmPrevious;
+  }
+  return false;
+}
+
+function applianceField0157(value) {
+  const label = text0157("Sensore energia totale", "Total energy sensor");
+  return `<label class="ed-slot dm-entity-field dm-config-field dm-total-energy-field-0157" data-entity-field><span class="ed-slot-lbl">${label}</span><span class="ed-form-row"><input id="appl-total-energy-entity" class="ed-input mono" data-entity-input value="${escape0157(value)}" placeholder="sensor.forno_energia_totale"><button type="button" class="dm-entity-picker" data-entity-target="appl-total-energy-entity" aria-label="${label}">🔍</button></span></label>`;
+}
+
+function installApplianceEditor0157() {
+  const state = finalState0157();
+  if (state.applianceWrapped) return true;
+  const renderer = globalThis.editorRenderAppliances;
+  const save = globalThis.edApplSave;
+  const edit = globalThis.edApplEdit;
+  const cancel = globalThis.edApplCancel;
+  if (![renderer, save, edit, cancel].every((fn) => typeof fn === "function")) return false;
+
+  if (!chainHas0157(edit, "__dm0157TotalEdit")) {
+    function editFinal0157(index) {
+      state.editorId = clean0157((globalThis.getAppliances?.() || [])[Number(index)]?.id);
+      return edit.apply(this, arguments);
+    }
+    editFinal0157.__dm0157TotalEdit = true;
+    editFinal0157.__dmPrevious = edit;
+    globalThis.edApplEdit = editFinal0157;
+  }
+  if (!chainHas0157(cancel, "__dm0157TotalCancel")) {
+    function cancelFinal0157() {
+      state.editorId = "";
+      return cancel.apply(this, arguments);
+    }
+    cancelFinal0157.__dm0157TotalCancel = true;
+    cancelFinal0157.__dmPrevious = cancel;
+    globalThis.edApplCancel = cancelFinal0157;
+  }
+  if (!chainHas0157(renderer, "__dm0157TotalRenderer")) {
+    function rendererFinal0157() {
+      const template = document.createElement("template");
+      template.innerHTML = renderer.apply(this, arguments);
+      const form = [...template.content.querySelectorAll(".ed-form")].at(-1);
+      if (!form || form.querySelector("#appl-total-energy-entity")) return template.innerHTML;
+      const items = globalThis.DashboardModernModules?.store?.getSection?.("appliances") || [];
+      const item = items.find((entry) => clean0157(entry.id) === state.editorId) || {};
+      const canonical = form.querySelector("[data-appliance-canonical-fields]");
+      const holder = canonical?.querySelector(".dm-config-grid") || canonical || form;
+      holder.insertAdjacentHTML("beforeend", applianceField0157(item.total_energy_entity || ""));
+      return template.innerHTML;
+    }
+    rendererFinal0157.__dm0157TotalRenderer = true;
+    rendererFinal0157.__dmPrevious = renderer;
+    globalThis.editorRenderAppliances = rendererFinal0157;
+  }
+  if (!chainHas0157(save, "__dm0157TotalSave")) {
+    async function saveFinal0157() {
+      const total = clean0157(document.getElementById("appl-total-energy-entity")?.value);
+      const name = clean0157(document.getElementById("appl-name")?.value);
+      const editId = state.editorId;
+      const result = await save.apply(this, arguments);
+      const store = globalThis.DashboardModernModules?.store;
+      if (!store?.getSection || !store?.updateItem) return result;
+      const items = store.getSection("appliances") || [];
+      const item = items.find((entry) => clean0157(entry.id) === editId) ||
+        [...items].reverse().find((entry) => !name || clean0157(entry.name) === name);
+      if (!item) return result;
+      await store.updateItem("appliances", item.id, {
+        total_energy_entity: total,
+        report_entity: total || item.report_entity || item.energy_entity || "",
+        history_entity: total || item.history_entity || item.report_entity || item.energy_entity || "",
+        entities: [...new Set([...(item.entities || []), total].filter(Boolean))],
+      });
+      state.editorId = "";
+      globalThis.cdRebuildReportDevices?.();
+      globalThis.buildReportSelect?.();
+      return result;
+    }
+    saveFinal0157.__dm0157TotalSave = true;
+    saveFinal0157.__dmPrevious = save;
+    globalThis.edApplSave = saveFinal0157;
+  }
+  state.applianceWrapped = true;
+  return true;
+}
+
+function installEnergyStore0157() {
+  const state = finalState0157();
+  const store = globalThis.DashboardModernModules?.store;
+  const original = store?.replaceSection;
+  if (state.storeWrapped) return true;
+  if (typeof original !== "function") return false;
+  async function replaceSectionFinal0157(section, value) {
+    if (section !== "energy") return original.apply(this, arguments);
+    const merged = structuredClone(value || {});
+    Object.entries(state.pendingEnergy).forEach(([path, entity]) => {
+      const [group, key] = path.split(".");
+      merged[group] ||= {};
+      merged[group][key] = clean0157(entity);
+    });
+    return original.call(this, section, merged);
+  }
+  replaceSectionFinal0157.__dm0157TotalMerge = true;
+  replaceSectionFinal0157.__dmPrevious = original;
+  store.replaceSection = replaceSectionFinal0157;
+  state.storeWrapped = true;
+  return true;
+}
+
+function decorateEnergyEditor0157() {
+  const root = document.querySelector('[data-editor="energy"]');
+  if (!root) return false;
+  installEnergyStore0157();
+  const model = globalThis.DashboardModernModules?.store?.getSection?.("energy") || {};
+  TOTAL_FIELDS_0157.forEach(([group, key, it, en, placeholder]) => {
+    const id = `dm-energy-${group}-${key}`;
+    if (root.querySelector(`#${id}`)) return;
+    const anchor = root.querySelector(`[name="${group}.power"], [name^="${group}."]`);
+    const body = anchor?.closest(".ed-acc-body");
+    if (!body) return;
+    const field = document.createElement("label");
+    field.className = "ed-slot dm-total-energy-field-0157";
+    field.innerHTML = `<span class="ed-slot-lbl">${english0157() ? en : it} <span class="ed-acc-n">kWh</span> <span class="ed-acc-n">${text0157("Facoltativo", "Optional")}</span></span><span class="ed-hint">${text0157("Contatore cumulativo Home Assistant", "Home Assistant cumulative meter")}</span><span class="dm-entity-field" data-entity-field><span class="ed-form-row"><input id="${id}" name="${group}.${key}" class="ed-input ed-slot-in mono" data-entity-input value="${escape0157(model?.[group]?.[key] || "")}" placeholder="${placeholder}"><button type="button" class="dm-entity-picker" data-entity-target="${id}" aria-label="${english0157() ? en : it}">🔍</button></span></span>`;
+    const input = field.querySelector("input");
+    const remember = () => { state.pendingEnergy[`${group}.${key}`] = input.value; };
+    input.addEventListener("input", remember);
+    input.addEventListener("change", remember);
+    body.append(field);
+  });
+  globalThis.DashboardModernModules?.render?.mountEntityPickers?.(root);
+  return true;
+}
+
+async function repairHistoricalSources0157() {
+  const state = finalState0157();
+  if (state.repaired) return true;
+  const store = globalThis.DashboardModernModules?.store;
+  if (!store?.getSection || !store?.replaceSection) return false;
+  const items = store.getSection("appliances") || [];
+  const repaired = items.map((item) => {
+    const total = clean0157(item.total_energy_entity);
+    if (!total || (item.report_entity === total && item.history_entity === total)) return item;
+    return {
+      ...item,
+      report_entity: total,
+      history_entity: total,
+      entities: [...new Set([...(item.entities || []), total])],
+    };
+  });
+  state.repaired = true;
+  if (repaired.some((item, index) => item !== items[index])) await store.replaceSection("appliances", repaired);
+  return true;
+}
+
+function injectStyle0157() {
+  if (document.getElementById("dm-release-0157-final-style")) return;
+  const style = document.createElement("style");
+  style.id = "dm-release-0157-final-style";
+  style.textContent = `
+    #page-appliances-main .dm-appliance-metrics-0157{width:auto!important;display:inline-flex!important;align-items:center!important;gap:4px!important;flex-wrap:wrap!important;margin:0!important}
+    #page-appliances-main .dm-appliance-metric-0157{display:inline-flex!important;align-items:baseline!important;gap:4px!important;padding:3px 6px!important;border-radius:8px!important;line-height:1.05!important}
+    #page-appliances-main .dm-appliance-metric-0157 small{font-size:7.5px!important;line-height:1!important}
+    #page-appliances-main .dm-appliance-metric-0157 strong{font-size:10.5px!important;line-height:1!important}
+    #page-appliances-main .dm-appliance-room-nav-0157 button{min-height:36px!important;padding:7px 10px!important}
+    .dm-total-energy-field-0157{border-color:rgba(16,185,129,.28)!important;background:rgba(236,253,245,.46)!important}
+  `;
+  document.head.append(style);
+}
+
+function settle0157() {
+  normalizeSelectors0157();
+  stopChurn0157();
+  const runtimeReady = wrapRuntime0157();
+  const editorReady = installApplianceEditor0157();
+  const storeReady = installEnergyStore0157();
+  decorateEnergyEditor0157();
+  repairHistoricalSources0157().catch((error) => console.warn("[DashboardModern] total energy repair", error));
+  return runtimeReady && editorReady && storeReady;
+}
+
+function retry0157(attempt = 0) {
+  const state = finalState0157();
+  if (settle0157() || attempt >= 12) return;
+  clearTimeout(state.retry);
+  state.retry = setTimeout(() => retry0157(attempt + 1), 75);
+}
+
+globalThis.__DASHBOARDMODERN_RELEASE_0157_FINALIZE__ = settle0157;
+
+function install0157() {
+  injectStyle0157();
+  document.addEventListener("change", (event) => {
+    if (event.target?.matches?.("#ed-sel-month,#ed-sel-year")) queueMicrotask(normalizeSelectors0157);
+  }, true);
+  document.addEventListener("click", (event) => {
+    if (event.target?.closest?.(".ed-tab,.ed-inner-tab")) queueMicrotask(decorateEnergyEditor0157);
+  }, true);
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", () => retry0157(0));
+  globalThis.addEventListener?.("pageshow", () => retry0157(0));
+  retry0157(0);
+}
+
+if (typeof document !== "undefined") {
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", install0157, { once: true });
+  else install0157();
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0157-month-range-fix.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0157-month-range-fix.js
@@ -1,0 +1,104 @@
+/* DashboardModern 0.14.17: completed months end inside the month, not at the next baseline boundary. */
+const MONTH_FIX_KEY_0157 = "__DASHBOARDMODERN_RELEASE_0157_MONTH_RANGE_FIX__";
+const FINAL_MONTH_RUNTIME_0157 = "__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__";
+
+function time0157(row) {
+  const raw = row?.start ?? row?.end ?? row?.last_updated ?? 0;
+  const value = typeof raw === "number" ? raw : Date.parse(raw);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function cumulative0157(row) {
+  for (const key of ["sum", "state", "max"]) {
+    const value = Number(row?.[key]);
+    if (Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function periodValue0157(rows, baseline) {
+  const ordered = (Array.isArray(rows) ? rows : [])
+    .filter(Boolean)
+    .slice()
+    .sort((left, right) => time0157(left) - time0157(right));
+  const changes = ordered
+    .map((row) => row?.change)
+    .filter((value) => value !== null && value !== undefined && Number.isFinite(Number(value)))
+    .map(Number);
+  if (changes.length) return Math.max(0, changes.reduce((total, value) => total + value, 0));
+  const values = ordered.map(cumulative0157).filter((value) => value != null);
+  const base = cumulative0157(baseline);
+  if (base != null && values.length) values.unshift(base);
+  if (values.length < 2) return null;
+  let total = 0;
+  for (let index = 1; index < values.length; index += 1) {
+    const delta = values[index] - values[index - 1];
+    total += delta >= 0 ? delta : Math.max(0, values[index]);
+  }
+  return Math.max(0, total);
+}
+
+function resolved0157(entity) {
+  const original = String(entity || "").trim();
+  try { return String(globalThis.resolveEntity?.(original) || original).trim(); }
+  catch (_error) { return original; }
+}
+
+function monthRange0157(month, year) {
+  const now = new Date();
+  const safeMonth = Number.isInteger(+month) && +month >= 1 && +month <= 12
+    ? +month
+    : now.getMonth() + 1;
+  const safeYear = Number.isInteger(+year) && +year >= 2000 ? +year : now.getFullYear();
+  const start = new Date(safeYear, safeMonth - 1, 1);
+  const next = new Date(safeYear, safeMonth, 1);
+  // A completed month must not end exactly at 00:00 of the next month: that
+  // timestamp is reserved for the cumulative baseline request.
+  const end = next > now ? now : new Date(next.getTime() - 1);
+  const baselineStart = new Date(start);
+  baselineStart.setDate(baselineStart.getDate() - 2);
+  return { start, end, baselineStart };
+}
+
+function installMonthRangeFix0157() {
+  const runtime = globalThis[FINAL_MONTH_RUNTIME_0157];
+  if (!runtime || typeof runtime.statistics !== "function") return false;
+  if (runtime.monthValues?.__dm0157MonthBoundary) return true;
+
+  async function monthValuesBoundary0157(ids, month, year) {
+    const unique = [...new Set((Array.isArray(ids) ? ids : []).map(String).filter(Boolean))];
+    const dates = monthRange0157(month, year);
+    if (!unique.length || dates.end <= dates.start) return new Map();
+    const rows = await runtime.statistics(unique, dates.start, dates.end, "day");
+    const unresolved = unique.filter((id) => periodValue0157(rows[id] || []) == null);
+    const baselines = unresolved.length
+      ? await runtime.statistics(unresolved, dates.baselineStart, dates.start, "day")
+      : {};
+    const values = new Map();
+    unique.forEach((id) => {
+      const baselineRows = (baselines[id] || [])
+        .slice()
+        .sort((left, right) => time0157(left) - time0157(right));
+      const value = periodValue0157(rows[id] || [], baselineRows.at(-1) || null);
+      if (value == null) return;
+      const rounded = Math.round(value * 1000) / 1000;
+      values.set(id, rounded);
+      values.set(resolved0157(id), rounded);
+    });
+    return values;
+  }
+
+  monthValuesBoundary0157.__dm0157MonthBoundary = true;
+  monthValuesBoundary0157.__dmPrevious = runtime.monthValues;
+  runtime.monthValues = monthValuesBoundary0157;
+  globalThis[MONTH_FIX_KEY_0157] = { installed: true, monthValues: monthValuesBoundary0157 };
+  return true;
+}
+
+if (!installMonthRangeFix0157()) {
+  let attempts = 0;
+  const timer = setInterval(() => {
+    attempts += 1;
+    if (installMonthRangeFix0157() || attempts >= 20) clearInterval(timer);
+  }, 50);
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0157-period-owner.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0157-period-owner.js
@@ -1,0 +1,287 @@
+/* DashboardModern 0.14.17: single owner for current slots and selected-period KPIs. */
+const OWNER_KEY = "__DASHBOARDMODERN_RELEASE_0157_PERIOD_OWNER__";
+const RUNTIME_KEY = "__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__";
+const LOCK_KEY = "__DASHBOARDMODERN_RELEASE_0156_CURRENT_PERIOD_LOCK__";
+const SOURCES = Object.freeze([
+  ["cons", "dm.energy_consumo_casa_mese", "house", "total_energy", "monthly_energy"],
+  ["prelevato", "dm.energy_rete_acquistata_mese", "grid", "total_import_energy", "monthly_import_energy"],
+  ["immesso", "dm.energy_rete_venduta_mese", "grid", "total_export_energy", "monthly_export_energy"],
+  ["prod", "dm.energy_produzione_solare_mese", "solar", "total_energy", "monthly_energy"],
+  ["batCar", "dm.energy_batteria_caricata_mese", "battery", "total_charged_energy", "monthly_charged_energy"],
+  ["batScar", "dm.energy_batteria_usata_mese", "battery", "total_discharged_energy", "monthly_discharged_energy"],
+]);
+
+function owner() {
+  const value = (globalThis[OWNER_KEY] ||= {});
+  value.installed = true;
+  value.retry ||= 0;
+  value.currentTimer ||= 0;
+  value.periodTimer ||= 0;
+  value.currentGeneration ||= 0;
+  value.periodGeneration ||= 0;
+  value.currentSlots ||= new Map();
+  value.expected ||= new Map();
+  value.periodToken ||= "";
+  value.writing ||= false;
+  value.observer ||= null;
+  return value;
+}
+
+const clean = (value) => String(value || "").trim();
+
+function selectedPeriod() {
+  const now = new Date();
+  const month = Number(document.getElementById("ed-sel-month")?.value);
+  const year = Number(document.getElementById("ed-sel-year")?.value);
+  return {
+    month: Number.isInteger(month) && month >= 1 && month <= 12 ? month : now.getMonth() + 1,
+    year: Number.isInteger(year) && year >= 2000 ? year : now.getFullYear(),
+  };
+}
+
+function configuredSources() {
+  let energy = {};
+  try { energy = globalThis.DashboardModernModules?.store?.getSection?.("energy") || {}; }
+  catch (_error) {}
+  return SOURCES.map(([key, slot, group, totalKey, monthlyKey]) => {
+    const config = energy?.[group] || {};
+    return { key, slot, entity: clean(config[totalKey] || config[monthlyKey]) };
+  }).filter(({ entity }) => entity);
+}
+
+function registry() {
+  try { if (typeof CD_PERIOD !== "undefined" && CD_PERIOD) return CD_PERIOD; }
+  catch (_error) {}
+  return (globalThis.CD_PERIOD ||= {});
+}
+
+function cloneState(state) {
+  return state ? { ...state, attributes: { ...(state.attributes || {}) } } : null;
+}
+
+function publishSlot(slot, value, source, month, year) {
+  const stamp = new Date().toISOString();
+  const next = {
+    entity_id: slot,
+    state: String(value),
+    attributes: {
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "measurement",
+      dashboardmodern_derived: true,
+      dashboardmodern_source: source,
+      dashboardmodern_selected: `${year}-${String(month).padStart(2, "0")}`,
+      dashboardmodern_owner: "0.14.17",
+    },
+    last_changed: stamp,
+    last_updated: stamp,
+  };
+  try { if (typeof _RAW_STATES !== "undefined" && _RAW_STATES) _RAW_STATES[slot] = cloneState(next); }
+  catch (_error) {}
+  try { globalThis._RAW_STATES ||= {}; globalThis._RAW_STATES[slot] = cloneState(next); }
+  catch (_error) {}
+  try { if (typeof STATES !== "undefined" && STATES) STATES[slot] = cloneState(next); }
+  catch (_error) {}
+  try { if (globalThis.STATES) globalThis.STATES[slot] = cloneState(next); }
+  catch (_error) {}
+  return next;
+}
+
+function stopLegacyWriters() {
+  const runtime = globalThis[RUNTIME_KEY];
+  if (runtime?.retryTimer) {
+    clearInterval(runtime.retryTimer);
+    clearTimeout(runtime.retryTimer);
+    runtime.retryTimer = 0;
+  }
+  const lock = globalThis[LOCK_KEY];
+  if (!lock) return;
+  clearInterval(lock.timer);
+  clearTimeout(lock.timer);
+  clearTimeout(lock.restoreTimer);
+  lock.timer = 0;
+  lock.restoreTimer = 0;
+  lock.locked = new Set(SOURCES.map(([, slot]) => slot));
+}
+
+function installCurrentOwners(values, sources, month, year) {
+  const state = owner();
+  const target = registry();
+  const lock = globalThis[LOCK_KEY];
+  sources.forEach(({ slot, entity }) => {
+    const parsed = Number(values.get(entity));
+    if (!Number.isFinite(parsed)) return;
+    let entry = state.currentSlots.get(slot);
+    if (!entry) {
+      entry = { value: 0, source: entity };
+      state.currentSlots.set(slot, entry);
+    }
+    entry.value = Math.max(0, parsed);
+    entry.source = entity;
+    try {
+      Object.defineProperty(target, slot, {
+        configurable: true,
+        enumerable: true,
+        get: () => entry.value,
+        // Historical renderers and obsolete delta writers are read-only here.
+        set: () => {},
+      });
+    } catch (_error) {}
+    const snapshot = publishSlot(slot, entry.value, entity, month, year);
+    lock?.snapshots?.set?.(slot, cloneState(snapshot));
+  });
+  stopLegacyWriters();
+}
+
+async function refreshCurrent() {
+  const state = owner();
+  const runtime = globalThis[RUNTIME_KEY];
+  const sources = configuredSources();
+  if (typeof runtime?.monthValues !== "function" || !sources.length) return false;
+  const generation = ++state.currentGeneration;
+  const now = new Date();
+  try {
+    const raw = await runtime.monthValues(
+      sources.map(({ entity }) => entity),
+      now.getMonth() + 1,
+      now.getFullYear(),
+    );
+    if (generation !== state.currentGeneration) return false;
+    const values = new Map();
+    sources.forEach(({ entity }) => {
+      const value = Number(raw.get(entity));
+      if (Number.isFinite(value)) values.set(entity, value);
+    });
+    installCurrentOwners(values, sources, now.getMonth() + 1, now.getFullYear());
+    return values.size > 0;
+  } catch (error) {
+    console.warn("[DashboardModern] current-period owner", error);
+    return false;
+  }
+}
+
+function scheduleCurrent(delay = 0) {
+  const state = owner();
+  clearTimeout(state.currentTimer);
+  state.currentTimer = setTimeout(refreshCurrent, delay);
+}
+
+function clearPeriodOwner() {
+  const state = owner();
+  state.observer?.disconnect?.();
+  state.observer = null;
+  state.expected.clear();
+  state.periodToken = "";
+}
+
+function restoreKpis() {
+  const state = owner();
+  if (state.writing || !state.periodToken) return;
+  const period = selectedPeriod();
+  if (`${period.year}-${period.month}` !== state.periodToken) {
+    clearPeriodOwner();
+    return;
+  }
+  state.writing = true;
+  try {
+    state.expected.forEach((html, id) => {
+      const node = document.getElementById(id);
+      if (node && node.innerHTML !== html) node.innerHTML = html;
+    });
+  } finally {
+    state.writing = false;
+  }
+}
+
+function observeKpis() {
+  const state = owner();
+  state.observer?.disconnect?.();
+  if (typeof MutationObserver !== "function" || !state.expected.size) return;
+  state.observer = new MutationObserver(() => queueMicrotask(restoreKpis));
+  state.expected.forEach((_html, id) => {
+    const node = document.getElementById(id);
+    if (node) state.observer.observe(node, { childList: true, subtree: true, characterData: true });
+  });
+}
+
+async function refreshSelected(generation) {
+  const state = owner();
+  const runtime = globalThis[RUNTIME_KEY];
+  const sources = configuredSources().filter(({ key }) => ["prod", "cons", "prelevato"].includes(key));
+  if (generation !== state.periodGeneration || typeof runtime?.monthValues !== "function" || !sources.length) return false;
+  const period = selectedPeriod();
+  const token = `${period.year}-${period.month}`;
+  try {
+    const raw = await runtime.monthValues(
+      sources.map(({ entity }) => entity),
+      period.month,
+      period.year,
+    );
+    const latest = selectedPeriod();
+    if (generation !== state.periodGeneration || token !== `${latest.year}-${latest.month}`) return false;
+    const values = Object.fromEntries(sources.map(({ key, entity }) => [key, Number(raw.get(entity))]));
+    const prod = Number.isFinite(values.prod) ? Math.max(0, values.prod) : 0;
+    const cons = Number.isFinite(values.cons) ? Math.max(0, values.cons) : 0;
+    const imported = Number.isFinite(values.prelevato) ? Math.max(0, values.prelevato) : 0;
+    const autonomy = cons > 0 ? Math.max(0, Math.min(100, Math.round(((cons - imported) / cons) * 100))) : 0;
+    state.expected = new Map([
+      ["ed-kpi-prod", `${prod.toFixed(1)} <small>kWh</small>`],
+      ["ed-kpi-cons", `${cons.toFixed(1)} <small>kWh</small>`],
+      ["ed-kpi-auto", `${autonomy} <small>%</small>`],
+    ]);
+    state.periodToken = token;
+    restoreKpis();
+    observeKpis();
+    return true;
+  } catch (error) {
+    console.warn("[DashboardModern] selected-period owner", error);
+    return false;
+  }
+}
+
+function scheduleSelected(delay = 120) {
+  const state = owner();
+  const generation = ++state.periodGeneration;
+  clearTimeout(state.periodTimer);
+  clearPeriodOwner();
+  state.periodTimer = setTimeout(() => refreshSelected(generation), delay);
+}
+
+function settle() {
+  const runtime = globalThis[RUNTIME_KEY];
+  if (typeof runtime?.monthValues !== "function") return false;
+  stopLegacyWriters();
+  scheduleCurrent(0);
+  if (document.getElementById("ed-sel-month") && document.getElementById("ed-sel-year")) {
+    scheduleSelected(150);
+  }
+  return true;
+}
+
+function retry(attempt = 0) {
+  const state = owner();
+  if (settle() || attempt >= 16) return;
+  clearTimeout(state.retry);
+  state.retry = setTimeout(() => retry(attempt + 1), 75);
+}
+
+function install() {
+  owner();
+  document.addEventListener("change", (event) => {
+    if (!event.target?.matches?.("#ed-sel-month,#ed-sel-year")) return;
+    scheduleSelected(120);
+  }, true);
+  document.addEventListener("click", (event) => {
+    if (!event.target?.closest?.('.tab[data-tab="energy"],.tab[data-tab="energia"]')) return;
+    scheduleCurrent(40);
+    scheduleSelected(160);
+  }, true);
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", () => retry(0));
+  globalThis.addEventListener?.("pageshow", () => retry(0));
+  retry(0);
+}
+
+if (typeof document !== "undefined") {
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", install, { once: true });
+  else install();
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0157-period-owner.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0157-period-owner.js
@@ -123,7 +123,6 @@ function installCurrentOwners(values, sources, month, year) {
         configurable: true,
         enumerable: true,
         get: () => entry.value,
-        // Historical renderers and obsolete delta writers are read-only here.
         set: () => {},
       });
     } catch (_error) {}
@@ -177,11 +176,6 @@ function clearPeriodOwner() {
 function restoreKpis() {
   const state = owner();
   if (state.writing || !state.periodToken) return;
-  const period = selectedPeriod();
-  if (`${period.year}-${period.month}` !== state.periodToken) {
-    clearPeriodOwner();
-    return;
-  }
   state.writing = true;
   try {
     state.expected.forEach((html, id) => {
@@ -204,12 +198,11 @@ function observeKpis() {
   });
 }
 
-async function refreshSelected(generation) {
+async function refreshSelected(generation, period) {
   const state = owner();
   const runtime = globalThis[RUNTIME_KEY];
   const sources = configuredSources().filter(({ key }) => ["prod", "cons", "prelevato"].includes(key));
   if (generation !== state.periodGeneration || typeof runtime?.monthValues !== "function" || !sources.length) return false;
-  const period = selectedPeriod();
   const token = `${period.year}-${period.month}`;
   try {
     const raw = await runtime.monthValues(
@@ -217,8 +210,7 @@ async function refreshSelected(generation) {
       period.month,
       period.year,
     );
-    const latest = selectedPeriod();
-    if (generation !== state.periodGeneration || token !== `${latest.year}-${latest.month}`) return false;
+    if (generation !== state.periodGeneration) return false;
     const values = Object.fromEntries(sources.map(({ key, entity }) => [key, Number(raw.get(entity))]));
     const prod = Number.isFinite(values.prod) ? Math.max(0, values.prod) : 0;
     const cons = Number.isFinite(values.cons) ? Math.max(0, values.cons) : 0;
@@ -239,12 +231,13 @@ async function refreshSelected(generation) {
   }
 }
 
-function scheduleSelected(delay = 120) {
+function scheduleSelected(delay = 120, period = selectedPeriod()) {
   const state = owner();
   const generation = ++state.periodGeneration;
+  const captured = { month: Number(period.month), year: Number(period.year) };
   clearTimeout(state.periodTimer);
   clearPeriodOwner();
-  state.periodTimer = setTimeout(() => refreshSelected(generation), delay);
+  state.periodTimer = setTimeout(() => refreshSelected(generation, captured), delay);
 }
 
 function settle() {
@@ -252,9 +245,6 @@ function settle() {
   if (typeof runtime?.monthValues !== "function") return false;
   stopLegacyWriters();
   scheduleCurrent(0);
-  if (document.getElementById("ed-sel-month") && document.getElementById("ed-sel-year")) {
-    scheduleSelected(150);
-  }
   return true;
 }
 
@@ -265,16 +255,17 @@ function retry(attempt = 0) {
   state.retry = setTimeout(() => retry(attempt + 1), 75);
 }
 
+globalThis.__DASHBOARDMODERN_RELEASE_0157_PERIOD_OWNER_SETTLE__ = settle;
+
 function install() {
   owner();
   document.addEventListener("change", (event) => {
     if (!event.target?.matches?.("#ed-sel-month,#ed-sel-year")) return;
-    scheduleSelected(120);
+    scheduleSelected(120, selectedPeriod());
   }, true);
   document.addEventListener("click", (event) => {
     if (!event.target?.closest?.('.tab[data-tab="energy"],.tab[data-tab="energia"]')) return;
     scheduleCurrent(40);
-    scheduleSelected(160);
   }, true);
   globalThis.addEventListener?.("dashboardmodern:legacy-ready", () => retry(0));
   globalThis.addEventListener?.("pageshow", () => retry(0));

--- a/custom_components/dashboardmodern/frontend/legacy/release-0157-period-owner.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0157-period-owner.js
@@ -21,8 +21,11 @@ function owner() {
   value.periodGeneration ||= 0;
   value.currentSlots ||= new Map();
   value.expected ||= new Map();
+  value.snapshots ||= new Map();
   value.periodToken ||= "";
   value.writing ||= false;
+  value.periodCommitted ||= false;
+  value.periodFinishTimer ||= 0;
   value.observer ||= null;
   return value;
 }
@@ -165,20 +168,53 @@ function scheduleCurrent(delay = 0) {
   state.currentTimer = setTimeout(refreshCurrent, delay);
 }
 
-function clearPeriodOwner() {
+function periodPage() {
+  return document.getElementById("view-panoramica") ||
+    document.getElementById("page-energy") ||
+    document.getElementById("page-energia") ||
+    document.getElementById("ed-kpi-prod")?.closest?.(".flow-view,.page") ||
+    null;
+}
+
+function ensurePeriodStatus() {
+  const page = periodPage();
+  if (!page) return null;
+  let status = page.querySelector("[data-dm-period-loading-0157]");
+  if (!status) {
+    status = document.createElement("div");
+    status.className = "dm-period-loading-0157";
+    status.setAttribute("data-dm-period-loading-0157", "");
+    status.setAttribute("role", "status");
+    status.setAttribute("aria-live", "polite");
+    const english = document.documentElement.lang === "en";
+    status.innerHTML = `<span aria-hidden="true"></span><strong>${english ? "Updating month…" : "Aggiornamento mese…"}</strong>`;
+    page.prepend(status);
+  }
+  return status;
+}
+
+function capturePeriodKpis() {
   const state = owner();
-  state.observer?.disconnect?.();
-  state.observer = null;
-  state.expected.clear();
-  state.periodToken = "";
+  state.snapshots.clear();
+  ["ed-kpi-prod", "ed-kpi-cons", "ed-kpi-auto"].forEach((id) => {
+    const node = document.getElementById(id);
+    if (node) state.snapshots.set(id, node.innerHTML);
+  });
+}
+
+function periodValuesToRestore() {
+  const state = owner();
+  return state.periodCommitted && state.expected.size ? state.expected : state.snapshots;
 }
 
 function restoreKpis() {
   const state = owner();
   if (state.writing || !state.periodToken) return;
+  const values = periodValuesToRestore();
+  if (!values.size) return;
   state.writing = true;
   try {
-    state.expected.forEach((html, id) => {
+    values.forEach((html, id) => {
       const node = document.getElementById(id);
       if (node && node.innerHTML !== html) node.innerHTML = html;
     });
@@ -190,53 +226,102 @@ function restoreKpis() {
 function observeKpis() {
   const state = owner();
   state.observer?.disconnect?.();
-  if (typeof MutationObserver !== "function" || !state.expected.size) return;
-  state.observer = new MutationObserver(() => queueMicrotask(restoreKpis));
-  state.expected.forEach((_html, id) => {
+  if (typeof MutationObserver !== "function") return;
+  state.observer = new MutationObserver(() => {
+    if (!state.writing) queueMicrotask(restoreKpis);
+  });
+  ["ed-kpi-prod", "ed-kpi-cons", "ed-kpi-auto"].forEach((id) => {
     const node = document.getElementById(id);
     if (node) state.observer.observe(node, { childList: true, subtree: true, characterData: true });
   });
+}
+
+function beginPeriodOwner(period) {
+  const state = owner();
+  clearTimeout(state.periodFinishTimer);
+  if (!state.periodToken) capturePeriodKpis();
+  state.periodToken = `${period.year}-${period.month}`;
+  state.periodCommitted = false;
+  state.expected.clear();
+  const page = periodPage();
+  page?.classList.add("dm-period-loading-active-0157");
+  page?.setAttribute("aria-busy", "true");
+  const status = ensurePeriodStatus();
+  if (status) status.hidden = false;
+  observeKpis();
+}
+
+function finishPeriodOwner(generation) {
+  const state = owner();
+  clearTimeout(state.periodFinishTimer);
+  state.periodFinishTimer = setTimeout(() => {
+    if (generation !== state.periodGeneration) return;
+    state.observer?.disconnect?.();
+    state.observer = null;
+    state.snapshots.clear();
+    state.expected.clear();
+    state.periodCommitted = false;
+    state.periodToken = "";
+    const page = periodPage();
+    page?.classList.remove("dm-period-loading-active-0157");
+    page?.removeAttribute("aria-busy");
+    const status = page?.querySelector?.("[data-dm-period-loading-0157]");
+    if (status) status.hidden = true;
+  }, 600);
+}
+
+function commitSelectedKpis(values, generation, token) {
+  const state = owner();
+  if (generation !== state.periodGeneration || token !== state.periodToken) return false;
+  const prod = Number.isFinite(values.prod) ? Math.max(0, values.prod) : 0;
+  const cons = Number.isFinite(values.cons) ? Math.max(0, values.cons) : 0;
+  const imported = Number.isFinite(values.prelevato) ? Math.max(0, values.prelevato) : 0;
+  const autonomy = cons > 0 ? Math.max(0, Math.min(100, Math.round(((cons - imported) / cons) * 100))) : 0;
+  state.expected = new Map([
+    ["ed-kpi-prod", `${prod.toFixed(1)} <small>kWh</small>`],
+    ["ed-kpi-cons", `${cons.toFixed(1)} <small>kWh</small>`],
+    ["ed-kpi-auto", `${autonomy} <small>%</small>`],
+  ]);
+  state.periodCommitted = true;
+  state.observer?.disconnect?.();
+  restoreKpis();
+  observeKpis();
+  finishPeriodOwner(generation);
+  return true;
 }
 
 async function refreshSelected(generation, period) {
   const state = owner();
   const runtime = globalThis[RUNTIME_KEY];
   const sources = configuredSources().filter(({ key }) => ["prod", "cons", "prelevato"].includes(key));
-  if (generation !== state.periodGeneration || typeof runtime?.monthValues !== "function" || !sources.length) return false;
   const token = `${period.year}-${period.month}`;
+  if (generation !== state.periodGeneration || token !== state.periodToken || typeof runtime?.monthValues !== "function" || !sources.length) {
+    finishPeriodOwner(generation);
+    return false;
+  }
   try {
     const raw = await runtime.monthValues(
       sources.map(({ entity }) => entity),
       period.month,
       period.year,
     );
-    if (generation !== state.periodGeneration) return false;
+    if (generation !== state.periodGeneration || token !== state.periodToken) return false;
     const values = Object.fromEntries(sources.map(({ key, entity }) => [key, Number(raw.get(entity))]));
-    const prod = Number.isFinite(values.prod) ? Math.max(0, values.prod) : 0;
-    const cons = Number.isFinite(values.cons) ? Math.max(0, values.cons) : 0;
-    const imported = Number.isFinite(values.prelevato) ? Math.max(0, values.prelevato) : 0;
-    const autonomy = cons > 0 ? Math.max(0, Math.min(100, Math.round(((cons - imported) / cons) * 100))) : 0;
-    state.expected = new Map([
-      ["ed-kpi-prod", `${prod.toFixed(1)} <small>kWh</small>`],
-      ["ed-kpi-cons", `${cons.toFixed(1)} <small>kWh</small>`],
-      ["ed-kpi-auto", `${autonomy} <small>%</small>`],
-    ]);
-    state.periodToken = token;
-    restoreKpis();
-    observeKpis();
-    return true;
+    return commitSelectedKpis(values, generation, token);
   } catch (error) {
     console.warn("[DashboardModern] selected-period owner", error);
+    restoreKpis();
+    finishPeriodOwner(generation);
     return false;
   }
 }
 
-function scheduleSelected(delay = 120, period = selectedPeriod()) {
+function scheduleSelected(delay = 90, period = selectedPeriod()) {
   const state = owner();
   const generation = ++state.periodGeneration;
   const captured = { month: Number(period.month), year: Number(period.year) };
   clearTimeout(state.periodTimer);
-  clearPeriodOwner();
+  beginPeriodOwner(captured);
   state.periodTimer = setTimeout(() => refreshSelected(generation, captured), delay);
 }
 
@@ -261,7 +346,9 @@ function install() {
   owner();
   document.addEventListener("change", (event) => {
     if (!event.target?.matches?.("#ed-sel-month,#ed-sel-year")) return;
-    scheduleSelected(120, selectedPeriod());
+    const period = selectedPeriod();
+    event.stopImmediatePropagation();
+    scheduleSelected(90, period);
   }, true);
   document.addEventListener("click", (event) => {
     if (!event.target?.closest?.('.tab[data-tab="energy"],.tab[data-tab="energia"]')) return;

--- a/custom_components/dashboardmodern/frontend/legacy/release-0157-period-prelude.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0157-period-prelude.js
@@ -1,0 +1,242 @@
+/* DashboardModern 0.14.17: first listener owns Report month changes before legacy locks. */
+const PRELUDE_KEY_0157 = "__DASHBOARDMODERN_RELEASE_0157_PERIOD_PRELUDE__";
+const FINAL_RUNTIME_KEY_0157 = "__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__";
+const KPI_IDS_PRELUDE_0157 = ["ed-kpi-prod", "ed-kpi-cons", "ed-kpi-auto"];
+const MIN_SNAPSHOT_MS_0157 = 650;
+const FINAL_GUARD_MS_0157 = 650;
+
+function preludeState0157() {
+  const state = (globalThis[PRELUDE_KEY_0157] ||= {});
+  state.installed = true;
+  state.generation ||= 0;
+  state.timer ||= 0;
+  state.finishTimer ||= 0;
+  state.observer ||= null;
+  state.snapshots ||= new Map();
+  state.expected ||= new Map();
+  state.token ||= "";
+  state.startedAt ||= 0;
+  state.committed ||= false;
+  state.writing ||= false;
+  return state;
+}
+
+const clock0157 = () => globalThis.performance?.now?.() ?? Date.now();
+const clean0157 = (value) => String(value || "").trim();
+
+function selectedPeriodPrelude0157() {
+  const now = new Date();
+  const month = Number(document.getElementById("ed-sel-month")?.value);
+  const year = Number(document.getElementById("ed-sel-year")?.value);
+  return {
+    month: Number.isInteger(month) && month >= 1 && month <= 12 ? month : now.getMonth() + 1,
+    year: Number.isInteger(year) && year >= 2000 ? year : now.getFullYear(),
+  };
+}
+
+function reportPagePrelude0157() {
+  return document.getElementById("view-panoramica") ||
+    document.getElementById("page-energy") ||
+    document.getElementById("page-energia") ||
+    document.getElementById("ed-kpi-prod")?.closest?.(".flow-view,.page") ||
+    null;
+}
+
+function ensureStatusPrelude0157() {
+  const page = reportPagePrelude0157();
+  if (!page) return null;
+  let status = page.querySelector("[data-dm-period-loading-0157]");
+  if (!status) {
+    status = document.createElement("div");
+    status.className = "dm-period-loading-0157";
+    status.setAttribute("data-dm-period-loading-0157", "");
+    status.setAttribute("role", "status");
+    status.setAttribute("aria-live", "polite");
+    const english = document.documentElement.lang === "en";
+    status.innerHTML = `<span aria-hidden="true"></span><strong>${english ? "Updating month…" : "Aggiornamento mese…"}</strong>`;
+    page.prepend(status);
+  }
+  return status;
+}
+
+function capturePrelude0157() {
+  const state = preludeState0157();
+  state.snapshots.clear();
+  KPI_IDS_PRELUDE_0157.forEach((id) => {
+    const node = document.getElementById(id);
+    if (node) state.snapshots.set(id, node.innerHTML);
+  });
+}
+
+function protectedValuesPrelude0157() {
+  const state = preludeState0157();
+  return state.committed && state.expected.size ? state.expected : state.snapshots;
+}
+
+function restorePrelude0157() {
+  const state = preludeState0157();
+  if (state.writing || !state.token) return;
+  const values = protectedValuesPrelude0157();
+  if (!values.size) return;
+  state.writing = true;
+  try {
+    values.forEach((html, id) => {
+      const node = document.getElementById(id);
+      if (node && node.innerHTML !== html) node.innerHTML = html;
+    });
+  } finally {
+    state.writing = false;
+  }
+}
+
+function observePrelude0157() {
+  const state = preludeState0157();
+  state.observer?.disconnect?.();
+  if (typeof MutationObserver !== "function") return;
+  state.observer = new MutationObserver(() => {
+    if (!state.writing) queueMicrotask(restorePrelude0157);
+  });
+  KPI_IDS_PRELUDE_0157.forEach((id) => {
+    const node = document.getElementById(id);
+    if (node) state.observer.observe(node, { childList: true, subtree: true, characterData: true });
+  });
+}
+
+function beginPrelude0157(period) {
+  const state = preludeState0157();
+  clearTimeout(state.finishTimer);
+  if (!state.token) capturePrelude0157();
+  state.token = `${period.year}-${period.month}`;
+  state.startedAt = clock0157();
+  state.committed = false;
+  state.expected.clear();
+  const page = reportPagePrelude0157();
+  page?.classList.add("dm-period-loading-active-0157");
+  page?.setAttribute("aria-busy", "true");
+  const status = ensureStatusPrelude0157();
+  if (status) status.hidden = false;
+  observePrelude0157();
+  restorePrelude0157();
+}
+
+function finishPrelude0157(generation) {
+  const state = preludeState0157();
+  clearTimeout(state.finishTimer);
+  state.finishTimer = setTimeout(() => {
+    if (generation !== state.generation) return;
+    state.observer?.disconnect?.();
+    state.observer = null;
+    state.snapshots.clear();
+    state.expected.clear();
+    state.token = "";
+    state.committed = false;
+    const page = reportPagePrelude0157();
+    page?.classList.remove("dm-period-loading-active-0157");
+    page?.removeAttribute("aria-busy");
+    const status = page?.querySelector?.("[data-dm-period-loading-0157]");
+    if (status) status.hidden = true;
+  }, FINAL_GUARD_MS_0157);
+}
+
+function sourcesPrelude0157() {
+  let energy = {};
+  try { energy = globalThis.DashboardModernModules?.store?.getSection?.("energy") || {}; }
+  catch (_error) {}
+  return [
+    ["prod", energy?.solar?.total_energy || energy?.solar?.monthly_energy],
+    ["cons", energy?.house?.total_energy || energy?.house?.monthly_energy],
+    ["grid", energy?.grid?.total_import_energy || energy?.grid?.monthly_import_energy],
+  ].map(([key, entity]) => ({ key, entity: clean0157(entity) })).filter(({ entity }) => entity);
+}
+
+function sleepPrelude0157(ms) {
+  return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
+}
+
+async function waitForRuntimePrelude0157(generation) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (generation !== preludeState0157().generation) return null;
+    const runtime = globalThis[FINAL_RUNTIME_KEY_0157];
+    if (typeof runtime?.monthValues === "function") return runtime;
+    await sleepPrelude0157(50);
+  }
+  return null;
+}
+
+function commitPrelude0157(values, generation, token) {
+  const state = preludeState0157();
+  if (generation !== state.generation || token !== state.token) return false;
+  const production = Number(values.prod);
+  const consumption = Number(values.cons);
+  const imported = Number(values.grid);
+  if (![production, consumption, imported].some(Number.isFinite)) return false;
+  const prod = Number.isFinite(production) ? Math.max(0, production) : 0;
+  const cons = Number.isFinite(consumption) ? Math.max(0, consumption) : 0;
+  const grid = Number.isFinite(imported) ? Math.max(0, imported) : 0;
+  const autonomy = cons > 0
+    ? Math.max(0, Math.min(100, Math.round(((cons - grid) / cons) * 100)))
+    : 0;
+  state.expected = new Map([
+    ["ed-kpi-prod", `${prod.toFixed(1)} <small>kWh</small>`],
+    ["ed-kpi-cons", `${cons.toFixed(1)} <small>kWh</small>`],
+    ["ed-kpi-auto", `${autonomy} <small>%</small>`],
+  ]);
+  state.committed = true;
+  state.observer?.disconnect?.();
+  restorePrelude0157();
+  observePrelude0157();
+  finishPrelude0157(generation);
+  return true;
+}
+
+async function refreshPrelude0157(generation, period) {
+  const state = preludeState0157();
+  const token = `${period.year}-${period.month}`;
+  const runtime = await waitForRuntimePrelude0157(generation);
+  const sources = sourcesPrelude0157();
+  if (!runtime || !sources.length || generation !== state.generation || token !== state.token) {
+    finishPrelude0157(generation);
+    return false;
+  }
+  try {
+    const raw = await runtime.monthValues(
+      sources.map(({ entity }) => entity),
+      period.month,
+      period.year,
+    );
+    if (generation !== state.generation || token !== state.token) return false;
+    const remaining = MIN_SNAPSHOT_MS_0157 - (clock0157() - state.startedAt);
+    if (remaining > 0) await sleepPrelude0157(remaining);
+    if (generation !== state.generation || token !== state.token) return false;
+    const values = Object.fromEntries(
+      sources.map(({ key, entity }) => [key, Number(raw.get(entity))]),
+    );
+    return commitPrelude0157(values, generation, token);
+  } catch (error) {
+    console.warn("[DashboardModern] selected Report month", error);
+    restorePrelude0157();
+    finishPrelude0157(generation);
+    return false;
+  }
+}
+
+function schedulePrelude0157(period) {
+  const state = preludeState0157();
+  const generation = ++state.generation;
+  const captured = { month: Number(period.month), year: Number(period.year) };
+  clearTimeout(state.timer);
+  beginPrelude0157(captured);
+  state.timer = setTimeout(() => refreshPrelude0157(generation, captured), 0);
+}
+
+function installPrelude0157() {
+  preludeState0157();
+  document.addEventListener("change", (event) => {
+    if (!event.target?.matches?.("#ed-sel-month,#ed-sel-year")) return;
+    const period = selectedPeriodPrelude0157();
+    event.stopImmediatePropagation();
+    schedulePrelude0157(period);
+  }, true);
+}
+
+if (typeof document !== "undefined") installPrelude0157();

--- a/custom_components/dashboardmodern/frontend/legacy/release-0157-stability-guard.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0157-stability-guard.js
@@ -1,0 +1,44 @@
+/* DashboardModern 0.14.17: stop observer/timer churn after the UI hooks are installed. */
+const UI_KEY_0157 = "__DASHBOARDMODERN_RELEASE_0157_UI_STABILITY__";
+
+function removeDuplicateRoomNavigation0157() {
+  const page = globalThis.document?.getElementById?.("page-appliances-main");
+  if (!page) return;
+  const navigations = [...page.querySelectorAll(".dm-appliance-room-nav-0157")];
+  navigations.slice(1).forEach((navigation) => navigation.remove());
+}
+
+function settleUiRuntime0157() {
+  const runtime = globalThis[UI_KEY_0157];
+  if (!runtime?.installed) return false;
+
+  runtime.pageObserver?.disconnect?.();
+  runtime.pageObserver = null;
+
+  if (runtime.wrapperTimer) {
+    globalThis.clearInterval?.(runtime.wrapperTimer);
+    runtime.wrapperTimer = 0;
+  }
+
+  removeDuplicateRoomNavigation0157();
+  runtime.decorateAppliances?.();
+  runtime.decorateTemperatures?.();
+  return true;
+}
+
+if (typeof globalThis.document !== "undefined") {
+  if (!settleUiRuntime0157()) {
+    let attempts = 0;
+    const timer = globalThis.setInterval?.(() => {
+      attempts += 1;
+      if (settleUiRuntime0157() || attempts >= 40) globalThis.clearInterval?.(timer);
+    }, 50);
+  }
+
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", () => {
+    globalThis.setTimeout?.(settleUiRuntime0157, 0);
+  });
+  globalThis.addEventListener?.("pageshow", () => {
+    globalThis.setTimeout?.(settleUiRuntime0157, 0);
+  });
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0157-temperature-icons.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0157-temperature-icons.js
@@ -1,0 +1,88 @@
+/* DashboardModern 0.14.17: local fallbacks for room icons when MDI is unavailable. */
+const ICON_STATE_0157 = "__DASHBOARDMODERN_RELEASE_0157_TEMPERATURE_ICONS__";
+
+const ROOM_GLYPHS_0157 = Object.freeze({
+  "mdi:sofa": "🛋️",
+  "mdi:balcony": "🌿",
+  "mdi:bed": "🛏️",
+  "mdi:bed-king-outline": "🛏️",
+  "mdi:chef-hat": "🍳",
+  "mdi:stove": "🍳",
+  "mdi:shower": "🚿",
+  "mdi:bathtub-outline": "🛁",
+  "mdi:desk": "🖥️",
+  "mdi:garage": "🚗",
+  "mdi:home": "🏠",
+  "mdi:home-outline": "🏠",
+  "mdi:thermometer": "🌡️"
+});
+
+function glyph0157(icon) {
+  const key = String(icon || "").trim().toLowerCase();
+  return ROOM_GLYPHS_0157[key] || (key.startsWith("mdi:") ? "🏠" : key || "🏠");
+}
+
+function ensureTemperatureIcons0157(root = document) {
+  root.querySelectorAll?.(".temp-room-icon[data-room-icon]").forEach((node) => {
+    if (String(node.textContent || "").trim()) return;
+    if (node.querySelector("svg,img,ha-icon")) return;
+    const fallback = document.createElement("span");
+    fallback.className = "dm-temperature-icon-fallback-0157";
+    fallback.setAttribute("aria-hidden", "true");
+    fallback.textContent = glyph0157(node.getAttribute("data-room-icon"));
+    node.append(fallback);
+  });
+}
+
+function wrapTemperatureRenderer0157(name) {
+  const original = globalThis[name];
+  if (typeof original !== "function" || original.__dm0157TemperatureIcons) return false;
+  function wrappedTemperatureRenderer0157(...args) {
+    const result = original.apply(this, args);
+    if (result && typeof result.finally === "function") {
+      return result.finally(() => queueMicrotask(() => ensureTemperatureIcons0157()));
+    }
+    queueMicrotask(() => ensureTemperatureIcons0157());
+    return result;
+  }
+  wrappedTemperatureRenderer0157.__dm0157TemperatureIcons = true;
+  wrappedTemperatureRenderer0157.__dmPrevious = original;
+  globalThis[name] = wrappedTemperatureRenderer0157;
+  return true;
+}
+
+function settleTemperatureIcons0157() {
+  const wrapped = ["buildTempCards", "renderTemperature"].map(wrapTemperatureRenderer0157).some(Boolean);
+  ensureTemperatureIcons0157();
+  return wrapped || ["buildTempCards", "renderTemperature"].some(
+    (name) => globalThis[name]?.__dm0157TemperatureIcons
+  );
+}
+
+function retryTemperatureIcons0157(attempt = 0) {
+  const state = (globalThis[ICON_STATE_0157] ||= { retry: 0 });
+  if (settleTemperatureIcons0157() || attempt >= 20) return;
+  clearTimeout(state.retry);
+  state.retry = setTimeout(() => retryTemperatureIcons0157(attempt + 1), 75);
+}
+
+function installTemperatureIcons0157() {
+  document.addEventListener("click", (event) => {
+    if (!event.target?.closest?.('.tab[data-tab="temp"],.tab[data-tab="temperature"]')) return;
+    queueMicrotask(() => ensureTemperatureIcons0157());
+    setTimeout(() => ensureTemperatureIcons0157(), 0);
+  }, true);
+  globalThis.addEventListener?.("dashboardmodern:legacy-ready", () => retryTemperatureIcons0157(0));
+  globalThis.addEventListener?.("pageshow", () => retryTemperatureIcons0157(0));
+  retryTemperatureIcons0157(0);
+}
+
+globalThis.__DASHBOARDMODERN_RELEASE_0157_ENSURE_TEMPERATURE_ICONS__ = ensureTemperatureIcons0157;
+
+if (typeof document !== "undefined") {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", installTemperatureIcons0157, { once: true });
+  } else {
+    installTemperatureIcons0157();
+  }
+}

--- a/custom_components/dashboardmodern/frontend/legacy/release-0157-ui-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0157-ui-stability.js
@@ -1,12 +1,12 @@
-/* DashboardModern 0.14.17: atomic Energy periods, room-aware appliances and clearer temperature cards. */
+/* DashboardModern 0.14.17: stable Energy periods and focused UI decorators. */
 const UI_0157_KEY = "__DASHBOARDMODERN_RELEASE_0157_UI_STABILITY__";
 const FINAL_RUNTIME_0156_KEY = "__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__";
-const KPI_IDS_0157 = Object.freeze(["ed-kpi-prod", "ed-kpi-cons", "ed-kpi-auto"]);
-const ENERGY_SOURCES_0157 = Object.freeze([
+const KPI_IDS_0157 = ["ed-kpi-prod", "ed-kpi-cons", "ed-kpi-auto"];
+const ENERGY_SOURCES_0157 = [
   ["prod", "solar", "total_energy", "monthly_energy"],
   ["cons", "house", "total_energy", "monthly_energy"],
   ["grid", "grid", "total_import_energy", "monthly_import_energy"],
-]);
+];
 
 function state0157() {
   return (globalThis[UI_0157_KEY] ||= {
@@ -14,24 +14,18 @@ function state0157() {
     generation: 0,
     refreshTimer: 0,
     finishTimer: 0,
-    decorateTimer: 0,
     wrapperTimer: 0,
     kpiObserver: null,
-    pageObserver: null,
     snapshots: new Map(),
     selectedRoomId: "",
+    transitioning: false,
+    committing: false,
     decorating: false,
-    restoring: false,
   });
 }
 
-function english0157() {
-  return globalThis.document?.documentElement?.lang === "en";
-}
-
-function t0157(it, en) {
-  return english0157() ? en : it;
-}
+const english0157 = () => globalThis.document?.documentElement?.lang === "en";
+const t0157 = (it, en) => (english0157() ? en : it);
 
 function slug0157(value) {
   return String(value || "")
@@ -56,76 +50,89 @@ function format0157(value, digits = 1) {
 
 function selectedPeriod0157() {
   const now = new Date();
-  const month = Number(globalThis.document?.getElementById?.("ed-sel-month")?.value);
-  const year = Number(globalThis.document?.getElementById?.("ed-sel-year")?.value);
+  const month = Number(document.getElementById("ed-sel-month")?.value);
+  const year = Number(document.getElementById("ed-sel-year")?.value);
   return {
     month: Number.isInteger(month) && month >= 1 && month <= 12 ? month : now.getMonth() + 1,
     year: Number.isInteger(year) && year >= 2000 ? year : now.getFullYear(),
   };
 }
 
-function energyConfig0157() {
+function section0157(name, fallback) {
   try {
-    return globalThis.DashboardModernModules?.store?.getSection?.("energy") || {};
+    const value = globalThis.DashboardModernModules?.store?.getSection?.(name);
+    return value ?? fallback;
   } catch (_error) {
-    return {};
+    return fallback;
   }
 }
 
+const rooms0157 = () => {
+  const value = section0157("rooms", []);
+  return Array.isArray(value) ? value : [];
+};
+const appliances0157 = () => {
+  const value = section0157("appliances", []);
+  return Array.isArray(value) ? value : [];
+};
+
 function energySources0157() {
-  const energy = energyConfig0157();
+  const energy = section0157("energy", {});
   return ENERGY_SOURCES_0157.map(([key, group, totalKey, monthlyKey]) => ({
     key,
     entity: String(energy?.[group]?.[totalKey] || energy?.[group]?.[monthlyKey] || "").trim(),
-  })).filter((source) => source.entity);
+  })).filter(({ entity }) => entity);
+}
+
+function kpiNode0157(id) {
+  return document.getElementById(id);
 }
 
 function captureKpis0157() {
   const runtime = state0157();
   runtime.snapshots.clear();
   KPI_IDS_0157.forEach((id) => {
-    const node = globalThis.document?.getElementById?.(id);
-    if (node) runtime.snapshots.set(id, node.innerHTML);
-  });
-}
-
-function refreshKpiSnapshots0157() {
-  const runtime = state0157();
-  KPI_IDS_0157.forEach((id) => {
-    const node = globalThis.document?.getElementById?.(id);
+    const node = kpiNode0157(id);
     if (node) runtime.snapshots.set(id, node.innerHTML);
   });
 }
 
 function restoreKpis0157() {
   const runtime = state0157();
-  if (runtime.restoring) return;
-  runtime.restoring = true;
+  if (!runtime.transitioning || runtime.committing) return;
+  runtime.committing = true;
   try {
     runtime.snapshots.forEach((html, id) => {
-      const node = globalThis.document?.getElementById?.(id);
+      const node = kpiNode0157(id);
       if (node && node.innerHTML !== html) node.innerHTML = html;
     });
   } finally {
-    runtime.restoring = false;
+    runtime.committing = false;
   }
 }
 
 function observeKpis0157() {
   const runtime = state0157();
   runtime.kpiObserver?.disconnect?.();
-  if (typeof globalThis.MutationObserver !== "function") return;
-  runtime.kpiObserver = new globalThis.MutationObserver(() => {
-    if (!runtime.restoring) globalThis.queueMicrotask?.(restoreKpis0157);
+  if (typeof MutationObserver !== "function") return;
+  runtime.kpiObserver = new MutationObserver(() => {
+    if (!runtime.committing) queueMicrotask(restoreKpis0157);
   });
   KPI_IDS_0157.forEach((id) => {
-    const node = globalThis.document?.getElementById?.(id);
+    const node = kpiNode0157(id);
     if (node) runtime.kpiObserver.observe(node, { childList: true, subtree: true, characterData: true });
   });
 }
 
 function energyPage0157() {
-  return globalThis.document?.getElementById?.("view-panoramica") || null;
+  const overview = document.getElementById("view-panoramica");
+  if (overview) return overview;
+  return (
+    kpiNode0157("ed-kpi-prod")?.closest?.(".flow-view,.page") ||
+    document.getElementById("page-energy") ||
+    document.getElementById("page-energia") ||
+    null
+  );
 }
 
 function energyStatus0157() {
@@ -133,7 +140,7 @@ function energyStatus0157() {
   if (!page) return null;
   let status = page.querySelector("[data-dm-period-loading-0157]");
   if (!status) {
-    status = globalThis.document.createElement("div");
+    status = document.createElement("div");
     status.className = "dm-period-loading-0157";
     status.dataset.dmPeriodLoading0157 = "";
     status.setAttribute("role", "status");
@@ -145,9 +152,13 @@ function energyStatus0157() {
 }
 
 function beginEnergyTransition0157() {
+  const runtime = state0157();
   const page = energyPage0157();
   if (!page) return false;
-  captureKpis0157();
+  if (!runtime.transitioning) {
+    runtime.transitioning = true;
+    captureKpis0157();
+  }
   observeKpis0157();
   page.classList.add("dm-period-loading-active-0157");
   page.setAttribute("aria-busy", "true");
@@ -158,25 +169,24 @@ function beginEnergyTransition0157() {
 
 function finishEnergyTransition0157(generation) {
   const runtime = state0157();
-  globalThis.clearTimeout?.(runtime.finishTimer);
-  runtime.finishTimer = globalThis.setTimeout?.(() => {
+  clearTimeout(runtime.finishTimer);
+  runtime.finishTimer = setTimeout(() => {
     if (generation !== runtime.generation) return;
     runtime.kpiObserver?.disconnect?.();
     runtime.kpiObserver = null;
+    runtime.transitioning = false;
+    runtime.snapshots.clear();
     const page = energyPage0157();
     page?.classList.remove("dm-period-loading-active-0157");
     page?.removeAttribute("aria-busy");
     const status = page?.querySelector?.("[data-dm-period-loading-0157]");
     if (status) status.hidden = true;
-    runtime.snapshots.clear();
-  }, 700);
+  }, 240);
 }
 
 function commitEnergy0157(values, generation) {
   const runtime = state0157();
   if (generation !== runtime.generation) return false;
-  runtime.kpiObserver?.disconnect?.();
-
   const production = values.get("prod");
   const consumption = values.get("cons");
   const imported = values.get("grid");
@@ -185,61 +195,57 @@ function commitEnergy0157(values, generation) {
       ? Math.max(0, Math.min(100, Math.round(((consumption - imported) / consumption) * 100)))
       : null;
 
-  const productionNode = globalThis.document?.getElementById?.("ed-kpi-prod");
-  const consumptionNode = globalThis.document?.getElementById?.("ed-kpi-cons");
-  const autonomyNode = globalThis.document?.getElementById?.("ed-kpi-auto");
-  if (productionNode && Number.isFinite(production)) {
-    productionNode.innerHTML = `${format0157(production)} <small>kWh</small>`;
+  runtime.kpiObserver?.disconnect?.();
+  runtime.committing = true;
+  try {
+    if (Number.isFinite(production) && kpiNode0157("ed-kpi-prod")) {
+      kpiNode0157("ed-kpi-prod").innerHTML = `${format0157(production)} <small>kWh</small>`;
+    }
+    if (Number.isFinite(consumption) && kpiNode0157("ed-kpi-cons")) {
+      kpiNode0157("ed-kpi-cons").innerHTML = `${format0157(consumption)} <small>kWh</small>`;
+    }
+    if (Number.isFinite(autonomy) && kpiNode0157("ed-kpi-auto")) {
+      kpiNode0157("ed-kpi-auto").innerHTML = `${autonomy} <small>%</small>`;
+    }
+    captureKpis0157();
+  } finally {
+    runtime.committing = false;
   }
-  if (consumptionNode && Number.isFinite(consumption)) {
-    consumptionNode.innerHTML = `${format0157(consumption)} <small>kWh</small>`;
-  }
-  if (autonomyNode && Number.isFinite(autonomy)) {
-    autonomyNode.innerHTML = `${autonomy} <small>%</small>`;
-  }
-
-  refreshKpiSnapshots0157();
   observeKpis0157();
   return true;
 }
 
-function nextFrame0157() {
-  return new Promise((resolve) => {
-    if (typeof globalThis.requestAnimationFrame === "function") globalThis.requestAnimationFrame(resolve);
-    else resolve();
-  });
-}
-
 async function refreshEnergy0157(generation) {
-  const runtime = globalThis[FINAL_RUNTIME_0156_KEY];
-  if (generation !== state0157().generation || typeof runtime?.monthValues !== "function") {
+  const runtime0156 = globalThis[FINAL_RUNTIME_0156_KEY];
+  if (generation !== state0157().generation || typeof runtime0156?.monthValues !== "function") {
     finishEnergyTransition0157(generation);
     return false;
   }
-  const selected = selectedPeriod0157();
   const sources = energySources0157();
   if (!sources.length) {
+    restoreKpis0157();
     finishEnergyTransition0157(generation);
     return false;
   }
+  const { month, year } = selectedPeriod0157();
   try {
-    const periodValues = await runtime.monthValues(
-      sources.map((source) => source.entity),
-      selected.month,
-      selected.year,
+    const periodValues = await runtime0156.monthValues(
+      sources.map(({ entity }) => entity),
+      month,
+      year,
     );
     if (generation !== state0157().generation) return false;
     const values = new Map();
-    sources.forEach((source) => {
-      const value = periodValues.get(source.entity);
-      if (Number.isFinite(value)) values.set(source.key, value);
+    sources.forEach(({ key, entity }) => {
+      const value = periodValues.get(entity);
+      if (Number.isFinite(value)) values.set(key, value);
     });
-    await nextFrame0157();
+    await new Promise((resolve) => requestAnimationFrame(resolve));
     commitEnergy0157(values, generation);
     finishEnergyTransition0157(generation);
     return true;
   } catch (error) {
-    globalThis.console?.warn?.("[DashboardModern] stable period refresh", error);
+    console.warn("[DashboardModern] stable period refresh", error);
     restoreKpis0157();
     finishEnergyTransition0157(generation);
     return false;
@@ -249,27 +255,9 @@ async function refreshEnergy0157(generation) {
 function scheduleEnergyRefresh0157() {
   const runtime = state0157();
   const generation = ++runtime.generation;
-  globalThis.clearTimeout?.(runtime.refreshTimer);
+  clearTimeout(runtime.refreshTimer);
   beginEnergyTransition0157();
-  runtime.refreshTimer = globalThis.setTimeout?.(() => refreshEnergy0157(generation), 80);
-}
-
-function rooms0157() {
-  try {
-    const rooms = globalThis.DashboardModernModules?.store?.getSection?.("rooms");
-    return Array.isArray(rooms) ? rooms : [];
-  } catch (_error) {
-    return [];
-  }
-}
-
-function appliances0157() {
-  try {
-    const items = globalThis.DashboardModernModules?.store?.getSection?.("appliances");
-    return Array.isArray(items) ? items : [];
-  } catch (_error) {
-    return [];
-  }
+  runtime.refreshTimer = setTimeout(() => refreshEnergy0157(generation), 90);
 }
 
 function roomForAppliance0157(item, rooms = rooms0157()) {
@@ -279,14 +267,14 @@ function roomForAppliance0157(item, rooms = rooms0157()) {
   for (const reference of references) {
     const lower = reference.toLowerCase();
     const token = slug0157(reference).replace(/^room-/, "");
-    const room = rooms.find((candidate) =>
-      String(candidate?.id || "") === reference ||
-      String(candidate?.id || "").toLowerCase() === lower ||
-      String(candidate?.name || "").toLowerCase() === lower ||
-      slug0157(candidate?.name).replace(/^room-/, "") === token ||
-      slug0157(candidate?.id).replace(/^room-/, "") === token,
+    const found = rooms.find((room) =>
+      String(room?.id || "") === reference ||
+      String(room?.id || "").toLowerCase() === lower ||
+      String(room?.name || "").toLowerCase() === lower ||
+      slug0157(room?.id).replace(/^room-/, "") === token ||
+      slug0157(room?.name).replace(/^room-/, "") === token,
     );
-    if (room) return room;
+    if (found) return found;
   }
   return null;
 }
@@ -301,19 +289,15 @@ function rawState0157(entity) {
 }
 
 function itemEntities0157(item) {
-  return [...new Set(
-    [
-      item?.power_entity,
-      item?.power,
-      item?.energy_entity,
-      item?.total_energy_entity,
-      item?.monthly_energy_entity,
-      item?.report_entity,
-      ...(Array.isArray(item?.entities) ? item.entities : []),
-    ]
-      .map((value) => (typeof value === "string" ? value : value?.entity))
-      .filter(Boolean),
-  )];
+  return [...new Set([
+    item?.power_entity,
+    item?.power,
+    item?.energy_entity,
+    item?.total_energy_entity,
+    item?.monthly_energy_entity,
+    item?.report_entity,
+    ...(Array.isArray(item?.entities) ? item.entities : []),
+  ].map((value) => (typeof value === "string" ? value : value?.entity)).filter(Boolean))];
 }
 
 function metricEntity0157(item, kind) {
@@ -350,7 +334,7 @@ function existingEnergyValue0157(card) {
   const values = [...card.querySelectorAll(".appl-mini")]
     .map((node) => String(node.textContent || "").trim())
     .filter((value) => /(?:wh|kwh|mwh)(?:\s|$)/i.test(value));
-  const match = values.at(-1)?.match(/(-?\d+(?:[.,]\d+)?)\s*(kwh|mwh|wh)/i);
+  const match = values[values.length - 1]?.match(/(-?\d+(?:[.,]\d+)?)\s*(kwh|mwh|wh)/i);
   return match ? `${match[1]} ${match[2]}` : "";
 }
 
@@ -359,140 +343,82 @@ function decorateApplianceCard0157(card, item) {
   const room = roomForAppliance0157(item);
   card.dataset.applianceId = String(item.id || card.dataset.applianceId || "");
   card.dataset.roomId = String(room?.id || "");
-  card.dataset.roomName = String(room?.name || "");
-
   const roomLabel = card.querySelector(".appl-wide-cat");
   const roomText = room ? `🏠 ${room.name}` : t0157("Senza stanza", "No room");
   if (roomLabel && roomLabel.textContent !== roomText) roomLabel.textContent = roomText;
 
-  const live = card.querySelector(".appl-live") || card.querySelector(".appl-wide-info") || card;
+  const host = card.querySelector(".appl-live") || card.querySelector(".appl-wide-info") || card;
   const energyEntity = metricEntity0157(item, "energy");
   const powerEntity = metricEntity0157(item, "power");
-  const energyValue = energyEntity
-    ? metricValue0157(energyEntity, "energy")
-    : existingEnergyValue0157(card) || "—";
+  const energyValue = energyEntity ? metricValue0157(energyEntity, "energy") : existingEnergyValue0157(card) || "—";
   const powerValue = powerEntity ? metricValue0157(powerEntity, "power") : "";
-
   card.querySelectorAll(".appl-mini").forEach((node) => {
     node.classList.add("dm-legacy-appliance-metric-0157");
     node.setAttribute("aria-hidden", "true");
   });
-
   let metrics = card.querySelector(".dm-appliance-metrics-0157");
   if (!metrics) {
-    metrics = globalThis.document.createElement("div");
+    metrics = document.createElement("div");
     metrics.className = "dm-appliance-metrics-0157";
-    live.append(metrics);
+    host.append(metrics);
   }
   const signature = `${energyValue}|${powerValue}`;
-  if (metrics.dataset.signature === signature) return;
-  metrics.dataset.signature = signature;
-  metrics.innerHTML = `<span class="dm-appliance-metric-0157 dm-appliance-energy-0157"><small>${t0157("Consumo totale", "Total energy")}</small><strong>${energyValue}</strong></span>${powerValue ? `<span class="dm-appliance-metric-0157"><small>${t0157("Adesso", "Now")}</small><strong>${powerValue}</strong></span>` : ""}`;
-}
-
-function roomFilterMatch0157(card, selectedRoomId) {
-  if (!selectedRoomId) return true;
-  if (selectedRoomId === "__unassigned__") return !String(card.dataset.roomId || "");
-  return String(card.dataset.roomId || "") === selectedRoomId;
+  if (metrics.dataset.signature !== signature) {
+    metrics.dataset.signature = signature;
+    metrics.innerHTML = `<span class="dm-appliance-metric-0157"><small>${t0157("Consumo totale", "Total energy")}</small><strong>${energyValue}</strong></span>${powerValue ? `<span class="dm-appliance-metric-0157"><small>${t0157("Adesso", "Now")}</small><strong>${powerValue}</strong></span>` : ""}`;
+  }
 }
 
 function applyRoomFilter0157() {
   const runtime = state0157();
-  const page = globalThis.document?.getElementById?.("page-appliances-main");
+  const page = document.getElementById("page-appliances-main");
   if (!page) return;
   page.querySelectorAll(".appl-wide-card[data-appliance-id]").forEach((card) => {
-    card.hidden = !roomFilterMatch0157(card, runtime.selectedRoomId);
+    card.hidden = runtime.selectedRoomId === "__unassigned__"
+      ? Boolean(card.dataset.roomId)
+      : Boolean(runtime.selectedRoomId) && card.dataset.roomId !== runtime.selectedRoomId;
   });
   page.querySelectorAll("[data-dm-appliance-room-0157]").forEach((button) => {
-    const active = String(button.dataset.dmApplianceRoom0157 || "") === runtime.selectedRoomId;
+    const active = button.dataset.dmApplianceRoom0157 === runtime.selectedRoomId;
     button.classList.toggle("active", active);
     button.setAttribute("aria-pressed", String(active));
   });
 }
 
-function exactOverviewNode0157(page) {
-  return [...page.querySelectorAll("button,a,[role='button']")].find((node) =>
-    /^(?:📊\s*)?(panoramica|overview)$/i.test(String(node.textContent || "").trim()),
-  ) || null;
-}
-
 function roomNav0157(page) {
-  let nav = page.querySelector(".dm-appliance-room-nav-0157");
+  const existing = [...page.querySelectorAll("#dm-appliance-room-nav-0157,.dm-appliance-room-nav-0157")];
+  const nav = existing.shift();
+  existing.forEach((node) => node.remove());
   if (nav) return nav;
-
-  const overview = exactOverviewNode0157(page);
-  const legacyHost = overview?.parentElement;
-  const legacyLooksLikeRoomNav = Boolean(
-    legacyHost && [...legacyHost.querySelectorAll("button,a,[role='button']")].some((node) =>
-      /nessuna stanza|no room|stanza|room/i.test(String(node.textContent || "")),
-    ),
-  );
-
-  if (legacyLooksLikeRoomNav) {
-    nav = legacyHost;
-    nav.classList.add("dm-appliance-room-nav-0157");
-    [...nav.querySelectorAll(":scope > button,:scope > a,:scope > [role='button']")].forEach((node) => {
-      if (node !== overview) node.remove();
-    });
-  } else {
-    nav = globalThis.document.createElement("nav");
-    nav.className = "dm-appliance-room-nav-0157";
-    const home = [...page.querySelectorAll("button,a,[role='button']")].find((node) =>
-      /^(?:←\s*)?home$/i.test(String(node.textContent || "").trim()),
-    );
-    if (home?.parentElement) home.parentElement.insertAdjacentElement("afterend", nav);
-    else page.prepend(nav);
-  }
-
-  nav.setAttribute("aria-label", t0157("Filtra per stanza", "Filter by room"));
-  let overviewButton = overview && overview.closest(".dm-appliance-room-nav-0157") ? overview : null;
-  if (!overviewButton) {
-    overviewButton = globalThis.document.createElement("button");
-    overviewButton.type = "button";
-    overviewButton.textContent = `📊 ${t0157("Panoramica", "Overview")}`;
-    nav.prepend(overviewButton);
-  }
-  overviewButton.dataset.dmApplianceRoom0157 = "";
-  overviewButton.removeAttribute("onclick");
-  if (overviewButton.dataset.dm0157Bound !== "true") {
-    overviewButton.dataset.dm0157Bound = "true";
-    overviewButton.addEventListener("click", (event) => {
-      event.preventDefault();
-      event.stopImmediatePropagation();
-      state0157().selectedRoomId = "";
-      applyRoomFilter0157();
-    }, true);
-  }
-  return nav;
+  const created = document.createElement("nav");
+  created.id = "dm-appliance-room-nav-0157";
+  created.className = "dm-appliance-room-nav-0157";
+  created.setAttribute("aria-label", t0157("Filtra per stanza", "Filter by room"));
+  const cards = page.querySelector(".appl-wide-card");
+  if (cards) cards.before(created);
+  else page.prepend(created);
+  return created;
 }
 
 function rebuildRoomNav0157(items) {
-  const page = globalThis.document?.getElementById?.("page-appliances-main");
+  const page = document.getElementById("page-appliances-main");
   if (!page) return;
   const rooms = rooms0157();
-  const groups = rooms
-    .map((room) => ({
-      room,
-      count: items.filter((item) => roomForAppliance0157(item, rooms)?.id === room.id).length,
-    }))
-    .filter((group) => group.count > 0);
-  const unassigned = items.filter((item) => !roomForAppliance0157(item, rooms));
+  const groups = rooms.map((room) => ({
+    room,
+    count: items.filter((item) => roomForAppliance0157(item, rooms)?.id === room.id).length,
+  })).filter(({ count }) => count > 0);
+  const unassigned = items.filter((item) => !roomForAppliance0157(item, rooms)).length;
   const nav = roomNav0157(page);
-  const signature = `${groups.map(({ room, count }) => `${room.id}:${room.name}:${count}`).join("|")}|unassigned:${unassigned.length}`;
-  if (nav.dataset.dm0157RoomSignature === signature) {
+  const signature = `${groups.map(({ room, count }) => `${room.id}:${count}`).join("|")}|${unassigned}`;
+  if (nav.dataset.signature === signature) {
     applyRoomFilter0157();
     return;
   }
-  nav.dataset.dm0157RoomSignature = signature;
-
-  nav.querySelectorAll("[data-dm-appliance-room-0157]:not([data-dm0157-bound])").forEach((node) => node.remove());
-  const existingOverview = nav.querySelector("[data-dm-appliance-room-0157='']");
-  [...nav.children].forEach((node) => {
-    if (node !== existingOverview && node.matches?.("[data-dm-appliance-room-0157]")) node.remove();
-  });
-
-  const append = (roomId, label, count) => {
-    const button = globalThis.document.createElement("button");
+  nav.dataset.signature = signature;
+  nav.replaceChildren();
+  const add = (roomId, label, count) => {
+    const button = document.createElement("button");
     button.type = "button";
     button.dataset.dmApplianceRoom0157 = roomId;
     button.innerHTML = `<span>${label}</span><small>${count}</small>`;
@@ -502,32 +428,26 @@ function rebuildRoomNav0157(items) {
     });
     nav.append(button);
   };
-
-  groups.forEach(({ room, count }) => append(String(room.id || ""), `🏠 ${room.name}`, count));
-  if (unassigned.length) {
-    append("__unassigned__", `❔ ${t0157("Senza stanza", "No room")}`, unassigned.length);
-  }
-
-  const validIds = new Set(["", "__unassigned__", ...groups.map(({ room }) => String(room.id || ""))]);
-  if (!validIds.has(state0157().selectedRoomId)) state0157().selectedRoomId = "";
+  add("", `📊 ${t0157("Panoramica", "Overview")}`, items.length);
+  groups.forEach(({ room, count }) => add(String(room.id || ""), `🏠 ${room.name}`, count));
+  if (unassigned) add("__unassigned__", `❔ ${t0157("Senza stanza", "No room")}`, unassigned);
+  const valid = new Set(["", "__unassigned__", ...groups.map(({ room }) => String(room.id || ""))]);
+  if (!valid.has(state0157().selectedRoomId)) state0157().selectedRoomId = "";
   applyRoomFilter0157();
 }
 
 function decorateAppliances0157() {
-  const page = globalThis.document?.getElementById?.("page-appliances-main");
+  const page = document.getElementById("page-appliances-main");
   if (!page) return false;
   const items = appliances0157();
   const byId = new Map(items.map((item) => [String(item.id || ""), item]));
   page.querySelectorAll(".appl-wide-card").forEach((card, index) => {
     const id = String(card.dataset.applianceId || "");
     const name = String(card.querySelector(".appl-wide-name")?.textContent || "").trim().toLowerCase();
-    const item =
-      byId.get(id) ||
-      items.find((candidate) => String(candidate.name || "").trim().toLowerCase() === name) ||
-      items[index];
+    const item = byId.get(id) || items.find((candidate) => String(candidate.name || "").trim().toLowerCase() === name) || items[index];
     if (item) decorateApplianceCard0157(card, item);
   });
-  rebuildRoomNav0157(items);
+  if (page.querySelector(".appl-wide-card")) rebuildRoomNav0157(items);
   return true;
 }
 
@@ -544,26 +464,15 @@ function comfort0157(temperature) {
 function roomForTemperatureCard0157(card, index) {
   const rooms = rooms0157();
   const id = String(card.dataset.roomId || "");
-  const name = String(card.querySelector(".cp-name")?.textContent || "").trim().toLowerCase();
-  return (
-    rooms.find((room) => String(room.id || "") === id) ||
+  const name = String(card.querySelector(".cp-name,.temp-room-name")?.textContent || "").trim().toLowerCase();
+  return rooms.find((room) => String(room.id || "") === id) ||
     rooms.find((room) => String(room.name || "").trim().toLowerCase() === name) ||
-    rooms[index] ||
-    null
-  );
-}
-
-function temperatureValue0157(card) {
-  return number0157(card.querySelector("[id^='tv_'],.temp-value")?.textContent);
-}
-
-function humidityValue0157(card) {
-  return number0157(card.querySelector("[id^='hv_'],.humidity-value,.hum-value")?.textContent);
+    rooms[index] || null;
 }
 
 function temperatureIcon0157(card, room) {
-  const stable = card.querySelector(".dm-room-icon-0151");
-  if (stable?.innerHTML) return stable.innerHTML;
+  const original = card.querySelector(".temp-room-icon,.dm-room-icon-0151");
+  if (original?.innerHTML) return original.innerHTML;
   try {
     const markup = globalThis.cdIconMarkup?.(room?.icon || "mdi:home-thermometer", 32);
     if (markup) return markup;
@@ -571,42 +480,30 @@ function temperatureIcon0157(card, room) {
   return "🏠";
 }
 
-function decorateTemperatureCard0157(card, room) {
-  if (!card || !room) return;
-  const temperature = temperatureValue0157(card);
-  const humidity = humidityValue0157(card);
-  const comfort = comfort0157(temperature);
-  card.dataset.roomId = String(room.id || "");
-  card.classList.add("dm-temperature-card-0157-ready");
-
-  let content = card.querySelector(":scope > .dm-temperature-card-0157");
-  if (!content) {
-    content = globalThis.document.createElement("div");
-    content.className = "dm-temperature-card-0157";
-    card.append(content);
-  }
-  const signature = `${room.id}|${temperature}|${humidity}|${comfort.key}|${room.icon || ""}`;
-  if (content.dataset.signature !== signature) {
-    content.dataset.signature = signature;
-    content.innerHTML = `<header><span class="dm-temperature-room-icon-0157">${temperatureIcon0157(card, room)}</span><span class="dm-temperature-room-title-0157"><strong>${room.name}</strong><small>${t0157("Clima ambiente", "Room climate")}</small></span><span class="dm-temperature-status-0157" data-status="${comfort.key}">${comfort.label}</span></header><div class="dm-temperature-values-0157"><span><small>${t0157("Temperatura", "Temperature")}</small><strong>${temperature == null ? "—" : format0157(temperature)}<em>°C</em></strong></span><span><small>${t0157("Umidità", "Humidity")}</small><strong>${humidity == null ? "—" : format0157(humidity, 0)}<em>%</em></strong></span></div>`;
-  }
-
-  const aria = `${room.name}, ${t0157("temperatura", "temperature")} ${temperature == null ? "—" : format0157(temperature)} °C, ${t0157("umidità", "humidity")} ${humidity == null ? "—" : format0157(humidity, 0)}%`;
-  if (card.getAttribute("aria-label") !== aria) card.setAttribute("aria-label", aria);
-  const legacyComfort = card.querySelector("[id^='tc_']");
-  if (legacyComfort) {
-    if (legacyComfort.textContent !== comfort.label) legacyComfort.textContent = comfort.label;
-    if (legacyComfort.getAttribute("title") !== comfort.label) legacyComfort.setAttribute("title", comfort.label);
-    if (legacyComfort.getAttribute("aria-label") !== comfort.label) legacyComfort.setAttribute("aria-label", comfort.label);
-  }
-}
-
 function decorateTemperatures0157() {
-  const grid = globalThis.document?.getElementById?.("temp-grid");
+  const grid = document.getElementById("temp-grid");
   if (!grid) return false;
   grid.querySelectorAll(".temp-card").forEach((card, index) => {
     const room = roomForTemperatureCard0157(card, index);
-    if (room) decorateTemperatureCard0157(card, room);
+    if (!room) return;
+    const temperature = number0157(card.querySelector("[id^='tv_'],.temp-value")?.textContent);
+    const humidity = number0157(card.querySelector("[id^='hv_'],.humidity-value,.hum-value")?.textContent);
+    const comfort = comfort0157(temperature);
+    card.dataset.roomId = String(room.id || "");
+    card.classList.add("dm-temperature-card-0157-ready");
+    const legacyComfort = card.querySelector("[id^='tc_']");
+    if (legacyComfort) legacyComfort.textContent = comfort.label;
+    let content = card.querySelector(":scope > .dm-temperature-card-0157");
+    if (!content) {
+      content = document.createElement("div");
+      content.className = "dm-temperature-card-0157";
+      card.append(content);
+    }
+    const signature = `${room.id}|${temperature}|${humidity}|${comfort.key}`;
+    if (content.dataset.signature !== signature) {
+      content.dataset.signature = signature;
+      content.innerHTML = `<header><span class="dm-temperature-room-icon-0157">${temperatureIcon0157(card, room)}</span><span class="dm-temperature-room-title-0157"><strong>${room.name}</strong><small>${t0157("Clima ambiente", "Room climate")}</small></span><span class="dm-temperature-status-0157" data-status="${comfort.key}">${comfort.label}</span></header><div class="dm-temperature-values-0157"><span><small>${t0157("Temperatura", "Temperature")}</small><strong>${temperature == null ? "—" : format0157(temperature)}<em>°C</em></strong></span><span><small>${t0157("Umidità", "Humidity")}</small><strong>${humidity == null ? "—" : format0157(humidity, 0)}<em>%</em></strong></span></div>`;
+    }
   });
   return true;
 }
@@ -623,7 +520,7 @@ function decorateAll0157() {
   }
 }
 
-function functionChainHas0157(fn, marker) {
+function chainHas0157(fn, marker) {
   const seen = new Set();
   let current = fn;
   while (typeof current === "function" && !seen.has(current)) {
@@ -636,13 +533,10 @@ function functionChainHas0157(fn, marker) {
 
 function wrapAfterRender0157(name, callback, marker) {
   const current = globalThis[name];
-  if (typeof current !== "function" || functionChainHas0157(current, marker)) return false;
+  if (typeof current !== "function" || chainHas0157(current, marker)) return false;
   function wrapped0157(...args) {
     const result = current.apply(this, args);
-    const finish = () => {
-      if (typeof globalThis.queueMicrotask === "function") globalThis.queueMicrotask(callback);
-      else callback();
-    };
+    const finish = () => queueMicrotask(callback);
     if (result && typeof result.finally === "function") return result.finally(finish);
     finish();
     return result;
@@ -653,154 +547,92 @@ function wrapAfterRender0157(name, callback, marker) {
   return true;
 }
 
-function installApplianceProjection0157() {
-  const current = globalThis.getAppliances;
-  if (functionChainHas0157(current, "__dm0157RoomProjection")) return true;
-  function projected0157() {
-    const canonical = appliances0157();
-    if (!canonical.length && typeof current === "function") return current.apply(this, arguments);
-    const rooms = rooms0157();
-    return canonical.map((item) => {
-      const room = roomForAppliance0157(item, rooms);
-      return {
-        ...item,
-        room_id: room?.id || item.room_id || "",
-        room: room?.name || item.room || "",
-      };
-    });
-  }
-  projected0157.__dm0157RoomProjection = true;
-  projected0157.__dmPrevious = current;
-  globalThis.getAppliances = projected0157;
-  return true;
+function installWrappers0157() {
+  const appliance =
+    wrapAfterRender0157("renderApplianceSection", decorateAppliances0157, "__dm0157ApplianceUi") ||
+    wrapAfterRender0157("renderAppliances", decorateAppliances0157, "__dm0157ApplianceUi");
+  const temperature =
+    wrapAfterRender0157("buildTempCards", decorateTemperatures0157, "__dm0157TemperatureUi") ||
+    wrapAfterRender0157("renderTemperature", decorateTemperatures0157, "__dm0157TemperatureUi");
+  return appliance && temperature;
 }
 
 function injectStyles0157() {
-  if (globalThis.document?.getElementById?.("dm-release-0157-styles")) return;
-  const style = globalThis.document.createElement("style");
+  if (document.getElementById("dm-release-0157-styles")) return;
+  const style = document.createElement("style");
   style.id = "dm-release-0157-styles";
   style.textContent = `
     #view-panoramica { position: relative; }
-    .dm-period-loading-0157 { position: sticky; top: 10px; z-index: 8; width: fit-content; margin: 0 auto 12px; display: inline-flex; align-items: center; gap: 9px; padding: 9px 14px; border: 1px solid rgba(14,165,233,.22); border-radius: 999px; color: #0369a1; background: rgba(240,249,255,.96); box-shadow: 0 8px 24px rgba(14,165,233,.14); font-size: 12px; letter-spacing: .06em; text-transform: uppercase; }
+    .dm-period-loading-0157 { position: sticky; top: 10px; z-index: 8; width: fit-content; margin: 0 auto 12px; display: inline-flex; align-items: center; gap: 9px; padding: 9px 14px; border: 1px solid rgba(14,165,233,.22); border-radius: 999px; color: #0369a1; background: rgba(240,249,255,.96); box-shadow: 0 8px 24px rgba(14,165,233,.14); font-size: 12px; font-weight: 800; }
     .dm-period-loading-0157[hidden] { display: none !important; }
     .dm-period-loading-0157 > span { width: 13px; height: 13px; border: 2px solid rgba(14,165,233,.25); border-top-color: #0ea5e9; border-radius: 50%; animation: dm-period-spin-0157 .75s linear infinite; }
-    .dm-period-loading-active-0157 #ed-kpi-prod, .dm-period-loading-active-0157 #ed-kpi-cons, .dm-period-loading-active-0157 #ed-kpi-auto { opacity: .72; transition: opacity .18s ease; }
+    .dm-period-loading-active-0157 #ed-kpi-prod,.dm-period-loading-active-0157 #ed-kpi-cons,.dm-period-loading-active-0157 #ed-kpi-auto { opacity: .72; }
     @keyframes dm-period-spin-0157 { to { transform: rotate(360deg); } }
-
     #page-appliances-main .dm-legacy-appliance-metric-0157 { display: none !important; }
-    #page-appliances-main .dm-appliance-metrics-0157 { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 9px; }
-    #page-appliances-main .dm-appliance-metric-0157 { min-width: 118px; display: grid; gap: 2px; padding: 8px 12px; border: 1px solid rgba(148,163,184,.28); border-radius: 14px; background: linear-gradient(145deg, rgba(248,250,252,.95), rgba(240,249,255,.88)); box-shadow: inset 0 1px 0 rgba(255,255,255,.9); }
-    #page-appliances-main .dm-appliance-metric-0157 small { color: #64748b; font-size: 10px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
-    #page-appliances-main .dm-appliance-metric-0157 strong { color: #0f172a; font-size: 15px; font-weight: 900; line-height: 1.2; }
-    #page-appliances-main .dm-appliance-energy-0157 { border-color: rgba(14,165,233,.25); background: linear-gradient(145deg, rgba(240,249,255,.98), rgba(224,242,254,.72)); }
-    #page-appliances-main .dm-appliance-room-nav-0157 { display: flex; align-items: center; gap: 10px; overflow-x: auto; scrollbar-width: none; padding: 4px 0 12px; }
-    #page-appliances-main .dm-appliance-room-nav-0157::-webkit-scrollbar { display: none; }
-    #page-appliances-main .dm-appliance-room-nav-0157 > button, #page-appliances-main .dm-appliance-room-nav-0157 > a { flex: 0 0 auto; min-height: 46px; display: inline-flex; align-items: center; gap: 9px; padding: 10px 16px; border: 1px solid rgba(148,163,184,.28); border-radius: 999px; color: #334155; background: rgba(255,255,255,.88); box-shadow: 0 8px 22px rgba(15,23,42,.07); font: inherit; font-weight: 850; text-decoration: none; cursor: pointer; }
-    #page-appliances-main .dm-appliance-room-nav-0157 > button small, #page-appliances-main .dm-appliance-room-nav-0157 > a small { display: grid; place-items: center; min-width: 22px; height: 22px; padding: 0 6px; border-radius: 999px; color: #0369a1; background: #e0f2fe; font-size: 11px; }
-    #page-appliances-main .dm-appliance-room-nav-0157 > .active { color: #075985; border-color: rgba(14,165,233,.4); background: linear-gradient(135deg, #e0f2fe, #bae6fd); box-shadow: 0 10px 28px rgba(14,165,233,.18); }
+    #page-appliances-main .dm-appliance-metrics-0157 { width: 100%; display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 6px; margin-top: 8px; }
+    #page-appliances-main .dm-appliance-metric-0157 { min-width: 0; display: grid; gap: 2px; padding: 7px 9px; border: 1px solid rgba(14,165,233,.22); border-radius: 12px; background: rgba(240,249,255,.9); }
+    #page-appliances-main .dm-appliance-metric-0157 small { overflow: hidden; color: #64748b; font-size: 9px; font-weight: 800; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
+    #page-appliances-main .dm-appliance-metric-0157 strong { overflow: hidden; color: #0f172a; font-size: 13px; font-weight: 900; text-overflow: ellipsis; white-space: nowrap; }
+    #page-appliances-main .dm-appliance-room-nav-0157 { display: flex; gap: 8px; overflow-x: auto; padding: 4px 0 10px; }
+    #page-appliances-main .dm-appliance-room-nav-0157 button { flex: 0 0 auto; min-height: 40px; display: inline-flex; align-items: center; gap: 7px; padding: 8px 12px; border: 1px solid rgba(148,163,184,.28); border-radius: 999px; background: #fff; font: inherit; font-weight: 800; }
+    #page-appliances-main .dm-appliance-room-nav-0157 button.active { color: #075985; border-color: #38bdf8; background: #e0f2fe; }
     #page-appliances-main .appl-wide-card[hidden] { display: none !important; }
-
-    #temp-grid .temp-card.dm-temperature-card-0157-ready { position: relative; padding: 0 !important; overflow: hidden; border: 1px solid rgba(148,163,184,.18); background: linear-gradient(145deg, rgba(255,255,255,.98), rgba(248,250,252,.96)); box-shadow: 0 20px 48px rgba(15,23,42,.10); }
-    #temp-grid .temp-card.dm-temperature-card-0157-ready > :not(.dm-temperature-card-0157) { position: absolute !important; width: 1px !important; height: 1px !important; overflow: hidden !important; clip: rect(0 0 0 0) !important; clip-path: inset(50%) !important; white-space: nowrap !important; }
-    #temp-grid .dm-temperature-card-0157 { display: grid; gap: 18px; padding: 22px; }
-    #temp-grid .dm-temperature-card-0157 header { display: grid; grid-template-columns: auto minmax(0,1fr) auto; align-items: center; gap: 13px; }
-    #temp-grid .dm-temperature-room-icon-0157 { width: 54px; height: 54px; display: grid; place-items: center; border-radius: 18px; color: #0369a1; background: linear-gradient(145deg, #e0f2fe, #dbeafe); box-shadow: inset 0 1px 0 rgba(255,255,255,.9); font-size: 28px; }
-    #temp-grid .dm-temperature-room-title-0157 { display: grid; gap: 3px; min-width: 0; }
-    #temp-grid .dm-temperature-room-title-0157 strong { overflow: hidden; color: #0f172a; font-size: clamp(21px,4vw,27px); font-weight: 950; text-overflow: ellipsis; white-space: nowrap; }
-    #temp-grid .dm-temperature-room-title-0157 small { color: #64748b; font-size: 11px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
-    #temp-grid .dm-temperature-status-0157 { justify-self: end; padding: 8px 11px; border-radius: 999px; color: #166534; background: #dcfce7; font-size: 11px; font-weight: 900; letter-spacing: .04em; text-transform: uppercase; white-space: nowrap; }
-    #temp-grid .dm-temperature-status-0157[data-status="warm"] { color: #92400e; background: #fef3c7; }
-    #temp-grid .dm-temperature-status-0157[data-status="hot"], #temp-grid .dm-temperature-status-0157[data-status="very-hot"] { color: #b91c1c; background: #fee2e2; }
-    #temp-grid .dm-temperature-status-0157[data-status="cool"], #temp-grid .dm-temperature-status-0157[data-status="cold"] { color: #1d4ed8; background: #dbeafe; }
-    #temp-grid .dm-temperature-values-0157 { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 12px; }
-    #temp-grid .dm-temperature-values-0157 > span { min-width: 0; display: grid; gap: 5px; padding: 16px; border: 1px solid rgba(148,163,184,.18); border-radius: 18px; background: rgba(248,250,252,.88); }
-    #temp-grid .dm-temperature-values-0157 > span:first-child { background: linear-gradient(145deg, rgba(240,249,255,.95), rgba(224,242,254,.7)); }
-    #temp-grid .dm-temperature-values-0157 small { color: #64748b; font-size: 10px; font-weight: 850; letter-spacing: .09em; text-transform: uppercase; }
-    #temp-grid .dm-temperature-values-0157 strong { color: #0f172a; font-size: clamp(32px,8vw,46px); font-weight: 950; line-height: 1; font-variant-numeric: tabular-nums; }
-    #temp-grid .dm-temperature-values-0157 em { margin-left: 4px; color: #64748b; font-size: .43em; font-style: normal; font-weight: 850; }
-    @media (max-width: 560px) {
-      #page-appliances-main .dm-appliance-metrics-0157 { gap: 6px; }
-      #page-appliances-main .dm-appliance-metric-0157 { min-width: 108px; padding: 7px 10px; }
-      #temp-grid .dm-temperature-card-0157 { padding: 18px; }
-      #temp-grid .dm-temperature-card-0157 header { grid-template-columns: auto minmax(0,1fr); }
-      #temp-grid .dm-temperature-status-0157 { grid-column: 1 / -1; justify-self: start; }
-    }
+    #temp-grid .temp-card.dm-temperature-card-0157-ready { position: relative; padding: 0 !important; overflow: hidden; }
+    #temp-grid .temp-card.dm-temperature-card-0157-ready > :not(.dm-temperature-card-0157) { position: absolute !important; width: 1px !important; height: 1px !important; overflow: hidden !important; clip-path: inset(50%) !important; white-space: nowrap !important; }
+    #temp-grid .dm-temperature-card-0157 { display: grid; gap: 16px; padding: 20px; }
+    #temp-grid .dm-temperature-card-0157 header { display: grid; grid-template-columns: auto minmax(0,1fr) auto; align-items: center; gap: 12px; }
+    #temp-grid .dm-temperature-room-icon-0157 { width: 50px; height: 50px; display: grid; place-items: center; border-radius: 16px; background: #e0f2fe; font-size: 26px; }
+    #temp-grid .dm-temperature-room-title-0157 { display: grid; gap: 2px; min-width: 0; }
+    #temp-grid .dm-temperature-room-title-0157 strong { overflow: hidden; font-size: 22px; font-weight: 900; text-overflow: ellipsis; white-space: nowrap; }
+    #temp-grid .dm-temperature-room-title-0157 small { color: #64748b; font-size: 10px; font-weight: 800; text-transform: uppercase; }
+    #temp-grid .dm-temperature-status-0157 { padding: 7px 10px; border-radius: 999px; color: #166534; background: #dcfce7; font-size: 10px; font-weight: 900; text-transform: uppercase; }
+    #temp-grid .dm-temperature-status-0157[data-status="hot"],#temp-grid .dm-temperature-status-0157[data-status="very-hot"] { color: #b91c1c; background: #fee2e2; }
+    #temp-grid .dm-temperature-status-0157[data-status="cold"],#temp-grid .dm-temperature-status-0157[data-status="cool"] { color: #1d4ed8; background: #dbeafe; }
+    #temp-grid .dm-temperature-values-0157 { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 10px; }
+    #temp-grid .dm-temperature-values-0157 > span { min-width: 0; display: grid; gap: 4px; padding: 14px; border-radius: 16px; background: #f8fafc; }
+    #temp-grid .dm-temperature-values-0157 small { color: #64748b; font-size: 9px; font-weight: 800; text-transform: uppercase; }
+    #temp-grid .dm-temperature-values-0157 strong { font-size: clamp(28px,7vw,42px); font-weight: 950; line-height: 1; }
+    #temp-grid .dm-temperature-values-0157 em { margin-left: 3px; color: #64748b; font-size: .43em; font-style: normal; }
+    @media (max-width:560px) { #temp-grid .dm-temperature-card-0157 header { grid-template-columns:auto minmax(0,1fr); } #temp-grid .dm-temperature-status-0157 { grid-column:1/-1; justify-self:start; } }
   `;
-  globalThis.document.head.append(style);
-}
-
-function installWrappers0157() {
-  installApplianceProjection0157();
-  wrapAfterRender0157("renderApplianceSection", decorateAppliances0157, "__dm0157ApplianceUi");
-  wrapAfterRender0157("renderAppliances", decorateAppliances0157, "__dm0157ApplianceUi");
-  wrapAfterRender0157("buildTempCards", decorateTemperatures0157, "__dm0157TemperatureUi");
-  wrapAfterRender0157("renderTemperature", decorateTemperatures0157, "__dm0157TemperatureUi");
-}
-
-function scheduleDecoration0157() {
-  const runtime = state0157();
-  if (runtime.decorating) return;
-  globalThis.clearTimeout?.(runtime.decorateTimer);
-  runtime.decorateTimer = globalThis.setTimeout?.(decorateAll0157, 25);
+  document.head.append(style);
 }
 
 function install0157() {
   const runtime = state0157();
   injectStyles0157();
   installWrappers0157();
-
   if (!runtime.installed) {
     runtime.installed = true;
     runtime.refreshEnergy = scheduleEnergyRefresh0157;
     runtime.decorateAppliances = decorateAppliances0157;
     runtime.decorateTemperatures = decorateTemperatures0157;
-
-    globalThis.document.addEventListener("change", (event) => {
-      if (event.target?.matches?.("#ed-sel-month, #ed-sel-year")) scheduleEnergyRefresh0157();
+    document.addEventListener("change", (event) => {
+      if (event.target?.matches?.("#ed-sel-month,#ed-sel-year")) scheduleEnergyRefresh0157();
     }, true);
-
-    if (typeof globalThis.MutationObserver === "function") {
-      runtime.pageObserver = new globalThis.MutationObserver(scheduleDecoration0157);
-      runtime.pageObserver.observe(globalThis.document.documentElement, {
-        childList: true,
-        subtree: true,
-        characterData: true,
-      });
-    }
-
     globalThis.addEventListener?.("dashboardmodern:legacy-ready", () => {
       installWrappers0157();
-      scheduleDecoration0157();
+      setTimeout(decorateAll0157, 0);
     });
     globalThis.addEventListener?.("pageshow", () => {
       installWrappers0157();
-      scheduleDecoration0157();
+      setTimeout(decorateAll0157, 0);
     });
   }
-
   decorateAll0157();
-  globalThis.clearInterval?.(runtime.wrapperTimer);
+  clearInterval(runtime.wrapperTimer);
   let attempts = 0;
-  runtime.wrapperTimer = globalThis.setInterval?.(() => {
+  runtime.wrapperTimer = setInterval(() => {
     attempts += 1;
-    installWrappers0157();
-    scheduleDecoration0157();
-    if (
-      attempts >= 80 ||
-      (globalThis.renderApplianceSection?.__dm0157ApplianceUi &&
-        globalThis.renderTemperature?.__dm0157TemperatureUi &&
-        globalThis[FINAL_RUNTIME_0156_KEY]?.monthValues)
-    ) {
-      globalThis.clearInterval?.(runtime.wrapperTimer);
+    if (installWrappers0157() || attempts >= 40) {
+      clearInterval(runtime.wrapperTimer);
       runtime.wrapperTimer = 0;
+      decorateAll0157();
     }
   }, 100);
 }
 
-if (typeof globalThis.document !== "undefined") {
-  if (globalThis.document.readyState === "loading") {
-    globalThis.document.addEventListener("DOMContentLoaded", install0157, { once: true });
-  } else {
-    install0157();
-  }
+if (typeof document !== "undefined") {
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", install0157, { once: true });
+  else install0157();
 }

--- a/custom_components/dashboardmodern/frontend/legacy/release-0157-ui-stability.js
+++ b/custom_components/dashboardmodern/frontend/legacy/release-0157-ui-stability.js
@@ -1,0 +1,806 @@
+/* DashboardModern 0.14.17: atomic Energy periods, room-aware appliances and clearer temperature cards. */
+const UI_0157_KEY = "__DASHBOARDMODERN_RELEASE_0157_UI_STABILITY__";
+const FINAL_RUNTIME_0156_KEY = "__DASHBOARDMODERN_RELEASE_0156_FINAL_RUNTIME__";
+const KPI_IDS_0157 = Object.freeze(["ed-kpi-prod", "ed-kpi-cons", "ed-kpi-auto"]);
+const ENERGY_SOURCES_0157 = Object.freeze([
+  ["prod", "solar", "total_energy", "monthly_energy"],
+  ["cons", "house", "total_energy", "monthly_energy"],
+  ["grid", "grid", "total_import_energy", "monthly_import_energy"],
+]);
+
+function state0157() {
+  return (globalThis[UI_0157_KEY] ||= {
+    installed: false,
+    generation: 0,
+    refreshTimer: 0,
+    finishTimer: 0,
+    decorateTimer: 0,
+    wrapperTimer: 0,
+    kpiObserver: null,
+    pageObserver: null,
+    snapshots: new Map(),
+    selectedRoomId: "",
+    decorating: false,
+    restoring: false,
+  });
+}
+
+function english0157() {
+  return globalThis.document?.documentElement?.lang === "en";
+}
+
+function t0157(it, en) {
+  return english0157() ? en : it;
+}
+
+function slug0157(value) {
+  return String(value || "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function number0157(value) {
+  const parsed = Number.parseFloat(String(value ?? "").replace(",", "."));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function format0157(value, digits = 1) {
+  return new Intl.NumberFormat(english0157() ? "en-GB" : "it-IT", {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  }).format(value);
+}
+
+function selectedPeriod0157() {
+  const now = new Date();
+  const month = Number(globalThis.document?.getElementById?.("ed-sel-month")?.value);
+  const year = Number(globalThis.document?.getElementById?.("ed-sel-year")?.value);
+  return {
+    month: Number.isInteger(month) && month >= 1 && month <= 12 ? month : now.getMonth() + 1,
+    year: Number.isInteger(year) && year >= 2000 ? year : now.getFullYear(),
+  };
+}
+
+function energyConfig0157() {
+  try {
+    return globalThis.DashboardModernModules?.store?.getSection?.("energy") || {};
+  } catch (_error) {
+    return {};
+  }
+}
+
+function energySources0157() {
+  const energy = energyConfig0157();
+  return ENERGY_SOURCES_0157.map(([key, group, totalKey, monthlyKey]) => ({
+    key,
+    entity: String(energy?.[group]?.[totalKey] || energy?.[group]?.[monthlyKey] || "").trim(),
+  })).filter((source) => source.entity);
+}
+
+function captureKpis0157() {
+  const runtime = state0157();
+  runtime.snapshots.clear();
+  KPI_IDS_0157.forEach((id) => {
+    const node = globalThis.document?.getElementById?.(id);
+    if (node) runtime.snapshots.set(id, node.innerHTML);
+  });
+}
+
+function refreshKpiSnapshots0157() {
+  const runtime = state0157();
+  KPI_IDS_0157.forEach((id) => {
+    const node = globalThis.document?.getElementById?.(id);
+    if (node) runtime.snapshots.set(id, node.innerHTML);
+  });
+}
+
+function restoreKpis0157() {
+  const runtime = state0157();
+  if (runtime.restoring) return;
+  runtime.restoring = true;
+  try {
+    runtime.snapshots.forEach((html, id) => {
+      const node = globalThis.document?.getElementById?.(id);
+      if (node && node.innerHTML !== html) node.innerHTML = html;
+    });
+  } finally {
+    runtime.restoring = false;
+  }
+}
+
+function observeKpis0157() {
+  const runtime = state0157();
+  runtime.kpiObserver?.disconnect?.();
+  if (typeof globalThis.MutationObserver !== "function") return;
+  runtime.kpiObserver = new globalThis.MutationObserver(() => {
+    if (!runtime.restoring) globalThis.queueMicrotask?.(restoreKpis0157);
+  });
+  KPI_IDS_0157.forEach((id) => {
+    const node = globalThis.document?.getElementById?.(id);
+    if (node) runtime.kpiObserver.observe(node, { childList: true, subtree: true, characterData: true });
+  });
+}
+
+function energyPage0157() {
+  return globalThis.document?.getElementById?.("view-panoramica") || null;
+}
+
+function energyStatus0157() {
+  const page = energyPage0157();
+  if (!page) return null;
+  let status = page.querySelector("[data-dm-period-loading-0157]");
+  if (!status) {
+    status = globalThis.document.createElement("div");
+    status.className = "dm-period-loading-0157";
+    status.dataset.dmPeriodLoading0157 = "";
+    status.setAttribute("role", "status");
+    status.setAttribute("aria-live", "polite");
+    status.innerHTML = `<span aria-hidden="true"></span><strong>${t0157("Aggiornamento mese…", "Updating month…")}</strong>`;
+    page.prepend(status);
+  }
+  return status;
+}
+
+function beginEnergyTransition0157() {
+  const page = energyPage0157();
+  if (!page) return false;
+  captureKpis0157();
+  observeKpis0157();
+  page.classList.add("dm-period-loading-active-0157");
+  page.setAttribute("aria-busy", "true");
+  const status = energyStatus0157();
+  if (status) status.hidden = false;
+  return true;
+}
+
+function finishEnergyTransition0157(generation) {
+  const runtime = state0157();
+  globalThis.clearTimeout?.(runtime.finishTimer);
+  runtime.finishTimer = globalThis.setTimeout?.(() => {
+    if (generation !== runtime.generation) return;
+    runtime.kpiObserver?.disconnect?.();
+    runtime.kpiObserver = null;
+    const page = energyPage0157();
+    page?.classList.remove("dm-period-loading-active-0157");
+    page?.removeAttribute("aria-busy");
+    const status = page?.querySelector?.("[data-dm-period-loading-0157]");
+    if (status) status.hidden = true;
+    runtime.snapshots.clear();
+  }, 700);
+}
+
+function commitEnergy0157(values, generation) {
+  const runtime = state0157();
+  if (generation !== runtime.generation) return false;
+  runtime.kpiObserver?.disconnect?.();
+
+  const production = values.get("prod");
+  const consumption = values.get("cons");
+  const imported = values.get("grid");
+  const autonomy =
+    Number.isFinite(consumption) && consumption > 0 && Number.isFinite(imported)
+      ? Math.max(0, Math.min(100, Math.round(((consumption - imported) / consumption) * 100)))
+      : null;
+
+  const productionNode = globalThis.document?.getElementById?.("ed-kpi-prod");
+  const consumptionNode = globalThis.document?.getElementById?.("ed-kpi-cons");
+  const autonomyNode = globalThis.document?.getElementById?.("ed-kpi-auto");
+  if (productionNode && Number.isFinite(production)) {
+    productionNode.innerHTML = `${format0157(production)} <small>kWh</small>`;
+  }
+  if (consumptionNode && Number.isFinite(consumption)) {
+    consumptionNode.innerHTML = `${format0157(consumption)} <small>kWh</small>`;
+  }
+  if (autonomyNode && Number.isFinite(autonomy)) {
+    autonomyNode.innerHTML = `${autonomy} <small>%</small>`;
+  }
+
+  refreshKpiSnapshots0157();
+  observeKpis0157();
+  return true;
+}
+
+function nextFrame0157() {
+  return new Promise((resolve) => {
+    if (typeof globalThis.requestAnimationFrame === "function") globalThis.requestAnimationFrame(resolve);
+    else resolve();
+  });
+}
+
+async function refreshEnergy0157(generation) {
+  const runtime = globalThis[FINAL_RUNTIME_0156_KEY];
+  if (generation !== state0157().generation || typeof runtime?.monthValues !== "function") {
+    finishEnergyTransition0157(generation);
+    return false;
+  }
+  const selected = selectedPeriod0157();
+  const sources = energySources0157();
+  if (!sources.length) {
+    finishEnergyTransition0157(generation);
+    return false;
+  }
+  try {
+    const periodValues = await runtime.monthValues(
+      sources.map((source) => source.entity),
+      selected.month,
+      selected.year,
+    );
+    if (generation !== state0157().generation) return false;
+    const values = new Map();
+    sources.forEach((source) => {
+      const value = periodValues.get(source.entity);
+      if (Number.isFinite(value)) values.set(source.key, value);
+    });
+    await nextFrame0157();
+    commitEnergy0157(values, generation);
+    finishEnergyTransition0157(generation);
+    return true;
+  } catch (error) {
+    globalThis.console?.warn?.("[DashboardModern] stable period refresh", error);
+    restoreKpis0157();
+    finishEnergyTransition0157(generation);
+    return false;
+  }
+}
+
+function scheduleEnergyRefresh0157() {
+  const runtime = state0157();
+  const generation = ++runtime.generation;
+  globalThis.clearTimeout?.(runtime.refreshTimer);
+  beginEnergyTransition0157();
+  runtime.refreshTimer = globalThis.setTimeout?.(() => refreshEnergy0157(generation), 80);
+}
+
+function rooms0157() {
+  try {
+    const rooms = globalThis.DashboardModernModules?.store?.getSection?.("rooms");
+    return Array.isArray(rooms) ? rooms : [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+function appliances0157() {
+  try {
+    const items = globalThis.DashboardModernModules?.store?.getSection?.("appliances");
+    return Array.isArray(items) ? items : [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+function roomForAppliance0157(item, rooms = rooms0157()) {
+  const references = [item?.room_id, item?.roomId, item?.room]
+    .map((value) => String(value || "").trim())
+    .filter(Boolean);
+  for (const reference of references) {
+    const lower = reference.toLowerCase();
+    const token = slug0157(reference).replace(/^room-/, "");
+    const room = rooms.find((candidate) =>
+      String(candidate?.id || "") === reference ||
+      String(candidate?.id || "").toLowerCase() === lower ||
+      String(candidate?.name || "").toLowerCase() === lower ||
+      slug0157(candidate?.name).replace(/^room-/, "") === token ||
+      slug0157(candidate?.id).replace(/^room-/, "") === token,
+    );
+    if (room) return room;
+  }
+  return null;
+}
+
+function rawState0157(entity) {
+  const id = String(entity || "").trim();
+  if (!id) return null;
+  try {
+    if (typeof _RAW_STATES !== "undefined" && _RAW_STATES?.[id]) return _RAW_STATES[id];
+  } catch (_error) {}
+  return globalThis._RAW_STATES?.[id] || globalThis.STATES?.[id] || null;
+}
+
+function itemEntities0157(item) {
+  return [...new Set(
+    [
+      item?.power_entity,
+      item?.power,
+      item?.energy_entity,
+      item?.total_energy_entity,
+      item?.monthly_energy_entity,
+      item?.report_entity,
+      ...(Array.isArray(item?.entities) ? item.entities : []),
+    ]
+      .map((value) => (typeof value === "string" ? value : value?.entity))
+      .filter(Boolean),
+  )];
+}
+
+function metricEntity0157(item, kind) {
+  return itemEntities0157(item).find((entity) => {
+    const state = rawState0157(entity);
+    const unit = String(state?.attributes?.unit_of_measurement || "").trim().toLowerCase().replaceAll(" ", "");
+    const deviceClass = String(state?.attributes?.device_class || "").toLowerCase();
+    return kind === "energy"
+      ? deviceClass === "energy" || /^(wh|kwh|mwh)$/.test(unit)
+      : deviceClass === "power" || /^(w|kw|mw)$/.test(unit);
+  }) || "";
+}
+
+function metricValue0157(entity, kind) {
+  const state = rawState0157(entity);
+  const value = number0157(state?.state);
+  if (value == null) return "—";
+  const rawUnit = String(state?.attributes?.unit_of_measurement || (kind === "energy" ? "kWh" : "W")).trim();
+  let normalized = value;
+  let unit = rawUnit;
+  if (kind === "energy" && rawUnit.toLowerCase() === "wh") {
+    normalized = value / 1000;
+    unit = "kWh";
+  }
+  if (kind === "power" && rawUnit.toLowerCase() === "kw") {
+    normalized = value * 1000;
+    unit = "W";
+  }
+  const digits = kind === "energy" ? 2 : normalized >= 100 ? 0 : 1;
+  return `${format0157(normalized, digits)} ${unit}`;
+}
+
+function existingEnergyValue0157(card) {
+  const values = [...card.querySelectorAll(".appl-mini")]
+    .map((node) => String(node.textContent || "").trim())
+    .filter((value) => /(?:wh|kwh|mwh)(?:\s|$)/i.test(value));
+  const match = values.at(-1)?.match(/(-?\d+(?:[.,]\d+)?)\s*(kwh|mwh|wh)/i);
+  return match ? `${match[1]} ${match[2]}` : "";
+}
+
+function decorateApplianceCard0157(card, item) {
+  if (!card || !item) return;
+  const room = roomForAppliance0157(item);
+  card.dataset.applianceId = String(item.id || card.dataset.applianceId || "");
+  card.dataset.roomId = String(room?.id || "");
+  card.dataset.roomName = String(room?.name || "");
+
+  const roomLabel = card.querySelector(".appl-wide-cat");
+  const roomText = room ? `🏠 ${room.name}` : t0157("Senza stanza", "No room");
+  if (roomLabel && roomLabel.textContent !== roomText) roomLabel.textContent = roomText;
+
+  const live = card.querySelector(".appl-live") || card.querySelector(".appl-wide-info") || card;
+  const energyEntity = metricEntity0157(item, "energy");
+  const powerEntity = metricEntity0157(item, "power");
+  const energyValue = energyEntity
+    ? metricValue0157(energyEntity, "energy")
+    : existingEnergyValue0157(card) || "—";
+  const powerValue = powerEntity ? metricValue0157(powerEntity, "power") : "";
+
+  card.querySelectorAll(".appl-mini").forEach((node) => {
+    node.classList.add("dm-legacy-appliance-metric-0157");
+    node.setAttribute("aria-hidden", "true");
+  });
+
+  let metrics = card.querySelector(".dm-appliance-metrics-0157");
+  if (!metrics) {
+    metrics = globalThis.document.createElement("div");
+    metrics.className = "dm-appliance-metrics-0157";
+    live.append(metrics);
+  }
+  const signature = `${energyValue}|${powerValue}`;
+  if (metrics.dataset.signature === signature) return;
+  metrics.dataset.signature = signature;
+  metrics.innerHTML = `<span class="dm-appliance-metric-0157 dm-appliance-energy-0157"><small>${t0157("Consumo totale", "Total energy")}</small><strong>${energyValue}</strong></span>${powerValue ? `<span class="dm-appliance-metric-0157"><small>${t0157("Adesso", "Now")}</small><strong>${powerValue}</strong></span>` : ""}`;
+}
+
+function roomFilterMatch0157(card, selectedRoomId) {
+  if (!selectedRoomId) return true;
+  if (selectedRoomId === "__unassigned__") return !String(card.dataset.roomId || "");
+  return String(card.dataset.roomId || "") === selectedRoomId;
+}
+
+function applyRoomFilter0157() {
+  const runtime = state0157();
+  const page = globalThis.document?.getElementById?.("page-appliances-main");
+  if (!page) return;
+  page.querySelectorAll(".appl-wide-card[data-appliance-id]").forEach((card) => {
+    card.hidden = !roomFilterMatch0157(card, runtime.selectedRoomId);
+  });
+  page.querySelectorAll("[data-dm-appliance-room-0157]").forEach((button) => {
+    const active = String(button.dataset.dmApplianceRoom0157 || "") === runtime.selectedRoomId;
+    button.classList.toggle("active", active);
+    button.setAttribute("aria-pressed", String(active));
+  });
+}
+
+function exactOverviewNode0157(page) {
+  return [...page.querySelectorAll("button,a,[role='button']")].find((node) =>
+    /^(?:📊\s*)?(panoramica|overview)$/i.test(String(node.textContent || "").trim()),
+  ) || null;
+}
+
+function roomNav0157(page) {
+  let nav = page.querySelector(".dm-appliance-room-nav-0157");
+  if (nav) return nav;
+
+  const overview = exactOverviewNode0157(page);
+  const legacyHost = overview?.parentElement;
+  const legacyLooksLikeRoomNav = Boolean(
+    legacyHost && [...legacyHost.querySelectorAll("button,a,[role='button']")].some((node) =>
+      /nessuna stanza|no room|stanza|room/i.test(String(node.textContent || "")),
+    ),
+  );
+
+  if (legacyLooksLikeRoomNav) {
+    nav = legacyHost;
+    nav.classList.add("dm-appliance-room-nav-0157");
+    [...nav.querySelectorAll(":scope > button,:scope > a,:scope > [role='button']")].forEach((node) => {
+      if (node !== overview) node.remove();
+    });
+  } else {
+    nav = globalThis.document.createElement("nav");
+    nav.className = "dm-appliance-room-nav-0157";
+    const home = [...page.querySelectorAll("button,a,[role='button']")].find((node) =>
+      /^(?:←\s*)?home$/i.test(String(node.textContent || "").trim()),
+    );
+    if (home?.parentElement) home.parentElement.insertAdjacentElement("afterend", nav);
+    else page.prepend(nav);
+  }
+
+  nav.setAttribute("aria-label", t0157("Filtra per stanza", "Filter by room"));
+  let overviewButton = overview && overview.closest(".dm-appliance-room-nav-0157") ? overview : null;
+  if (!overviewButton) {
+    overviewButton = globalThis.document.createElement("button");
+    overviewButton.type = "button";
+    overviewButton.textContent = `📊 ${t0157("Panoramica", "Overview")}`;
+    nav.prepend(overviewButton);
+  }
+  overviewButton.dataset.dmApplianceRoom0157 = "";
+  overviewButton.removeAttribute("onclick");
+  if (overviewButton.dataset.dm0157Bound !== "true") {
+    overviewButton.dataset.dm0157Bound = "true";
+    overviewButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      state0157().selectedRoomId = "";
+      applyRoomFilter0157();
+    }, true);
+  }
+  return nav;
+}
+
+function rebuildRoomNav0157(items) {
+  const page = globalThis.document?.getElementById?.("page-appliances-main");
+  if (!page) return;
+  const rooms = rooms0157();
+  const groups = rooms
+    .map((room) => ({
+      room,
+      count: items.filter((item) => roomForAppliance0157(item, rooms)?.id === room.id).length,
+    }))
+    .filter((group) => group.count > 0);
+  const unassigned = items.filter((item) => !roomForAppliance0157(item, rooms));
+  const nav = roomNav0157(page);
+  const signature = `${groups.map(({ room, count }) => `${room.id}:${room.name}:${count}`).join("|")}|unassigned:${unassigned.length}`;
+  if (nav.dataset.dm0157RoomSignature === signature) {
+    applyRoomFilter0157();
+    return;
+  }
+  nav.dataset.dm0157RoomSignature = signature;
+
+  nav.querySelectorAll("[data-dm-appliance-room-0157]:not([data-dm0157-bound])").forEach((node) => node.remove());
+  const existingOverview = nav.querySelector("[data-dm-appliance-room-0157='']");
+  [...nav.children].forEach((node) => {
+    if (node !== existingOverview && node.matches?.("[data-dm-appliance-room-0157]")) node.remove();
+  });
+
+  const append = (roomId, label, count) => {
+    const button = globalThis.document.createElement("button");
+    button.type = "button";
+    button.dataset.dmApplianceRoom0157 = roomId;
+    button.innerHTML = `<span>${label}</span><small>${count}</small>`;
+    button.addEventListener("click", () => {
+      state0157().selectedRoomId = roomId;
+      applyRoomFilter0157();
+    });
+    nav.append(button);
+  };
+
+  groups.forEach(({ room, count }) => append(String(room.id || ""), `🏠 ${room.name}`, count));
+  if (unassigned.length) {
+    append("__unassigned__", `❔ ${t0157("Senza stanza", "No room")}`, unassigned.length);
+  }
+
+  const validIds = new Set(["", "__unassigned__", ...groups.map(({ room }) => String(room.id || ""))]);
+  if (!validIds.has(state0157().selectedRoomId)) state0157().selectedRoomId = "";
+  applyRoomFilter0157();
+}
+
+function decorateAppliances0157() {
+  const page = globalThis.document?.getElementById?.("page-appliances-main");
+  if (!page) return false;
+  const items = appliances0157();
+  const byId = new Map(items.map((item) => [String(item.id || ""), item]));
+  page.querySelectorAll(".appl-wide-card").forEach((card, index) => {
+    const id = String(card.dataset.applianceId || "");
+    const name = String(card.querySelector(".appl-wide-name")?.textContent || "").trim().toLowerCase();
+    const item =
+      byId.get(id) ||
+      items.find((candidate) => String(candidate.name || "").trim().toLowerCase() === name) ||
+      items[index];
+    if (item) decorateApplianceCard0157(card, item);
+  });
+  rebuildRoomNav0157(items);
+  return true;
+}
+
+function comfort0157(temperature) {
+  if (temperature == null) return { key: "unknown", label: "—" };
+  if (temperature < 16) return { key: "cold", label: t0157("Freddo", "Cold") };
+  if (temperature < 19) return { key: "cool", label: t0157("Fresco", "Cool") };
+  if (temperature <= 24) return { key: "comfort", label: "Comfort" };
+  if (temperature <= 27) return { key: "warm", label: t0157("Tiepido", "Warm") };
+  if (temperature <= 32) return { key: "hot", label: t0157("Caldo", "Hot") };
+  return { key: "very-hot", label: t0157("Molto caldo", "Very hot") };
+}
+
+function roomForTemperatureCard0157(card, index) {
+  const rooms = rooms0157();
+  const id = String(card.dataset.roomId || "");
+  const name = String(card.querySelector(".cp-name")?.textContent || "").trim().toLowerCase();
+  return (
+    rooms.find((room) => String(room.id || "") === id) ||
+    rooms.find((room) => String(room.name || "").trim().toLowerCase() === name) ||
+    rooms[index] ||
+    null
+  );
+}
+
+function temperatureValue0157(card) {
+  return number0157(card.querySelector("[id^='tv_'],.temp-value")?.textContent);
+}
+
+function humidityValue0157(card) {
+  return number0157(card.querySelector("[id^='hv_'],.humidity-value,.hum-value")?.textContent);
+}
+
+function temperatureIcon0157(card, room) {
+  const stable = card.querySelector(".dm-room-icon-0151");
+  if (stable?.innerHTML) return stable.innerHTML;
+  try {
+    const markup = globalThis.cdIconMarkup?.(room?.icon || "mdi:home-thermometer", 32);
+    if (markup) return markup;
+  } catch (_error) {}
+  return "🏠";
+}
+
+function decorateTemperatureCard0157(card, room) {
+  if (!card || !room) return;
+  const temperature = temperatureValue0157(card);
+  const humidity = humidityValue0157(card);
+  const comfort = comfort0157(temperature);
+  card.dataset.roomId = String(room.id || "");
+  card.classList.add("dm-temperature-card-0157-ready");
+
+  let content = card.querySelector(":scope > .dm-temperature-card-0157");
+  if (!content) {
+    content = globalThis.document.createElement("div");
+    content.className = "dm-temperature-card-0157";
+    card.append(content);
+  }
+  const signature = `${room.id}|${temperature}|${humidity}|${comfort.key}|${room.icon || ""}`;
+  if (content.dataset.signature !== signature) {
+    content.dataset.signature = signature;
+    content.innerHTML = `<header><span class="dm-temperature-room-icon-0157">${temperatureIcon0157(card, room)}</span><span class="dm-temperature-room-title-0157"><strong>${room.name}</strong><small>${t0157("Clima ambiente", "Room climate")}</small></span><span class="dm-temperature-status-0157" data-status="${comfort.key}">${comfort.label}</span></header><div class="dm-temperature-values-0157"><span><small>${t0157("Temperatura", "Temperature")}</small><strong>${temperature == null ? "—" : format0157(temperature)}<em>°C</em></strong></span><span><small>${t0157("Umidità", "Humidity")}</small><strong>${humidity == null ? "—" : format0157(humidity, 0)}<em>%</em></strong></span></div>`;
+  }
+
+  const aria = `${room.name}, ${t0157("temperatura", "temperature")} ${temperature == null ? "—" : format0157(temperature)} °C, ${t0157("umidità", "humidity")} ${humidity == null ? "—" : format0157(humidity, 0)}%`;
+  if (card.getAttribute("aria-label") !== aria) card.setAttribute("aria-label", aria);
+  const legacyComfort = card.querySelector("[id^='tc_']");
+  if (legacyComfort) {
+    if (legacyComfort.textContent !== comfort.label) legacyComfort.textContent = comfort.label;
+    if (legacyComfort.getAttribute("title") !== comfort.label) legacyComfort.setAttribute("title", comfort.label);
+    if (legacyComfort.getAttribute("aria-label") !== comfort.label) legacyComfort.setAttribute("aria-label", comfort.label);
+  }
+}
+
+function decorateTemperatures0157() {
+  const grid = globalThis.document?.getElementById?.("temp-grid");
+  if (!grid) return false;
+  grid.querySelectorAll(".temp-card").forEach((card, index) => {
+    const room = roomForTemperatureCard0157(card, index);
+    if (room) decorateTemperatureCard0157(card, room);
+  });
+  return true;
+}
+
+function decorateAll0157() {
+  const runtime = state0157();
+  if (runtime.decorating) return;
+  runtime.decorating = true;
+  try {
+    decorateAppliances0157();
+    decorateTemperatures0157();
+  } finally {
+    runtime.decorating = false;
+  }
+}
+
+function functionChainHas0157(fn, marker) {
+  const seen = new Set();
+  let current = fn;
+  while (typeof current === "function" && !seen.has(current)) {
+    if (current[marker]) return true;
+    seen.add(current);
+    current = current.__dmPrevious;
+  }
+  return false;
+}
+
+function wrapAfterRender0157(name, callback, marker) {
+  const current = globalThis[name];
+  if (typeof current !== "function" || functionChainHas0157(current, marker)) return false;
+  function wrapped0157(...args) {
+    const result = current.apply(this, args);
+    const finish = () => {
+      if (typeof globalThis.queueMicrotask === "function") globalThis.queueMicrotask(callback);
+      else callback();
+    };
+    if (result && typeof result.finally === "function") return result.finally(finish);
+    finish();
+    return result;
+  }
+  wrapped0157[marker] = true;
+  wrapped0157.__dmPrevious = current;
+  globalThis[name] = wrapped0157;
+  return true;
+}
+
+function installApplianceProjection0157() {
+  const current = globalThis.getAppliances;
+  if (functionChainHas0157(current, "__dm0157RoomProjection")) return true;
+  function projected0157() {
+    const canonical = appliances0157();
+    if (!canonical.length && typeof current === "function") return current.apply(this, arguments);
+    const rooms = rooms0157();
+    return canonical.map((item) => {
+      const room = roomForAppliance0157(item, rooms);
+      return {
+        ...item,
+        room_id: room?.id || item.room_id || "",
+        room: room?.name || item.room || "",
+      };
+    });
+  }
+  projected0157.__dm0157RoomProjection = true;
+  projected0157.__dmPrevious = current;
+  globalThis.getAppliances = projected0157;
+  return true;
+}
+
+function injectStyles0157() {
+  if (globalThis.document?.getElementById?.("dm-release-0157-styles")) return;
+  const style = globalThis.document.createElement("style");
+  style.id = "dm-release-0157-styles";
+  style.textContent = `
+    #view-panoramica { position: relative; }
+    .dm-period-loading-0157 { position: sticky; top: 10px; z-index: 8; width: fit-content; margin: 0 auto 12px; display: inline-flex; align-items: center; gap: 9px; padding: 9px 14px; border: 1px solid rgba(14,165,233,.22); border-radius: 999px; color: #0369a1; background: rgba(240,249,255,.96); box-shadow: 0 8px 24px rgba(14,165,233,.14); font-size: 12px; letter-spacing: .06em; text-transform: uppercase; }
+    .dm-period-loading-0157[hidden] { display: none !important; }
+    .dm-period-loading-0157 > span { width: 13px; height: 13px; border: 2px solid rgba(14,165,233,.25); border-top-color: #0ea5e9; border-radius: 50%; animation: dm-period-spin-0157 .75s linear infinite; }
+    .dm-period-loading-active-0157 #ed-kpi-prod, .dm-period-loading-active-0157 #ed-kpi-cons, .dm-period-loading-active-0157 #ed-kpi-auto { opacity: .72; transition: opacity .18s ease; }
+    @keyframes dm-period-spin-0157 { to { transform: rotate(360deg); } }
+
+    #page-appliances-main .dm-legacy-appliance-metric-0157 { display: none !important; }
+    #page-appliances-main .dm-appliance-metrics-0157 { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 9px; }
+    #page-appliances-main .dm-appliance-metric-0157 { min-width: 118px; display: grid; gap: 2px; padding: 8px 12px; border: 1px solid rgba(148,163,184,.28); border-radius: 14px; background: linear-gradient(145deg, rgba(248,250,252,.95), rgba(240,249,255,.88)); box-shadow: inset 0 1px 0 rgba(255,255,255,.9); }
+    #page-appliances-main .dm-appliance-metric-0157 small { color: #64748b; font-size: 10px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+    #page-appliances-main .dm-appliance-metric-0157 strong { color: #0f172a; font-size: 15px; font-weight: 900; line-height: 1.2; }
+    #page-appliances-main .dm-appliance-energy-0157 { border-color: rgba(14,165,233,.25); background: linear-gradient(145deg, rgba(240,249,255,.98), rgba(224,242,254,.72)); }
+    #page-appliances-main .dm-appliance-room-nav-0157 { display: flex; align-items: center; gap: 10px; overflow-x: auto; scrollbar-width: none; padding: 4px 0 12px; }
+    #page-appliances-main .dm-appliance-room-nav-0157::-webkit-scrollbar { display: none; }
+    #page-appliances-main .dm-appliance-room-nav-0157 > button, #page-appliances-main .dm-appliance-room-nav-0157 > a { flex: 0 0 auto; min-height: 46px; display: inline-flex; align-items: center; gap: 9px; padding: 10px 16px; border: 1px solid rgba(148,163,184,.28); border-radius: 999px; color: #334155; background: rgba(255,255,255,.88); box-shadow: 0 8px 22px rgba(15,23,42,.07); font: inherit; font-weight: 850; text-decoration: none; cursor: pointer; }
+    #page-appliances-main .dm-appliance-room-nav-0157 > button small, #page-appliances-main .dm-appliance-room-nav-0157 > a small { display: grid; place-items: center; min-width: 22px; height: 22px; padding: 0 6px; border-radius: 999px; color: #0369a1; background: #e0f2fe; font-size: 11px; }
+    #page-appliances-main .dm-appliance-room-nav-0157 > .active { color: #075985; border-color: rgba(14,165,233,.4); background: linear-gradient(135deg, #e0f2fe, #bae6fd); box-shadow: 0 10px 28px rgba(14,165,233,.18); }
+    #page-appliances-main .appl-wide-card[hidden] { display: none !important; }
+
+    #temp-grid .temp-card.dm-temperature-card-0157-ready { position: relative; padding: 0 !important; overflow: hidden; border: 1px solid rgba(148,163,184,.18); background: linear-gradient(145deg, rgba(255,255,255,.98), rgba(248,250,252,.96)); box-shadow: 0 20px 48px rgba(15,23,42,.10); }
+    #temp-grid .temp-card.dm-temperature-card-0157-ready > :not(.dm-temperature-card-0157) { position: absolute !important; width: 1px !important; height: 1px !important; overflow: hidden !important; clip: rect(0 0 0 0) !important; clip-path: inset(50%) !important; white-space: nowrap !important; }
+    #temp-grid .dm-temperature-card-0157 { display: grid; gap: 18px; padding: 22px; }
+    #temp-grid .dm-temperature-card-0157 header { display: grid; grid-template-columns: auto minmax(0,1fr) auto; align-items: center; gap: 13px; }
+    #temp-grid .dm-temperature-room-icon-0157 { width: 54px; height: 54px; display: grid; place-items: center; border-radius: 18px; color: #0369a1; background: linear-gradient(145deg, #e0f2fe, #dbeafe); box-shadow: inset 0 1px 0 rgba(255,255,255,.9); font-size: 28px; }
+    #temp-grid .dm-temperature-room-title-0157 { display: grid; gap: 3px; min-width: 0; }
+    #temp-grid .dm-temperature-room-title-0157 strong { overflow: hidden; color: #0f172a; font-size: clamp(21px,4vw,27px); font-weight: 950; text-overflow: ellipsis; white-space: nowrap; }
+    #temp-grid .dm-temperature-room-title-0157 small { color: #64748b; font-size: 11px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+    #temp-grid .dm-temperature-status-0157 { justify-self: end; padding: 8px 11px; border-radius: 999px; color: #166534; background: #dcfce7; font-size: 11px; font-weight: 900; letter-spacing: .04em; text-transform: uppercase; white-space: nowrap; }
+    #temp-grid .dm-temperature-status-0157[data-status="warm"] { color: #92400e; background: #fef3c7; }
+    #temp-grid .dm-temperature-status-0157[data-status="hot"], #temp-grid .dm-temperature-status-0157[data-status="very-hot"] { color: #b91c1c; background: #fee2e2; }
+    #temp-grid .dm-temperature-status-0157[data-status="cool"], #temp-grid .dm-temperature-status-0157[data-status="cold"] { color: #1d4ed8; background: #dbeafe; }
+    #temp-grid .dm-temperature-values-0157 { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 12px; }
+    #temp-grid .dm-temperature-values-0157 > span { min-width: 0; display: grid; gap: 5px; padding: 16px; border: 1px solid rgba(148,163,184,.18); border-radius: 18px; background: rgba(248,250,252,.88); }
+    #temp-grid .dm-temperature-values-0157 > span:first-child { background: linear-gradient(145deg, rgba(240,249,255,.95), rgba(224,242,254,.7)); }
+    #temp-grid .dm-temperature-values-0157 small { color: #64748b; font-size: 10px; font-weight: 850; letter-spacing: .09em; text-transform: uppercase; }
+    #temp-grid .dm-temperature-values-0157 strong { color: #0f172a; font-size: clamp(32px,8vw,46px); font-weight: 950; line-height: 1; font-variant-numeric: tabular-nums; }
+    #temp-grid .dm-temperature-values-0157 em { margin-left: 4px; color: #64748b; font-size: .43em; font-style: normal; font-weight: 850; }
+    @media (max-width: 560px) {
+      #page-appliances-main .dm-appliance-metrics-0157 { gap: 6px; }
+      #page-appliances-main .dm-appliance-metric-0157 { min-width: 108px; padding: 7px 10px; }
+      #temp-grid .dm-temperature-card-0157 { padding: 18px; }
+      #temp-grid .dm-temperature-card-0157 header { grid-template-columns: auto minmax(0,1fr); }
+      #temp-grid .dm-temperature-status-0157 { grid-column: 1 / -1; justify-self: start; }
+    }
+  `;
+  globalThis.document.head.append(style);
+}
+
+function installWrappers0157() {
+  installApplianceProjection0157();
+  wrapAfterRender0157("renderApplianceSection", decorateAppliances0157, "__dm0157ApplianceUi");
+  wrapAfterRender0157("renderAppliances", decorateAppliances0157, "__dm0157ApplianceUi");
+  wrapAfterRender0157("buildTempCards", decorateTemperatures0157, "__dm0157TemperatureUi");
+  wrapAfterRender0157("renderTemperature", decorateTemperatures0157, "__dm0157TemperatureUi");
+}
+
+function scheduleDecoration0157() {
+  const runtime = state0157();
+  if (runtime.decorating) return;
+  globalThis.clearTimeout?.(runtime.decorateTimer);
+  runtime.decorateTimer = globalThis.setTimeout?.(decorateAll0157, 25);
+}
+
+function install0157() {
+  const runtime = state0157();
+  injectStyles0157();
+  installWrappers0157();
+
+  if (!runtime.installed) {
+    runtime.installed = true;
+    runtime.refreshEnergy = scheduleEnergyRefresh0157;
+    runtime.decorateAppliances = decorateAppliances0157;
+    runtime.decorateTemperatures = decorateTemperatures0157;
+
+    globalThis.document.addEventListener("change", (event) => {
+      if (event.target?.matches?.("#ed-sel-month, #ed-sel-year")) scheduleEnergyRefresh0157();
+    }, true);
+
+    if (typeof globalThis.MutationObserver === "function") {
+      runtime.pageObserver = new globalThis.MutationObserver(scheduleDecoration0157);
+      runtime.pageObserver.observe(globalThis.document.documentElement, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+      });
+    }
+
+    globalThis.addEventListener?.("dashboardmodern:legacy-ready", () => {
+      installWrappers0157();
+      scheduleDecoration0157();
+    });
+    globalThis.addEventListener?.("pageshow", () => {
+      installWrappers0157();
+      scheduleDecoration0157();
+    });
+  }
+
+  decorateAll0157();
+  globalThis.clearInterval?.(runtime.wrapperTimer);
+  let attempts = 0;
+  runtime.wrapperTimer = globalThis.setInterval?.(() => {
+    attempts += 1;
+    installWrappers0157();
+    scheduleDecoration0157();
+    if (
+      attempts >= 80 ||
+      (globalThis.renderApplianceSection?.__dm0157ApplianceUi &&
+        globalThis.renderTemperature?.__dm0157TemperatureUi &&
+        globalThis[FINAL_RUNTIME_0156_KEY]?.monthValues)
+    ) {
+      globalThis.clearInterval?.(runtime.wrapperTimer);
+      runtime.wrapperTimer = 0;
+    }
+  }, 100);
+}
+
+if (typeof globalThis.document !== "undefined") {
+  if (globalThis.document.readyState === "loading") {
+    globalThis.document.addEventListener("DOMContentLoaded", install0157, { once: true });
+  } else {
+    install0157();
+  }
+}

--- a/custom_components/dashboardmodern/frontend/tests/release-0152-version.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-0152-version.test.js
@@ -4,7 +4,7 @@ import test from "node:test";
 
 const manifestUrl = new URL("../../manifest.json", import.meta.url);
 
-test("the public corrective release is version 0.14.16", async () => {
+test("the public corrective release is version 0.14.17", async () => {
   const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
-  assert.equal(manifest.version, "0.14.16");
+  assert.equal(manifest.version, "0.14.17");
 });

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "0.14.16"
+  "version": "0.14.17"
 }


### PR DESCRIPTION
## Base pulita

Questa lavorazione riparte esclusivamente da `main` 0.14.16, dopo la chiusura della precedente PR e la rimozione delle vecchie branch.

## Modifiche

- **Report Energia:** cambio mese atomico; i KPI esistenti restano visibili durante il caricamento e Produzione, Consumo e Autosufficienza vengono aggiornati insieme.
- **Elettrodomestici:** ripristino dell'associazione alla stanza e dei relativi filtri.
- **Card Elettrodomestici:** sostituzione del vecchio `∑ Totale` con **Consumo totale** e **Adesso**, senza modificare l'immagine configurata.
- **Temperature:** nuova card con temperatura, umidità e stato testuale; la fiamma non è più visibile.
- Versione portata a **0.14.17** e changelog aggiornato.

## Test ricostruiti

Il precedente test temporizzato è stato sostituito con verifiche deterministiche separate:

- un solo evento dopo l'impostazione congiunta di mese e anno;
- tentativo esplicito di azzeramento dei KPI e verifica del ripristino;
- valori finali del mese selezionato;
- stanze, filtri e immagini degli elettrodomestici;
- card Temperature italiana e inglese senza fiamma.
