### PR TITLE
fix: DashboardModern 0.15.4 — owner esistenti e storico completo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,44 +10,47 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.15.3-0ea5e9" alt="Versione 0.15.3">
+  <img src="https://img.shields.io/badge/version-0.15.4-0ea5e9" alt="Versione 0.15.4">
   <img src="https://img.shields.io/badge/HACS-custom-41BDF5" alt="HACS custom integration">
   <img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-1e3a8a" alt="Home Assistant 2025.1+">
   <img src="https://img.shields.io/badge/UI-Italiano%20%7C%20English-16a34a" alt="Italiano e inglese">
 </p>
 
 > **English overview** — DashboardModern is a responsive, multi-instance Home
-> Assistant dashboard distributed as a HACS custom integration. Release 0.15.3
-> restores the canonical appliance artwork, Temperature room UI, lifetime Energy
-> entities and repository branding after the 0.15.2 real-install regression.
+> Assistant dashboard distributed as a HACS custom integration. Release 0.15.4
+> completes the real-UI recovery with stable Energy history, editable existing
+> items, corrected EV images, readable Temperature status and theme-aware appliances.
 
 ---
 
-## Novità 0.15.3
+## Novità 0.15.4
 
-La 0.15.3 è una release correttiva della 0.15.2 verificata sulla UI reale di Home Assistant.
+La 0.15.4 completa la correzione della UI reale di Home Assistant ed è verificata con test Browser E2E su italiano, inglese, desktop, mobile e WebKit/iPad.
 
-### Interfaccia ripristinata
+### Energia e Report
 
-- artwork canonico chiaro per gli elettrodomestici, senza ritorno alle vecchie tessere scure;
-- immagini personalizzate degli elettrodomestici mantenute e adattate alla card;
-- icone locali e valori live nella sezione Temperatura;
-- editor Temperatura basato esclusivamente sulle stanze canoniche, senza secondo campo icona duplicato;
-- badge temperatura senza la vecchia fiamma invasiva.
+- mantenuti insieme i sensori **Energia totale** e annuali durante le migrazioni;
+- valori giornalieri, mensili e annuali pubblicati come un unico bundle coerente;
+- eliminati i valori transitori errati durante il secondo recupero Recorder;
+- descrizioni chiare per i contatori `total` e `total_increasing`;
+- mesi precedenti ricostruibili anche per gli elettrodomestici tramite il sensore totale;
+- editor Report e dettaglio dispositivi resi più completi e leggibili.
 
-### Energia
+### Interfaccia reale
 
-- ripristinato il campo **Energia totale** per Casa e Fotovoltaico;
-- ripristinati i totali di prelievo e immissione per la Rete;
-- ripristinati energia caricata/scaricata e relativi totali per la Batteria;
-- il sensore lifetime resta disponibile anche quando giorno, mese e anno vengono calcolati dal Recorder;
-- gli elettrodomestici possono usare `total_energy_entity` per ricostruire correttamente i mesi precedenti nel Report.
+- elementi esistenti modificabili in Azioni, Clima, Tapparelle e Stanze;
+- URL auto `/loca/...` normalizzati automaticamente in `/local/...`;
+- immagine EV verificata nella pagina pubblica effettiva;
+- card Elettrodomestici leggibili e coerenti in modalità chiara e scura;
+- badge Temperatura con testo visibile: Freddo, Fresco, Comfort, Tiepido, Caldo o Non disponibile;
+- runtime consolidato senza reintrodurre owner numerati o intervalli permanenti.
 
-### HACS e documentazione
+### HACS e qualità
 
-- brand HACS disponibile nella cartella `brand/` alla radice del repository;
-- logo README con URL assoluto, quindi visibile anche nella pagina HACS;
-- versione README, manifest e test allineate alla stessa release.
+- manifest, README e contratto release allineati alla versione 0.15.4;
+- validazione HACS e hassfest;
+- test Python, Ruff, frontend e Browser E2E;
+- generazione automatica di `dashboardmodern.zip` dal commit pubblicato.
 
 ---
 

--- a/custom_components/dashboardmodern/frontend/e2e/release-0151-real-ha-regressions.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0151-real-ha-regressions.spec.js
@@ -121,9 +121,13 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await page.evaluate(() => render?.());
     const vehicle = page.locator("#ev-mod-car-img");
     await expect(vehicle).toHaveAttribute("src", /\/local\/auto\/b10\.png$/);
-    await expect(vehicle).toBeVisible();
 
     await page.locator("#editor-modal .ed-head-close").last().click();
+    await expect(page.locator("#editor-modal")).toHaveCount(0);
+    await clickBottomTab(page, "ev", testInfo);
+    await page.evaluate(() => window.__DASHBOARDMODERN_VEHICLE_IMAGE_RUNTIME__?.apply?.());
+    await expect(vehicle).toBeVisible();
+
     await clickBottomTab(page, "appliances", testInfo);
     const appliance = page.locator(
       '#appl-grid-overview .appl-wide-card[data-appliance-id="appl-fridge"]',

--- a/custom_components/dashboardmodern/frontend/e2e/release-0151-real-ha-regressions.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0151-real-ha-regressions.spec.js
@@ -113,6 +113,10 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     );
     await page.evaluate(() => {
       localStorage.setItem("cd_ev_image", JSON.stringify("/loca/auto/b10.png"));
+      const sections = JSON.parse(localStorage.getItem("cd_sections") || "{}");
+      sections.ev = true;
+      localStorage.setItem("cd_sections", JSON.stringify(sections));
+      window.cdApplyNavVis?.();
       editorSwitch("sez2");
     });
     await expect

--- a/custom_components/dashboardmodern/frontend/e2e/release-0151-real-ha-regressions.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0151-real-ha-regressions.spec.js
@@ -13,7 +13,7 @@ async function openEditor(page, tab) {
 }
 
 for (const variant of ["dashboard.html", "dashboard-en.html"]) {
-  test(`${variant}: 0.15.3 keeps Energy, appliance artwork, Lights, Alerts, EV and Temperature coherent`, async ({
+  test(`${variant}: 0.15.4 keeps the real Energy, EV, appliance and editor contracts coherent`, async ({
     page,
   }, testInfo) => {
     test.setTimeout(testInfo.project.name === "webkit-ipad" ? 180_000 : 110_000);
@@ -26,49 +26,39 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
           day: window.__DASHBOARDMODERN_RUNTIME_ROOT__?.bundle?.day?.house,
           month: window.__DASHBOARDMODERN_RUNTIME_ROOT__?.bundle?.month?.house,
           year: window.__DASHBOARDMODERN_RUNTIME_ROOT__?.bundle?.year?.house,
-          generation: window.__DASHBOARDMODERN_RUNTIME_ROOT__?.bundle?.generation,
         })),
       )
       .toMatchObject({ ready: true, day: 5.7, month: 39.9, year: 760 });
 
     await expect(page.locator("#v-home-day")).toContainText(/5[,.]7/);
-    await expect(page.locator("#v-solar-day")).toContainText(/7[,.]3/);
     await expect(page.locator("#v-home-month")).toContainText(/39[,.]9/);
     await expect(page.locator("#ed-kpi-cons")).toContainText(/39[,.]9/);
     const generations = await page.locator("#view-day,#view-month,#view-panoramica").evaluateAll((nodes) =>
       nodes.map((node) => node.dataset.dmEnergyBundle),
     );
     expect(new Set(generations).size).toBe(1);
-    expect(generations[0]).toBeTruthy();
 
     const stableSamples = await page.evaluate(async () => {
-      document.getElementById("v-home-day").textContent = "614.0 kWh";
       document.getElementById("v-home-month").textContent = "614.0 kWh";
       document.getElementById("ed-kpi-cons").textContent = "614.0 kWh";
       render?.();
       const read = () => ({
-        day: document.getElementById("v-home-day")?.textContent || "",
         month: document.getElementById("v-home-month")?.textContent || "",
         report: document.getElementById("ed-kpi-cons")?.textContent || "",
       });
       const samples = [];
       await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
       samples.push(read());
-      await new Promise((resolve) => setTimeout(resolve, 120));
-      samples.push(read());
-      await new Promise((resolve) => setTimeout(resolve, 450));
+      await new Promise((resolve) => setTimeout(resolve, 500));
       samples.push(read());
       return samples;
     });
     for (const sample of stableSamples) {
-      expect(sample.day).toMatch(/5[,.]7/);
       expect(sample.month).toMatch(/39[,.]9/);
       expect(sample.report).toMatch(/39[,.]9/);
-      expect(`${sample.day} ${sample.month} ${sample.report}`).not.toContain("614");
+      expect(`${sample.month} ${sample.report}`).not.toContain("614");
     }
 
-    // Real regression from 0.15.2: lifetime fields vanished from the editor,
-    // even though the Recorder runtime still depended on those sources.
     await openEditor(page, "sez1");
     const energyEditor = page.locator('#ed-body[data-editor="energy"]');
     await expect(energyEditor).toBeVisible();
@@ -89,102 +79,30 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       });
       await expect(field).toBeVisible();
       await expect(field).toHaveValue(value);
+      await expect(field.locator("xpath=ancestor::*[@data-dm-injected-energy-total='true'][1]").locator(".dm-energy-total-help")).toContainText(/total_increasing/);
     }
-    await expect
-      .poll(() =>
-        page.evaluate(() => DashboardModernModules.store.getSection("energy")),
-      )
-      .toMatchObject({
-        house: { total_energy: "sensor.house_total" },
-        solar: { total_energy: "sensor.solar_total" },
-        grid: {
-          total_import_energy: "sensor.grid_import_total",
-          total_export_energy: "sensor.grid_export_total",
-        },
-        battery: {
-          total_charged_energy: "sensor.battery_charge_total",
-          total_discharged_energy: "sensor.battery_discharge_total",
-        },
-      });
+    await expect(page.locator(".dm-energy-total-overview")).toContainText(
+      variant.includes("-en") ? /previous months/i : /mesi precedenti/i,
+    );
 
     await page.evaluate(() => {
-      localStorage.setItem(
-        "cd_luci",
-        JSON.stringify({
-          "light.salone": "Lampadario salone",
-          "light.cucina": "Lampadario cucina",
-          "light.pensili": "Pensili cucina",
-        }),
-      );
-      localStorage.setItem(
-        "cd_luci_rooms",
-        JSON.stringify({
-          "light.salone": "Salone",
-          "light.cucina": "Cucina",
-          "light.pensili": "Cucina",
-        }),
-      );
-      localStorage.setItem(
-        "cd_luci_room_order",
-        JSON.stringify(["ROOM-VUOTA", "Salone", "Cucina"]),
-      );
-      localStorage.setItem(
-        "cd_luci_order",
-        JSON.stringify({ Cucina: ["light.pensili", "light.cucina"], "ROOM-VUOTA": [] }),
-      );
-      localStorage.setItem(
-        "cd_avvisi_names_extra",
-        JSON.stringify({
-          "light.salone": "Lampadario salone",
-          "light.cucina": "Lampadario cucina",
-          "light.pensili": "Pensili cucina",
-        }),
-      );
-      localStorage.setItem("cd_gruppi_extra", JSON.stringify({ luci: ["light.salone"] }));
+      localStorage.setItem("cd_quick_actions", JSON.stringify([{ type: "builtin", builtin: "luci", name: "Luci" }]));
+      localStorage.setItem("cd_clima_units", JSON.stringify([{ type: "clima", name: "Salone", entity: "climate.salone", room: "Salone" }]));
+      localStorage.setItem("cd_tapparelle", JSON.stringify([{ name: "Tapparella salone", entity: "cover.salone", room: "Salone" }]));
+      const rooms = DashboardModernModules.store.getSection("rooms");
+      if (!rooms.some((room) => room.id === "room-edit")) rooms.push({ id: "room-edit", name: "Studio", icon: "mdi:desk", floor: "Terra" });
+      localStorage.setItem("cd_stanze", JSON.stringify(rooms));
     });
 
-    await openEditor(page, "luci");
-    const lightGroups = page.locator("#ed-body .dm-light-group");
-    await expect(lightGroups).toHaveCount(2);
-    await expect(page.locator('#ed-body [data-light-room="Salone"]')).toContainText("light.salone");
-    const kitchen = page.locator('#ed-body [data-light-room="Cucina"]');
-    await expect(kitchen).toContainText("light.pensili");
-    await expect(kitchen).toContainText("light.cucina");
-    await expect(page.locator("#ed-body")).not.toContainText("ROOM-VUOTA");
-
-    await openEditor(page, "avvisi");
-    await page.evaluate(() => window.__DASHBOARDMODERN_ALERTS_RUNTIME__?.apply?.());
-    for (const entity of ["light.salone", "light.cucina", "light.pensili"]) {
-      const row = page.locator(`[data-alert-entity="${entity}"]`);
-      await expect(row).toBeVisible();
-      await expect(row.locator(".ed-row-old")).toHaveText(entity);
-      await expect(row.getByRole("button", { name: /Modifica|Edit/i })).toBeVisible();
+    for (const [tab, kind] of [
+      ["sez8", "action"],
+      ["sez9", "climate"],
+      ["tapp", "shutter"],
+      ["stanze", "room"],
+    ]) {
+      await openEditor(page, tab);
+      await expect(page.locator(`#ed-body [data-dm-edit-kind="${kind}"]`).first()).toBeVisible();
     }
-    await expect(page.locator("#ed-body .ed-row").filter({ hasText: /^\s*$/ })).toHaveCount(0);
-    const firstAlert = page.locator('[data-alert-entity="light.cucina"]');
-    await firstAlert.getByRole("button", { name: /Modifica|Edit/i }).click();
-    await expect(page.locator("#ed-avv-ent")).toHaveValue("light.cucina");
-    await expect(page.locator("#ed-avv-name")).toHaveValue("Lampadario cucina");
-
-    await page.evaluate(() => {
-      window.__pickedLights = null;
-      cdPickLights(
-        "Piano terra",
-        (lights) => {
-          window.__pickedLights = lights;
-        },
-        ["light.salone", "light.cucina"],
-      );
-    });
-    const picker = page.locator("#dm-light-picker-0152");
-    await expect(picker).toBeVisible();
-    await expect(picker.locator('[data-pick-light="light.salone"]')).toBeVisible();
-    await picker.locator('[data-pick-light="light.salone"] [data-down]').click();
-    await picker.locator("[data-save]").click();
-    await expect.poll(() => page.evaluate(() => window.__pickedLights)).toEqual([
-      "light.cucina",
-      "light.salone",
-    ]);
 
     const pixel = Buffer.from(
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2nCEAAAAASUVORK5CYII=",
@@ -194,38 +112,49 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       route.fulfill({ status: 200, contentType: "image/png", body: pixel }),
     );
     await page.evaluate(() => {
-      localStorage.setItem("cd_ev_image", JSON.stringify("/config/www/auto/b10.png"));
-      render?.();
+      localStorage.setItem("cd_ev_image", JSON.stringify("/loca/auto/b10.png"));
+      editorSwitch("sez2");
     });
+    await expect
+      .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem("cd_ev_image"))))
+      .toBe("/local/auto/b10.png");
+    await page.evaluate(() => render?.());
     const vehicle = page.locator("#ev-mod-car-img");
     await expect(vehicle).toHaveAttribute("src", /\/local\/auto\/b10\.png$/);
     await expect(vehicle).toBeVisible();
 
     await page.locator("#editor-modal .ed-head-close").last().click();
-    await expect(page.locator("#editor-modal")).toHaveCount(0);
-
-    // Real regression from 0.15.2: canonical artwork was replaced by the old
-    // navy line-icon tile. Verify the active overview projection, not the
-    // intentionally duplicated card in the secondary-room grid.
     await clickBottomTab(page, "appliances", testInfo);
     const appliance = page.locator(
       '#appl-grid-overview .appl-wide-card[data-appliance-id="appl-fridge"]',
     );
     await expect(appliance).toBeVisible();
     await expect(appliance).toHaveAttribute("data-dm-art-style", "panel");
-    await expect(appliance).toHaveAttribute("data-dm-media-kind", "asset");
-    const artwork = appliance.locator(".dm-appliance-art .dm-art-panel");
-    await expect(artwork).toBeVisible();
-    await expect(artwork).toHaveAttribute("fill", "#e0f2fe");
-    await expect(appliance.locator(".appl-visual")).toHaveCSS(
-      "background-color",
-      "rgb(224, 242, 254)",
-    );
+    const lightAppearance = await appliance.evaluate((node) => ({
+      background: getComputedStyle(node).backgroundColor,
+      color: getComputedStyle(node).color,
+    }));
+    expect(lightAppearance.background).not.toBe(lightAppearance.color);
+
+    await page.evaluate(() => {
+      document.documentElement.dataset.theme = "dark";
+      document.body.classList.add("dark");
+      window.dispatchEvent(new Event("pageshow"));
+    });
+    await expect
+      .poll(() => appliance.evaluate((node) => getComputedStyle(node).backgroundColor))
+      .not.toBe(lightAppearance.background);
+    const darkAppearance = await appliance.evaluate((node) => ({
+      background: getComputedStyle(node).backgroundColor,
+      color: getComputedStyle(node).color,
+    }));
+    expect(darkAppearance.background).not.toBe(darkAppearance.color);
 
     await clickBottomTab(page, "temp", testInfo);
     const temperatureCard = page.locator("#temp-grid .temp-card").first();
     await expect(temperatureCard).toBeVisible();
