### PR TITLE
fix: correct live daily energy and appliance daily totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,33 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.15.21-0ea5e9" alt="Versione 0.15.21">
+  <img src="https://img.shields.io/badge/version-0.15.22-0ea5e9" alt="Versione 0.15.22">
   <img src="https://img.shields.io/badge/HACS-custom-41BDF5" alt="HACS custom integration">
   <img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-1e3a8a" alt="Home Assistant 2025.1+">
   <img src="https://img.shields.io/badge/UI-Italiano%20%7C%20English-16a34a" alt="Italiano e inglese">
 </p>
 
 > **English overview** — DashboardModern is a responsive, multi-instance Home
-> Assistant dashboard distributed as a HACS custom integration. Release 0.15.21
-> restores full appliance catalog parity between Add and Edit, preserves linked
-> entities while editing, and hardens stale frontend asset recovery after updates.
+> Assistant dashboard distributed as a HACS custom integration. Release 0.15.22
+> fixes current-day Energy freshness, prevents appliance lifetime counters from
+> being displayed as daily consumption, and adds a per-entity daily breakdown.
 
 ---
 
-## Novità 0.15.21
+## Novità 0.15.22
+
+La 0.15.22 corregge i valori **Energia giornaliera** e il totale giornaliero degli **Elettrodomestici** verificati contro i dati reali dell'impianto.
+
+- i contatori cumulativi usati per il giorno corrente vengono letti con statistiche Recorder a breve intervallo, evitando che FV, rete, batteria e Casa restino indietro dell'ora ancora aperta;
+- il bilancio Casa resta quello canonico: `FV + Rete prelevata + Batteria scaricata − Rete immessa − Batteria caricata`;
+- un sensore totale/lifetime di un elettrodomestico non viene mai più sommato direttamente nel KPI **Energia giornaliera**;
+- se esiste un sensore giornaliero esplicito viene usato direttamente; altrimenti un contatore `total` / `total_increasing` viene trasformato nel delta di oggi tramite Recorder;
+- sensori energia non cumulativi e non dichiarati come giornalieri non entrano nel totale;
+- cliccando il totale **Energia giornaliera** degli Elettrodomestici si apre un popup responsive con dispositivo, entità sorgente, kWh, percentuale e tipo di sorgente;
+- dal dettaglio è possibile passare allo storico della singola entità quando disponibile;
+- Browser E2E e test unitari coprono esplicitamente il caso in cui un contatore lifetime da 20 kWh non deve diventare consumo di oggi.
+
+### 0.15.21 — catalogo Elettrodomestici e runtime frontend
 
 La 0.15.21 completa la correzione Elettrodomestici e del runtime frontend emersa dopo la 0.15.20.
 

