### PR TITLE
style: align appliance daily popup with dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,31 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.15.22-0ea5e9" alt="Versione 0.15.22">
+  <img src="https://img.shields.io/badge/version-0.15.23-0ea5e9" alt="Versione 0.15.23">
   <img src="https://img.shields.io/badge/HACS-custom-41BDF5" alt="HACS custom integration">
   <img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-1e3a8a" alt="Home Assistant 2025.1+">
   <img src="https://img.shields.io/badge/UI-Italiano%20%7C%20English-16a34a" alt="Italiano e inglese">
 </p>
 
 > **English overview** — DashboardModern is a responsive, multi-instance Home
-> Assistant dashboard distributed as a HACS custom integration. Release 0.15.22
-> fixes current-day Energy freshness, prevents appliance lifetime counters from
-> being displayed as daily consumption, and adds a per-entity daily breakdown.
+> Assistant dashboard distributed as a HACS custom integration. Release 0.15.23
+> restyles the appliance daily-energy popup to match the dashboard and hides
+> technical entity/source labels from the visible breakdown.
 
 ---
 
-## Novità 0.15.22
+## Novità 0.15.23
+
+La 0.15.23 rifinisce il popup **Energia giornaliera** degli Elettrodomestici senza cambiare i calcoli introdotti nella 0.15.22.
+
+- il popup usa lo stesso linguaggio visivo della dashboard: superfici chiare, accenti azzurri, card arrotondate, ombre leggere e layout mobile a bottom sheet;
+- nel dettaglio sono visibili soltanto il **nome dell'elettrodomestico**, i **kWh consumati oggi** e la **percentuale sul totale**;
+- `entity_id`, nome del sensore, tipo sorgente e diciture tecniche Recorder non vengono più mostrati;
+- il totale giornaliero resta invariato e continua a usare sensori giornalieri o delta Recorder dei contatori cumulativi;
+- il popup mantiene l'apertura dello storico dalla riga dell'elettrodomestico senza esporre l'entità tecnica;
+- Browser E2E verifica che le entità non siano presenti nel testo visibile e che il layout resti coerente su italiano, inglese, mobile e WebKit/iPad.
+
+### 0.15.22 — energia giornaliera e dettaglio consumi
 
 La 0.15.22 corregge i valori **Energia giornaliera** e il totale giornaliero degli **Elettrodomestici** verificati contro i dati reali dell'impianto.
 
@@ -32,7 +43,7 @@ La 0.15.22 corregge i valori **Energia giornaliera** e il totale giornaliero deg
 - un sensore totale/lifetime di un elettrodomestico non viene mai più sommato direttamente nel KPI **Energia giornaliera**;
 - se esiste un sensore giornaliero esplicito viene usato direttamente; altrimenti un contatore `total` / `total_increasing` viene trasformato nel delta di oggi tramite Recorder;
 - sensori energia non cumulativi e non dichiarati come giornalieri non entrano nel totale;
-- cliccando il totale **Energia giornaliera** degli Elettrodomestici si apre un popup responsive con dispositivo, entità sorgente, kWh, percentuale e tipo di sorgente;
+- cliccando il totale **Energia giornaliera** degli Elettrodomestici si apre un popup responsive con il dettaglio dei consumi del giorno;
 - dal dettaglio è possibile passare allo storico della singola entità quando disponibile;
 - Browser E2E e test unitari coprono esplicitamente il caso in cui un contatore lifetime da 20 kWh non deve diventare consumo di oggi.
 
@@ -54,7 +65,7 @@ La 0.15.20 corregge la regressione dell'anteprima **Modifica elettrodomestico** 
 
 - l'anteprima Modifica usa di nuovo lo stesso `applianceArtwork()` della prima configurazione e della card, non l'emoji del menu;
 - Chart.js, panzoom e hls.js sono versionati esattamente e protetti da SRI;
-- il digest frontend viene calcolato una sola volta fuori dall'event loop e riusato per statici, custom card e pannello;
+- il digest frontend viene calcolato una sola volta fuori dall'event loop e riusato da statici, custom card e pannello;
 - i file statici pubblici sono limitati agli asset runtime realmente raggiungibili;
 - la release fallisce se il tag della versione esiste già e gli E2E girano anche su push a `main` e nel gate di release;
 - il marker Energia usa `build-info.js` e non una versione hardcoded obsoleta;