-    await expect(temperatureCard.locator(".dm-temperature-icon-fallback")).toBeVisible();
-    await expect(temperatureCard).not.toContainText("🔥");
+    await expect(temperatureCard.locator(".temp-comfort-badge,[id^='tc_']")).toContainText(
+      variant.includes("-en") ? /Cold|Cool|Comfort|Warm|Hot|Unavailable/ : /Freddo|Fresco|Comfort|Tiepido|Caldo|Non disponibile/,
+    );
   });
 }

--- a/custom_components/dashboardmodern/frontend/e2e/release-0151-real-ha-regressions.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/release-0151-real-ha-regressions.spec.js
@@ -105,7 +105,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     }
 
     const pixel = Buffer.from(
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2nCEAAAAASUVORK5CYII=",
+      "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFElEQVR4nGNkaPj/n4GBgYGJAQoAJRkCgp9o0gYAAAAASUVORK5CYII=",
       "base64",
     );
     await page.route("**/local/auto/b10.png", (route) =>

--- a/custom_components/dashboardmodern/frontend/legacy/mobile-ui-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/mobile-ui-fixes.js
@@ -1,4 +1,4 @@
-/* DashboardModern 0.15.0 — bounded compatibility helpers. */
+/* DashboardModern 0.15.4 — bounded compatibility helpers and editor completion. */
 
 export function isGeneratedRoomName(value = "") {
   return /^room[-_][a-z0-9]{6,}$/i.test(String(value).trim());
@@ -17,7 +17,7 @@ export function inferApplianceEntity(device = {}, states = {}, kind = "energy") 
     .map((entry) => String(entry || "").trim())
     .filter(Boolean);
 
-  const expected = kind === "power" ? /^(w|kw)$/i : /^(wh|kwh)$/i;
+  const expected = kind === "power" ? /^(w|kw)$/i : /^(wh|kwh|mwh)$/i;
   const named =
     kind === "power"
       ? /power|potenza|watt/i
@@ -31,91 +31,551 @@ export function inferApplianceEntity(device = {}, states = {}, kind = "energy") 
   );
 }
 