--- a/custom_components/dashboardmodern/frontend/e2e/appliance-daily-energy.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/appliance-daily-energy.spec.js
@@ -1,0 +1,168 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const states = [
+  {
+    entity_id: "switch.fridge",
+    state: "on",
+    attributes: { friendly_name: "Frigorifero", device_class: "outlet" },
+  },
+  {
+    entity_id: "sensor.fridge_power",
+    state: "85",
+    attributes: { friendly_name: "Frigorifero power", unit_of_measurement: "W" },
+  },
+  {
+    entity_id: "sensor.fridge_today",
+    state: "0.81",
+    attributes: {
+      friendly_name: "Frigorifero oggi",
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "total_increasing",
+    },
+  },
+  {
+    entity_id: "sensor.fridge_total",
+    state: "120.4",
+    attributes: {
+      friendly_name: "Frigorifero totale",
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "total_increasing",
+    },
+  },
+  {
+    entity_id: "sensor.microwave_total",
+    state: "20.0",
+    attributes: {
+      friendly_name: "Microonde totale",
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "total_increasing",
+    },
+  },
+];
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [{ id: "room-home", name: "Casa", icon: "mdi:home" }],
+    appliances: [
+      {
+        id: "fridge",
+        name: "Frigorifero",
+        device_type: "frigo",
+        visual_key: "frigo",
+        room_id: "room-home",
+        control_entity: "switch.fridge",
+        power_entity: "sensor.fridge_power",
+        daily_energy_entity: "sensor.fridge_today",
+        total_energy_entity: "sensor.fridge_total",
+        entities: ["switch.fridge", "sensor.fridge_power", "sensor.fridge_total"],
+      },
+      {
+        id: "microwave",
+        name: "Microonde",
+        device_type: "microonde",
+        visual_key: "microonde",
+        room_id: "room-home",
+        total_energy_entity: "sensor.microwave_total",
+        entities: ["sensor.microwave_total"],
+      },
+    ],
+    loads: [],
+  },
+  visibility: { appliances: true },
+};
+
+async function boot(page, variant, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript((haStates) => {
+    window.__dmStatisticsPeriods = [];
+    class MockSocket extends EventTarget {
+      static OPEN = 1;
+      readyState = MockSocket.OPEN;
+      onopen = null;
+      onmessage = null;
+      onclose = null;
+      onerror = null;
+      constructor() {
+        super();
+        queueMicrotask(() => {
+          this.onopen?.({});
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+        });
+      }
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") return;
+        let result = null;
+        if (message.type === "get_states") result = haStates;
+        else if (message.type === "frontend/get_user_data") result = { value: null };
+        else if (message.type === "subscribe_events") result = null;
+        else if (message.type === "recorder/statistics_during_period") {
+          window.__dmStatisticsPeriods.push(message.period);
+          const requestStart = new Date(message.start_time).getTime();
+          const requestEnd = new Date(message.end_time).getTime();
+          result = {};
+          for (const entity of message.statistic_ids || []) {
+            if (entity !== "sensor.microwave_total") {
+              result[entity] = [];
+              continue;
+            }
+            result[entity] = [
+              { start: new Date(requestStart + 30 * 60 * 1000).toISOString(), sum: 100 },
+              { start: new Date(requestEnd - 60 * 1000).toISOString(), sum: 100.05 },
+            ];
+          }
+        }
+        this.onmessage?.({
+          data: JSON.stringify({ id: message.id, type: "result", success: true, result }),
+        });
+      }
+      close() {
+        this.onclose?.({});
+      }
+    }
+    window.__DASHBOARDMODERN_BRIDGE_WS__ = MockSocket;
+    window.WebSocket = MockSocket;
+  }, states);
+
+  await bootNamespacedDashboard(page, variant, testInfo, seed);
+  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await page.waitForFunction(() => window.__DASHBOARDMODERN_RUNTIME_ROOT__?.ready === true);
+  await page.evaluate(
+    (haStates) => haStates.forEach((item) => {
+      _RAW_STATES[item.entity_id] = structuredClone(item);
+      STATES[item.entity_id] = structuredClone(item);
+    }),
+    states,
+  );
+  await page.locator(".tab[data-tab='appliances-main']").click();
+}
+
+for (const variant of ["dashboard.html", "dashboard-en.html"]) {
+  test(`${variant}: daily appliance KPI uses period-safe values and opens entity breakdown`, async ({ page }, testInfo) => {
+    if (testInfo.project.name === "webkit-ipad") test.slow(true, "Recorder-backed popup is slower on WebKit/iPad");
+    await boot(page, variant, testInfo);
+
+    const dailyCard = page.locator('#appl-kpi-grid [data-dm-appliance-daily-total="true"]');
+    await expect(dailyCard).toBeVisible();
+    await expect.poll(async () => dailyCard.locator(".g-val").textContent()).toMatch(/0[.,]86 kWh/i);
+    await expect(dailyCard.locator(".g-val")).not.toContainText("20.0");
+
+    await dailyCard.click();
+    const popup = page.locator("#dm-appliance-daily-popup");
+    await expect(popup).toBeVisible();
+    await expect(popup.locator("[data-dm-daily-popup-total]")).toContainText(/0[.,]86 kWh/i);
+    await expect(popup.locator("[data-dm-daily-entity]")).toHaveCount(2);
+    await expect(popup).toContainText("sensor.fridge_today");
+    await expect(popup).toContainText("sensor.microwave_total");
+    await expect(popup).toContainText(/0[.,]81 kWh/i);
+    await expect(popup).toContainText(/0[.,]05 kWh/i);
+
+    const periods = await page.evaluate(() => window.__dmStatisticsPeriods);
+    expect(periods).toContain("5minute");
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/appliance-daily-energy.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/appliance-daily-energy.spec.js
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { clickBottomTab } from "./helpers/navigation.js";
 
 const states = [
   {
@@ -139,7 +140,7 @@ async function boot(page, variant, testInfo) {
     }),
     states,
   );
-  await page.locator(".tab[data-tab='appliances-main']").click();
+  await clickBottomTab(page, "appliances", testInfo);
 }
 
 for (const variant of ["dashboard.html", "dashboard-en.html"]) {

--- a/custom_components/dashboardmodern/frontend/e2e/helpers/consolidated-runtime.js
+++ b/custom_components/dashboardmodern/frontend/e2e/helpers/consolidated-runtime.js
@@ -285,7 +285,7 @@ export async function bootConsolidatedDashboard(page, variant, testInfo) {
             const isCurrentMonth =
               message.period === "day" && endTime > currentTime && endTime <= now.getTime() + 86_400_000;
             const selected =
-              message.period === "hour"
+              message.period === "hour" || message.period === "5minute"
                 ? daily
                 : message.period === "month"
                   ? annual

--- a/custom_components/dashboardmodern/frontend/src/sections/appliances-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/appliances-section.js
@@ -1,5 +1,6 @@
 import { applianceArtwork, canonicalArtworkType } from "../core/appliance-artwork.js";
 import { createApplianceViewModel } from "../core/appliance-view-model.js";
+import { isCumulativeEnergyEntity, resolveEntity } from "../core/period-service.js";
 import { runtimeMetrics } from "../core/runtime-metrics.js";
 import {
   allStates,
@@ -7,6 +8,7 @@ import {
   dashboardStore,
   doc,
   english,
+  esc,
   installStyle,
   root,
   section,
@@ -14,13 +16,143 @@ import {
 } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_APPLIANCES_SECTION__";
+const DAILY_REFRESH_MS = 5000;
 const state = (root[KEY] ||= {
   installed: false,
   listeners: false,
   normalizing: false,
   frame: 0,
   storeUnsubscribe: null,
+  dailyBreakdown: Object.freeze({ total: 0, rows: [] }),
+  dailyUpdatedAt: 0,
+  dailyPromise: null,
+  dailyGeneration: 0,
 });
+
+function configuredEntity(value) {
+  return clean(typeof value === "string" ? value : value?.entity || value?.entity_id);
+}
+
+function resolvedEntity(value) {
+  const entity = configuredEntity(value);
+  return entity ? resolveEntity(entity) : "";
+}
+
+function energyValueKwh(entity, states = {}) {
+  const id = resolvedEntity(entity);
+  const snapshot = states[id] || states[configuredEntity(entity)];
+  const numeric = Number(snapshot?.state);
+  if (!Number.isFinite(numeric)) return null;
+  const unit = clean(snapshot?.attributes?.unit_of_measurement).toLowerCase();
+  if (unit === "wh") return Math.max(0, numeric / 1000);
+  if (unit === "mwh") return Math.max(0, numeric * 1000);
+  if (unit && unit !== "kwh") return null;
+  return Math.max(0, numeric);
+}
+
+export function applianceDailySource(device = {}, states = {}) {
+  const directCandidates = [
+    device.daily_energy_entity,
+    device.energy_today,
+    device.daily_energy,
+  ]
+    .map(configuredEntity)
+    .filter(Boolean);
+  const direct = directCandidates.find((entity) => energyValueKwh(entity, states) != null);
+  if (direct) {
+    return {
+      entity: resolvedEntity(direct),
+      source: direct,
+      direct: true,
+      reason: "explicit-daily",
+    };
+  }
+
+  const cumulativeCandidates = [
+    device.total_energy_entity,
+    device.history_entity,
+    device.report_entity,
+    device.energy_entity,
+    device.energy,
+    ...(device.entities || []),
+  ]
+    .map(configuredEntity)
+    .filter(Boolean);
+  const seen = new Set();
+  const cumulative = cumulativeCandidates.find((entity) => {
+    if (seen.has(entity)) return false;
+    seen.add(entity);
+    return isCumulativeEnergyEntity(entity, states, (value) => resolveEntity(value));
+  });
+  if (!cumulative) return null;
+  return {
+    entity: resolvedEntity(cumulative),
+    source: cumulative,
+    direct: false,
+    reason: "cumulative-recorder",
+  };
+}
+
+export async function buildApplianceDailyBreakdown(
+  applianceList = [],
+  states = {},
+  broker = root.DashboardModernEnergyService?.broker,
+  selected = new Date(),
+) {
+  const rows = [];
+  const plans = [];
+  const planRows = new Map();
+
+  applianceList.forEach((device, index) => {
+    const source = applianceDailySource(device, states);
+    if (!source) return;
+    const row = {
+      id: clean(device.id) || `appliance-${index}`,
+      name: clean(device.name) || (english() ? "Appliance" : "Elettrodomestico"),
+      entity: source.entity,
+      source: source.source,
+      direct: source.direct,
+      reason: source.reason,
+      value: null,
+    };
+    if (source.direct) {
+      row.value = energyValueKwh(source.source, states);
+    } else {
+      const key = `appliance:${row.id}:${index}`;
+      plans.push({
+        key,
+        entity: source.entity,
+        source: source.source,
+        kind: "day",
+        direct: false,
+        reason: source.reason,
+      });
+      planRows.set(key, row);
+    }
+    rows.push(row);
+  });
+
+  if (plans.length && broker?.valuesForPlans) {
+    try {
+      const values = await broker.valuesForPlans(plans, selected, states);
+      planRows.forEach((row, key) => {
+        const value = Number(values?.get?.(key));
+        row.value = Number.isFinite(value) ? Math.max(0, value) : null;
+      });
+    } catch (error) {
+      root.console?.warn?.("[DashboardModern] appliance daily Recorder lookup failed", error);
+    }
+  }
+
+  const consumed = rows
+    .filter((row) => Number.isFinite(row.value) && row.value > 0.0005)
+    .sort((left, right) => right.value - left.value);
+  const total = consumed.reduce((sum, row) => sum + row.value, 0);
+  return Object.freeze({
+    total: Math.round(total * 1000) / 1000,
+    rows: Object.freeze(consumed.map((row) => Object.freeze({ ...row }))),
+  });
+}
 
 export function inferApplianceEntity(device = {}, states = {}, kind = "energy") {
   const candidates = [
@@ -72,7 +204,7 @@ function applianceEntityIds() {
       device.report_entity,
       ...(device.entities || []),
     ]) {
-      const id = clean(typeof value === "string" ? value : value?.entity || value?.entity_id);
+      const id = configuredEntity(value);
       if (id) ids.add(id);
     }
   });
@@ -232,6 +364,147 @@ function ensureToggle(card, model) {
   hideLegacyPowerOnly(card);
 }
 
+function dailyCard() {
+  const cards = [...(doc?.querySelectorAll?.("#appl-kpi-grid .glance-card") || [])];
+  return (
+    cards.find((card) => /energia giornaliera|daily energy/i.test(clean(card.textContent))) ||
+    cards[2] ||
+    null
+  );
+}
+
+function formatDaily(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return "— kWh";
+  if (numeric >= 10) return `${numeric.toFixed(1)} kWh`;
+  return `${numeric.toFixed(2).replace(/0+$/, "").replace(/\.$/, "")} kWh`;
+}
+
+function renderDailyPopup(breakdown = state.dailyBreakdown, { loading = false } = {}) {
+  const popup = doc?.getElementById("dm-appliance-daily-popup");
+  if (!popup) return;
+  const total = popup.querySelector("[data-dm-daily-popup-total]");
+  const list = popup.querySelector("[data-dm-daily-popup-list]");
+  if (total) total.textContent = loading ? "…" : formatDaily(breakdown.total);
+  if (!list) return;
+  if (loading) {
+    list.innerHTML = `<div class="dm-appliance-daily-empty">${english() ? "Updating Recorder data…" : "Aggiornamento dati Recorder…"}</div>`;
+    return;
+  }
+  if (!breakdown.rows.length) {
+    list.innerHTML = `<div class="dm-appliance-daily-empty">${english() ? "No appliance has measurable consumption today." : "Nessun elettrodomestico ha un consumo giornaliero misurabile."}</div>`;
+    return;
+  }
+  list.innerHTML = breakdown.rows
+    .map((row) => {
+      const pct = breakdown.total > 0 ? Math.round((row.value / breakdown.total) * 100) : 0;
+      const source = row.direct
+        ? english() ? "Daily sensor" : "Sensore giornaliero"
+        : english() ? "Total meter → Recorder" : "Contatore totale → Recorder";
+      return `<button type="button" class="dm-appliance-daily-row" data-dm-daily-entity="${esc(row.entity)}">
+        <span class="dm-appliance-daily-row-main"><strong>${esc(row.name)}</strong><small>${esc(row.entity)}</small><small>${source}</small></span>
+        <span class="dm-appliance-daily-row-value"><strong>${formatDaily(row.value)}</strong><small>${pct}%</small></span>
+      </button>`;
+    })
+    .join("");
+  list.querySelectorAll("[data-dm-daily-entity]").forEach((row) => {
+    row.addEventListener("click", (event) => {
+      const entity = clean(row.dataset.dmDailyEntity);
+      if (!entity || typeof root.apriStorico !== "function") return;
+      event.stopPropagation();
+      root.apriStorico(event, entity, row.querySelector("strong")?.textContent || entity);
+    });
+  });
+}
+
+function ensureDailyPopup() {
+  if (!doc?.body) return null;
+  let popup = doc.getElementById("dm-appliance-daily-popup");
+  if (popup) return popup;
+  popup = doc.createElement("div");
+  popup.id = "dm-appliance-daily-popup";
+  popup.className = "dm-appliance-daily-overlay";
+  popup.hidden = true;
+  popup.innerHTML = `<div class="dm-appliance-daily-dialog" role="dialog" aria-modal="true" aria-labelledby="dm-appliance-daily-title">
+    <div class="dm-appliance-daily-head"><div><small>${english() ? "TODAY" : "OGGI"}</small><h3 id="dm-appliance-daily-title">${english() ? "Appliance energy" : "Energia elettrodomestici"}</h3></div><button type="button" data-dm-daily-close aria-label="${english() ? "Close" : "Chiudi"}">✕</button></div>
+    <div class="dm-appliance-daily-total"><span>${english() ? "Measured total" : "Totale misurato"}</span><strong data-dm-daily-popup-total>— kWh</strong></div>
+    <div class="dm-appliance-daily-list" data-dm-daily-popup-list></div>
+    <div class="dm-appliance-daily-note">${english() ? "Only daily sensors or Recorder deltas from cumulative total meters are counted. Lifetime values are never added directly." : "Sono conteggiati solo sensori giornalieri o delta Recorder dei contatori cumulativi. I valori lifetime non vengono mai sommati direttamente."}</div>
+  </div>`;
+  const close = () => {
+    popup.hidden = true;
+    popup.classList.remove("show");
+  };
+  popup.addEventListener("click", (event) => {
+    if (event.target === popup) close();
+  });
+  popup.querySelector("[data-dm-daily-close]")?.addEventListener("click", close);
+  doc.body.append(popup);
+  return popup;
+}
+
+async function refreshApplianceDailyKpi({ force = false, openPopup = false } = {}) {
+  const card = dailyCard();
+  if (!card) return state.dailyBreakdown;
+  if (openPopup) {
+    const popup = ensureDailyPopup();
+    if (popup) {
+      popup.hidden = false;
+      popup.classList.add("show");
+      renderDailyPopup(state.dailyBreakdown, { loading: true });
+    }
+  }
+  const age = Date.now() - state.dailyUpdatedAt;
+  if (!force && state.dailyUpdatedAt && age < DAILY_REFRESH_MS) {
+    applyDailyKpi(state.dailyBreakdown);
+    if (openPopup) renderDailyPopup(state.dailyBreakdown);
+    return state.dailyBreakdown;
+  }
+  if (state.dailyPromise) return state.dailyPromise;
+  const generation = ++state.dailyGeneration;
+  const applianceList = devices();
+  const states = allStates();
+  const broker = root.DashboardModernEnergyService?.broker;
+  state.dailyPromise = buildApplianceDailyBreakdown(applianceList, states, broker)
+    .then((breakdown) => {
+      if (generation !== state.dailyGeneration) return state.dailyBreakdown;
+      state.dailyBreakdown = breakdown;
+      state.dailyUpdatedAt = Date.now();
+      applyDailyKpi(breakdown);
+      if (!ensureDailyPopup()?.hidden) renderDailyPopup(breakdown);
+      return breakdown;
+    })
+    .finally(() => {
+      if (generation === state.dailyGeneration) state.dailyPromise = null;
+    });
+  return state.dailyPromise;
+}
+
+function applyDailyKpi(breakdown = state.dailyBreakdown) {
+  const card = dailyCard();
+  if (!card) return false;
+  card.dataset.dmApplianceDailyTotal = "true";
+  card.setAttribute("role", "button");
+  card.tabIndex = 0;
+  card.setAttribute(
+    "aria-label",
+    english() ? "Open today's appliance energy breakdown" : "Apri dettaglio energia elettrodomestici di oggi",
+  );
+  card.title = english() ? "Show devices and energy sources" : "Mostra dispositivi ed entità che hanno consumato";
+  const value = card.querySelector(".g-val");
+  if (value) value.textContent = formatDaily(breakdown.total);
+  if (!card.dataset.dmDailyMounted) {
+    card.dataset.dmDailyMounted = "true";
+    card.addEventListener("click", () => refreshApplianceDailyKpi({ force: true, openPopup: true }));
+    card.addEventListener("keydown", (event) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      refreshApplianceDailyKpi({ force: true, openPopup: true });
+    });
+  }
+  return true;
+}
+
 export function normalizeApplianceCards() {
   if (!doc || state.normalizing) return false;
   const configured = devices();
@@ -275,7 +548,9 @@ export function scheduleApplianceNormalization() {
   if (!appliancesVisible() || state.frame) return;
   const run = () => {
     state.frame = 0;
-    if (appliancesVisible()) normalizeApplianceCards();
+    if (!appliancesVisible()) return;
+    normalizeApplianceCards();
+    refreshApplianceDailyKpi();
   };
   state.frame = root.requestAnimationFrame?.(run) || root.setTimeout?.(run, 0);
 }
@@ -303,6 +578,15 @@ function installStyles() {
       #page-appliances-main .dm-appliance-image,#appl-grid-overview .dm-appliance-image{
         object-fit:cover!important;object-position:center!important
       }
+      #appl-kpi-grid [data-dm-appliance-daily-total="true"]{cursor:pointer!important;outline-offset:3px}
+      #appl-kpi-grid [data-dm-appliance-daily-total="true"]:active{transform:scale(.985)}
+      .dm-appliance-daily-overlay[hidden]{display:none!important}
+      .dm-appliance-daily-overlay{position:fixed;inset:0;z-index:2147483000;background:rgba(15,23,42,.58);display:flex;align-items:center;justify-content:center;padding:18px;backdrop-filter:blur(7px)}
+      .dm-appliance-daily-dialog{width:min(560px,100%);max-height:min(78vh,720px);overflow:hidden;background:var(--card-bg,#fff);color:var(--text,#0f172a);border:1px solid var(--card-border,#e2e8f0);border-radius:24px;box-shadow:0 24px 70px rgba(15,23,42,.28);display:flex;flex-direction:column}
+      .dm-appliance-daily-head{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:20px 20px 12px}.dm-appliance-daily-head small{font-size:10px;letter-spacing:2px;font-weight:900;color:var(--text-dim,#64748b)}.dm-appliance-daily-head h3{margin:2px 0 0;font-size:22px}.dm-appliance-daily-head button{width:40px;height:40px;border:0;border-radius:12px;background:rgba(148,163,184,.14);color:inherit;font-size:18px;cursor:pointer}
+      .dm-appliance-daily-total{margin:0 20px 12px;padding:16px 18px;border-radius:18px;background:linear-gradient(135deg,rgba(14,165,233,.14),rgba(56,189,248,.05));display:flex;align-items:center;justify-content:space-between;gap:14px}.dm-appliance-daily-total span{font-size:12px;font-weight:800;color:var(--text-dim,#64748b);text-transform:uppercase;letter-spacing:1px}.dm-appliance-daily-total strong{font-size:24px;color:#0284c7;white-space:nowrap}
+      .dm-appliance-daily-list{overflow:auto;padding:0 20px 10px;display:grid;gap:8px}.dm-appliance-daily-row{width:100%;display:flex;align-items:center;justify-content:space-between;gap:14px;text-align:left;padding:13px 14px;border:1px solid var(--card-border,#e2e8f0);border-radius:15px;background:rgba(148,163,184,.06);color:inherit;cursor:pointer}.dm-appliance-daily-row-main,.dm-appliance-daily-row-value{display:flex;flex-direction:column;min-width:0}.dm-appliance-daily-row-main{gap:2px}.dm-appliance-daily-row-main strong{font-size:14px}.dm-appliance-daily-row-main small{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-dim,#64748b);font:10px/1.35 ui-monospace,SFMono-Regular,Menlo,monospace}.dm-appliance-daily-row-value{align-items:flex-end;flex:0 0 auto}.dm-appliance-daily-row-value strong{color:#0284c7;font-size:14px}.dm-appliance-daily-row-value small{color:var(--text-dim,#64748b);font-size:10px;font-weight:800}.dm-appliance-daily-empty{padding:22px;text-align:center;color:var(--text-dim,#64748b);font-weight:700}.dm-appliance-daily-note{margin:0 20px 18px;padding-top:10px;border-top:1px solid var(--card-border,#e2e8f0);color:var(--text-dim,#64748b);font-size:10px;line-height:1.45}
+      @media(max-width:520px){.dm-appliance-daily-overlay{align-items:flex-end;padding:10px}.dm-appliance-daily-dialog{max-height:82vh;border-radius:24px 24px 18px 18px}.dm-appliance-daily-head{padding:18px 16px 10px}.dm-appliance-daily-total{margin:0 16px 10px}.dm-appliance-daily-list{padding:0 16px 10px}.dm-appliance-daily-note{margin:0 16px 16px}.dm-appliance-daily-row{padding:12px}}
     `,
   );
 }
@@ -322,7 +606,11 @@ function installWrappers() {
 function subscribeStore() {
   if (state.storeUnsubscribe || !dashboardStore()?.subscribe) return;
   state.storeUnsubscribe = dashboardStore().subscribe((change) => {
-    if (change.section === "appliances" && appliancesVisible()) scheduleApplianceNormalization();
+    if (change.section === "appliances" && appliancesVisible()) {
+      state.dailyUpdatedAt = 0;
+      state.dailyGeneration += 1;
+      scheduleApplianceNormalization();
+    }
   });
 }
 
@@ -331,10 +619,12 @@ export function installAppliancesSection() {
   installStyles();
   installWrappers();
   subscribeStore();
+  ensureDailyPopup();
   if (!state.listeners) {
     state.listeners = true;
     root.addEventListener?.("dashboardmodern:state-changed", (event) => {
       if (appliancesVisible() && stateChangeAffectsAppliances(event)) {
+        state.dailyUpdatedAt = 0;
         scheduleApplianceNormalization();
       }
     });

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-refresh-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-refresh-section.js
@@ -1,7 +1,12 @@
 import { doc, root } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_ENERGY_REFRESH_SECTION__";
-const state = (root[KEY] ||= { installed: false, refreshQueued: false });
+const LIVE_WINDOW_MS = 10 * 60 * 1000;
+const state = (root[KEY] ||= {
+  installed: false,
+  refreshQueued: false,
+  liveStatisticsInstalled: false,
+});
 
 export function initializeEnergyPeriodControls(now = new Date(), documentRef = doc) {
   const month = documentRef?.getElementById("ed-sel-month");
@@ -21,6 +26,31 @@ export function initializeEnergyPeriodControls(now = new Date(), documentRef = d
   return true;
 }
 
+export function liveStatisticsPeriod(period, end, now = Date.now()) {
+  if (period !== "hour") return period;
+  const endMs = new Date(end).getTime();
+  if (!Number.isFinite(endMs) || Math.abs(now - endMs) > LIVE_WINDOW_MS) return period;
+  // Current-day totals previously used hourly Recorder buckets. During the open
+  // hour that can leave Solar/Grid/Battery almost one hour behind the live
+  // inverter. Short-term 5-minute statistics keep the same reset-aware `sum`
+  // contract while reducing that live gap to one short-statistics interval.
+  return "5minute";
+}
+
+export function installLiveStatisticsGranularity(service = root.DashboardModernEnergyService) {
+  const broker = service?.broker;
+  if (!broker?.statistics || broker.__dmLiveStatisticsGranularity) return false;
+  const original = broker.statistics.bind(broker);
+  broker.statistics = (ids, start, end, period = "day") =>
+    original(ids, start, end, liveStatisticsPeriod(period, end));
+  Object.defineProperty(broker, "__dmLiveStatisticsGranularity", {
+    value: true,
+    configurable: true,
+  });
+  state.liveStatisticsInstalled = true;
+  return true;
+}
+
 function energyVisible() {
   return Boolean(
     doc?.querySelector("#page-energy.active,#page-energy-main.active") ||
@@ -30,6 +60,7 @@ function energyVisible() {
 
 function queueRefresh({ force = true } = {}) {
   initializeEnergyPeriodControls();
+  installLiveStatisticsGranularity();
   if (state.refreshQueued) return;
   state.refreshQueued = true;
   root.queueMicrotask?.(() => {
@@ -47,6 +78,7 @@ export function installEnergyRefreshSection() {
   // Synchronous on purpose: this runs in the same module turn as Energy and
   // therefore beats the setTimeout(0) used by its first scheduled refresh.
   initializeEnergyPeriodControls();
+  installLiveStatisticsGranularity();
 
   root.addEventListener?.("dashboardmodern:states-ready", () => queueRefresh({ force: true }));
   root.addEventListener?.("dashboardmodern:legacy-ready", () => queueRefresh({ force: true }));

--- a/custom_components/dashboardmodern/frontend/tests/daily-energy-breakdown.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/daily-energy-breakdown.test.js
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applianceDailySource,
+  buildApplianceDailyBreakdown,
+} from "../src/sections/appliances-section.js";
+import { liveStatisticsPeriod } from "../src/sections/energy-refresh-section.js";
+
+test("appliance daily total never adds a lifetime meter state directly", async () => {
+  const states = {
+    "sensor.fridge_today": {
+      state: "0.81",
+      attributes: { unit_of_measurement: "kWh", state_class: "total_increasing" },
+    },
+    "sensor.fridge_total": {
+      state: "120.4",
+      attributes: { unit_of_measurement: "kWh", state_class: "total_increasing" },
+    },
+    "sensor.microwave_total": {
+      state: "20.0",
+      attributes: { unit_of_measurement: "kWh", state_class: "total_increasing" },
+    },
+    "sensor.bad_energy": {
+      state: "99",
+      attributes: { unit_of_measurement: "kWh", state_class: "measurement" },
+    },
+  };
+  const appliances = [
+    {
+      id: "fridge",
+      name: "Frigorifero",
+      daily_energy_entity: "sensor.fridge_today",
+      total_energy_entity: "sensor.fridge_total",
+      entities: ["sensor.fridge_total"],
+    },
+    {
+      id: "microwave",
+      name: "Microonde",
+      total_energy_entity: "sensor.microwave_total",
+      entities: ["sensor.microwave_total"],
+    },
+    {
+      id: "bad",
+      name: "Valore non periodale",
+      entities: ["sensor.bad_energy"],
+    },
+  ];
+  let receivedPlans = [];
+  const broker = {
+    async valuesForPlans(plans) {
+      receivedPlans = plans;
+      return new Map([[plans[0].key, 0.05]]);
+    },
+  };
+
+  const result = await buildApplianceDailyBreakdown(appliances, states, broker, new Date());
+
+  assert.equal(receivedPlans.length, 1);
+  assert.equal(receivedPlans[0].entity, "sensor.microwave_total");
+  assert.equal(receivedPlans[0].direct, false);
+  assert.equal(result.rows.length, 2);
+  assert.equal(result.rows[0].name, "Frigorifero");
+  assert.equal(result.rows[0].value, 0.81);
+  assert.equal(result.rows[1].name, "Microonde");
+  assert.equal(result.rows[1].value, 0.05);
+  assert.equal(result.total, 0.86);
+  assert.notEqual(result.total, 20.81);
+  assert.ok(!result.rows.some((row) => row.entity === "sensor.bad_energy"));
+});
+
+test("explicit daily appliance sensor wins over a configured lifetime total", () => {
+  const states = {
+    "sensor.device_today": {
+      state: "1250",
+      attributes: { unit_of_measurement: "Wh", state_class: "total_increasing" },
+    },
+    "sensor.device_total": {
+      state: "600",
+      attributes: { unit_of_measurement: "kWh", state_class: "total_increasing" },
+    },
+  };
+  const source = applianceDailySource(
+    {
+      daily_energy_entity: "sensor.device_today",
+      total_energy_entity: "sensor.device_total",
+    },
+    states,
+  );
+  assert.equal(source.entity, "sensor.device_today");
+  assert.equal(source.direct, true);
+  assert.equal(source.reason, "explicit-daily");
+});
+
+test("live hourly Recorder requests use five-minute short statistics", () => {
+  const now = Date.parse("2026-08-09T11:49:00.000Z");
+  assert.equal(liveStatisticsPeriod("hour", "2026-08-09T11:49:00.000Z", now), "5minute");
+  assert.equal(liveStatisticsPeriod("hour", "2026-08-09T11:30:00.000Z", now), "hour");
+  assert.equal(liveStatisticsPeriod("day", "2026-08-09T11:49:00.000Z", now), "day");
+});

--- a/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
@@ -15,14 +15,14 @@ const refreshUrl = new URL("../src/sections/energy-refresh-section.js", import.m
 const analysisUrl = new URL("../src/sections/energy-analysis-section.js", import.meta.url);
 const contractsUrl = new URL("../src/sections/editor-contracts-section.js", import.meta.url);
 
-test("the appliance catalog/runtime hotfix release is consistently versioned as 0.15.21", async () => {
+test("the daily energy/appliance breakdown release is consistently versioned as 0.15.22", async () => {
   const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
   const readme = await readFile(readmeUrl, "utf8");
   const buildInfo = await readFile(buildInfoUrl, "utf8");
 
-  assert.equal(manifest.version, "0.15.21");
-  assert.match(readme, /version-0\.15\.21/);
-  assert.match(readme, /Novità 0\.15\.21/);
+  assert.equal(manifest.version, "0.15.22");
+  assert.match(readme, /version-0\.15\.22/);
+  assert.match(readme, /Novità 0\.15\.22/);
   assert.match(readme, /Confronto settimanale dei consumi Casa/i);
   assert.match(readme, /contatore totale kWh/i);
   assert.match(readme, /SALVA MODIFICHE/);
@@ -32,8 +32,8 @@ test("the appliance catalog/runtime hotfix release is consistently versioned as 
     /https:\/\/raw\.githubusercontent\.com\/danigio15\/dashboardmodern-v2\/main\/brand\/logo\.png/,
   );
   assert.doesNotMatch(readme, /main\/assets\/logo|brand\/logo@2x\.png/);
-  assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']0\.15\.21["']/);
-  assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']0\.15\.21["']/);
+  assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']0\.15\.22["']/);
+  assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']0\.15\.22["']/);
   assert.match(buildInfo, /["']?moduleVersion["']?\s*:\s*14/);
 });
 

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "0.15.21"
+  "version": "0.15.22"
 }


### PR DESCRIPTION
## Problemi riprodotti dalle schermate reali

- La vista Energia giornaliera resta indietro durante l'ora corrente perché il fallback dai contatori cumulativi usa statistiche Recorder orarie.
- Il KPI Elettrodomestici `Energia giornaliera` può sommare direttamente un sensore totale/lifetime quando manca `energy_today`/`daily_energy`, mostrando valori impossibili come 20 kWh.

## Correzione

- le richieste Recorder live del giorno corrente usano short statistics a 5 minuti, mantenendo invariato il contratto reset-aware `sum` e senza cambiare i periodi storici;
- gli elettrodomestici usano prima un sensore giornaliero esplicito;
- in assenza del sensore giornaliero, un contatore `total`/`total_increasing` viene usato solo come delta giornaliero via Recorder e mai come valore raw;
- i sensori energia non cumulativi e non esplicitamente giornalieri non vengono sommati nel totale;
- il KPI Energia giornaliera è cliccabile e apre un popup con elettrodomestico, entità sorgente, kWh, percentuale e tipo sorgente (giornaliero oppure totale → Recorder);
- il popup è responsive e consente di aprire lo storico della singola entità;
- release metadata allineati a 0.15.22.

## Test

- lifetime raw non può diventare consumo giornaliero;
- sensore giornaliero esplicito prevale sul totale;
- fallback totale usa `valuesForPlans`/Recorder;
- richieste live orarie vengono portate a `5minute` senza alterare periodi storici o aggregazioni giornaliere/mensili;
- Browser E2E dedicato verifica KPI 0,86 kWh con sensore giornaliero 0,81 kWh + delta Recorder 0,05 kWh, impedendo che il raw lifetime 20,0 kWh venga mostrato come consumo di oggi.