--- a/custom_components/dashboardmodern/frontend/e2e/appliance-daily-energy.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/appliance-daily-energy.spec.js
@@ -144,7 +144,7 @@ async function boot(page, variant, testInfo) {
 }
 
 for (const variant of ["dashboard.html", "dashboard-en.html"]) {
-  test(`${variant}: daily appliance KPI uses period-safe values and opens entity breakdown`, async ({ page }, testInfo) => {
+  test(`${variant}: daily appliance KPI opens dashboard-style breakdown without visible entity labels`, async ({ page }, testInfo) => {
     if (testInfo.project.name === "webkit-ipad") test.slow(true, "Recorder-backed popup is slower on WebKit/iPad");
     await boot(page, variant, testInfo);
 
@@ -158,10 +158,25 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await expect(popup).toBeVisible();
     await expect(popup.locator("[data-dm-daily-popup-total]")).toContainText(/0[.,]86 kWh/i);
     await expect(popup.locator("[data-dm-daily-entity]")).toHaveCount(2);
-    await expect(popup).toContainText("sensor.fridge_today");
-    await expect(popup).toContainText("sensor.microwave_total");
+    await expect(popup.locator(".dm-appliance-daily-row-main strong")).toHaveText(["Frigorifero", "Microonde"]);
+    await expect(popup.locator(".dm-appliance-daily-row-main small").first()).toBeHidden();
+    await expect(popup.locator(".dm-appliance-daily-note")).toBeHidden();
     await expect(popup).toContainText(/0[.,]81 kWh/i);
     await expect(popup).toContainText(/0[.,]05 kWh/i);
+
+    const visibleCopy = await popup.evaluate((node) => node.innerText);
+    expect(visibleCopy).not.toContain("sensor.fridge_today");
+    expect(visibleCopy).not.toContain("sensor.microwave_total");
+    expect(visibleCopy).not.toMatch(/Recorder|Sensore giornaliero|Daily sensor|Total meter/i);
+
+    const dialog = popup.locator(".dm-appliance-daily-dialog");
+    const row = popup.locator(".dm-appliance-daily-row").first();
+    await expect
+      .poll(async () => dialog.evaluate((node) => getComputedStyle(node).borderRadius))
+      .toMatch(/3[24]px/);
+    await expect
+      .poll(async () => row.evaluate((node) => getComputedStyle(node).borderRadius))
+      .toMatch(/2[14]px/);
 
     const periods = await page.evaluate(() => window.__dmStatisticsPeriods);
     expect(periods).toContain("5minute");

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -32,6 +32,7 @@ const root = globalThis;
 const RUNTIME_KEY = "__DASHBOARDMODERN_SECTION_RUNTIME__";
 const INSTALLING_KEY = "__DASHBOARDMODERN_SECTION_RUNTIME_INSTALLING__";
 const APPLIANCE_PICKER_LAYER_STYLE_ID = "dm-appliance-picker-layer-style";
+const APPLIANCE_DAILY_POPUP_STYLE_ID = "dm-appliance-daily-dashboard-style";
 
 function installAppliancePickerLayer() {
   const doc = root.document;
@@ -51,6 +52,242 @@ function installAppliancePickerLayer() {
     #dm-applpick .dm-appliance-type-grid,
     #dm-applpick .dm-appliance-type-option {
       pointer-events: auto !important;
+    }
+  `;
+  doc.head.append(style);
+}
+
+function installApplianceDailyPopupStyle() {
+  const doc = root.document;
+  if (!doc?.head || doc.getElementById(APPLIANCE_DAILY_POPUP_STYLE_ID)) return;
+  const style = doc.createElement("style");
+  style.id = APPLIANCE_DAILY_POPUP_STYLE_ID;
+  style.textContent = `
+    /* Daily appliance breakdown follows the same soft cards and cyan accents
+       used by the Appliances dashboard. Technical entity/source labels stay
+       available to the runtime but are deliberately not visible to the user. */
+    #dm-appliance-daily-popup.dm-appliance-daily-overlay {
+      background:rgba(30,41,59,.42)!important;
+      backdrop-filter:blur(15px) saturate(120%)!important;
+      -webkit-backdrop-filter:blur(15px) saturate(120%)!important;
+      padding:18px!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-dialog {
+      width:min(620px,100%)!important;
+      max-height:min(82vh,760px)!important;
+      border:1px solid rgba(148,163,184,.24)!important;
+      border-radius:34px!important;
+      background:
+        radial-gradient(circle at 8% 2%,rgba(125,211,252,.24),transparent 33%),
+        radial-gradient(circle at 94% 18%,rgba(167,243,208,.18),transparent 30%),
+        linear-gradient(180deg,rgba(255,255,255,.99),rgba(244,249,255,.98))!important;
+      box-shadow:0 26px 80px rgba(15,23,42,.30)!important;
+      overflow:hidden!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-head {
+      padding:26px 26px 15px!important;
+      align-items:flex-start!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-head small {
+      display:inline-flex!important;
+      align-items:center!important;
+      min-height:28px!important;
+      padding:0 12px!important;
+      border:1px solid rgba(14,165,233,.18)!important;
+      border-radius:999px!important;
+      background:rgba(224,242,254,.72)!important;
+      color:#0284c7!important;
+      font-size:10px!important;
+      font-weight:900!important;
+      letter-spacing:2px!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-head h3 {
+      margin:8px 0 0!important;
+      color:#111827!important;
+      font-size:clamp(24px,4vw,32px)!important;
+      font-weight:950!important;
+      line-height:1.04!important;
+      letter-spacing:1.1px!important;
+      text-transform:uppercase!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-head button {
+      width:48px!important;
+      height:48px!important;
+      flex:0 0 48px!important;
+      border:1px solid rgba(148,163,184,.18)!important;
+      border-radius:17px!important;
+      background:rgba(248,250,252,.92)!important;
+      color:#0f172a!important;
+      box-shadow:0 8px 24px rgba(15,23,42,.07)!important;
+      font-size:21px!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-total {
+      position:relative!important;
+      min-height:108px!important;
+      margin:0 26px 18px!important;
+      padding:22px 24px 22px 92px!important;
+      overflow:hidden!important;
+      border:1px solid rgba(14,165,233,.18)!important;
+      border-radius:26px!important;
+      background:linear-gradient(135deg,rgba(224,242,254,.96),rgba(240,249,255,.84))!important;
+      box-shadow:0 13px 34px rgba(14,165,233,.10)!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-total::before {
+      content:"⚡";
+      position:absolute;
+      left:22px;
+      top:50%;
+      width:54px;
+      height:54px;
+      transform:translateY(-50%);
+      display:grid;
+      place-items:center;
+      border:1px solid rgba(14,165,233,.16);
+      border-radius:19px;
+      background:rgba(255,255,255,.78);
+      box-shadow:0 8px 24px rgba(14,165,233,.10);
+      font-size:30px;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-total span {
+      color:#64748b!important;
+      font-size:12px!important;
+      font-weight:900!important;
+      letter-spacing:1.6px!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-total strong {
+      color:#0797d5!important;
+      font-size:clamp(27px,5vw,38px)!important;
+      font-weight:950!important;
+      letter-spacing:-1px!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-list {
+      gap:12px!important;
+      padding:0 26px 26px!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-row {
+      position:relative!important;
+      min-height:92px!important;
+      padding:17px 18px 17px 88px!important;
+      overflow:hidden!important;
+      border:1px solid rgba(148,163,184,.20)!important;
+      border-radius:24px!important;
+      background:rgba(255,255,255,.90)!important;
+      box-shadow:0 10px 30px rgba(15,23,42,.07)!important;
+      transition:transform .16s ease,box-shadow .16s ease!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-row::before {
+      content:"⚡";
+      position:absolute;
+      left:18px;
+      top:50%;
+      width:54px;
+      height:54px;
+      transform:translateY(-50%);
+      display:grid;
+      place-items:center;
+      border-radius:18px;
+      background:linear-gradient(145deg,#e0f2fe,#f0f9ff);
+      color:#0284c7;
+      box-shadow:inset 0 0 0 1px rgba(14,165,233,.12),0 8px 22px rgba(14,165,233,.09);
+      font-size:25px;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-row:hover {
+      transform:translateY(-1px)!important;
+      box-shadow:0 14px 34px rgba(15,23,42,.10)!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-row-main {
+      gap:0!important;
+      justify-content:center!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-row-main strong {
+      color:#111827!important;
+      font-size:18px!important;
+      font-weight:900!important;
+      line-height:1.15!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-row-main small {
+      display:none!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-row-value {
+      gap:4px!important;
+      justify-content:center!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-row-value strong {
+      color:#078dc7!important;
+      font-size:19px!important;
+      font-weight:950!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-row-value small {
+      min-width:45px!important;
+      padding:4px 8px!important;
+      border-radius:999px!important;
+      background:#e0f2fe!important;
+      color:#0369a1!important;
+      font-size:10px!important;
+      font-weight:900!important;
+      text-align:center!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-empty {
+      margin-bottom:4px!important;
+      border:1px solid rgba(148,163,184,.18)!important;
+      border-radius:22px!important;
+      background:rgba(255,255,255,.76)!important;
+      color:#64748b!important;
+    }
+    #dm-appliance-daily-popup .dm-appliance-daily-note {
+      display:none!important;
+    }
+    @media(max-width:520px) {
+      #dm-appliance-daily-popup.dm-appliance-daily-overlay {
+        align-items:flex-end!important;
+        padding:10px!important;
+      }
+      #dm-appliance-daily-popup .dm-appliance-daily-dialog {
+        max-height:86vh!important;
+        border-radius:32px 32px 22px 22px!important;
+      }
+      #dm-appliance-daily-popup .dm-appliance-daily-head {
+        padding:22px 18px 13px!important;
+      }
+      #dm-appliance-daily-popup .dm-appliance-daily-head h3 {
+        font-size:27px!important;
+      }
+      #dm-appliance-daily-popup .dm-appliance-daily-head button {
+        width:46px!important;
+        height:46px!important;
+        flex-basis:46px!important;
+      }
+      #dm-appliance-daily-popup .dm-appliance-daily-total {
+        min-height:96px!important;
+        margin:0 18px 14px!important;
+        padding:18px 18px 18px 82px!important;
+        border-radius:23px!important;
+      }
+      #dm-appliance-daily-popup .dm-appliance-daily-total::before {
+        left:17px;
+        width:50px;
+        height:50px;
+      }
+      #dm-appliance-daily-popup .dm-appliance-daily-list {
+        gap:10px!important;
+        padding:0 18px max(20px,env(safe-area-inset-bottom))!important;
+      }
+      #dm-appliance-daily-popup .dm-appliance-daily-row {
+        min-height:84px!important;
+        padding:14px 14px 14px 78px!important;
+        border-radius:21px!important;
+      }
+      #dm-appliance-daily-popup .dm-appliance-daily-row::before {
+        left:14px;
+        width:50px;
+        height:50px;
+      }
+      #dm-appliance-daily-popup .dm-appliance-daily-row-main strong {
+        font-size:17px!important;
+      }
+      #dm-appliance-daily-popup .dm-appliance-daily-row-value strong {
+        font-size:17px!important;
+      }
     }
   `;
   doc.head.append(style);
@@ -80,6 +317,7 @@ export function installSectionRuntime() {
     installTemperatureLayoutSection();
     installAppliancesSection();
     installApplianceLayoutSection();
+    installApplianceDailyPopupStyle();
     installAppliancePickerLayer();
     installApplianceEditorSection();
     installLightsAlertsSection();

--- a/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
@@ -15,14 +15,14 @@ const refreshUrl = new URL("../src/sections/energy-refresh-section.js", import.m
 const analysisUrl = new URL("../src/sections/energy-analysis-section.js", import.meta.url);
 const contractsUrl = new URL("../src/sections/editor-contracts-section.js", import.meta.url);
 
-test("the daily energy/appliance breakdown release is consistently versioned as 0.15.22", async () => {
+test("the appliance daily popup polish release is consistently versioned as 0.15.23", async () => {
   const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
   const readme = await readFile(readmeUrl, "utf8");
   const buildInfo = await readFile(buildInfoUrl, "utf8");
 
-  assert.equal(manifest.version, "0.15.22");
-  assert.match(readme, /version-0\.15\.22/);
-  assert.match(readme, /Novità 0\.15\.22/);
+  assert.equal(manifest.version, "0.15.23");
+  assert.match(readme, /version-0\.15\.23/);
+  assert.match(readme, /Novità 0\.15\.23/);
   assert.match(readme, /Confronto settimanale dei consumi Casa/i);
   assert.match(readme, /contatore totale kWh/i);
   assert.match(readme, /SALVA MODIFICHE/);
@@ -32,8 +32,8 @@ test("the daily energy/appliance breakdown release is consistently versioned as 
     /https:\/\/raw\.githubusercontent\.com\/danigio15\/dashboardmodern-v2\/main\/brand\/logo\.png/,
   );
   assert.doesNotMatch(readme, /main\/assets\/logo|brand\/logo@2x\.png/);
-  assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']0\.15\.22["']/);
-  assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']0\.15\.22["']/);
+  assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']0\.15\.23["']/);
+  assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']0\.15\.23["']/);
   assert.match(buildInfo, /["']?moduleVersion["']?\s*:\s*14/);
 });
 

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "0.15.22"
+  "version": "0.15.23"
 }


### PR DESCRIPTION
## Obiettivo

Rifinire il popup **Energia giornaliera** degli Elettrodomestici dopo la correzione funzionale della 0.15.22.

## Modifiche

- popup ridisegnato con lo stesso linguaggio visivo della dashboard: card chiare, accenti azzurri, angoli ampi, ombre morbide e bottom-sheet su mobile;
- nel dettaglio restano visibili solo nome dell'elettrodomestico, kWh di oggi e percentuale sul totale;
- `entity_id`, sensore sorgente, tipo sorgente e nota tecnica Recorder vengono nascosti dalla UI;
- nessuna modifica ai calcoli giornalieri introdotti in 0.15.22;
- E2E aggiornato per verificare che le entità non compaiano nel testo visibile e che il popup mantenga la geometria dashboard-style;
- versione allineata a 0.15.23.

## Verifica attesa

Test frontend, Browser E2E IT/EN desktop/mobile/WebKit-iPad, Python/Ruff, HACS e hassfest.