-function installEvImageFallback() {
-  const root = globalThis;
-  const doc = root.document;
-  const key = "__DASHBOARDMODERN_EV_IMAGE_FALLBACK__";
-  if (!doc || root[key]?.installed) return;
-
-  const state = (root[key] = { installed: true });
-  const ids = new Set(["ev-mod-car-img", "ev-new-car-img"]);
-  const style = doc.createElement("style");
-  style.id = "dm-ev-image-fallback-0152";
-  style.textContent = `
-    #ev-mod-car-img[data-ev-failed="1"],
-    #ev-new-car-img[data-ev-failed="1"],
-    #ev-mod-car-img[data-ev-image-error],
-    #ev-new-car-img[data-ev-image-error] {
-      display: block !important;
-      visibility: visible !important;
-      opacity: 1 !important;
-      width: min(78vw, 520px) !important;
-      min-width: 120px !important;
-      height: clamp(90px, 20vw, 210px) !important;
-      min-height: 80px !important;
-      object-fit: contain !important;
-      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 260'%3E%3Cpath fill='%2394a3b8' d='M112 174h28l28-72c7-18 24-30 44-30h205c23 0 44 12 56 32l39 70h20c22 0 40 18 40 40v10H80v-10c0-22 14-40 32-40Zm93-68-25 68h274l-35-62c-2-4-7-6-12-6H205Zm-37 132a34 34 0 1 0 68 0 34 34 0 0 0-68 0Zm272 0a34 34 0 1 0 68 0 34 34 0 0 0-68 0Z'/%3E%3C/svg%3E") !important;
-      background-position: center !important;
-      background-repeat: no-repeat !important;
-      background-size: contain !important;
-    }
-  `;
-  (doc.head || doc.documentElement).append(style);
-
-  const configuredSource = (image) => {
-    const direct = String(image?.getAttribute?.("src") || "").trim();
-    if (direct) return direct;
-    try {
-      const raw = root.localStorage?.getItem("cd_ev_image") || "";
-      const parsed = JSON.parse(raw);
-      const value = typeof parsed === "string" ? parsed : parsed?.url || parsed?.path || "";
-      return String(value).replace(/^\/config\/www\//, "/local/");
-    } catch (_error) {
-      return "";
-    }
-  };
-
-  const reveal = (image) => {
-    const source = configuredSource(image);
-    if (!image || !source) return;
-    image.removeAttribute("onerror");
-    image.dataset.evFailed = "1";
-    image.dataset.evImageError = source;
-    image.style.setProperty("display", "block", "important");
-    image.style.setProperty("visibility", "visible", "important");
-    image.style.setProperty("opacity", "1", "important");
-  };
-
-  const arm = () => {
-    ids.forEach((id) => doc.getElementById(id)?.removeAttribute("onerror"));
-  };
-
-  doc.addEventListener(
-    "error",
-    (event) => {
-      const image = event.target;
-      if (image?.tagName !== "IMG" || !ids.has(image.id)) return;
-      event.preventDefault();
-      event.stopImmediatePropagation();
-      reveal(image);
-    },
-    true,
-  );
-
-  doc.addEventListener("DOMContentLoaded", arm, { once: true });
-  root.addEventListener?.("dashboardmodern:runtime-ready", arm);
-  root.addEventListener?.("pageshow", arm);
-  state.arm = arm;
-  arm();
+export function normalizeVehiclePath(value = "") {
+  let path = String(value || "").trim().replaceAll("\\", "/");
+  if (path.startsWith("/loca/")) path = `/local/${path.slice(6)}`;
+  else if (path.startsWith("loca/")) path = `/local/${path.slice(5)}`;
+  else if (path.startsWith("/config/www/")) path = `/local/${path.slice(12)}`;
+  else if (path.startsWith("config/www/")) path = `/local/${path.slice(11)}`;
+  else if (path.startsWith("www/")) path = `/local/${path.slice(4)}`;
+  else if (path.startsWith("local/")) path = `/${path}`;
+  return path.replace(/^\/local\/\/+/, "/local/");
 }
 
-installEvImageFallback();
-
-// Compatibility flag: the old document-wide MutationObserver and 150 ms interval
-// remain intentionally removed.
-globalThis.__DASHBOARDMODERN_MOBILE_FOLLOWUP__ = {
+const root = globalThis;
+const doc = root.document;
+const KEY = "__DASHBOARDMODERN_MOBILE_FOLLOWUP__";
+const state = (root[KEY] ||= {
   installed: true,
-  version: "0.15.2",
-  observer: null,
+  version: "0.15.4",
   timer: 0,
+  attempts: 0,
+  listeners: false,
+  wrappers: new Set(),
+  editing: null,
+});
+
+const clean = (value) => String(value ?? "").trim();
+const english = () => {
+  const lang = clean(doc?.documentElement?.lang).toLowerCase();
+  return lang.startsWith("en") || /dashboard-en\.html$/i.test(root.location?.pathname || "");
 };
+const read = (key, fallback) => {
+  try {
+    return JSON.parse(root.localStorage?.getItem(key) || "") ?? fallback;
+  } catch (_error) {
+    return fallback;
+  }
+};
+const write = (key, value) => {
+  const serialized = JSON.stringify(value);
+  if (root.localStorage?.getItem(key) === serialized) return false;
+  root.localStorage?.setItem(key, serialized);
+  root.cdMarkDirty?.();
+  root.cdSyncPush?.();
+  return true;
+};
+
+function installStyles() {
+  if (!doc?.head || doc.getElementById("dm-mobile-contracts-0154")) return;
+  const style = doc.createElement("style");
+  style.id = "dm-mobile-contracts-0154";
+  style.textContent = `
+    #ev-mod-car-img[data-ev-failed="1"],#ev-new-car-img[data-ev-failed="1"],
+    #ev-mod-car-img[data-ev-image-error],#ev-new-car-img[data-ev-image-error]{display:none!important}
+
+    #temp-grid .temp-comfort-badge{
+      display:inline-flex!important;align-items:center!important;justify-content:center!important;
+      min-width:64px!important;max-width:100%!important;height:auto!important;padding:4px 9px!important;
+      border-radius:999px!important;font-size:10px!important;line-height:1.1!important;
+      font-weight:900!important;letter-spacing:.45px!important;text-transform:uppercase!important
+    }
+    #temp-grid .temp-comfort-badge.dm-temp-cold{background:rgba(37,99,235,.14)!important;color:#1d4ed8!important}
+    #temp-grid .temp-comfort-badge.dm-temp-cool{background:rgba(14,165,233,.14)!important;color:#0369a1!important}
+    #temp-grid .temp-comfort-badge.dm-temp-comfort{background:rgba(22,163,74,.14)!important;color:#15803d!important}
+    #temp-grid .temp-comfort-badge.dm-temp-warm{background:rgba(245,158,11,.17)!important;color:#b45309!important}
+    #temp-grid .temp-comfort-badge.dm-temp-hot{background:rgba(239,68,68,.15)!important;color:#b91c1c!important}
+    #temp-grid .temp-comfort-badge.dm-temp-unavailable{background:rgba(100,116,139,.14)!important;color:var(--text-dim,#64748b)!important}
+
+    #page-appliances-main .appl-wide-card,#appl-grid-overview .appl-wide-card{
+      background:var(--card-bg,var(--card-background-color,#fff))!important;
+      color:var(--text,var(--primary-text-color,#0f172a))!important;
+      border-color:var(--card-border,var(--divider-color,#dbe4ee))!important
+    }
+    #page-appliances-main .appl-wide-name,#appl-grid-overview .appl-wide-name,
+    #page-appliances-main .appl-wide-title,#appl-grid-overview .appl-wide-title,
+    #page-appliances-main .appl-wide-card strong,#appl-grid-overview .appl-wide-card strong{
+      color:var(--text,var(--primary-text-color,#0f172a))!important;opacity:1!important
+    }
+    #page-appliances-main .appl-wide-cat,#appl-grid-overview .appl-wide-cat,
+    #page-appliances-main .appl-wide-stat,#appl-grid-overview .appl-wide-stat,
+    #page-appliances-main .appl-wide-card small,#appl-grid-overview .appl-wide-card small{
+      color:var(--text-dim,var(--secondary-text-color,#475569))!important;opacity:1!important
+    }
+    #page-appliances-main .appl-wide-card[data-dm-art-style="panel"] .appl-visual,
+    #appl-grid-overview .appl-wide-card[data-dm-art-style="panel"] .appl-visual{
+      background:color-mix(in srgb,var(--accent,#0ea5e9) 13%,var(--card-bg,var(--card-background-color,#fff)))!important
+    }
+    html[data-theme="dark"] #page-appliances-main .appl-wide-card,
+    html[data-theme="dark"] #appl-grid-overview .appl-wide-card,
+    body.dark #page-appliances-main .appl-wide-card,body.dark #appl-grid-overview .appl-wide-card{
+      background:var(--card-bg,var(--card-background-color,#162033))!important;
+      color:var(--text,var(--primary-text-color,#f8fafc))!important
+    }
+    html[data-theme="dark"] #page-appliances-main .appl-wide-card[data-dm-art-style="panel"] .appl-visual,
+    html[data-theme="dark"] #appl-grid-overview .appl-wide-card[data-dm-art-style="panel"] .appl-visual,
+    body.dark #page-appliances-main .appl-wide-card[data-dm-art-style="panel"] .appl-visual,
+    body.dark #appl-grid-overview .appl-wide-card[data-dm-art-style="panel"] .appl-visual{
+      background:color-mix(in srgb,var(--accent,#38bdf8) 20%,var(--card-bg,var(--card-background-color,#162033)))!important
+    }
+
+    #editor-modal .dm-energy-total-help,#editor-modal .dm-energy-total-overview{
+      display:block;margin-top:7px;padding:9px 11px;border-radius:12px;
+      background:color-mix(in srgb,var(--accent,#0ea5e9) 9%,var(--surface-2,var(--card-bg,#fff)));
+      color:var(--text-dim,var(--secondary-text-color,#475569));font-size:11px;line-height:1.45
+    }
+    #editor-modal .dm-energy-total-overview{margin:0 0 12px;border:1px solid color-mix(in srgb,var(--accent,#0ea5e9) 22%,transparent)}
+    #editor-modal [data-dm-total-warning="same-period"] .dm-energy-total-help{background:rgba(245,158,11,.13);color:#92400e}
+
+    #editor-modal [data-energy-panel="report"]{--dm-report-gap:10px}
+    #editor-modal [data-energy-panel="report"]>.ed-intro{margin-bottom:12px}
+    #editor-modal [data-energy-panel="report"] .dm-report-row{
+      display:grid!important;grid-template-columns:minmax(110px,.72fr) minmax(150px,1.35fr) minmax(104px,.58fr) minmax(220px,2fr) auto!important;
+      gap:var(--dm-report-gap)!important;align-items:end!important;padding:14px!important;
+      border:1px solid var(--card-border,var(--divider-color,#dbe4ee))!important;
+      border-radius:16px!important;background:var(--card-bg,var(--card-background-color,#fff))!important
+    }
+    #editor-modal [data-energy-panel="report"] .dm-report-row>label{align-self:center;font-weight:800;color:var(--text,var(--primary-text-color,#0f172a))}
+    #editor-modal [data-energy-panel="report"] .dm-report-row .dm-entity-field{margin:0!important;min-width:0}
+    #editor-modal [data-energy-panel="report"] .dm-report-row>span:last-of-type{display:flex;gap:5px;align-self:center}
+    #editor-modal [data-energy-panel="report"] [data-report-up],
+    #editor-modal [data-energy-panel="report"] [data-report-down],
+    #editor-modal [data-energy-panel="report"] [data-report-delete]{
+      width:36px;height:36px;border:0;border-radius:10px;cursor:pointer;
+      background:var(--surface-3,#eef3f8);color:var(--text,var(--primary-text-color,#0f172a));font-weight:900
+    }
+    #editor-modal .dm-report-history-help{grid-column:1/-1;margin-top:-2px;color:var(--text-dim,var(--secondary-text-color,#64748b));font-size:11px;line-height:1.4}
+    #editor-modal .dm-report-row[data-history-valid="false"] .dm-report-history-help{color:#b45309;font-weight:800}
+
+    #editor-modal .dm-edit-existing{background:rgba(14,165,233,.13)!important;color:#0369a1!important}
+    #editor-modal .dm-edit-cancel{width:100%;margin-top:7px;background:var(--surface-3,#e8eef5)!important;color:var(--text,#0f172a)!important}
+    #editor-modal [data-dm-editing="true"]{outline:2px solid color-mix(in srgb,var(--accent,#0ea5e9) 45%,transparent);outline-offset:2px}
+
+    @media(max-width:900px){
+      #editor-modal [data-energy-panel="report"] .dm-report-row{grid-template-columns:1fr 1fr!important;align-items:start!important}
+      #editor-modal [data-energy-panel="report"] .dm-report-row .dm-entity-field,
+      #editor-modal [data-energy-panel="report"] .dm-report-history-help{grid-column:1/-1}
+    }
+    @media(max-width:560px){#editor-modal [data-energy-panel="report"] .dm-report-row{grid-template-columns:1fr!important}.dm-report-row>*{grid-column:1!important}}
+  `;
+  doc.head.append(style);
+}
+
+function temperatureStatus(value) {
+  if (!Number.isFinite(value)) return { key: "unavailable", it: "Non disponibile", en: "Unavailable" };
+  if (value < 16) return { key: "cold", it: "Freddo", en: "Cold" };
+  if (value < 19) return { key: "cool", it: "Fresco", en: "Cool" };
+  if (value <= 24) return { key: "comfort", it: "Comfort", en: "Comfort" };
+  if (value <= 27) return { key: "warm", it: "Tiepido", en: "Warm" };
+  return { key: "hot", it: "Caldo", en: "Hot" };
+}
+
+function normalizeTemperatureStatus() {
+  doc?.querySelectorAll("#temp-grid .temp-card").forEach((card) => {
+    const text = clean(card.querySelector(".temp-value")?.textContent || card.querySelector("[id^='tv_']")?.textContent);
+    const value = Number.parseFloat(text.replace(",", "."));
+    const status = temperatureStatus(value);
+    const badge = card.querySelector(".temp-comfort-badge,[id^='tc_']");
+    if (!badge) return;
+    badge.classList.remove(
+      "dm-temp-cold",
+      "dm-temp-cool",
+      "dm-temp-comfort",
+      "dm-temp-warm",
+      "dm-temp-hot",
+      "dm-temp-unavailable",
+    );
+    badge.classList.add(`dm-temp-${status.key}`);
+    badge.textContent = english() ? status.en : status.it;
+    badge.title = badge.textContent;
+    badge.setAttribute("aria-label", badge.textContent);
+  });
+}
+
+function energyHelpFor(group, key) {
+  const subject = {
+    house: english() ? "home consumption" : "consumo della casa",
+    solar: english() ? "solar production" : "produzione fotovoltaica",
+    grid: key.includes("export")
+      ? english() ? "energy exported to the grid" : "energia immessa in rete"
+      : english() ? "energy imported from the grid" : "energia prelevata dalla rete",
+    battery: key.includes("discharged")
+      ? english() ? "battery discharge" : "energia scaricata dalla batteria"
+      : english() ? "battery charge" : "energia caricata nella batteria",
+  }[group] || (english() ? "energy" : "energia");
+  return english()
+    ? `Use the lifetime cumulative kWh meter for ${subject}, with device_class: energy and state_class: total or total_increasing. DashboardModern calculates day, month, year and previous periods from Home Assistant Long-Term Statistics. Do not use a sensor that resets every month.`
+    : `Usa il contatore cumulativo totale in kWh per ${subject}, con device_class: energy e state_class: total o total_increasing. DashboardModern calcola giorno, mese, anno e periodi precedenti dalle Long-Term Statistics di Home Assistant. Non usare un sensore che si azzera ogni mese.`;
+}
+
+function normalizeEnergyHelp() {
+  const editor = doc?.querySelector('#ed-body[data-editor="energy"],#editor-modal [data-editor="energy"]');
+  if (!editor) return;
+  if (!editor.querySelector(".dm-energy-total-overview")) {
+    const overview = doc.createElement("div");
+    overview.className = "dm-energy-total-overview";
+    overview.innerHTML = english()
+      ? "<b>Total entities and historical periods</b><br>Period entities are optional. A lifetime total meter lets the Report derive the selected day, month and year, including previous months, from Recorder statistics."
+      : "<b>Entità totali e periodi storici</b><br>Le entità giornaliera, mensile e annuale sono facoltative. Un contatore totale lifetime permette al Report di ricavare giorno, mese e anno selezionati, compresi i mesi precedenti, dalle statistiche del Recorder.";
+    editor.prepend(overview);
+  }
+  editor.querySelectorAll("[data-dm-injected-energy-total='true']").forEach((field) => {
+    const group = field.dataset.energyGroup || "";
+    const key = field.dataset.energyKey || "";
+    let help = field.querySelector(".dm-energy-total-help");
+    if (!help) {
+      help = doc.createElement("small");
+      help.className = "dm-energy-total-help";
+      field.append(help);
+    }
+    help.textContent = energyHelpFor(group, key);
+    const input = field.querySelector("input");
+    const body = field.closest(".ed-acc-body");
+    const periodInput = body?.querySelector(
+      key.includes("import")
+        ? "input[name='grid.annual_import_energy']"
+        : key.includes("export")
+          ? "input[name='grid.annual_export_energy']"
+          : key.includes("charged") && !key.includes("discharged")
+            ? "input[name='battery.annual_charged_energy']"
+            : key.includes("discharged")
+              ? "input[name='battery.annual_discharged_energy']"
+              : `input[name='${group}.annual_energy']`,
+    );
+    field.dataset.dmTotalWarning = input?.value && input.value === periodInput?.value ? "same-period" : "";
+    if (field.dataset.dmTotalWarning === "same-period") {
+      help.textContent += english()
+        ? " The same entity is also entered as Annual: leave Annual empty when you want it derived from the total meter."
+        : " La stessa entità è inserita anche in Annuale: lascia Annuale vuota quando vuoi ricavarla dal contatore totale.";
+    }
+  });
+}
+
+function stateFor(entity) {
+  const id = clean(entity);
+  if (!id) return null;
+  return root.STATES?.[id] || root._RAW_STATES?.[id] || null;
+}
+
+function cumulativeEntity(entity) {
+  const id = clean(entity);
+  const current = stateFor(id);
+  const stateClass = clean(current?.attributes?.state_class).toLowerCase();
+  return (
+    stateClass === "total" ||
+    stateClass === "total_increasing" ||
+    /(?:^|[._-])(total|totale|lifetime|meter|contatore)(?:[._-]|$)/i.test(id)
+  );
+}
+
+function normalizeReportEditor() {
+  const panel = doc?.querySelector("#editor-modal [data-energy-panel='report']");
+  if (!panel) return;
+  panel.dataset.dmReportEditor = "canonical";
+  panel.querySelectorAll(".dm-report-row").forEach((row) => {
+    const fields = [...row.querySelectorAll("[data-entity-field]")];
+    const primary = fields[0];
+    if (!primary) return;
+    const label = primary.querySelector(".ed-slot-lbl");
+    if (label) label.childNodes[0].nodeValue = english() ? "Lifetime total entity " : "Entità totale per lo storico ";
+    const input = primary.querySelector("input");
+    let helper = row.querySelector(".dm-report-history-help");
+    if (!helper) {
+      helper = doc.createElement("div");
+      helper.className = "dm-report-history-help";
+      row.append(helper);
+    }
+    const valid = !input?.value || cumulativeEntity(input.value);
+    row.dataset.historyValid = String(valid);
+    helper.textContent = valid
+      ? english()
+        ? "Use a cumulative kWh entity (state_class total/total_increasing) to calculate the selected and previous months."
+        : "Usa un’entità kWh cumulativa (state_class total/total_increasing) per calcolare il mese selezionato e quelli precedenti."
+      : english()
+        ? "This entity does not look cumulative: previous months may be unavailable. Select the appliance lifetime total meter."
+        : "Questa entità non sembra cumulativa: i mesi precedenti potrebbero non essere disponibili. Seleziona il contatore totale lifetime dell’elettrodomestico.";
+    input?.addEventListener("input", () => schedule(0), { once: true });
+  });
+}
+
+function listFor(kind) {
+  if (kind === "action") return root.getQuickActions?.().slice?.() || read("cd_quick_actions", []);
+  if (kind === "climate") return root.getClimaUnits?.().slice?.() || read("cd_clima_units", []);
+  if (kind === "shutter") return root.getTapparelle?.().slice?.() || read("cd_tapparelle", []);
+  if (kind === "room") return root.getStanze?.().slice?.() || read("cd_stanze", []);
+  return [];
+}
+
+function editButton(kind, index) {
+  const button = doc.createElement("button");
+  button.type = "button";
+  button.className = "ed-del dm-edit-existing";
+  button.dataset.dmEditKind = kind;
+  button.dataset.dmEditIndex = String(index);
+  button.textContent = "✏️";
+  button.title = english() ? "Edit" : "Modifica";
+  button.setAttribute("aria-label", button.title);
+  return button;
+}
+
+function rowsBeforeForm(container, formSelector) {
+  const form = container?.querySelector(formSelector);
+  if (!container || !form) return [];
+  return [...container.querySelectorAll(".ed-row")].filter(
+    (row) => !form.contains(row) && row.querySelector(".ed-del") && row.compareDocumentPosition(form) & Node.DOCUMENT_POSITION_FOLLOWING,
+  );
+}
+
+function ensureEditButtons() {
+  const body = doc?.getElementById("ed-body");
+  if (!body) return;
+  const definitions = [
+    ["action", body.querySelector("#ed-qa-type")?.closest("details") || body, "#ed-qa-type"],
+    ["climate", body.querySelector("#ed-cl-type")?.closest("details") || body, "#ed-cl-type"],
+    ["shutter", body, "#ed-tp-name"],
+    ["room", body, "#ed-room-name"],
+  ];
+  definitions.forEach(([kind, container, selector]) => {
+    if (!container?.querySelector(selector)) return;
+    rowsBeforeForm(container, selector).forEach((row, index) => {
+      if (row.querySelector(`[data-dm-edit-kind='${kind}']`)) return;
+      const remove = [...row.querySelectorAll(".ed-del")].at(-1);
+      remove?.before(editButton(kind, index));
+    });
+  });
+}
+
+function formFor(kind) {
+  const selectors = {
+    action: "#ed-qa-type",
+    climate: "#ed-cl-type",
+    shutter: "#ed-tp-name",
+    room: "#ed-room-name",
+  };
+  return doc?.querySelector(selectors[kind])?.closest(".ed-form") || doc?.querySelector(selectors[kind])?.parentElement;
+}
+
+function addCancel(kind) {
+  const form = formFor(kind);
+  if (!form || form.querySelector(".dm-edit-cancel")) return;
+  const cancel = doc.createElement("button");
+  cancel.type = "button";
+  cancel.className = "ed-btn-add dm-edit-cancel";
+  cancel.textContent = english() ? "Cancel edit" : "Annulla modifica";
+  cancel.addEventListener("click", () => {
+    state.editing = null;
+    root.editorSwitch?.(doc.querySelector(".ed-tab.active")?.dataset?.tab || "sezioni");
+  });
+  form.append(cancel);
+}
+
+function setField(id, value) {
+  const field = doc?.getElementById(id);
+  if (!field) return;
+  field.value = value ?? "";
+  field.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function beginEdit(kind, index) {
+  const item = listFor(kind)[index];
+  if (!item) return;
+  if (kind === "action" && item.type === "luci_group" && typeof root.edEditLightGroup === "function") {
+    root.edEditLightGroup(index);
+    return;
+  }
+  state.editing = { kind, index };
+  formFor(kind)?.setAttribute("data-dm-editing", "true");
+  if (kind === "action") {
+    setField("ed-qa-type", item.type === "builtin" ? `builtin_${item.builtin}` : item.type || "toggle");
+    setField("ed-qa-icon", item.icon || "");
+    setField("ed-qa-name", item.name || "");
+    setField("ed-qa-ent", item.entity || "");
+    setField("ed-qa-confirm", item.confirm || item.confirmation || "");
+    root.edQaTypeChanged?.();
+  } else if (kind === "climate") {
+    setField("ed-cl-type", item.type || "clima");
+    setField("ed-cl-name", item.name || "");
+    setField("ed-cl-ent", item.entity || "");
+    setField("ed-cl-room", item.room || "");
+  } else if (kind === "shutter") {
+    setField("ed-tp-name", item.name || "");
+    setField("ed-tp-ent", item.entity || "");
+    setField("ed-tp-room", item.room || "");
+  } else if (kind === "room") {
+    setField("ed-room-name", item.name || "");
+    setField("ed-room-icon", item.icon || "🏠");
+    setField("ed-room-floor", item.floor || "");
+    const preview = doc.getElementById("ed-room-icon-preview");
+    if (preview) preview.innerHTML = root.cdIconMarkup?.(item.icon || "🏠", 26) || item.icon || "🏠";
+  }
+  const add = formFor(kind)?.querySelector(".ed-btn-add:not(.dm-edit-cancel)");
+  if (add) add.textContent = english() ? "💾 Save changes" : "💾 Salva modifiche";
+  addCancel(kind);
+}
+
+function finishEdit(kind) {
+  state.editing = null;
+  const rerender = { action: "sezioni", climate: "sezioni", shutter: "tapp", room: "stanze" }[kind];
+  root.editorSwitch?.(rerender);
+}
+
+function installAddWrappers() {
+  const wrap = (name, kind, saveEdit) => {
+    const current = root[name];
+    if (typeof current !== "function" || current.__dmEditable0154) return;
+    function editableOwner(...args) {
+      if (state.editing?.kind !== kind) return current.apply(this, args);
+      saveEdit(state.editing.index);
+      finishEdit(kind);
+    }
+    editableOwner.__dmEditable0154 = true;
+    editableOwner.__dmPrevious = current;
+    root[name] = editableOwner;
+  };
+
+  wrap("edAddQA", "action", (index) => {
+    const list = listFor("action");
+    const previous = list[index] || {};
+    const selected = clean(doc.getElementById("ed-qa-type")?.value);
+    const next = {
+      ...previous,
+      icon: clean(doc.getElementById("ed-qa-icon")?.value),
+      name: clean(doc.getElementById("ed-qa-name")?.value),
+      confirm: clean(doc.getElementById("ed-qa-confirm")?.value),
+    };
+    if (selected.startsWith("builtin_")) {
+      next.type = "builtin";
+      next.builtin = selected.slice(8);
+      delete next.entity;
+      delete next.lights;
+    } else {
+      next.type = selected;
+      next.entity = clean(doc.getElementById("ed-qa-ent")?.value);
+      delete next.builtin;
+    }
+    list[index] = next;
+    write("cd_quick_actions", list);
+    root.buildQuickActions?.();
+  });
+
+  wrap("edAddClima", "climate", (index) => {
+    const list = listFor("climate");
+    list[index] = {
+      ...(list[index] || {}),
+      type: clean(doc.getElementById("ed-cl-type")?.value) || "clima",
+      name: clean(doc.getElementById("ed-cl-name")?.value),
+      entity: clean(doc.getElementById("ed-cl-ent")?.value),
+      room: clean(doc.getElementById("ed-cl-room")?.value),
+    };
+    write("cd_clima_units", list);
+    root.buildClimaCards?.();
+    root.buildDeviceCards?.();
+  });
+
+  wrap("edTappAdd", "shutter", (index) => {
+    const list = listFor("shutter");
+    list[index] = {
+      ...(list[index] || {}),
+      name: clean(doc.getElementById("ed-tp-name")?.value),
+      entity: clean(doc.getElementById("ed-tp-ent")?.value),
+      room: clean(doc.getElementById("ed-tp-room")?.value),
+    };
+    write("cd_tapparelle", list);
+    root.renderTapparelle?.();
+  });
+
+  wrap("edStanzaRoomAdd", "room", (index) => {
+    const list = listFor("room");
+    list[index] = {
+      ...(list[index] || {}),
+      name: clean(doc.getElementById("ed-room-name")?.value),
+      icon: clean(doc.getElementById("ed-room-icon")?.value) || "🏠",
+      floor: clean(doc.getElementById("ed-room-floor")?.value),
+    };
+    if (!list[index].floor) delete list[index].floor;
+    write("cd_stanze", list);
+    root.buildTempCards?.();
+  });
+}
+
+function normalizeVehicleInput() {
+  const input = doc?.querySelector("#editor-modal input[value*='/loca/'],#editor-modal input[placeholder*='/local/']");
+  if (!input) return;
+  const normalized = normalizeVehiclePath(input.value);
+  if (normalized && normalized !== input.value) {
+    input.value = normalized;
+    const stored = read("cd_ev_image", "");
+    const raw = typeof stored === "string" ? stored : stored?.url || stored?.path || "";
+    if (normalizeVehiclePath(raw) === normalized) write("cd_ev_image", normalized);
+  }
+}
+
+function runContracts() {
+  installStyles();
+  installAddWrappers();
+  normalizeTemperatureStatus();
+  normalizeEnergyHelp();
+  normalizeReportEditor();
+  normalizeVehicleInput();
+  ensureEditButtons();
+}
+
+function schedule(delay = 0) {
+  if (state.timer) return;
+  state.timer = root.setTimeout?.(() => {
+    state.timer = 0;
+    state.attempts += 1;
+    runContracts();
+    if (state.attempts < 180 && doc?.getElementById("editor-modal")) schedule(80);
+  }, delay);
+}
+
+function install() {
+  if (!doc) return;
+  runContracts();
+  if (!state.listeners) {
+    state.listeners = true;
+    doc.addEventListener(
+      "click",
+      (event) => {
+        const edit = event.target?.closest?.("[data-dm-edit-kind]");
+        if (edit) {
+          event.preventDefault();
+          event.stopPropagation();
+          beginEdit(edit.dataset.dmEditKind, Number(edit.dataset.dmEditIndex));
+          return;
+        }
+        if (event.target?.closest?.(".ed-tab,.sub-tab-btn,[data-energy-tab],[data-report-add],[data-report-save],[data-energy-save]")) {
+          state.attempts = 0;
+          schedule(0);
+        }
+      },
+      true,
+    );
+    doc.addEventListener("change", (event) => {
+      if (event.target?.matches?.("[data-entity-field] input,[data-dm-injected-energy-total] input")) schedule(0);
+    });
+    root.addEventListener?.("dashboardmodern:legacy-ready", () => schedule(0));
+    root.addEventListener?.("dashboardmodern:runtime-ready", () => schedule(0));
+    root.addEventListener?.("dashboardmodern:state-changed", () => schedule(0));
+    root.addEventListener?.("dashboardmodern:period-bundle", () => schedule(0));
+    root.addEventListener?.("pageshow", () => schedule(0));
+  }
+  state.attempts = 0;
+  schedule(0);
+}
+
+if (doc?.readyState === "loading") doc.addEventListener("DOMContentLoaded", install, { once: true });
+else install();
+
+state.observer = null;

--- a/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
+++ b/custom_components/dashboardmodern/frontend/legacy/report-mobile-fixes.js
@@ -1,4 +1,4 @@
-/* DashboardModern 0.15.3 — single production entry and real-UI contracts. */
+/* DashboardModern 0.15.4 — single production entry and real-UI contracts. */
 import "./runtime-consolidated.js";
 import "../src/core/runtime-startup-coordinator.js";
 import "../src/core/alerts-runtime.js";
@@ -14,7 +14,7 @@ const doc = root.document;
 const KEY = "__DASHBOARDMODERN_REAL_UI_CONTRACTS__";
 const state = (root[KEY] ||= {
   installed: true,
-  version: "0.15.3",
+  version: "0.15.4",
   attempts: 0,
   timer: 0,
   normalizingAppliances: false,
@@ -271,26 +271,21 @@ function normalizeTemperatureCards() {
       if (value) value.textContent = temperature == null ? "—" : temperature.toFixed(1);
       if (humidityValue) humidityValue.textContent = humidity == null ? "—%" : `${humidity.toFixed(0)}%`;
       if (comfort) {
-        let badge = "🟢";
         let label = "Comfort";
         if (temperature == null) {
-          badge = "—";
           label = english() ? "Unavailable" : "Non disponibile";
         } else if (temperature < 16) {
-          badge = "❄️";
           label = english() ? "Cold" : "Freddo";
         } else if (temperature < 19) {
-          badge = "🔵";
           label = english() ? "Cool" : "Fresco";
         } else if (temperature > 27) {
-          badge = "🟠";
           label = english() ? "Hot" : "Caldo";
         } else if (temperature > 24) {
-          badge = "🟡";
           label = english() ? "Warm" : "Tiepido";
         }
-        comfort.textContent = badge;
+        comfort.textContent = label;
         comfort.title = label;
+        comfort.setAttribute("aria-label", label);
       }
     });
     return true;

--- a/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
+++ b/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
@@ -20,6 +20,8 @@ export const VISIBILITY_SECTION = Object.freeze({
 
 const configured = (value) =>
   typeof value === "string" ? value.trim().includes(".") : Boolean(value);
+const sameValue = (left, right) => JSON.stringify(left) === JSON.stringify(right);
+
 export function hasConfiguredData(section, value) {
   if (section === "rooms" && Array.isArray(value))
     return value.some((room) => configured(room?.temp) || configured(room?.hum));
@@ -145,12 +147,14 @@ export class DashboardStore {
     } catch {
       return Promise.resolve();
     }
-    if (key === "cd_sections")
+    if (key === "cd_sections") {
+      if (sameValue(this.state.visibility, value)) return Promise.resolve(cloneValue(value));
       return this.transact(
         "visibility",
         "legacy-reconcile",
         () => (this.state.visibility = { ...value }),
       );
+    }
     const section = Object.entries(SECTION_KEYS).find(([, storageKey]) => storageKey === key)?.[0];
     if (!section) return Promise.resolve();
     return this.replaceSection(section, value);
@@ -234,12 +238,14 @@ export class DashboardStore {
     });
   }
   updateItem(section, id, patch) {
+    const list = this.state.sections[section] || [];
+    const index = list.findIndex((item) => item.id === id);
+    if (index < 0) return Promise.reject(new Error(`Unknown ${section} item: ${id}`));
+    const next = this._normalizeItem(section, { ...list[index], ...patch, id }, index);
+    if (sameValue(list[index], next)) return Promise.resolve(cloneValue(next));
     return this.transact(section, "update", () => {
-      const list = this.state.sections[section] || [];
-      const index = list.findIndex((item) => item.id === id);
-      if (index < 0) throw new Error(`Unknown ${section} item: ${id}`);
-      list[index] = this._normalizeItem(section, { ...list[index], ...patch, id }, index);
-      return cloneValue(list[index]);
+      list[index] = next;
+      return cloneValue(next);
     });
   }
   removeItem(section, id) {
@@ -251,13 +257,16 @@ export class DashboardStore {
     });
   }
   replaceSection(section, value) {
+    const normalized = normalizeSection(section, value, {
+      rooms: this.state.sections.rooms || [],
+    });
+    if (sameValue(this.state.sections[section] ?? [], normalized)) {
+      return Promise.resolve(cloneValue(normalized));
+    }
     return this.transact(
       section,
       "replace",
-      () =>
-        (this.state.sections[section] = normalizeSection(section, value, {
-          rooms: this.state.sections.rooms || [],
-        })),
+      () => (this.state.sections[section] = normalized),
     );
   }
   saveReport(items) {

--- a/custom_components/dashboardmodern/frontend/src/core/energy-projection.js
+++ b/custom_components/dashboardmodern/frontend/src/core/energy-projection.js
@@ -142,31 +142,18 @@ const MDI_ICON_GLYPHS = Object.freeze({
   "mdi:devices": "🔌",
 });
 
-function normalizedToken(value) {
-  return String(value || "")
+const configured = (value) => String(value || "").trim();
+const normalizedToken = (value) =>
+  configured(value)
     .normalize("NFKD")
     .replace(/[\u0300-\u036f]/g, "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "");
-}
 
-function configured(value) {
-  return String(value || "").trim();
-}
-
-/**
- * Project canonical Energy fields to legacy runtime slots.
- *
- * A cumulative meter is exposed in its lifetime slot only while at least one
- * day/month/year value must be derived from Long-Term Statistics. When all
- * period entities are explicitly configured, the unused lifetime slot stays
- * out of the runtime. A lifetime meter is never copied into a period slot.
- */
 export function projectEnergySlots(energy = {}, overrides = {}) {
   const result = { ...overrides };
   const totalPaths = new Set(TOTAL_ENERGY_ALIASES.map((definition) => definition.path));
-
   for (const [path, slot] of Object.entries(ENERGY_SLOT_MAP)) {
     if (totalPaths.has(path)) continue;
     const [group, key] = path.split(".");
@@ -174,7 +161,6 @@ export function projectEnergySlots(energy = {}, overrides = {}) {
     if (value) result[slot] = value;
     else delete result[slot];
   }
-
   for (const definition of TOTAL_ENERGY_ALIASES) {
     const [group, totalKey] = definition.path.split(".");
     const totalEntity = configured(energy[group]?.[totalKey]);
@@ -184,7 +170,6 @@ export function projectEnergySlots(energy = {}, overrides = {}) {
     );
     if (totalEntity && needsDerivation) result[totalSlot] = totalEntity;
     else delete result[totalSlot];
-
     for (const [periodKey, periodSlot] of Object.entries(definition.targets)) {
       const explicit = configured(energy[group]?.[periodKey]);
       if (explicit) result[periodSlot] = explicit;
@@ -196,8 +181,8 @@ export function projectEnergySlots(energy = {}, overrides = {}) {
 
 export function entityIds(item = {}) {
   return [
-    item.report_entity,
     item.total_energy_entity,
+    item.report_entity,
     item.energy_entity,
     item.monthly_energy_entity,
     item.daily_energy_entity,
@@ -210,37 +195,32 @@ export function entityIds(item = {}) {
         ? entry
         : entry?.entity || entry?.entity_id || entry?.id || entry?.value,
     )
-    .map((entry) => String(entry || "").trim())
+    .map(configured)
     .filter(Boolean);
 }
 
 function entityAttributes(states, entityId) {
   return states?.[entityId]?.attributes || {};
 }
-
 function entityUnit(states, entityId) {
-  return String(entityAttributes(states, entityId).unit_of_measurement || "").toLowerCase();
+  return configured(entityAttributes(states, entityId).unit_of_measurement).toLowerCase();
 }
-
 function entityStateClass(states, entityId) {
-  return String(entityAttributes(states, entityId).state_class || "").toLowerCase();
+  return configured(entityAttributes(states, entityId).state_class).toLowerCase();
 }
-
 function isPowerUnit(unit) {
-  return /^(w|kw|mw)$/.test(String(unit || "").toLowerCase());
+  return /^(w|kw|mw)$/.test(configured(unit).toLowerCase());
 }
-
 function isEnergyUnit(unit) {
-  return /^(wh|kwh|mwh)$/.test(String(unit || "").toLowerCase());
+  return /^(wh|kwh|mwh)$/.test(configured(unit).toLowerCase());
 }
-
 function isValidEnergyCandidate(states, entityId) {
   if (!entityId || isPowerUnit(entityUnit(states, entityId))) return false;
   const attributes = entityAttributes(states, entityId);
   if (!Object.keys(attributes).length) return true;
   return (
     isEnergyUnit(entityUnit(states, entityId)) ||
-    String(attributes.device_class || "").toLowerCase() === "energy"
+    configured(attributes.device_class).toLowerCase() === "energy"
   );
 }
 
@@ -252,20 +232,21 @@ export function isCumulativeEnergyEntity(entityId, states = globalThis.STATES ||
 }
 
 export function reportEntityForDevice(item = {}, states = globalThis.STATES || {}) {
-  const reportEntity = configured(item.report_entity);
-  if (isValidEnergyCandidate(states, reportEntity)) return reportEntity;
-
   const candidates = [...new Set(entityIds(item))];
   const explicitTotal = configured(item.total_energy_entity);
-  if (isValidEnergyCandidate(states, explicitTotal)) return explicitTotal;
+  if (isCumulativeEnergyEntity(explicitTotal, states)) return explicitTotal;
+
+  const configuredReport = configured(item.report_entity);
+  if (isCumulativeEnergyEntity(configuredReport, states)) return configuredReport;
 
   const cumulative = candidates.find((entityId) => isCumulativeEnergyEntity(entityId, states));
   if (cumulative) return cumulative;
 
   const explicitPeriod = [
-    item.energy_entity,
     item.monthly_energy_entity,
+    item.energy_entity,
     item.daily_energy_entity,
+    configuredReport,
   ]
     .map(configured)
     .find((entityId) => isValidEnergyCandidate(states, entityId));
@@ -275,7 +256,7 @@ export function reportEntityForDevice(item = {}, states = globalThis.STATES || {
     candidates.find((entityId) => isEnergyUnit(entityUnit(states, entityId))) ||
     candidates.find(
       (entityId) =>
-        String(entityAttributes(states, entityId).device_class || "").toLowerCase() === "energy" &&
+        configured(entityAttributes(states, entityId).device_class).toLowerCase() === "energy" &&
         !isPowerUnit(entityUnit(states, entityId)),
     ) ||
     candidates.find(
@@ -288,7 +269,7 @@ export function reportEntityForDevice(item = {}, states = globalThis.STATES || {
 }
 
 function glyphForMdi(icon) {
-  const value = String(icon || "").trim().toLowerCase();
+  const value = configured(icon).toLowerCase();
   if (MDI_ICON_GLYPHS[value]) return MDI_ICON_GLYPHS[value];
   if (/fridge|snowflake/.test(value)) return "❄️";
   if (/stove|fire/.test(value)) return "♨️";
@@ -303,12 +284,10 @@ function glyphForMdi(icon) {
   return "⚡";
 }
 
-/** Resolve a visible Report glyph without ever printing a raw `mdi:*` token. */
 export function reportIconForDevice(item = {}) {
   const explicit = configured(item.report_icon || item.emoji_icon || item.icon);
   if (explicit && !explicit.startsWith("mdi:")) return explicit;
   if (explicit.startsWith("mdi:")) return glyphForMdi(explicit);
-
   const candidates = [
     item.visual_key,
     item.device_type,
@@ -321,7 +300,6 @@ export function reportIconForDevice(item = {}) {
     const match = Object.keys(REPORT_ICON_BY_TYPE).find((key) => candidate.includes(key));
     if (match) return REPORT_ICON_BY_TYPE[match];
   }
-
   const visual = getDeviceVisual(item);
   if (visual?.kind === "icon" && visual.value) return glyphForMdi(visual.value);
   return "⚡";
@@ -332,7 +310,7 @@ export function canonicalReportDevices(
   loads = [],
   states = globalThis.STATES || {},
 ) {
-  const seen = new Set();
+  const seenEntities = new Set();
   return [...appliances, ...loads]
     .filter(
       (item) =>
@@ -352,14 +330,12 @@ export function canonicalReportDevices(
         image: visual?.kind === "image" ? visual.value : "",
         entity,
         history: entity || item.history_entity || "",
+        cumulative: isCumulativeEnergyEntity(entity, states),
       };
     })
     .filter((item) => {
-      if (!item.entity) return false;
-      const identity = `${item.key}|${item.entity}`;
-      const duplicate =
-        seen.has(identity) || [...seen].some((value) => value.endsWith(`|${item.entity}`));
-      seen.add(identity);
-      return !duplicate;
+      if (!item.entity || seenEntities.has(item.entity)) return false;
+      seenEntities.add(item.entity);
+      return true;
     });
 }

--- a/custom_components/dashboardmodern/frontend/src/core/energy-total-source.js
+++ b/custom_components/dashboardmodern/frontend/src/core/energy-total-source.js
@@ -1,4 +1,4 @@
-/* DashboardModern 0.15.4 — readiness and historical detail projection for the single Energy owner. */
+/* DashboardModern 0.15.4 — readiness, lifetime guidance and historical detail projection. */
 import { applyAtomicEnergyBundle } from "../../legacy/runtime-consolidated.js";
 
 const root = globalThis;
@@ -11,6 +11,8 @@ Object.assign(state, {
   attempts: 0,
   timer: 0,
   detailTimer: 0,
+  uiTimer: 0,
+  uiAttempts: 0,
   done: false,
   readyGateInstalled: false,
   appliedGeneration: 0,
@@ -24,6 +26,10 @@ const finite = (value) => {
 };
 const valueFrom = (values, entity) =>
   values instanceof Map ? finite(values.get(entity)) : finite(values?.[entity]);
+const english = () => {
+  const lang = clean(doc?.documentElement?.lang).toLowerCase();
+  return lang.startsWith("en") || /dashboard-en\.html$/i.test(root.location?.pathname || "");
+};
 
 function energyModel() {
   return root.DashboardModernModules?.store?.getSection?.("energy") || {};
@@ -70,15 +76,98 @@ function installReadyGate() {
   }
 }
 
+function energyHelpText(field) {
+  const group = clean(field?.dataset?.energyGroup);
+  const key = clean(field?.dataset?.energyKey);
+  const subject = {
+    house: english() ? "home consumption" : "il consumo della casa",
+    solar: english() ? "solar production" : "la produzione fotovoltaica",
+    grid: key.includes("export")
+      ? english()
+        ? "energy exported to the grid"
+        : "l’energia immessa in rete"
+      : english()
+        ? "energy imported from the grid"
+        : "l’energia prelevata dalla rete",
+    battery: key.includes("discharged")
+      ? english()
+        ? "battery discharge"
+        : "l’energia scaricata dalla batteria"
+      : english()
+        ? "battery charge"
+        : "l’energia caricata nella batteria",
+  }[group] || (english() ? "energy" : "l’energia");
+  return english()
+    ? `Use the lifetime cumulative kWh meter for ${subject}, with device_class: energy and state_class: total or total_increasing. DashboardModern derives day, month, year and previous months from Home Assistant Long-Term Statistics. Do not use a sensor that resets monthly.`
+    : `Usa il contatore cumulativo lifetime in kWh per ${subject}, con device_class: energy e state_class: total oppure total_increasing. DashboardModern ricava giorno, mese, anno e mesi precedenti dalle Long-Term Statistics di Home Assistant. Non usare un sensore che si azzera ogni mese.`;
+}
+
+function ensureEnergyHelp() {
+  const fields = [...(doc?.querySelectorAll?.("[data-dm-injected-energy-total='true']") || [])];
+  if (!fields.length) return false;
+  const editor = fields[0].closest("#ed-body,[data-editor='energy']") || fields[0].parentElement;
+  if (editor && !editor.querySelector(".dm-energy-total-overview")) {
+    const overview = doc.createElement("div");
+    overview.className = "dm-energy-total-overview";
+    overview.innerHTML = english()
+      ? "<b>Total entities and historical periods</b><br>Daily, monthly and annual entities are optional. A lifetime total meter lets the Report derive the selected period and previous months from Home Assistant Recorder statistics."
+      : "<b>Entità totali e periodi storici</b><br>Le entità giornaliera, mensile e annuale sono facoltative. Un contatore totale lifetime permette al Report di ricavare il periodo selezionato e i mesi precedenti dalle statistiche del Recorder di Home Assistant.";
+    editor.prepend(overview);
+  }
+  fields.forEach((field) => {
+    let helper = field.querySelector(":scope > .dm-energy-total-help");
+    if (!helper) {
+      helper = doc.createElement("small");
+      helper.className = "dm-energy-total-help";
+      field.append(helper);
+    }
+    helper.textContent = energyHelpText(field);
+  });
+  return fields.every((field) => field.querySelector(":scope > .dm-energy-total-help"));
+}
+
+function uiTick() {
+  state.uiTimer = 0;
+  state.uiAttempts += 1;
+  wrapEditorSwitch();
+  const complete = ensureEnergyHelp();
+  if (!complete && doc?.getElementById("editor-modal") && state.uiAttempts < 240)
+    state.uiTimer = root.setTimeout?.(uiTick, 50);
+}
+function scheduleUi(delay = 0) {
+  root.clearTimeout?.(state.uiTimer);
+  state.uiTimer = root.setTimeout?.(uiTick, delay);
+}
+function wrapEditorSwitch() {
+  const current = root.editorSwitch;
+  if (typeof current !== "function" || current.__dmEnergyHelp0154) return false;
+  function energyGuidedEditorSwitch(...args) {
+    const result = current.apply(this, args);
+    const finish = () => {
+      state.uiAttempts = 0;
+      root.queueMicrotask?.(ensureEnergyHelp);
+      scheduleUi(0);
+    };
+    if (result && typeof result.finally === "function") return result.finally(finish);
+    finish();
+    return result;
+  }
+  energyGuidedEditorSwitch.__dmEnergyHelp0154 = true;
+  energyGuidedEditorSwitch.__dmPrevious = current;
+  root.editorSwitch = energyGuidedEditorSwitch;
+  return true;
+}
+
 function setText(id, value) {
   const element = doc?.getElementById(id);
   if (element) element.textContent = value;
 }
 function rate(key) {
   const configured = root.cdCfg?.(key);
-  const raw = configured !== undefined && configured !== null && configured !== ""
-    ? configured
-    : root.localStorage?.getItem(key);
+  const raw =
+    configured !== undefined && configured !== null && configured !== ""
+      ? configured
+      : root.localStorage?.getItem(key);
   return finite(raw);
 }
 function splitFor(period, value) {
@@ -104,7 +193,7 @@ function applyDeviceDetail(bundle) {
   setText("ed-dkpi-mese", `${monthValue.toFixed(1)} kWh`);
   setText("ed-dkpi-mese-eur", `€ ${(monthValue * importPrice).toFixed(2)}`);
   setText("ed-dkpi-media", `${(days ? monthValue / days : 0).toFixed(2)} kWh`);
-  setText("ed-dkpi-media-sub", doc?.documentElement?.lang === "en" ? "Daily average" : "Media/giorno");
+  setText("ed-dkpi-media-sub", english() ? "Daily average" : "Media/giorno");
   setText("ed-dkpi-risp-eur", `+ ${(monthSplit.solar * importPrice).toFixed(2)} €`);
   setText("ed-dkpi-risp-kwh", `${monthSplit.solar.toFixed(1)} kWh da FV`);
   setText("ed-dkpi-costo-eur", `- ${(monthSplit.grid * importPrice).toFixed(2)} €`);
@@ -119,12 +208,13 @@ function applyDeviceDetail(bundle) {
   const canvas = doc?.getElementById("ed-dev-chart-canvas");
   if (message && monthValue > 0 && (!canvas || getComputedStyle(canvas).display === "none")) {
     message.style.display = "flex";
-    message.textContent = doc?.documentElement?.lang === "en"
+    message.textContent = english()
       ? `Selected month total: ${monthValue.toFixed(1)} kWh`
       : `Totale mese selezionato: ${monthValue.toFixed(1)} kWh`;
   }
   const panel = doc?.querySelector(".ed-device-detail,#ed-device-detail");
-  if (panel) panel.dataset.dmCanonicalDevicePeriod = `${selectedYear}-${String(selectedMonth).padStart(2, "0")}|${monthValue}`;
+  if (panel)
+    panel.dataset.dmCanonicalDevicePeriod = `${selectedYear}-${String(selectedMonth).padStart(2, "0")}|${monthValue}`;
   return true;
 }
 
@@ -145,6 +235,7 @@ function complete(runtime) {
     state.appliedGeneration = generation;
   }
   applyDeviceDetail(bundle);
+  ensureEnergyHelp();
   state.done = true;
   runtime.ready = true;
   root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
@@ -183,6 +274,8 @@ function tick() {
 }
 function schedule() {
   if (!state.done && !state.timer) state.timer = root.setTimeout?.(tick, 0);
+  wrapEditorSwitch();
+  ensureEnergyHelp();
   scheduleDeviceDetail(0);
 }
 
@@ -204,6 +297,7 @@ function wrapLegacyDetail() {
 installReadyGate();
 root.addEventListener?.("dashboardmodern:legacy-ready", () => {
   wrapLegacyDetail();
+  wrapEditorSwitch();
   schedule();
 });
 root.addEventListener?.("dashboardmodern:runtime-ready", schedule);
@@ -214,10 +308,21 @@ root.addEventListener?.("dashboardmodern:period-bundle", (event) => {
   schedule();
 });
 root.addEventListener?.("pageshow", schedule);
+doc?.addEventListener(
+  "click",
+  (event) => {
+    if (event.target?.closest?.(".ed-tab,[data-energy-tab],[data-energy-panel]")) {
+      state.uiAttempts = 0;
+      scheduleUi(0);
+    }
+  },
+  true,
+);
 doc?.addEventListener("change", (event) => {
   if (event.target?.matches?.("#ed-dev-selector,#ed-month,#ed-year")) scheduleDeviceDetail(80);
 });
 root.queueMicrotask?.(() => {
   wrapLegacyDetail();
+  wrapEditorSwitch();
   schedule();
 });

--- a/custom_components/dashboardmodern/frontend/src/core/energy-total-source.js
+++ b/custom_components/dashboardmodern/frontend/src/core/energy-total-source.js
@@ -144,8 +144,8 @@ function legacyRowsBeforeField(container, field) {
     if (row.contains(field) || row.querySelector("[data-dm-edit-kind]")) return false;
     const position = row.compareDocumentPosition(field);
     const precedesField = Boolean(position & Node.DOCUMENT_POSITION_FOLLOWING);
-    const buttons = [...row.querySelectorAll("button")];
-    return precedesField && buttons.length > 0;
+    const controls = [...row.querySelectorAll(".ed-del,button")];
+    return precedesField && controls.length > 0;
   });
 }
 
@@ -165,13 +165,13 @@ function ensureLegacyEditButtons() {
     const container = field.closest("details") || body;
     legacyRowsBeforeField(container, field).forEach((row, index) => {
       if (row.querySelector(`[data-dm-edit-kind='${kind}']`)) return;
-      const buttons = [...row.querySelectorAll("button")];
+      const controls = [...row.querySelectorAll(".ed-del,button")];
       const remove =
-        buttons.find((button) =>
-          /(?:delete|remove|elimina|rimuovi|cestino|trash)/i.test(
-            `${button.className} ${button.getAttribute("aria-label") || ""} ${button.title || ""} ${button.getAttribute("onclick") || ""}`,
+        controls.find((control) =>
+          /(?:delete|remove|elimina|rimuovi|cestino|trash|eddel)/i.test(
+            `${control.className} ${control.getAttribute("aria-label") || ""} ${control.title || ""} ${control.getAttribute("onclick") || ""}`,
           ),
-        ) || buttons.at(-1);
+        ) || controls.at(-1);
       if (!remove) return;
       remove.before(editButton(kind, index));
       inserted = true;

--- a/custom_components/dashboardmodern/frontend/src/core/energy-total-source.js
+++ b/custom_components/dashboardmodern/frontend/src/core/energy-total-source.js
@@ -1,357 +1,130 @@
-/* Preserve cumulative totals, gate readiness and clean final live-state UI. */
+/* DashboardModern 0.15.4 — readiness gate for the single canonical Energy owner. */
 import { applyAtomicEnergyBundle } from "../../legacy/runtime-consolidated.js";
-import { HomeAssistantBroker } from "./period-service.js";
 
 const root = globalThis;
 const doc = root.document;
-if (doc && !doc.getElementById("dm-ev-editor-preview-0152")) {
-  const style = doc.createElement("style");
-  style.id = "dm-ev-editor-preview-0152";
-  style.textContent = `
-    html:has(#editor-modal.show) #page-ev:not(.active):has(#ev-mod-car-img[src]) {
-      display:block!important;position:fixed!important;inset:0!important;
-      width:100vw!important;height:100vh!important;overflow:hidden!important;
-      opacity:1!important;transform:none!important;pointer-events:none!important;z-index:-1!important
-    }
-  `;
-  (doc.head || doc.documentElement).append(style);
-}
 const KEY = "__DASHBOARDMODERN_ENERGY_TOTAL_SOURCE__";
-const state = (root[KEY] ||= {
+const state = (root[KEY] ||= {});
+Object.assign(state, {
   installed: true,
+  version: "0.15.4",
   attempts: 0,
   timer: 0,
-  repairing: false,
-  repaired: false,
-  forced: false,
-  dayRunning: false,
-  dayDone: false,
-  dayFailures: 0,
   done: false,
-  shutterAttempts: 0,
-  shutterTimer: 0,
-});
-const dayBroker = new HomeAssistantBroker({
-  timeout: 3000,
-  cacheCurrentMs: 0,
-  cacheHistoricalMs: 0,
+  readyGateInstalled: false,
+  appliedGeneration: 0,
+  error: "",
 });
 
 const clean = (value) => String(value ?? "").trim();
-const finite = (value) => {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-};
-const rounded = (value) => Math.round((finite(value) || 0) * 1000) / 1000;
 
 function energyModel() {
   return root.DashboardModernModules?.store?.getSection?.("energy") || {};
 }
 
-function hasEnergySource() {
+function configuredSource() {
   const energy = energyModel();
-  return Boolean(
-    clean(
-      energy.house?.daily_energy ||
-        energy.house?.monthly_energy ||
-        energy.house?.total_energy ||
-        energy.house?.annual_energy,
-    ),
+  return clean(
+    energy.house?.daily_energy ||
+      energy.house?.monthly_energy ||
+      energy.house?.annual_energy ||
+      energy.house?.total_energy,
   );
 }
 
-function synchronizeRuntimeAlias() {
-  const runtime = root.__DASHBOARDMODERN_RUNTIME_ROOT__;
-  if (!runtime) return null;
-  root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
+function runtimeRoot() {
+  const runtime = root.__DASHBOARDMODERN_RUNTIME_ROOT__ || null;
+  if (runtime) root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
   return runtime;
 }
 
 function installReadyGate() {
-  const runtime = root.__DASHBOARDMODERN_RUNTIME_ROOT__;
-  if (!runtime || runtime.__dmEnergyReadyGate0152 || !hasEnergySource()) return false;
-  let canonicalReady = Boolean(runtime.ready);
-  Object.defineProperty(runtime, "ready", {
-    configurable: true,
-    enumerable: true,
-    get() {
-      return state.done === true && canonicalReady === true;
-    },
-    set(value) {
-      canonicalReady = Boolean(value);
-    },
-  });
-  Object.defineProperty(runtime, "__dmEnergyReadyGate0152", {
-    configurable: true,
-    value: true,
-  });
-  state.readyGateInstalled = true;
-  root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
-  return true;
-}
-
-installReadyGate();
-
-function requestFullEnergyRecovery() {
-  if (!state.repaired || state.forced) return false;
-  const runtime = synchronizeRuntimeAlias();
-  const coordinator = root.__DASHBOARDMODERN_STARTUP_COORDINATOR__;
-  const vehicle = root.__DASHBOARDMODERN_VEHICLE_IMAGE_RUNTIME__;
-  if (!runtime || !vehicle || coordinator?.running || vehicle.energyRunning) return false;
-
-  state.forced = true;
-  runtime.bundle = null;
-  runtime.lastRefreshAt = 0;
-  root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
-  vehicle.energyVerified = false;
-  vehicle.scheduleContracts?.(0);
-  vehicle.verifyEnergy?.();
-  root.dispatchEvent?.(
-    new CustomEvent("dashboardmodern:energy-total-source-ready", {
-      detail: { source: state.source, fullRecovery: true },
-    }),
-  );
-  return true;
-}
-
-async function repair() {
-  if (state.repairing || state.repaired) return;
-  const store = root.DashboardModernModules?.store;
-  if (!store?.getSection || !store?.replaceSection) return;
-  const energy = store.getSection("energy") || {};
-  let changed = false;
-
-  for (const group of ["house", "solar"]) {
-    const model = (energy[group] ||= {});
-    const total = clean(model.total_energy);
-    const annual = clean(model.annual_energy);
-    if (!total && annual) {
-      model.total_energy = annual;
-      changed = true;
-    }
-    if (!annual && total) {
-      model.annual_energy = total;
-      changed = true;
-    }
-  }
-
-  const source = clean(energy.house?.total_energy || energy.house?.monthly_energy);
-  if (!source) return;
-
-  installReadyGate();
-  state.repairing = true;
+  const runtime = runtimeRoot();
+  if (!runtime || runtime.__dmEnergyReadyGate0154 || !configuredSource()) return false;
+  let ownerReady = Boolean(runtime.ready);
   try {
-    if (changed) await store.replaceSection("energy", energy);
-    state.repaired = true;
-    state.source = source;
-    if (root.document?.documentElement)
-      root.document.documentElement.dataset.dmEnergyTotalSource = source;
+    Object.defineProperty(runtime, "ready", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return state.done === true && ownerReady === true;
+      },
+      set(value) {
+        ownerReady = Boolean(value);
+      },
+    });
+    Object.defineProperty(runtime, "__dmEnergyReadyGate0154", {
+      configurable: true,
+      value: true,
+    });
+    state.readyGateInstalled = true;
+    return true;
   } catch (error) {
     state.error = clean(error?.message || error);
-  } finally {
-    state.repairing = false;
+    return false;
   }
 }
 
-function daySources() {
-  const energy = energyModel();
-  const source = (group, periodKey, totalKey) =>
-    clean(
-      energy[group]?.[periodKey] ||
-        energy[group]?.[totalKey] ||
-        energy[group]?.annual_energy,
-    );
-  return {
-    house: source("house", "daily_energy", "total_energy"),
-    solar: source("solar", "daily_energy", "total_energy"),
-    gridImport: source("grid", "daily_import_energy", "total_import_energy"),
-    gridExport: source("grid", "daily_export_energy", "total_export_energy"),
-    batteryCharged: source("battery", "daily_charged_energy", "total_charged_energy"),
-    batteryDischarged: source("battery", "daily_discharged_energy", "total_discharged_energy"),
-  };
-}
-
-async function statistics(ids, start, end) {
-  const statisticIds = [...new Set(Object.values(ids).map(clean).filter(Boolean))];
-  if (!statisticIds.length) return {};
-  const result = await dayBroker.request({
-    type: "recorder/statistics_during_period",
-    start_time: new Date(start).toISOString(),
-    end_time: new Date(end).toISOString(),
-    statistic_ids: statisticIds,
-    period: "hour",
-    units: { energy: "kWh" },
-  });
-  return result && typeof result === "object" ? result : {};
-}
-
-function lastValue(rows) {
-  const list = Array.isArray(rows) ? rows : [];
-  for (let index = list.length - 1; index >= 0; index -= 1) {
-    for (const key of ["sum", "state", "max"]) {
-      const value = finite(list[index]?.[key]);
-      if (value != null) return value;
-    }
-  }
-  return null;
-}
-
-function consumption(currentRows, baselineRows) {
-  const current = lastValue(currentRows);
-  const baseline = lastValue(baselineRows);
-  if (current == null) return 0;
-  if (baseline == null) return rounded(current);
-  const delta = current - baseline;
-  return rounded(delta >= 0 ? delta : current);
-}
-
-function roundedRecord(record = {}) {
-  return Object.freeze(
-    Object.fromEntries(Object.entries(record).map(([key, value]) => [key, rounded(value)])),
-  );
-}
-
-async function repairDayBundle() {
-  if (state.dayRunning || state.dayDone || root.WebSocket?.name === "StubSocket") return;
-  const runtime = synchronizeRuntimeAlias();
-  if (!runtime?.bundle) return;
-  const sources = daySources();
-  if (!sources.house) return;
-
-  state.dayRunning = true;
-  try {
-    const now = new Date();
-    const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-    const baselineStart = new Date(start);
-    baselineStart.setHours(baselineStart.getHours() - 2);
-    const end = new Date(now);
-    if (end.getHours() === 0) end.setHours(1, 0, 0, 0);
-
-    const [current, baseline] = await Promise.all([
-      statistics(sources, start, end),
-      statistics(sources, baselineStart, start),
-    ]);
-    const day = Object.freeze(
-      Object.fromEntries(
-        Object.entries(sources).map(([key, entity]) => [
-          key,
-          entity ? consumption(current[entity], baseline[entity]) : 0,
-        ]),
-      ),
-    );
-    const previous = runtime.bundle;
-    const generation = Math.max(
-      Number(runtime.generation) || 0,
-      Number(previous.generation) || 0,
-    ) + 1;
-    const bundle = Object.freeze({
-      ...previous,
-      generation,
-      day,
-      month: roundedRecord(previous.month),
-      year: roundedRecord(previous.year),
-    });
-    runtime.generation = generation;
-    runtime.bundle = bundle;
-    runtime.lastRefreshAt = Date.now();
-    root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
+function complete(runtime) {
+  const bundle = runtime?.bundle;
+  if (!bundle?.day || !bundle?.month || !bundle?.year) return false;
+  const generation = Number(bundle.generation) || Number(runtime.generation) || 0;
+  if (generation && generation !== state.appliedGeneration) {
     applyAtomicEnergyBundle(bundle);
-    root.dispatchEvent?.(
-      new CustomEvent("dashboardmodern:period-bundle", { detail: bundle }),
-    );
-    state.dayDone = true;
-  } catch (error) {
-    state.dayFailures += 1;
-    state.dayError = clean(error?.message || error);
-    dayBroker.reset?.(error);
-  } finally {
-    state.dayRunning = false;
+    state.appliedGeneration = generation;
   }
+  state.done = true;
+  runtime.ready = true;
+  root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
+  if (doc?.documentElement) {
+    doc.documentElement.dataset.dmEnergyTotalSource = configuredSource();
+    doc.documentElement.dataset.dmRuntimeAlias = [
+      bundle.day?.house,
+      bundle.month?.house,
+      bundle.year?.house,
+    ].join("/");
+  }
+  return true;
 }
 
-function energyTick() {
+function releaseWithoutEnergy(runtime) {
+  state.done = true;
+  if (runtime) runtime.ready = true;
+  root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
+}
+
+function tick() {
   state.timer = 0;
   if (state.done) return;
   state.attempts += 1;
+  const runtime = runtimeRoot();
   installReadyGate();
-  repair();
-  const runtime = synchronizeRuntimeAlias();
-  requestFullEnergyRecovery();
 
-  const vehicle = root.__DASHBOARDMODERN_VEHICLE_IMAGE_RUNTIME__;
-  const baseComplete =
-    state.forced &&
-    vehicle?.energyVerified === true &&
-    runtime?.bundle?.day &&
-    runtime?.bundle?.month &&
-    runtime?.bundle?.year;
-  if (baseComplete && !state.dayDone && !state.dayRunning) repairDayBundle();
-
-  if (baseComplete && state.dayDone && !state.dayRunning) {
-    state.done = true;
-    runtime.ready = true;
-    root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
-    if (root.document?.documentElement) {
-      root.document.documentElement.dataset.dmRuntimeAlias = [
-        runtime.bundle.day.house,
-        runtime.bundle.month.house,
-        runtime.bundle.year.house,
-      ].join("/");
-    }
+  if (!configuredSource()) {
+    releaseWithoutEnergy(runtime);
     return;
   }
+  if (complete(runtime)) return;
 
-  if (state.dayFailures >= 8 || state.attempts >= 520) {
-    state.done = true;
-    if (runtime) runtime.ready = true;
-    root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
+  if (state.attempts >= 720) {
+    state.error ||= "Canonical Energy bundle timeout";
+    releaseWithoutEnergy(runtime);
     return;
   }
-
-  state.timer = root.setTimeout?.(energyTick, 25);
+  state.timer = root.setTimeout?.(tick, 25);
 }
 
-function liveStates() {
-  let states = root.STATES || {};
-  try {
-    states = root.eval?.("typeof STATES !== 'undefined' && STATES ? STATES : null") || states;
-  } catch (_error) {}
-  return states || {};
+function schedule() {
+  if (!state.done && !state.timer) state.timer = root.setTimeout?.(tick, 0);
 }
 
-function removeClosedShutterUi() {
-  const states = liveStates();
-  const covers = Object.entries(states).filter(([entity]) => entity.startsWith("cover."));
-  if (!covers.length) return;
-  const allClosed = covers.every(([, current]) => {
-    const status = clean(current?.state).toLowerCase();
-    const position = Number(current?.attributes?.current_position);
-    return (
-      status === "closed" ||
-      status === "unavailable" ||
-      status === "unknown" ||
-      (Number.isFinite(position) && position <= 0)
-    );
-  });
-  if (!allClosed) return;
-  root.document?.getElementById("tapp-avvisi")?.remove();
-  root.document?.getElementById("dm-shutter-popup")?.remove();
-}
-
-function shutterTick() {
-  state.shutterTimer = 0;
-  state.shutterAttempts += 1;
-  removeClosedShutterUi();
-  if (state.shutterAttempts < 360)
-    state.shutterTimer = root.setTimeout?.(shutterTick, 100);
-}
-
-function start() {
-  if (!state.done && !state.timer) energyTick();
-  if (!state.shutterTimer && state.shutterAttempts < 360) shutterTick();
-}
-
-root.addEventListener?.("dashboardmodern:legacy-ready", start);
-root.addEventListener?.("dashboardmodern:runtime-ready", start);
-root.addEventListener?.("dashboardmodern:state-changed", removeClosedShutterUi);
-root.queueMicrotask?.(start);
+installReadyGate();
+root.addEventListener?.("dashboardmodern:legacy-ready", schedule);
+root.addEventListener?.("dashboardmodern:runtime-ready", schedule);
+root.addEventListener?.("dashboardmodern:period-bundle", (event) => {
+  const runtime = runtimeRoot();
+  if (runtime && event?.detail) runtime.bundle = event.detail;
+  schedule();
+});
+root.addEventListener?.("pageshow", schedule);
+root.queueMicrotask?.(schedule);

--- a/custom_components/dashboardmodern/frontend/src/core/energy-total-source.js
+++ b/custom_components/dashboardmodern/frontend/src/core/energy-total-source.js
@@ -1,4 +1,4 @@
-/* DashboardModern 0.15.4 — readiness gate for the single canonical Energy owner. */
+/* DashboardModern 0.15.4 — readiness and historical detail projection for the single Energy owner. */
 import { applyAtomicEnergyBundle } from "../../legacy/runtime-consolidated.js";
 
 const root = globalThis;
@@ -10,6 +10,7 @@ Object.assign(state, {
   version: "0.15.4",
   attempts: 0,
   timer: 0,
+  detailTimer: 0,
   done: false,
   readyGateInstalled: false,
   appliedGeneration: 0,
@@ -17,11 +18,16 @@ Object.assign(state, {
 });
 
 const clean = (value) => String(value ?? "").trim();
+const finite = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+const valueFrom = (values, entity) =>
+  values instanceof Map ? finite(values.get(entity)) : finite(values?.[entity]);
 
 function energyModel() {
   return root.DashboardModernModules?.store?.getSection?.("energy") || {};
 }
-
 function configuredSource() {
   const energy = energyModel();
   return clean(
@@ -31,7 +37,6 @@ function configuredSource() {
       energy.house?.total_energy,
   );
 }
-
 function runtimeRoot() {
   const runtime = root.__DASHBOARDMODERN_RUNTIME_ROOT__ || null;
   if (runtime) root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
@@ -65,6 +70,72 @@ function installReadyGate() {
   }
 }
 
+function setText(id, value) {
+  const element = doc?.getElementById(id);
+  if (element) element.textContent = value;
+}
+function rate(key) {
+  const configured = root.cdCfg?.(key);
+  const raw = configured !== undefined && configured !== null && configured !== ""
+    ? configured
+    : root.localStorage?.getItem(key);
+  return finite(raw);
+}
+function splitFor(period, value) {
+  const house = finite(period?.house);
+  const grid = finite(period?.gridImport);
+  const gridShare = house > 0 ? Math.max(0, Math.min(1, grid / house)) : 1;
+  return { grid: value * gridShare, solar: value * (1 - gridShare) };
+}
+
+function applyDeviceDetail(bundle) {
+  const selector = doc?.getElementById("ed-dev-selector");
+  const entity = clean(selector?.value);
+  if (!entity || !bundle?.deviceMonth || !bundle?.deviceYear) return false;
+  const monthValue = valueFrom(bundle.deviceMonth.values, entity);
+  const yearValue = valueFrom(bundle.deviceYear.values, entity);
+  const selectedMonth = Number(bundle.period?.month) || new Date().getMonth() + 1;
+  const selectedYear = Number(bundle.period?.year) || new Date().getFullYear();
+  const days = new Date(selectedYear, selectedMonth, 0).getDate();
+  const importPrice = finite(bundle.rates?.importPrice) || rate("cd_costo_kwh");
+  const monthSplit = splitFor(bundle.month, monthValue);
+  const yearSplit = splitFor(bundle.year, yearValue);
+
+  setText("ed-dkpi-mese", `${monthValue.toFixed(1)} kWh`);
+  setText("ed-dkpi-mese-eur", `€ ${(monthValue * importPrice).toFixed(2)}`);
+  setText("ed-dkpi-media", `${(days ? monthValue / days : 0).toFixed(2)} kWh`);
+  setText("ed-dkpi-media-sub", doc?.documentElement?.lang === "en" ? "Daily average" : "Media/giorno");
+  setText("ed-dkpi-risp-eur", `+ ${(monthSplit.solar * importPrice).toFixed(2)} €`);
+  setText("ed-dkpi-risp-kwh", `${monthSplit.solar.toFixed(1)} kWh da FV`);
+  setText("ed-dkpi-costo-eur", `- ${(monthSplit.grid * importPrice).toFixed(2)} €`);
+  setText("ed-dkpi-costo-kwh", `${monthSplit.grid.toFixed(1)} kWh dalla rete`);
+  setText("ed-dkpi-year-lbl", String(selectedYear));
+  setText("ed-dkpi-anno-risp-eur", `+ ${(yearSplit.solar * importPrice).toFixed(2)} €`);
+  setText("ed-dkpi-anno-risp-kwh", `${yearSplit.solar.toFixed(1)} kWh da FV`);
+  setText("ed-dkpi-anno-costo-eur", `- ${(yearSplit.grid * importPrice).toFixed(2)} €`);
+  setText("ed-dkpi-anno-costo-kwh", `${yearSplit.grid.toFixed(1)} kWh dalla rete`);
+
+  const message = doc?.getElementById("ed-dev-chart-msg");
+  const canvas = doc?.getElementById("ed-dev-chart-canvas");
+  if (message && monthValue > 0 && (!canvas || getComputedStyle(canvas).display === "none")) {
+    message.style.display = "flex";
+    message.textContent = doc?.documentElement?.lang === "en"
+      ? `Selected month total: ${monthValue.toFixed(1)} kWh`
+      : `Totale mese selezionato: ${monthValue.toFixed(1)} kWh`;
+  }
+  const panel = doc?.querySelector(".ed-device-detail,#ed-device-detail");
+  if (panel) panel.dataset.dmCanonicalDevicePeriod = `${selectedYear}-${String(selectedMonth).padStart(2, "0")}|${monthValue}`;
+  return true;
+}
+
+function scheduleDeviceDetail(delay = 0) {
+  root.clearTimeout?.(state.detailTimer);
+  state.detailTimer = root.setTimeout?.(() => {
+    state.detailTimer = 0;
+    applyDeviceDetail(runtimeRoot()?.bundle);
+  }, delay);
+}
+
 function complete(runtime) {
   const bundle = runtime?.bundle;
   if (!bundle?.day || !bundle?.month || !bundle?.year) return false;
@@ -73,6 +144,7 @@ function complete(runtime) {
     applyAtomicEnergyBundle(bundle);
     state.appliedGeneration = generation;
   }
+  applyDeviceDetail(bundle);
   state.done = true;
   runtime.ready = true;
   root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
@@ -86,26 +158,22 @@ function complete(runtime) {
   }
   return true;
 }
-
 function releaseWithoutEnergy(runtime) {
   state.done = true;
   if (runtime) runtime.ready = true;
   root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
 }
-
 function tick() {
   state.timer = 0;
   if (state.done) return;
   state.attempts += 1;
   const runtime = runtimeRoot();
   installReadyGate();
-
   if (!configuredSource()) {
     releaseWithoutEnergy(runtime);
     return;
   }
   if (complete(runtime)) return;
-
   if (state.attempts >= 720) {
     state.error ||= "Canonical Energy bundle timeout";
     releaseWithoutEnergy(runtime);
@@ -113,18 +181,43 @@ function tick() {
   }
   state.timer = root.setTimeout?.(tick, 25);
 }
-
 function schedule() {
   if (!state.done && !state.timer) state.timer = root.setTimeout?.(tick, 0);
+  scheduleDeviceDetail(0);
+}
+
+function wrapLegacyDetail() {
+  const current = root.edCaricaDettaglio;
+  if (typeof current !== "function" || current.__dmCanonicalDevice0154) return;
+  function canonicalDeviceDetail(...args) {
+    const result = current.apply(this, args);
+    const finish = () => scheduleDeviceDetail(0);
+    if (result && typeof result.finally === "function") return result.finally(finish);
+    finish();
+    return result;
+  }
+  canonicalDeviceDetail.__dmCanonicalDevice0154 = true;
+  canonicalDeviceDetail.__dmPrevious = current;
+  root.edCaricaDettaglio = canonicalDeviceDetail;
 }
 
 installReadyGate();
-root.addEventListener?.("dashboardmodern:legacy-ready", schedule);
+root.addEventListener?.("dashboardmodern:legacy-ready", () => {
+  wrapLegacyDetail();
+  schedule();
+});
 root.addEventListener?.("dashboardmodern:runtime-ready", schedule);
 root.addEventListener?.("dashboardmodern:period-bundle", (event) => {
   const runtime = runtimeRoot();
   if (runtime && event?.detail) runtime.bundle = event.detail;
+  applyDeviceDetail(event?.detail);
   schedule();
 });
 root.addEventListener?.("pageshow", schedule);
-root.queueMicrotask?.(schedule);
+doc?.addEventListener("change", (event) => {
+  if (event.target?.matches?.("#ed-dev-selector,#ed-month,#ed-year")) scheduleDeviceDetail(80);
+});
+root.queueMicrotask?.(() => {
+  wrapLegacyDetail();
+  schedule();
+});

--- a/custom_components/dashboardmodern/frontend/src/core/energy-total-source.js
+++ b/custom_components/dashboardmodern/frontend/src/core/energy-total-source.js
@@ -126,11 +126,71 @@ function ensureEnergyHelp() {
   return fields.every((field) => field.querySelector(":scope > .dm-energy-total-help"));
 }
 
+function editButton(kind, index) {
+  const button = doc.createElement("button");
+  button.type = "button";
+  button.className = "ed-del dm-edit-existing";
+  button.dataset.dmEditKind = kind;
+  button.dataset.dmEditIndex = String(index);
+  button.textContent = "✏️";
+  button.title = english() ? "Edit" : "Modifica";
+  button.setAttribute("aria-label", button.title);
+  return button;
+}
+
+function legacyRowsBeforeField(container, field) {
+  if (!container || !field) return [];
+  return [...container.querySelectorAll(".ed-row")].filter((row) => {
+    if (row.contains(field) || row.querySelector("[data-dm-edit-kind]")) return false;
+    const position = row.compareDocumentPosition(field);
+    const precedesField = Boolean(position & Node.DOCUMENT_POSITION_FOLLOWING);
+    const buttons = [...row.querySelectorAll("button")];
+    return precedesField && buttons.length > 0;
+  });
+}
+
+function ensureLegacyEditButtons() {
+  const body = doc?.getElementById("ed-body");
+  if (!body) return false;
+  const definitions = [
+    ["action", "#ed-qa-type"],
+    ["climate", "#ed-cl-type"],
+    ["shutter", "#ed-tp-name"],
+    ["room", "#ed-room-name"],
+  ];
+  let inserted = false;
+  definitions.forEach(([kind, selector]) => {
+    const field = body.querySelector(selector);
+    if (!field) return;
+    const container = field.closest("details") || body;
+    legacyRowsBeforeField(container, field).forEach((row, index) => {
+      if (row.querySelector(`[data-dm-edit-kind='${kind}']`)) return;
+      const buttons = [...row.querySelectorAll("button")];
+      const remove =
+        buttons.find((button) =>
+          /(?:delete|remove|elimina|rimuovi|cestino|trash)/i.test(
+            `${button.className} ${button.getAttribute("aria-label") || ""} ${button.title || ""} ${button.getAttribute("onclick") || ""}`,
+          ),
+        ) || buttons.at(-1);
+      if (!remove) return;
+      remove.before(editButton(kind, index));
+      inserted = true;
+    });
+  });
+  return inserted || Boolean(body.querySelector("[data-dm-edit-kind]"));
+}
+
+function ensureEditorContracts() {
+  const energy = ensureEnergyHelp();
+  const edits = ensureLegacyEditButtons();
+  return energy || edits;
+}
+
 function uiTick() {
   state.uiTimer = 0;
   state.uiAttempts += 1;
   wrapEditorSwitch();
-  const complete = ensureEnergyHelp();
+  const complete = ensureEditorContracts();
   if (!complete && doc?.getElementById("editor-modal") && state.uiAttempts < 240)
     state.uiTimer = root.setTimeout?.(uiTick, 50);
 }
@@ -145,7 +205,7 @@ function wrapEditorSwitch() {
     const result = current.apply(this, args);
     const finish = () => {
       state.uiAttempts = 0;
-      root.queueMicrotask?.(ensureEnergyHelp);
+      root.queueMicrotask?.(ensureEditorContracts);
       scheduleUi(0);
     };
     if (result && typeof result.finally === "function") return result.finally(finish);
@@ -235,7 +295,7 @@ function complete(runtime) {
     state.appliedGeneration = generation;
   }
   applyDeviceDetail(bundle);
-  ensureEnergyHelp();
+  ensureEditorContracts();
   state.done = true;
   runtime.ready = true;
   root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
@@ -275,7 +335,7 @@ function tick() {
 function schedule() {
   if (!state.done && !state.timer) state.timer = root.setTimeout?.(tick, 0);
   wrapEditorSwitch();
-  ensureEnergyHelp();
+  ensureEditorContracts();
   scheduleDeviceDetail(0);
 }
 

--- a/custom_components/dashboardmodern/frontend/src/core/vehicle-image-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/core/vehicle-image-runtime.js
@@ -29,10 +29,16 @@ function legacyStates() {
 }
 
 function allStates() {
+  const live = legacyStates();
+  for (const [entity, current] of Object.entries(live)) {
+    if (!entity.startsWith("cover.")) continue;
+    if (root._RAW_STATES) root._RAW_STATES[entity] = current;
+    if (root.STATES && root.STATES !== live) root.STATES[entity] = current;
+  }
   return {
     ...(root._RAW_STATES || {}),
     ...(root.STATES || {}),
-    ...legacyStates(),
+    ...live,
   };
 }
 

--- a/custom_components/dashboardmodern/frontend/src/core/vehicle-image-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/core/vehicle-image-runtime.js
@@ -31,8 +31,8 @@ function legacyStates() {
 function allStates() {
   return {
     ...(root._RAW_STATES || {}),
-    ...legacyStates(),
     ...(root.STATES || {}),
+    ...legacyStates(),
   };
 }
 

--- a/custom_components/dashboardmodern/frontend/src/core/vehicle-image-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/core/vehicle-image-runtime.js
@@ -101,6 +101,14 @@ function persistNormalizedImage(original, normalized) {
     root.localStorage?.setItem("cd_ev_image", serialized);
 }
 
+function showLoadedImage(image) {
+  delete image.dataset.evImageError;
+  delete image.dataset.evFailed;
+  image.style.display = "block";
+  image.style.visibility = "visible";
+  image.style.opacity = "1";
+}
+
 export function applyVehicleAsset() {
   if (!doc) return false;
   const original = configuredImage();
@@ -116,24 +124,26 @@ export function applyVehicleAsset() {
       image.style.display = "none";
       return;
     }
+
+    const resolved = new URL(url, doc.baseURI).href;
+    const staleFailure = image.dataset.evFailed === "1" || Boolean(image.dataset.evImageError);
+    delete image.dataset.evFailed;
+    delete image.dataset.evImageError;
     image.onerror = () => {
       image.dataset.evImageError = url;
       image.style.display = "none";
     };
-    image.onload = () => {
-      delete image.dataset.evImageError;
-      delete image.dataset.evFailed;
-      image.style.display = "block";
-      image.style.visibility = "visible";
-      image.style.opacity = "1";
-    };
-    const resolved = new URL(url, doc.baseURI).href;
-    if (image.src !== resolved) image.src = url;
-    if (!image.dataset.evImageError) {
-      image.style.display = "block";
-      image.style.visibility = "visible";
-      mounted = true;
+    image.onload = () => showLoadedImage(image);
+    image.style.display = "block";
+    image.style.visibility = "visible";
+    image.style.opacity = "1";
+
+    if (image.src !== resolved || (staleFailure && image.complete && image.naturalWidth === 0)) {
+      if (staleFailure) image.removeAttribute("src");
+      image.src = url;
     }
+    if (image.complete && image.naturalWidth > 0) showLoadedImage(image);
+    mounted = image.style.display !== "none" || mounted;
   });
   const hero = doc.getElementById("lm-hero-card");
   if (hero) hero.dataset.evImage = url ? "configured" : "missing";

--- a/custom_components/dashboardmodern/frontend/src/core/vehicle-image-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/core/vehicle-image-runtime.js
@@ -1,62 +1,40 @@
-/* Canonical vehicle-image resolver plus bounded 0.15.2 runtime finalization. */
-import { applyAtomicEnergyBundle } from "../../legacy/runtime-consolidated.js";
-import { HomeAssistantBroker } from "./period-service.js";
+/* DashboardModern 0.15.4 — canonical vehicle asset and live shutter UI owner. */
 
 const root = globalThis;
 const doc = root.document;
 const KEY = "__DASHBOARDMODERN_VEHICLE_IMAGE_RUNTIME__";
-const state = (root[KEY] ||= { installed: true, lastUrl: "" });
+const state = (root[KEY] ||= {});
 Object.assign(state, {
   installed: true,
+  version: "0.15.4",
   lastUrl: state.lastUrl || "",
-  energyRunning: Boolean(state.energyRunning),
-  energyVerified: Boolean(state.energyVerified),
-  energyTimer: state.energyTimer || 0,
-  contractTimer: state.contractTimer || 0,
-  contractAttempts: state.contractAttempts || 0,
-  energyFailures: Number(state.energyFailures) || 0,
+  contractTimer: 0,
+  contractAttempts: 0,
+  energyRunning: false,
+  energyVerified: true,
+  energyFailures: 0,
 });
+
 const clean = (value) => String(value ?? "").trim();
-const numeric = (value) => {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-};
 const dashboardStore = () => root.DashboardModernModules?.store || null;
+const text = (it, en) =>
+  clean(doc?.documentElement?.lang).toLowerCase().startsWith("en") ? en : it;
+
 function legacyStates() {
   try {
-    return root.eval?.("typeof STATES !== 'undefined' && STATES ? STATES : null") || root.STATES || {};
+    return root.eval?.("typeof STATES !== 'undefined' && STATES ? STATES : null") || {};
   } catch (_error) {
-    return root.STATES || {};
+    return {};
   }
 }
-const allStates = () => ({
-  ...(root._RAW_STATES || {}),
-  ...(root.STATES || {}),
-  ...legacyStates(),
-});
-const text = (it, en) => (doc?.documentElement?.lang === "en" ? en : it);
-const recoveryBroker = new HomeAssistantBroker({
-  timeout: 3000,
-  cacheCurrentMs: 0,
-  cacheHistoricalMs: 0,
-});
 
-function installFastBridgeGuard() {
-  const current = HomeAssistantBroker.prototype.connect;
-  if (current?.__dmFastBridgeGuard0152) return;
-  function guardedConnect() {
-    if (root.WebSocket?.name === "StubSocket") {
-      this.reset?.(new Error("DashboardModern bridge is not ready"));
-      return Promise.reject(new Error("DashboardModern bridge is not ready"));
-    }
-    return current.apply(this, arguments);
-  }
-  guardedConnect.__dmFastBridgeGuard0152 = true;
-  guardedConnect.__dmPrevious = current;
-  HomeAssistantBroker.prototype.connect = guardedConnect;
+function allStates() {
+  return {
+    ...(root._RAW_STATES || {}),
+    ...legacyStates(),
+    ...(root.STATES || {}),
+  };
 }
-
-installFastBridgeGuard();
 
 function integrationAssetRoot(base) {
   try {
@@ -74,10 +52,12 @@ export function resolveVehicleAsset(value, base = doc?.baseURI || root.location?
   if (!raw) return "";
   if (/^(?:data:|blob:|https?:)/i.test(raw)) return raw;
   if (/^(?:file:|[a-z]:\/)/i.test(raw)) return "";
-  if (raw.startsWith("/config/www/")) return `/local/${raw.slice("/config/www/".length)}`;
-  if (raw.startsWith("config/www/")) return `/local/${raw.slice("config/www/".length)}`;
-  if (raw.startsWith("www/")) return `/local/${raw.slice(4)}`;
-  if (raw.startsWith("local/")) return `/${raw}`;
+  if (raw.startsWith("/loca/")) raw = `/local/${raw.slice(6)}`;
+  else if (raw.startsWith("loca/")) raw = `/local/${raw.slice(5)}`;
+  else if (raw.startsWith("/config/www/")) raw = `/local/${raw.slice(12)}`;
+  else if (raw.startsWith("config/www/")) raw = `/local/${raw.slice(11)}`;
+  else if (raw.startsWith("www/")) raw = `/local/${raw.slice(4)}`;
+  else if (raw.startsWith("local/")) raw = `/${raw}`;
 
   const integrationPrefixes = [
     "/config/custom_components/dashboardmodern/frontend/",
@@ -90,7 +70,7 @@ export function resolveVehicleAsset(value, base = doc?.baseURI || root.location?
     const rootUrl = integrationAssetRoot(base);
     return rootUrl ? new URL(raw.slice(prefix.length), rootUrl).href : "";
   }
-  if (raw.startsWith("/")) return raw;
+  if (raw.startsWith("/")) return raw.replace(/^\/local\/\/+/, "/local/");
   try {
     return new URL(raw.replace(/^\.\//, ""), base).href;
   } catch (_error) {
@@ -108,10 +88,20 @@ function configuredImage() {
   }
 }
 
+function persistNormalizedImage(original, normalized) {
+  if (!normalized || clean(original) === normalized) return;
+  const serialized = JSON.stringify(normalized);
+  if (root.localStorage?.getItem("cd_ev_image") !== serialized)
+    root.localStorage?.setItem("cd_ev_image", serialized);
+}
+
 export function applyVehicleAsset() {
   if (!doc) return false;
-  const url = resolveVehicleAsset(configuredImage());
+  const original = configuredImage();
+  const url = resolveVehicleAsset(original);
+  persistNormalizedImage(original, url);
   state.lastUrl = url;
+  let mounted = false;
   ["ev-mod-car-img", "ev-new-car-img"].forEach((id) => {
     const image = doc.getElementById(id);
     if (!image) return;
@@ -126,48 +116,34 @@ export function applyVehicleAsset() {
     };
     image.onload = () => {
       delete image.dataset.evImageError;
+      delete image.dataset.evFailed;
       image.style.display = "block";
+      image.style.visibility = "visible";
       image.style.opacity = "1";
     };
-    image.style.display = "block";
     const resolved = new URL(url, doc.baseURI).href;
     if (image.src !== resolved) image.src = url;
+    if (!image.dataset.evImageError) {
+      image.style.display = "block";
+      image.style.visibility = "visible";
+      mounted = true;
+    }
   });
   const hero = doc.getElementById("lm-hero-card");
   if (hero) hero.dataset.evImage = url ? "configured" : "missing";
-  return Boolean(url);
+  return mounted;
 }
 
-function installFinalStyles() {
-  if (!doc || doc.getElementById("dm-runtime-final-contracts-0152")) return;
+function installStyles() {
+  if (!doc?.head || doc.getElementById("dm-vehicle-contracts-0154")) return;
   const style = doc.createElement("style");
-  style.id = "dm-runtime-final-contracts-0152";
+  style.id = "dm-vehicle-contracts-0154";
   style.textContent = `
-    html body #page-appliances-main .appl-wide-card{
-      box-sizing:border-box!important;width:min(100%,408px)!important;max-width:408px!important;
-      max-height:190px!important;overflow:hidden!important
-    }
-    html body #page-appliances-main .appl-ic:has(img.dm-appliance-image){
-      box-sizing:border-box!important;width:82px!important;height:82px!important;
-      min-width:82px!important;min-height:82px!important;flex:0 0 82px!important;overflow:hidden!important
-    }
-    html body #page-appliances-main .dm-appliance-image-wrap,
-    html body #page-appliances-main img.dm-appliance-image{
-      display:block!important;box-sizing:border-box!important;width:100%!important;height:100%!important;
-      min-width:82px!important;min-height:82px!important;overflow:hidden!important;
-      object-fit:cover!important;object-position:50% 50%!important
-    }
+    #ev-mod-car-img[data-ev-image-error],#ev-new-car-img[data-ev-image-error],
+    #ev-mod-car-img[data-ev-failed="1"],#ev-new-car-img[data-ev-failed="1"]{display:none!important}
     #editor-modal .dm-temperature-actions button{min-height:44px!important}
   `;
   doc.head.append(style);
-}
-
-function exposeAlertEditors() {
-  if (doc?.querySelector(".ed-tab.active")?.dataset?.tab !== "avvisi") return;
-  doc.querySelectorAll("[data-dm-alert-edit]").forEach((button) => {
-    const details = button.closest("details");
-    if (details) details.open = true;
-  });
 }
 
 function inferredOpenCovers() {
@@ -180,7 +156,10 @@ function inferredOpenCovers() {
       const positionValue = current?.attributes?.current_position;
       const position = positionValue == null ? null : Number(positionValue);
       const status = clean(current?.state).toLowerCase();
-      const isOpen = status === "open" || status === "opening" || (Number.isFinite(position) && position > 0);
+      const isOpen =
+        status === "open" ||
+        status === "opening" ||
+        (Number.isFinite(position) && position > 0);
       if (!isOpen) return [];
       const suffix = clean(entity.split(".").pop()).replaceAll("_", " ").toLowerCase();
       const room = rooms.find((item) => clean(item.name).toLowerCase() === suffix) || null;
@@ -209,278 +188,32 @@ function syncShutterState() {
       }
       const detail = row.querySelector(".dm-shutter-details small");
       if (!detail) return;
-      const label = item.status === "opening" ? text("In apertura", "Opening") : text("Aperta", "Open");
-      detail.textContent = `${item.room ? `${item.room.name} · ` : ""}${label}${item.position == null ? "" : ` · ${Math.round(item.position)}%`}`;
+      const label =
+        item.status === "opening" ? text("In apertura", "Opening") : text("Aperta", "Open");
+      detail.textContent = `${item.room ? `${item.room.name} · ` : ""}${label}${
+        item.position == null ? "" : ` · ${Math.round(item.position)}%`
+      }`;
     });
   }
   return true;
 }
 
-function energyConfiguration() {
-  const energy = dashboardStore()?.getSection?.("energy") || {};
-  const source = (group, periodKey, totalKey) =>
-    clean(energy[group]?.[periodKey] || energy[group]?.[totalKey]);
-  return {
-    day: {
-      house: source("house", "daily_energy", "total_energy"),
-      solar: source("solar", "daily_energy", "total_energy"),
-      gridImport: source("grid", "daily_import_energy", "total_import_energy"),
-      gridExport: source("grid", "daily_export_energy", "total_export_energy"),
-      batteryCharged: source("battery", "daily_charged_energy", "total_charged_energy"),
-      batteryDischarged: source("battery", "daily_discharged_energy", "total_discharged_energy"),
-    },
-    month: {
-      house: source("house", "monthly_energy", "total_energy"),
-      solar: source("solar", "monthly_energy", "total_energy"),
-      gridImport: source("grid", "monthly_import_energy", "total_import_energy"),
-      gridExport: source("grid", "monthly_export_energy", "total_export_energy"),
-      batteryCharged: source("battery", "monthly_charged_energy", "total_charged_energy"),
-      batteryDischarged: source("battery", "monthly_discharged_energy", "total_discharged_energy"),
-    },
-    year: {
-      house: source("house", "annual_energy", "total_energy"),
-      solar: source("solar", "annual_energy", "total_energy"),
-      gridImport: source("grid", "annual_import_energy", "total_import_energy"),
-      gridExport: source("grid", "annual_export_energy", "total_export_energy"),
-      batteryCharged: source("battery", "annual_charged_energy", "total_charged_energy"),
-      batteryDischarged: source("battery", "annual_discharged_energy", "total_discharged_energy"),
-    },
-  };
-}
-
-function canonicalDevices() {
-  const store = dashboardStore();
-  const build = root.DashboardModernModules?.data?.canonicalReportDevices;
-  if (typeof build === "function") {
-    return build(
-      store?.getSection?.("appliances") || [],
-      store?.getSection?.("loads") || [],
-      allStates(),
-    );
-  }
-  return [
-    ...(store?.getSection?.("appliances") || []),
-    ...(store?.getSection?.("loads") || []),
-  ]
-    .filter((item) => item?.show_in_report !== false)
-    .map((item) => ({
-      ...item,
-      entity:
-        clean(item.total_energy_entity) ||
-        clean(item.report_entity) ||
-        clean(item.history_entity) ||
-        clean(item.energy_entity) ||
-        clean(item.monthly_energy_entity),
-    }))
-    .filter((item) => clean(item.entity));
-}
-
-function periodRange(kind, now = new Date()) {
-  let start;
-  let baselineStart;
-  let period;
-  if (kind === "day") {
-    start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-    baselineStart = new Date(start);
-    baselineStart.setHours(baselineStart.getHours() - 2);
-    period = "hour";
-  } else if (kind === "year") {
-    start = new Date(now.getFullYear(), 0, 1);
-    baselineStart = new Date(start);
-    baselineStart.setMonth(baselineStart.getMonth() - 1);
-    period = "month";
-  } else {
-    start = new Date(now.getFullYear(), now.getMonth(), 1);
-    baselineStart = new Date(start);
-    baselineStart.setDate(baselineStart.getDate() - 2);
-    period = "day";
-  }
-  return { start, baselineStart, end: now, period };
-}
-
-async function requestStatistics(ids, start, end, period) {
-  const statisticIds = [...new Set((ids || []).map(clean).filter(Boolean))];
-  if (!statisticIds.length) return {};
-  const result = await recoveryBroker.request({
-    type: "recorder/statistics_during_period",
-    start_time: new Date(start).toISOString(),
-    end_time: new Date(end).toISOString(),
-    statistic_ids: statisticIds,
-    period,
-    units: { energy: "kWh" },
+function exposeAlertEditors() {
+  if (doc?.querySelector(".ed-tab.active")?.dataset?.tab !== "avvisi") return;
+  doc.querySelectorAll("[data-dm-alert-edit]").forEach((button) => {
+    const details = button.closest("details");
+    if (details) details.open = true;
   });
-  return result && typeof result === "object" ? result : {};
-}
-
-function lastStatisticValue(rows) {
-  const list = Array.isArray(rows) ? rows : [];
-  for (let index = list.length - 1; index >= 0; index -= 1) {
-    for (const key of ["sum", "state", "max"]) {
-      const value = numeric(list[index]?.[key]);
-      if (value != null) return value;
-    }
-  }
-  return null;
-}
-
-function periodConsumption(currentRows, baselineRows) {
-  const current = lastStatisticValue(currentRows);
-  const baseline = lastStatisticValue(baselineRows);
-  if (current == null) return 0;
-  if (baseline == null) return Math.max(0, current);
-  const delta = current - baseline;
-  return Math.max(0, delta >= 0 ? delta : current);
-}
-
-async function loadPeriod(kind, sources, now) {
-  const range = periodRange(kind, now);
-  const ids = Object.values(sources).filter(Boolean);
-  const [current, baseline] = await Promise.all([
-    requestStatistics(ids, range.start, range.end, range.period),
-    requestStatistics(ids, range.baselineStart, range.start, range.period),
-  ]);
-  return Object.freeze(
-    Object.fromEntries(
-      Object.entries(sources).map(([key, entity]) => [
-        key,
-        entity ? periodConsumption(current[entity], baseline[entity]) : 0,
-      ]),
-    ),
-  );
-}
-
-async function loadDevicePeriod(kind, devices, now) {
-  const range = periodRange(kind, now);
-  const ids = [...new Set(devices.map((device) => clean(device.entity)).filter(Boolean))];
-  const [current, baseline] = await Promise.all([
-    requestStatistics(ids, range.start, range.end, range.period),
-    requestStatistics(ids, range.baselineStart, range.start, range.period),
-  ]);
-  return new Map(
-    ids.map((entity) => [
-      entity,
-      periodConsumption(current[entity], baseline[entity]),
-    ]),
-  );
-}
-
-function energyRates() {
-  const read = (key) => {
-    const configured = root.cdCfg?.(key);
-    const raw = configured !== undefined && configured !== null && configured !== ""
-      ? configured
-      : root.localStorage?.getItem(key);
-    return numeric(raw) || 0;
-  };
-  return Object.freeze({
-    importPrice: read("cd_costo_kwh"),
-    exportPrice: read("cd_prezzo_immissione"),
-  });
-}
-
-function exposeEnergyState(label, detail = "") {
-  if (!doc?.documentElement) return;
-  doc.documentElement.dataset.dmVehicleEnergy = [
-    label,
-    root.WebSocket?.name || "none",
-    state.energyFailures,
-    detail,
-  ].join("|");
-}
-
-async function recoverEnergyBundle() {
-  const now = new Date();
-  const configuration = energyConfiguration();
-  if (!configuration.month.house) return false;
-  const devices = canonicalDevices();
-  const [day, month, year, deviceMonth, deviceYear] = await Promise.all([
-    loadPeriod("day", configuration.day, now),
-    loadPeriod("month", configuration.month, now),
-    loadPeriod("year", configuration.year, now),
-    loadDevicePeriod("month", devices, now),
-    loadDevicePeriod("year", devices, now),
-  ]);
-  const runtime = root.__DASHBOARDMODERN_RUNTIME_ROOT__;
-  if (!runtime) return false;
-  const generation = Math.max(
-    Number(runtime.generation) || 0,
-    Number(runtime.bundle?.generation) || 0,
-  ) + 1;
-  const bundle = Object.freeze({
-    generation,
-    period: Object.freeze({ month: now.getMonth() + 1, year: now.getFullYear() }),
-    day,
-    month,
-    year,
-    deviceMonth: Object.freeze({ devices, values: deviceMonth }),
-    deviceYear: Object.freeze({ devices, values: deviceYear }),
-    rates: energyRates(),
-  });
-  runtime.generation = generation;
-  runtime.bundle = bundle;
-  runtime.selected = bundle.period;
-  runtime.lastRefreshAt = Date.now();
-  root.__DASHBOARDMODERN_RUNTIME_0150__ = runtime;
-  applyAtomicEnergyBundle(bundle);
-  root.dispatchEvent?.(new CustomEvent("dashboardmodern:period-bundle", { detail: bundle }));
-  exposeEnergyState("done", `${day.house}/${month.house}/${year.house}`);
-  return true;
-}
-
-async function verifyEnergyBundle() {
-  const runtime = root.__DASHBOARDMODERN_RUNTIME_ROOT__;
-  const currentHouse = numeric(runtime?.bundle?.month?.house) || 0;
-  if (currentHouse !== 0) {
-    state.energyVerified = true;
-    exposeEnergyState("existing", String(currentHouse));
-    return;
-  }
-  if (state.energyRunning || !dashboardStore()) return;
-  if (root.WebSocket?.name === "StubSocket") {
-    state.energyVerified = false;
-    scheduleEnergyVerification();
-    return;
-  }
-  if (root.__DASHBOARDMODERN_STARTUP_COORDINATOR__?.running) {
-    state.energyVerified = false;
-    scheduleEnergyVerification();
-    return;
-  }
-
-  state.energyRunning = true;
-  state.energyVerified = false;
-  exposeEnergyState("running", energyConfiguration().month.house);
-  try {
-    const applied = await recoverEnergyBundle();
-    state.energyVerified = Boolean(applied);
-  } catch (error) {
-    state.energyFailures += 1;
-    exposeEnergyState("error", clean(error?.message || error));
-    recoveryBroker.reset?.(error);
-  } finally {
-    state.energyRunning = false;
-    if (!state.energyVerified && state.energyFailures < 8) scheduleEnergyVerification();
-  }
-}
-
-function scheduleEnergyVerification(delay = 80) {
-  root.clearTimeout?.(state.energyTimer);
-  state.energyTimer = root.setTimeout?.(() => {
-    state.energyTimer = 0;
-    verifyEnergyBundle();
-  }, delay);
 }
 
 function contractTick() {
   state.contractTimer = 0;
   state.contractAttempts += 1;
-  installFinalStyles();
+  installStyles();
+  applyVehicleAsset();
   exposeAlertEditors();
   const shuttersActive = syncShutterState();
-  scheduleEnergyVerification(0);
-  if (state.contractAttempts < 1200 || shuttersActive || !state.energyVerified) {
-    scheduleContracts(shuttersActive ? 100 : 50);
-  }
+  if (state.contractAttempts < 180 || shuttersActive) scheduleContracts(shuttersActive ? 100 : 60);
 }
 
 function scheduleContracts(delay = 0) {
@@ -490,17 +223,16 @@ function scheduleContracts(delay = 0) {
 
 function schedule() {
   root.queueMicrotask?.(applyVehicleAsset);
-  root.setTimeout?.(applyVehicleAsset, 40);
   scheduleContracts(0);
 }
 
 function install() {
-  if (!doc || doc.documentElement.dataset.dmVehicleImageRuntime === "1") return;
-  doc.documentElement.dataset.dmVehicleImageRuntime = "1";
+  if (!doc || doc.documentElement.dataset.dmVehicleImageRuntime === "2") return;
+  doc.documentElement.dataset.dmVehicleImageRuntime = "2";
   doc.addEventListener(
     "click",
     (event) => {
-      if (event.target?.closest?.('[data-tab="ev"],[data-page="ev"]')) schedule();
+      if (event.target?.closest?.('[data-tab="ev"],[data-page="ev"],.ed-tab[data-tab="sez2"]')) schedule();
       else scheduleContracts(0);
     },
     true,
@@ -515,6 +247,10 @@ function install() {
 state.apply = applyVehicleAsset;
 state.resolve = resolveVehicleAsset;
 state.scheduleContracts = scheduleContracts;
-state.verifyEnergy = verifyEnergyBundle;
+state.verifyEnergy = async () => {
+  state.energyRunning = false;
+  state.energyVerified = true;
+  return true;
+};
 if (doc?.readyState === "loading") doc.addEventListener("DOMContentLoaded", install, { once: true });
 else install();

--- a/custom_components/dashboardmodern/frontend/src/legacy/host.js
+++ b/custom_components/dashboardmodern/frontend/src/legacy/host.js
@@ -2,43 +2,26 @@
  * Hosts the vendored legacy dashboard inside the DashboardModern panel.
  *
  * The legacy dashboard is a complete HTML document that owns <html>, <body> and
- * ~250KB of unscoped CSS, so it is mounted in a same-origin iframe rather than
- * adopted into the panel's shadow root.
- *
- * No credential is passed into that iframe. Same-origin means the host can do
- * something better than handing over a token: it replaces the hosted document's
- * WebSocket constructor with a shim that forwards a fixed set of message types
- * through the panel's own authenticated connection. The hosted page therefore
- * has no credential to leak to the three CDN scripts it loads, and can perform
- * exactly the operations the dashboard needs and nothing else.
- *
- * The hosted HTML owns the single DashboardModern runtime. This host only owns
- * iframe lifecycle and the authenticated transport bridge; it never injects a
- * second runtime or a post-load patch into the child document.
+ * unscoped CSS, so it is mounted in a same-origin iframe. Authentication stays
+ * exclusively in the parent Home Assistant connection: the child receives only
+ * the restricted BridgeSocket constructor and never an access token.
  */
 
 import { createBridgeSocket } from "./bridge-socket.js";
 
 export const HOST_KEY = "__DASHBOARDMODERN_HOST__";
-export const LEGACY_FRAME_PERMISSIONS = "autoplay; fullscreen; picture-in-picture; encrypted-media";
+export const LEGACY_FRAME_PERMISSIONS =
+  "autoplay; fullscreen; picture-in-picture; encrypted-media";
 export const LEGACY_VARIANTS = Object.freeze({
   it: "dashboard.html",
   en: "dashboard-en.html",
 });
 
-/** Pick the vendored language variant for a Home Assistant locale. */
 export function legacyVariantForLocale(locale) {
   const normalized = typeof locale === "string" ? locale.toLowerCase() : "";
   return normalized.startsWith("it") ? LEGACY_VARIANTS.it : LEGACY_VARIANTS.en;
 }
 
-/**
- * Mount the hosted legacy dashboard.
- *
- * `staticBase` is the versioned static mount registered by frontend.py, so a
- * shipped dashboard update changes the URL and defeats the browser cache
- * without any user action.
- */
 export function mountLegacyHost(
   container,
   {
@@ -60,14 +43,12 @@ export function mountLegacyHost(
   }
 
   hostWindow[HOST_KEY] = true;
-  try {
-    const realToken = hass?.auth?.data?.access_token;
-    if (realToken) hostWindow.__DASHBOARDMODERN_REAL_TOKEN__ = realToken;
-    hostWindow.__DASHBOARDMODERN_INSTANCE__ = instanceId;
-    hostWindow.__DASHBOARDMODERN_PRIMARY__ = primary !== false;
-  } catch (_error) {
-    /* REST-dependent widgets degrade without turning the dashboard into a failed login. */
-  }
+  hostWindow.__DASHBOARDMODERN_INSTANCE__ = instanceId;
+  hostWindow.__DASHBOARDMODERN_PRIMARY__ = primary !== false;
+  // Remove credentials left by older DashboardModern versions. The bridge is
+  // already authenticated by Home Assistant and must be the only transport.
+  delete hostWindow.__DASHBOARDMODERN_REAL_TOKEN__;
+  delete hostWindow.DASHBOARDMODERN_AUTH_TOKEN;
 
   const file = variant || legacyVariantForLocale(hass?.locale?.language);
   const frame = documentRef.createElement("iframe");
@@ -85,8 +66,7 @@ export function mountLegacyHost(
   hostWindow.__DASHBOARDMODERN_BRIDGE_WS__ = BridgeSocket;
 
   const ensureHeight = () => {
-    if (typeof frame.clientHeight !== "number") return;
-    if (frame.clientHeight > 0) return;
+    if (typeof frame.clientHeight !== "number" || frame.clientHeight > 0) return;
     frame.style.height = "100dvh";
   };
 
@@ -96,8 +76,10 @@ export function mountLegacyHost(
     child.__DASHBOARDMODERN_INSTANCE__ = instanceId;
     child.__DASHBOARDMODERN_PRIMARY__ = primary !== false;
     child.__DASHBOARDMODERN_HOSTED__ = true;
-    child.WebSocket = BridgeSocket;
     child.__DASHBOARDMODERN_BRIDGED__ = true;
+    delete child.__DASHBOARDMODERN_REAL_TOKEN__;
+    delete child.DASHBOARDMODERN_AUTH_TOKEN;
+    child.WebSocket = BridgeSocket;
   };
 
   frame.addEventListener?.("load", install);
@@ -112,10 +94,11 @@ export function mountLegacyHost(
     destroy() {
       frame.remove();
       delete hostWindow[HOST_KEY];
-      delete hostWindow.__DASHBOARDMODERN_REAL_TOKEN__;
       delete hostWindow.__DASHBOARDMODERN_INSTANCE__;
       delete hostWindow.__DASHBOARDMODERN_PRIMARY__;
       delete hostWindow.__DASHBOARDMODERN_BRIDGE_WS__;
+      delete hostWindow.__DASHBOARDMODERN_REAL_TOKEN__;
+      delete hostWindow.DASHBOARDMODERN_AUTH_TOKEN;
     },
   };
 }

--- a/custom_components/dashboardmodern/frontend/tests/energy-report-inference.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energy-report-inference.test.js
@@ -8,7 +8,11 @@ import {
   reportEntityForDevice,
   reportIconForDevice,
 } from "../src/core/energy-projection.js";
-import { inferApplianceEntity, isGeneratedRoomName } from "../legacy/mobile-ui-fixes.js";
+import {
+  inferApplianceEntity,
+  isGeneratedRoomName,
+  normalizeVehiclePath,
+} from "../legacy/mobile-ui-fixes.js";
 
 test("infers a report entity from a generic kWh appliance entity", () => {
   const states = {
@@ -35,6 +39,7 @@ test("infers a report entity from a generic kWh appliance entity", () => {
       image: "",
       entity: "sensor.forno_consumo",
       history: "sensor.forno_consumo",
+      cumulative: false,
     },
   ]);
 });
@@ -67,6 +72,7 @@ test("prefers a cumulative total meter so Report can calculate months and years"
   const appliance = {
     id: "appliance-forno",
     name: "Forno",
+    report_entity: "sensor.forno_mese",
     monthly_energy_entity: "sensor.forno_mese",
     total_energy_entity: "sensor.forno_totale",
     entities: ["sensor.forno_mese", "sensor.forno_totale"],
@@ -75,6 +81,7 @@ test("prefers a cumulative total meter so Report can calculate months and years"
   assert.equal(isCumulativeEnergyEntity("sensor.forno_totale", states), true);
   assert.equal(reportEntityForDevice(appliance, states), "sensor.forno_totale");
   assert.equal(canonicalReportDevices([appliance], [], states)[0].history, "sensor.forno_totale");
+  assert.equal(canonicalReportDevices([appliance], [], states)[0].cumulative, true);
 });
 
 test("projects a cumulative grid meter only to its lifetime slot and preserves explicit periods", () => {
@@ -196,4 +203,9 @@ test("appliance entity inference distinguishes energy from power", () => {
   };
   assert.equal(inferApplianceEntity(device, states, "power"), "sensor.forno_assorbimento");
   assert.equal(inferApplianceEntity(device, states, "energy"), "sensor.forno_totale");
+});
+
+test("normalizes the common /loca typo without creating a new asset path", () => {
+  assert.equal(normalizeVehiclePath("/loca/ev/idle.png"), "/local/ev/idle.png");
+  assert.equal(normalizeVehiclePath("config/www/ev/idle.png"), "/local/ev/idle.png");
 });

--- a/custom_components/dashboardmodern/frontend/tests/release-0152-version.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-0152-version.test.js
@@ -9,13 +9,13 @@ const rootIconUrl = new URL("../../../../brand/icon.png", import.meta.url);
 const rootLogoUrl = new URL("../../../../brand/logo.png", import.meta.url);
 const productionEntryUrl = new URL("../legacy/report-mobile-fixes.js", import.meta.url);
 
-test("the real UI hotfix release is consistently versioned as 0.15.3", async () => {
+test("the real UI hotfix release is consistently versioned as 0.15.4", async () => {
   const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
   const readme = await readFile(readmeUrl, "utf8");
 
-  assert.equal(manifest.version, "0.15.3");
-  assert.match(readme, /version-0\.15\.3/);
-  assert.match(readme, /Release 0\.15\.3/);
+  assert.equal(manifest.version, "0.15.4");
+  assert.match(readme, /version-0\.15\.4/);
+  assert.match(readme, /Release 0\.15\.4/);
   assert.doesNotMatch(readme, /version-0\.14\.15|Release 0\.14\.15|Novità 0\.14\.15/);
   assert.match(
     readme,

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "0.15.3"
+  "version": "0.15.4"
 }


### PR DESCRIPTION
## Problemi riprodotti su Home Assistant reale

- descrizioni mancanti per i contatori Energia totale;
- URL auto `/loca/...` non normalizzato e immagine fallita forzata visibile;
- stato Temperatura mostrato come pallino anziché testo;
- card Elettrodomestici poco leggibili e non coerenti in dark mode;
- flussi mensili transitoriamente errati per un secondo recupero Recorder;
- tentativo di autenticazione locale non necessario;
- dettaglio Report dispositivo incompleto sui mesi precedenti;
- editor Report graficamente incoerente;
- elementi esistenti non modificabili in Azioni, Clima, Tapparelle e Stanze.

## Vincolo strutturale

La correzione modifica esclusivamente file già esistenti. Non vengono creati nuovi runtime, moduli, test file, observer document-wide o intervalli permanenti.

## Lavoro in corso

Il PR non verrà unito né pubblicato finché Tests, HACS, hassfest e Browser E2E con i nuovi contratti reali non saranno tutti verdi.