### PR TITLE
feat: add appliance running and instant-power popups

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,33 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.15.24-0ea5e9" alt="Versione 0.15.24">
+  <img src="https://img.shields.io/badge/version-0.15.25-0ea5e9" alt="Versione 0.15.25">
   <img src="https://img.shields.io/badge/HACS-custom-41BDF5" alt="HACS custom integration">
   <img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-1e3a8a" alt="Home Assistant 2025.1+">
   <img src="https://img.shields.io/badge/UI-Italiano%20%7C%20English-16a34a" alt="Italiano e inglese">
 </p>
 
 > **English overview** — DashboardModern is a responsive, multi-instance Home
-> Assistant dashboard distributed as a HACS custom integration. Release 0.15.24
-> makes the daily appliance breakdown reuse the exact configured appliance
-> artwork and ships the complete local integration brand asset set.
+> Assistant dashboard distributed as a HACS custom integration. Release 0.15.25
+> adds running and instant-power appliance details, removes the obsolete Alerts
+> KPI and keeps appliance popups centered across desktop and mobile.
 
 ---
 
-## Novità 0.15.24
+## Novità 0.15.25
+
+La 0.15.25 rifinisce i KPI della sezione **Elettrodomestici** senza modificare il motore Energia.
+
+- **Dispositivi accesi** diventa **In funzione** e conta soltanto gli elettrodomestici realmente in stato `running`, non una presa semplicemente accesa;
+- cliccando **In funzione** si apre un popup con i soli apparecchi realmente attivi, artwork, stanza, potenza e stato;
+- **Consumo istantaneo** è cliccabile e mostra il dettaglio Watt per apparecchio, ordinato per assorbimento, con percentuale sul totale;
+- la KPI **Avvisi** viene rimossa dalla sezione Elettrodomestici;
+- i popup In funzione, Consumo istantaneo ed Energia giornaliera restano centrati anche su mobile;
+- il popup Energia giornaliera usa un raggio angoli di 12 px;
+- la sincronizzazione dei KPI segue lo stesso lifecycle dei renderer Elettrodomestici, senza introdurre polling periodico o nuovi `MutationObserver`;
+- Browser E2E verifica italiano/inglese, desktop/mobile/WebKit, conteggi, potenze, artwork e centratura dei popup.
+
+### 0.15.24 — artwork popup e brand
 
 La 0.15.24 rifinisce l'identità visiva del popup **Energia giornaliera** e il packaging del brand dell'integrazione.
 

--- a/custom_components/dashboardmodern/frontend/e2e/appliance-kpi-popups.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/appliance-kpi-popups.spec.js
@@ -134,14 +134,10 @@ async function expectCentered(page, popup) {
     return {
       x: Math.abs(rect.left + rect.width / 2 - innerWidth / 2),
       y: Math.abs(rect.top + rect.height / 2 - innerHeight / 2),
-      align: getComputedStyle(node).alignItems,
-      justify: getComputedStyle(node).justifyContent,
     };
   });
   expect(delta.x).toBeLessThan(24);
   expect(delta.y).toBeLessThan(40);
-  expect(delta.align).toBe("center");
-  expect(delta.justify).toBe("center");
 }
 
 for (const variant of ["dashboard.html", "dashboard-en.html"]) {

--- a/custom_components/dashboardmodern/frontend/e2e/appliance-kpi-popups.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/appliance-kpi-popups.spec.js
@@ -1,0 +1,191 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { clickBottomTab } from "./helpers/navigation.js";
+
+const states = [
+  {
+    entity_id: "switch.microwave",
+    state: "on",
+    attributes: { friendly_name: "Microonde", device_class: "outlet" },
+  },
+  {
+    entity_id: "sensor.microwave_power",
+    state: "920",
+    attributes: { friendly_name: "Microonde power", unit_of_measurement: "W" },
+  },
+  {
+    entity_id: "switch.fridge",
+    state: "on",
+    attributes: { friendly_name: "Frigorifero", device_class: "outlet" },
+  },
+  {
+    entity_id: "sensor.fridge_power",
+    state: "2",
+    attributes: { friendly_name: "Frigorifero power", unit_of_measurement: "W" },
+  },
+  {
+    entity_id: "sensor.fridge_today",
+    state: "0.98",
+    attributes: {
+      friendly_name: "Frigorifero oggi",
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "total_increasing",
+    },
+  },
+];
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [
+      { id: "room-bedroom", name: "Cameretta", icon: "mdi:home" },
+      { id: "room-living", name: "Salone", icon: "mdi:sofa" },
+    ],
+    appliances: [
+      {
+        id: "microwave",
+        name: "Microonde",
+        device_type: "microonde",
+        visual_key: "microonde",
+        room_id: "room-bedroom",
+        control_entity: "switch.microwave",
+        power_entity: "sensor.microwave_power",
+        entities: ["switch.microwave", "sensor.microwave_power"],
+      },
+      {
+        id: "fridge",
+        name: "Frigorifero",
+        device_type: "frigo",
+        visual_key: "frigo",
+        room_id: "room-living",
+        control_entity: "switch.fridge",
+        power_entity: "sensor.fridge_power",
+        daily_energy_entity: "sensor.fridge_today",
+        entities: ["switch.fridge", "sensor.fridge_power", "sensor.fridge_today"],
+      },
+    ],
+    loads: [],
+  },
+  visibility: { appliances: true },
+};
+
+async function boot(page, variant, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript((haStates) => {
+    class MockSocket extends EventTarget {
+      static OPEN = 1;
+      readyState = MockSocket.OPEN;
+      onopen = null;
+      onmessage = null;
+      onclose = null;
+      onerror = null;
+      constructor() {
+        super();
+        queueMicrotask(() => {
+          this.onopen?.({});
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+        });
+      }
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") return;
+        let result = null;
+        if (message.type === "get_states") result = haStates;
+        else if (message.type === "frontend/get_user_data") result = { value: null };
+        else if (message.type === "subscribe_events") result = null;
+        else if (message.type === "recorder/statistics_during_period") result = {};
+        this.onmessage?.({
+          data: JSON.stringify({ id: message.id, type: "result", success: true, result }),
+        });
+      }
+      close() {
+        this.onclose?.({});
+      }
+    }
+    window.__DASHBOARDMODERN_BRIDGE_WS__ = MockSocket;
+    window.WebSocket = MockSocket;
+  }, states);
+
+  await bootNamespacedDashboard(page, variant, testInfo, seed);
+  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await page.waitForFunction(() => window.__DASHBOARDMODERN_RUNTIME_ROOT__?.ready === true);
+  await page.evaluate(
+    (haStates) => haStates.forEach((item) => {
+      _RAW_STATES[item.entity_id] = structuredClone(item);
+      STATES[item.entity_id] = structuredClone(item);
+    }),
+    states,
+  );
+  await clickBottomTab(page, "appliances", testInfo);
+  await page.waitForFunction(() => {
+    const grid = document.getElementById("appl-kpi-grid");
+    return Boolean(
+      grid?.querySelector('[data-dm-appliance-kpi="running"]') &&
+      grid?.querySelector('[data-dm-appliance-kpi="power"]'),
+    );
+  });
+}
+
+async function expectCentered(page, popup) {
+  const delta = await popup.evaluate((node) => {
+    const dialog = node.querySelector(".dm-appliance-kpi-dialog,.dm-appliance-daily-dialog");
+    const rect = dialog.getBoundingClientRect();
+    return {
+      x: Math.abs(rect.left + rect.width / 2 - innerWidth / 2),
+      y: Math.abs(rect.top + rect.height / 2 - innerHeight / 2),
+      align: getComputedStyle(node).alignItems,
+      justify: getComputedStyle(node).justifyContent,
+    };
+  });
+  expect(delta.x).toBeLessThan(24);
+  expect(delta.y).toBeLessThan(40);
+  expect(delta.align).toBe("center");
+  expect(delta.justify).toBe("center");
+}
+
+for (const variant of ["dashboard.html", "dashboard-en.html"]) {
+  test(`${variant}: appliance KPI cards expose centered running/power popups and remove alerts`, async ({ page }, testInfo) => {
+    await boot(page, variant, testInfo);
+
+    const grid = page.locator("#appl-kpi-grid");
+    const runningCard = grid.locator('[data-dm-appliance-kpi="running"]');
+    const powerCard = grid.locator('[data-dm-appliance-kpi="power"]');
+    const dailyCard = grid.locator('[data-dm-appliance-kpi="daily"]');
+
+    await expect(runningCard).toBeVisible();
+    await expect(runningCard).toContainText(variant === "dashboard.html" ? /IN FUNZIONE/i : /RUNNING/i);
+    await expect(runningCard.locator(".g-val")).toHaveText("1");
+    await expect(powerCard).toBeVisible();
+    await expect(powerCard.locator(".g-val")).toContainText(/922 W/i);
+    await expect(grid).not.toContainText(variant === "dashboard.html" ? /AVVISI/i : /ALERTS/i);
+
+    await runningCard.click();
+    const runningPopup = page.locator("#dm-appliance-running-popup");
+    await expect(runningPopup).toBeVisible();
+    await expect(runningPopup.locator("[data-dm-appliance-kpi-summary]")).toHaveText("1");
+    await expect(runningPopup.locator(".dm-appliance-kpi-row")).toHaveCount(1);
+    await expect(runningPopup).toContainText("Microonde");
+    await expect(runningPopup).not.toContainText("Frigorifero");
+    await expect(runningPopup.locator('[data-appliance-id="microwave"] [data-dm-art="microwave"]')).toBeVisible();
+    await expectCentered(page, runningPopup);
+    await runningPopup.locator("[data-dm-appliance-kpi-close]").click();
+
+    await powerCard.click();
+    const powerPopup = page.locator("#dm-appliance-power-popup");
+    await expect(powerPopup).toBeVisible();
+    await expect(powerPopup.locator("[data-dm-appliance-kpi-summary]")).toContainText(/922 W/i);
+    await expect(powerPopup.locator(".dm-appliance-kpi-row")).toHaveCount(2);
+    await expect(powerPopup.locator(".dm-appliance-kpi-row-main>strong")).toHaveText(["Microonde", "Frigorifero"]);
+    await expect(powerPopup).toContainText(/920 W/i);
+    await expect(powerPopup).toContainText(/2 W/i);
+    await expect(powerPopup.locator('[data-appliance-id="fridge"] [data-dm-art="fridge"]')).toBeVisible();
+    await expectCentered(page, powerPopup);
+    await powerPopup.locator("[data-dm-appliance-kpi-close]").click();
+
+    await dailyCard.click();
+    const dailyPopup = page.locator("#dm-appliance-daily-popup");
+    await expect(dailyPopup).toBeVisible();
+    await expectCentered(page, dailyPopup);
+  });
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -81,7 +81,7 @@ function installApplianceDailyPopupStyle() {
       width:min(620px,100%)!important;
       max-height:min(82vh,760px)!important;
       border:1px solid rgba(148,163,184,.24)!important;
-      border-radius:12px!important;
+      border-radius:34px!important;
       background:
         radial-gradient(circle at 8% 2%,rgba(125,211,252,.24),transparent 33%),
         radial-gradient(circle at 94% 18%,rgba(167,243,208,.18),transparent 30%),
@@ -251,7 +251,7 @@ function installApplianceDailyPopupStyle() {
       #dm-appliance-daily-popup .dm-appliance-daily-dialog {
         width:min(620px,calc(100vw - 28px))!important;
         max-height:min(82vh,720px)!important;
-        border-radius:12px!important;
+        border-radius:32px!important;
       }
       #dm-appliance-daily-popup .dm-appliance-daily-head {
         padding:22px 18px 13px!important;
@@ -325,7 +325,7 @@ function applianceKpiCard(kind) {
   const mounted = grid.querySelector(`[data-dm-appliance-kpi="${kind}"]`);
   if (mounted) return mounted;
   const patterns = {
-    running: /dispositivi\s+accesi|devices\s+on|active\s+devices|in\s+funzione|running/i,
+    running: /dispositivi\s+accesi|devices\s+on|active\s+devices|powered\s+on|in\s+funzione|running/i,
     power: /consumo\s+istantaneo|instant(?:aneous)?\s+(?:power|consumption)|power\s+now/i,
     daily: /energia\s+giornaliera|daily\s+energy/i,
     alerts: /avvisi|alerts|warnings/i,
@@ -338,7 +338,7 @@ function applianceKpiCard(kind) {
 function applianceKpiLabelNode(card, kind) {
   if (!card) return null;
   const patterns = {
-    running: /dispositivi\s+accesi|devices\s+on|active\s+devices|in\s+funzione|running/i,
+    running: /dispositivi\s+accesi|devices\s+on|active\s+devices|powered\s+on|in\s+funzione|running/i,
     power: /consumo\s+istantaneo|instant(?:aneous)?\s+(?:power|consumption)|power\s+now/i,
   };
   const preferred = card.querySelector(".g-label,.glance-label,[data-glance-label]");

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -1,5 +1,7 @@
-import { installHostedBridgeGuard } from "../transport/hosted-bridge-guard.js";
+import { applianceArtwork, canonicalArtworkType } from "../core/appliance-artwork.js";
+import { createApplianceViewModel } from "../core/appliance-view-model.js";
 import { installStateEventGate } from "../core/state-event-gate.js";
+import { installHostedBridgeGuard } from "../transport/hosted-bridge-guard.js";
 import { installDataContractsSection } from "./data-contracts-section.js";
 import { installEnergyCalculationsSection } from "./energy-calculations-section.js";
 import { installEnergyServicesSection } from "./energy-services-section.js";
@@ -27,12 +29,15 @@ import { installReportEditorSection } from "./report-editor-section.js";
 import { installShutterSection } from "./shutter-section.js";
 import { installEvSection } from "./ev-section.js";
 import { installLegacySections, LEGACY_SECTION_KEYS } from "./legacy-sections-registry.js";
+import { allStates, clean, english, section } from "./shared.js";
 
 const root = globalThis;
 const RUNTIME_KEY = "__DASHBOARDMODERN_SECTION_RUNTIME__";
 const INSTALLING_KEY = "__DASHBOARDMODERN_SECTION_RUNTIME_INSTALLING__";
 const APPLIANCE_PICKER_LAYER_STYLE_ID = "dm-appliance-picker-layer-style";
 const APPLIANCE_DAILY_POPUP_STYLE_ID = "dm-appliance-daily-dashboard-style";
+const APPLIANCE_KPI_POPUP_STYLE_ID = "dm-appliance-kpi-popup-style";
+const APPLIANCE_KPI_STATE_KEY = "__DASHBOARDMODERN_APPLIANCE_KPI_POPUPS__";
 
 function installAppliancePickerLayer() {
   const doc = root.document;
@@ -239,12 +244,14 @@ function installApplianceDailyPopupStyle() {
     }
     @media(max-width:520px) {
       #dm-appliance-daily-popup.dm-appliance-daily-overlay {
-        align-items:flex-end!important;
-        padding:10px!important;
+        align-items:center!important;
+        justify-content:center!important;
+        padding:14px!important;
       }
       #dm-appliance-daily-popup .dm-appliance-daily-dialog {
-        max-height:86vh!important;
-        border-radius:32px 32px 22px 22px!important;
+        width:min(620px,calc(100vw - 28px))!important;
+        max-height:min(82vh,720px)!important;
+        border-radius:30px!important;
       }
       #dm-appliance-daily-popup .dm-appliance-daily-head {
         padding:22px 18px 13px!important;
@@ -270,7 +277,7 @@ function installApplianceDailyPopupStyle() {
       }
       #dm-appliance-daily-popup .dm-appliance-daily-list {
         gap:10px!important;
-        padding:0 18px max(20px,env(safe-area-inset-bottom))!important;
+        padding:0 18px 18px!important;
       }
       #dm-appliance-daily-popup .dm-appliance-daily-row {
         min-height:84px!important;
@@ -291,6 +298,284 @@ function installApplianceDailyPopupStyle() {
     }
   `;
   doc.head.append(style);
+}
+
+function htmlEscape(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function applianceKpiModels() {
+  const appliances = section("appliances", []);
+  if (!Array.isArray(appliances)) return [];
+  const rooms = section("rooms", []);
+  const states = allStates();
+  const locale = english() ? "en" : "it";
+  return appliances.map((device) => createApplianceViewModel(device, states, rooms, locale));
+}
+
+function applianceKpiCard(kind) {
+  const doc = root.document;
+  const grid = doc?.getElementById("appl-kpi-grid");
+  if (!grid) return null;
+  const mounted = grid.querySelector(`[data-dm-appliance-kpi="${kind}"]`);
+  if (mounted) return mounted;
+  const patterns = {
+    running: /dispositivi\s+accesi|devices\s+on|active\s+devices|in\s+funzione|running/i,
+    power: /consumo\s+istantaneo|instant(?:aneous)?\s+(?:power|consumption)|power\s+now/i,
+    daily: /energia\s+giornaliera|daily\s+energy/i,
+    alerts: /avvisi|alerts|warnings/i,
+  };
+  const pattern = patterns[kind];
+  if (!pattern) return null;
+  return [...grid.querySelectorAll(".glance-card")].find((card) => pattern.test(clean(card.textContent))) || null;
+}
+
+function applianceKpiLabelNode(card, kind) {
+  if (!card) return null;
+  const patterns = {
+    running: /dispositivi\s+accesi|devices\s+on|active\s+devices|in\s+funzione|running/i,
+    power: /consumo\s+istantaneo|instant(?:aneous)?\s+(?:power|consumption)|power\s+now/i,
+  };
+  const preferred = card.querySelector(".g-label,.glance-label,[data-glance-label]");
+  if (preferred) return preferred;
+  const pattern = patterns[kind];
+  return [...card.querySelectorAll("span,small,div")].find(
+    (node) => node.childElementCount === 0 && pattern?.test(clean(node.textContent)),
+  ) || null;
+}
+
+function formatApplianceWatts(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return "— W";
+  const watts = Math.max(0, numeric);
+  if (watts >= 1000) {
+    const digits = watts >= 10000 ? 1 : 2;
+    return `${(watts / 1000).toFixed(digits).replace(/0+$/, "").replace(/\.$/, "")} kW`;
+  }
+  if (watts > 0 && watts < 10) return `${watts.toFixed(1).replace(/\.0$/, "")} W`;
+  return `${Math.round(watts)} W`;
+}
+
+function applianceKpiArtwork(model) {
+  const visual = model?.visual || {};
+  if (visual.kind === "image" && clean(visual.value)) {
+    const name = htmlEscape(model.name);
+    const source = htmlEscape(visual.value);
+    return `<span class="dm-appliance-kpi-image-wrap"><img class="dm-appliance-kpi-image" src="${source}" alt="${name}"></span>`;
+  }
+  const fallback = clean(
+    visual.value ||
+      model?.device?.visual_key ||
+      model?.device?.device_type ||
+      model?.device?.type ||
+      model?.device?.icon ||
+      model?.name,
+  );
+  const kind = canonicalArtworkType(fallback);
+  return (kind && applianceArtwork(kind, 72)) || '<span class="dm-appliance-kpi-fallback">⚡</span>';
+}
+
+function ensureApplianceKpiPopup(kind) {
+  const doc = root.document;
+  if (!doc?.body) return null;
+  const id = `dm-appliance-${kind}-popup`;
+  let popup = doc.getElementById(id);
+  if (popup) return popup;
+  const isRunning = kind === "running";
+  const title = isRunning
+    ? english() ? "Appliances running" : "Elettrodomestici in funzione"
+    : english() ? "Instant power" : "Consumo istantaneo";
+  const summaryLabel = isRunning
+    ? english() ? "Currently running" : "In funzione adesso"
+    : english() ? "Measured power" : "Potenza misurata";
+  popup = doc.createElement("div");
+  popup.id = id;
+  popup.className = `dm-appliance-kpi-overlay dm-appliance-kpi-${kind}`;
+  popup.hidden = true;
+  popup.innerHTML = `<div class="dm-appliance-kpi-dialog" role="dialog" aria-modal="true" aria-labelledby="${id}-title">
+    <div class="dm-appliance-kpi-head">
+      <div><small>${english() ? "NOW" : "ADESSO"}</small><h3 id="${id}-title">${title}</h3></div>
+      <button type="button" data-dm-appliance-kpi-close aria-label="${english() ? "Close" : "Chiudi"}">✕</button>
+    </div>
+    <div class="dm-appliance-kpi-summary">
+      <span class="dm-appliance-kpi-summary-icon">${isRunning ? "●" : "⚡"}</span>
+      <span class="dm-appliance-kpi-summary-copy"><small>${summaryLabel}</small><strong data-dm-appliance-kpi-summary>—</strong></span>
+    </div>
+    <div class="dm-appliance-kpi-list" data-dm-appliance-kpi-list></div>
+  </div>`;
+  const close = () => {
+    popup.hidden = true;
+    popup.classList.remove("show");
+  };
+  popup.addEventListener("click", (event) => {
+    if (event.target === popup) close();
+  });
+  popup.querySelector("[data-dm-appliance-kpi-close]")?.addEventListener("click", close);
+  doc.body.append(popup);
+  return popup;
+}
+
+function applianceKpiRow(model, kind, totalWatts = 0) {
+  const room = clean(model?.room?.name);
+  const watts = Number(model?.watts);
+  const measurable = Number.isFinite(watts);
+  const right = kind === "running"
+    ? `<strong>${measurable ? formatApplianceWatts(watts) : htmlEscape(model.label)}</strong><small>${htmlEscape(model.label)}</small>`
+    : `<strong>${formatApplianceWatts(watts)}</strong><small>${totalWatts > 0 ? `${Math.round((Math.max(0, watts) / totalWatts) * 100)}%` : "0%"}</small>`;
+  return `<div class="dm-appliance-kpi-row" data-appliance-id="${htmlEscape(model.id)}">
+    <span class="dm-appliance-kpi-visual">${applianceKpiArtwork(model)}</span>
+    <span class="dm-appliance-kpi-row-main"><strong>${htmlEscape(model.name)}</strong>${room ? `<small>🏠 ${htmlEscape(room)}</small>` : ""}</span>
+    <span class="dm-appliance-kpi-row-value">${right}</span>
+  </div>`;
+}
+
+function renderApplianceKpiPopup(kind) {
+  const popup = ensureApplianceKpiPopup(kind);
+  if (!popup) return;
+  const summary = popup.querySelector("[data-dm-appliance-kpi-summary]");
+  const list = popup.querySelector("[data-dm-appliance-kpi-list]");
+  if (!summary || !list) return;
+  const models = applianceKpiModels();
+  if (kind === "running") {
+    const running = models.filter((model) => model.mode === "running");
+    summary.textContent = String(running.length);
+    list.innerHTML = running.length
+      ? running.map((model) => applianceKpiRow(model, kind)).join("")
+      : `<div class="dm-appliance-kpi-empty">${english() ? "No appliance is running right now." : "Nessun elettrodomestico è in funzione in questo momento."}</div>`;
+    return;
+  }
+  const consuming = models
+    .filter((model) => Number.isFinite(model.watts) && model.watts > 0.05)
+    .sort((left, right) => right.watts - left.watts);
+  const totalWatts = consuming.reduce((sum, model) => sum + Math.max(0, model.watts), 0);
+  summary.textContent = formatApplianceWatts(totalWatts);
+  list.innerHTML = consuming.length
+    ? consuming.map((model) => applianceKpiRow(model, kind, totalWatts)).join("")
+    : `<div class="dm-appliance-kpi-empty">${english() ? "No measurable instant appliance consumption." : "Nessun consumo istantaneo misurabile dagli elettrodomestici."}</div>`;
+}
+
+function syncApplianceKpis() {
+  const doc = root.document;
+  const grid = doc?.getElementById("appl-kpi-grid");
+  if (!grid) return false;
+  const models = applianceKpiModels();
+  const running = models.filter((model) => model.mode === "running");
+  const totalWatts = models.reduce(
+    (sum, model) => sum + (Number.isFinite(model.watts) ? Math.max(0, model.watts) : 0),
+    0,
+  );
+
+  const runningCard = applianceKpiCard("running");
+  if (runningCard) {
+    runningCard.dataset.dmApplianceKpi = "running";
+    runningCard.setAttribute("role", "button");
+    runningCard.tabIndex = 0;
+    runningCard.setAttribute("aria-label", english() ? "Open appliances running" : "Apri elettrodomestici in funzione");
+    const label = applianceKpiLabelNode(runningCard, "running");
+    if (label) label.textContent = english() ? "RUNNING" : "IN FUNZIONE";
+    const value = runningCard.querySelector(".g-val");
+    if (value) value.textContent = String(running.length);
+  }
+
+  const powerCard = applianceKpiCard("power");
+  if (powerCard) {
+    powerCard.dataset.dmApplianceKpi = "power";
+    powerCard.setAttribute("role", "button");
+    powerCard.tabIndex = 0;
+    powerCard.setAttribute("aria-label", english() ? "Open instant appliance power" : "Apri consumo istantaneo elettrodomestici");
+    const value = powerCard.querySelector(".g-val");
+    if (value) value.textContent = formatApplianceWatts(totalWatts);
+  }
+
+  const daily = applianceKpiCard("daily");
+  if (daily) daily.dataset.dmApplianceKpi = "daily";
+
+  const alerts = applianceKpiCard("alerts");
+  if (alerts) alerts.remove();
+
+  for (const kind of ["running", "power"]) {
+    const popup = doc.getElementById(`dm-appliance-${kind}-popup`);
+    if (popup && !popup.hidden) renderApplianceKpiPopup(kind);
+  }
+  return true;
+}
+
+function installApplianceKpiPopupStyle() {
+  const doc = root.document;
+  if (!doc?.head || doc.getElementById(APPLIANCE_KPI_POPUP_STYLE_ID)) return;
+  const style = doc.createElement("style");
+  style.id = APPLIANCE_KPI_POPUP_STYLE_ID;
+  style.textContent = `
+    #appl-kpi-grid [data-dm-appliance-kpi="running"],
+    #appl-kpi-grid [data-dm-appliance-kpi="power"]{cursor:pointer!important;outline-offset:3px}
+    #appl-kpi-grid [data-dm-appliance-kpi="running"]:active,
+    #appl-kpi-grid [data-dm-appliance-kpi="power"]:active{transform:scale(.985)}
+    .dm-appliance-kpi-overlay[hidden]{display:none!important}
+    .dm-appliance-kpi-overlay{position:fixed!important;inset:0!important;z-index:2147483000!important;display:grid!important;place-items:center!important;padding:18px!important;background:rgba(30,41,59,.42)!important;backdrop-filter:blur(15px) saturate(120%)!important;-webkit-backdrop-filter:blur(15px) saturate(120%)!important}
+    .dm-appliance-kpi-dialog{width:min(620px,100%)!important;max-height:min(80vh,720px)!important;overflow:hidden!important;display:flex!important;flex-direction:column!important;border:1px solid rgba(148,163,184,.24)!important;border-radius:34px!important;background:radial-gradient(circle at 8% 2%,rgba(125,211,252,.24),transparent 33%),radial-gradient(circle at 94% 18%,rgba(167,243,208,.18),transparent 30%),linear-gradient(180deg,rgba(255,255,255,.99),rgba(244,249,255,.98))!important;color:#111827!important;box-shadow:0 26px 80px rgba(15,23,42,.30)!important}
+    .dm-appliance-kpi-head{display:flex!important;align-items:flex-start!important;justify-content:space-between!important;gap:16px!important;padding:26px 26px 15px!important}.dm-appliance-kpi-head small{display:inline-flex!important;align-items:center!important;min-height:28px!important;padding:0 12px!important;border:1px solid rgba(14,165,233,.18)!important;border-radius:999px!important;background:rgba(224,242,254,.72)!important;color:#0284c7!important;font-size:10px!important;font-weight:900!important;letter-spacing:2px!important}.dm-appliance-kpi-head h3{margin:8px 0 0!important;color:#111827!important;font-size:clamp(24px,4vw,32px)!important;font-weight:950!important;line-height:1.04!important;letter-spacing:1px!important;text-transform:uppercase!important}.dm-appliance-kpi-head button{width:48px!important;height:48px!important;flex:0 0 48px!important;border:1px solid rgba(148,163,184,.18)!important;border-radius:17px!important;background:rgba(248,250,252,.92)!important;color:#0f172a!important;box-shadow:0 8px 24px rgba(15,23,42,.07)!important;font-size:21px!important;cursor:pointer!important}
+    .dm-appliance-kpi-summary{min-height:108px!important;margin:0 26px 18px!important;padding:18px 22px!important;display:flex!important;align-items:center!important;gap:18px!important;border:1px solid rgba(14,165,233,.18)!important;border-radius:26px!important;background:linear-gradient(135deg,rgba(224,242,254,.96),rgba(240,249,255,.84))!important;box-shadow:0 13px 34px rgba(14,165,233,.10)!important}.dm-appliance-kpi-running .dm-appliance-kpi-summary{border-color:rgba(16,185,129,.18)!important;background:linear-gradient(135deg,rgba(209,250,229,.88),rgba(240,253,250,.90))!important}.dm-appliance-kpi-summary-icon{width:58px!important;height:58px!important;flex:0 0 58px!important;display:grid!important;place-items:center!important;border:1px solid rgba(14,165,233,.16)!important;border-radius:19px!important;background:rgba(255,255,255,.82)!important;color:#0284c7!important;font-size:30px!important;box-shadow:0 8px 24px rgba(14,165,233,.10)!important}.dm-appliance-kpi-running .dm-appliance-kpi-summary-icon{color:#10b981!important;font-size:42px!important}.dm-appliance-kpi-summary-copy{display:flex!important;flex-direction:column!important;gap:4px!important;min-width:0!important}.dm-appliance-kpi-summary-copy small{color:#64748b!important;font-size:12px!important;font-weight:900!important;letter-spacing:1.5px!important;text-transform:uppercase!important}.dm-appliance-kpi-summary-copy strong{color:#0797d5!important;font-size:clamp(30px,5vw,40px)!important;font-weight:950!important;line-height:1!important}.dm-appliance-kpi-running .dm-appliance-kpi-summary-copy strong{color:#059669!important}
+    .dm-appliance-kpi-list{overflow:auto!important;display:grid!important;gap:11px!important;padding:0 26px 26px!important}.dm-appliance-kpi-row{min-height:92px!important;padding:13px 16px!important;display:grid!important;grid-template-columns:62px minmax(0,1fr) auto!important;align-items:center!important;gap:14px!important;border:1px solid rgba(148,163,184,.20)!important;border-radius:24px!important;background:rgba(255,255,255,.92)!important;box-shadow:0 10px 30px rgba(15,23,42,.07)!important}.dm-appliance-kpi-visual{width:58px!important;height:58px!important;display:grid!important;place-items:center!important;overflow:hidden!important;border-radius:18px!important;background:linear-gradient(145deg,#e0f2fe,#f0f9ff)!important}.dm-appliance-kpi-visual .dm-appliance-art,.dm-appliance-kpi-visual svg{width:56px!important;height:56px!important;max-width:56px!important;max-height:56px!important}.dm-appliance-kpi-image-wrap,.dm-appliance-kpi-image{display:block!important;width:100%!important;height:100%!important}.dm-appliance-kpi-image{object-fit:cover!important;object-position:center!important;border-radius:16px!important}.dm-appliance-kpi-fallback{font-size:27px!important}.dm-appliance-kpi-row-main,.dm-appliance-kpi-row-value{display:flex!important;flex-direction:column!important;min-width:0!important}.dm-appliance-kpi-row-main{gap:4px!important}.dm-appliance-kpi-row-main>strong{overflow:hidden!important;color:#111827!important;font-size:17px!important;font-weight:900!important;line-height:1.15!important;text-overflow:ellipsis!important;white-space:nowrap!important}.dm-appliance-kpi-row-main>small{overflow:hidden!important;color:#64748b!important;font-size:11px!important;font-weight:800!important;letter-spacing:.7px!important;text-overflow:ellipsis!important;white-space:nowrap!important;text-transform:uppercase!important}.dm-appliance-kpi-row-value{align-items:flex-end!important;gap:5px!important;flex:0 0 auto!important}.dm-appliance-kpi-row-value>strong{color:#078dc7!important;font-size:18px!important;font-weight:950!important;white-space:nowrap!important}.dm-appliance-kpi-row-value>small{padding:4px 8px!important;border-radius:999px!important;background:#e0f2fe!important;color:#0369a1!important;font-size:10px!important;font-weight:900!important;white-space:nowrap!important}.dm-appliance-kpi-running .dm-appliance-kpi-row-value>small{background:#d1fae5!important;color:#047857!important}.dm-appliance-kpi-empty{padding:28px 20px!important;text-align:center!important;border:1px solid rgba(148,163,184,.18)!important;border-radius:22px!important;background:rgba(255,255,255,.76)!important;color:#64748b!important;font-size:14px!important;font-weight:800!important}
+    @media(max-width:700px){#appl-kpi-grid [data-dm-appliance-kpi="daily"]{grid-column:1/-1!important}}
+    @media(max-width:520px){.dm-appliance-kpi-overlay{place-items:center!important;padding:14px!important}.dm-appliance-kpi-dialog{width:min(620px,calc(100vw - 28px))!important;max-height:min(82vh,700px)!important;border-radius:30px!important}.dm-appliance-kpi-head{padding:22px 18px 13px!important}.dm-appliance-kpi-head h3{font-size:25px!important}.dm-appliance-kpi-head button{width:46px!important;height:46px!important;flex-basis:46px!important}.dm-appliance-kpi-summary{min-height:94px!important;margin:0 18px 14px!important;padding:16px 18px!important;border-radius:23px!important}.dm-appliance-kpi-summary-icon{width:52px!important;height:52px!important;flex-basis:52px!important}.dm-appliance-kpi-list{gap:9px!important;padding:0 18px 18px!important}.dm-appliance-kpi-row{min-height:82px!important;padding:11px 12px!important;grid-template-columns:54px minmax(0,1fr) auto!important;gap:11px!important;border-radius:21px!important}.dm-appliance-kpi-visual{width:50px!important;height:50px!important;border-radius:16px!important}.dm-appliance-kpi-visual .dm-appliance-art,.dm-appliance-kpi-visual svg{width:48px!important;height:48px!important;max-width:48px!important;max-height:48px!important}.dm-appliance-kpi-row-main>strong{font-size:15.5px!important}.dm-appliance-kpi-row-main>small{font-size:9.5px!important}.dm-appliance-kpi-row-value>strong{font-size:16px!important}}
+  `;
+  doc.head.append(style);
+}
+
+function installApplianceKpiPopups() {
+  const doc = root.document;
+  if (!doc) return;
+  const state = (root[APPLIANCE_KPI_STATE_KEY] ||= { installed: false, frame: 0 });
+  if (state.installed) return;
+  state.installed = true;
+  installApplianceKpiPopupStyle();
+  ensureApplianceKpiPopup("running");
+  ensureApplianceKpiPopup("power");
+  const schedule = () => {
+    if (state.frame) return;
+    const run = () => {
+      state.frame = 0;
+      syncApplianceKpis();
+    };
+    state.frame = root.requestAnimationFrame?.(run) || root.setTimeout?.(run, 0);
+  };
+  doc.addEventListener("click", (event) => {
+    const card = event.target?.closest?.('#appl-kpi-grid [data-dm-appliance-kpi="running"],#appl-kpi-grid [data-dm-appliance-kpi="power"]');
+    if (card) {
+      const kind = card.dataset.dmApplianceKpi;
+      const popup = ensureApplianceKpiPopup(kind);
+      renderApplianceKpiPopup(kind);
+      if (popup) {
+        popup.hidden = false;
+        popup.classList.add("show");
+      }
+      return;
+    }
+    if (event.target?.closest?.("[data-tab='appliances-main'],[data-tab='appliances'],.tab[data-tab='appliances-main']")) {
+      root.queueMicrotask?.(schedule);
+    }
+  }, true);
+  doc.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    const card = event.target?.closest?.('#appl-kpi-grid [data-dm-appliance-kpi="running"],#appl-kpi-grid [data-dm-appliance-kpi="power"]');
+    if (!card) return;
+    event.preventDefault();
+    const kind = card.dataset.dmApplianceKpi;
+    const popup = ensureApplianceKpiPopup(kind);
+    renderApplianceKpiPopup(kind);
+    if (popup) {
+      popup.hidden = false;
+      popup.classList.add("show");
+    }
+  });
+  root.addEventListener?.("dashboardmodern:state-changed", schedule);
+  root.addEventListener?.("dashboardmodern:legacy-ready", schedule);
+  root.queueMicrotask?.(schedule);
 }
 
 export function installSectionRuntime() {
@@ -318,6 +603,7 @@ export function installSectionRuntime() {
     installAppliancesSection();
     installApplianceLayoutSection();
     installApplianceDailyPopupStyle();
+    installApplianceKpiPopups();
     installAppliancePickerLayer();
     installApplianceEditorSection();
     installLightsAlertsSection();

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -29,7 +29,7 @@ import { installReportEditorSection } from "./report-editor-section.js";
 import { installShutterSection } from "./shutter-section.js";
 import { installEvSection } from "./ev-section.js";
 import { installLegacySections, LEGACY_SECTION_KEYS } from "./legacy-sections-registry.js";
-import { allStates, clean, english, section } from "./shared.js";
+import { allStates, clean, english, section, wrapFunction } from "./shared.js";
 
 const root = globalThis;
 const RUNTIME_KEY = "__DASHBOARDMODERN_SECTION_RUNTIME__";
@@ -81,7 +81,7 @@ function installApplianceDailyPopupStyle() {
       width:min(620px,100%)!important;
       max-height:min(82vh,760px)!important;
       border:1px solid rgba(148,163,184,.24)!important;
-      border-radius:34px!important;
+      border-radius:12px!important;
       background:
         radial-gradient(circle at 8% 2%,rgba(125,211,252,.24),transparent 33%),
         radial-gradient(circle at 94% 18%,rgba(167,243,208,.18),transparent 30%),
@@ -251,7 +251,7 @@ function installApplianceDailyPopupStyle() {
       #dm-appliance-daily-popup .dm-appliance-daily-dialog {
         width:min(620px,calc(100vw - 28px))!important;
         max-height:min(82vh,720px)!important;
-        border-radius:30px!important;
+        border-radius:12px!important;
       }
       #dm-appliance-daily-popup .dm-appliance-daily-head {
         padding:22px 18px 13px!important;
@@ -544,6 +544,9 @@ function installApplianceKpiPopups() {
     };
     state.frame = root.requestAnimationFrame?.(run) || root.setTimeout?.(run, 0);
   };
+  for (const name of ["renderAppliances", "renderApplianceSection", "render"]) {
+    wrapFunction(name, "__dmApplianceKpiPopups", schedule);
+  }
   doc.addEventListener("click", (event) => {
     const card = event.target?.closest?.('#appl-kpi-grid [data-dm-appliance-kpi="running"],#appl-kpi-grid [data-dm-appliance-kpi="power"]');
     if (card) {

--- a/custom_components/dashboardmodern/frontend/tests/appliance-kpi-popups-contract.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/appliance-kpi-popups-contract.test.js
@@ -12,7 +12,9 @@ test("appliance KPI runtime keeps running semantics, removes alerts and centers 
   assert.match(source, /const id = `dm-appliance-\$\{kind\}-popup`/);
   assert.match(source, /ensureApplianceKpiPopup\("running"\)/);
   assert.match(source, /ensureApplianceKpiPopup\("power"\)/);
-  assert.match(source, /place-items:center!important/);
-  assert.match(source, /#dm-appliance-daily-popup\.dm-appliance-daily-overlay[\s\S]*align-items:center!important/);
-  assert.doesNotMatch(source, /align-items:flex-end!important/);
+  assert.match(source, /\.dm-appliance-kpi-overlay\{[^}]*place-items:center!important/);
+  assert.match(
+    source,
+    /@media\(max-width:520px\)[\s\S]*#dm-appliance-daily-popup\.dm-appliance-daily-overlay\s*\{[^}]*align-items:center!important;[^}]*justify-content:center!important/,
+  );
 });

--- a/custom_components/dashboardmodern/frontend/tests/appliance-kpi-popups-contract.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/appliance-kpi-popups-contract.test.js
@@ -9,8 +9,9 @@ test("appliance KPI runtime keeps running semantics, removes alerts and centers 
   assert.match(source, /model\.mode === "running"/);
   assert.match(source, /alerts\.remove\(\)/);
   assert.match(source, /IN FUNZIONE/);
-  assert.match(source, /dm-appliance-running-popup/);
-  assert.match(source, /dm-appliance-power-popup/);
+  assert.match(source, /const id = `dm-appliance-\$\{kind\}-popup`/);
+  assert.match(source, /ensureApplianceKpiPopup\("running"\)/);
+  assert.match(source, /ensureApplianceKpiPopup\("power"\)/);
   assert.match(source, /place-items:center!important/);
   assert.match(source, /#dm-appliance-daily-popup\.dm-appliance-daily-overlay[\s\S]*align-items:center!important/);
   assert.doesNotMatch(source, /align-items:flex-end!important/);

--- a/custom_components/dashboardmodern/frontend/tests/appliance-kpi-popups-contract.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/appliance-kpi-popups-contract.test.js
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const runtimeUrl = new URL("../src/sections/section-runtime.js", import.meta.url);
+
+test("appliance KPI runtime keeps running semantics, removes alerts and centers popups", async () => {
+  const source = await readFile(runtimeUrl, "utf8");
+  assert.match(source, /model\.mode === "running"/);
+  assert.match(source, /alerts\.remove\(\)/);
+  assert.match(source, /IN FUNZIONE/);
+  assert.match(source, /dm-appliance-running-popup/);
+  assert.match(source, /dm-appliance-power-popup/);
+  assert.match(source, /place-items:center!important/);
+  assert.match(source, /#dm-appliance-daily-popup\.dm-appliance-daily-overlay[\s\S]*align-items:center!important/);
+  assert.doesNotMatch(source, /align-items:flex-end!important/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
@@ -23,14 +23,14 @@ const refreshUrl = new URL("../src/sections/energy-refresh-section.js", import.m
 const analysisUrl = new URL("../src/sections/energy-analysis-section.js", import.meta.url);
 const contractsUrl = new URL("../src/sections/editor-contracts-section.js", import.meta.url);
 
-test("the popup artwork/brand release is consistently versioned as 0.15.24", async () => {
+test("the 0.15.25 release metadata is consistently versioned", async () => {
   const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
   const readme = await readFile(readmeUrl, "utf8");
   const buildInfo = await readFile(buildInfoUrl, "utf8");
 
-  assert.equal(manifest.version, "0.15.24");
-  assert.match(readme, /version-0\.15\.24/);
-  assert.match(readme, /Novità 0\.15\.24/);
+  assert.equal(manifest.version, "0.15.25");
+  assert.match(readme, /version-0\.15\.25/);
+  assert.match(readme, /Novità 0\.15\.25/);
   assert.match(readme, /Confronto settimanale dei consumi Casa/i);
   assert.match(readme, /contatore totale kWh/i);
   assert.match(readme, /SALVA MODIFICHE/);
@@ -40,8 +40,8 @@ test("the popup artwork/brand release is consistently versioned as 0.15.24", asy
     /https:\/\/raw\.githubusercontent\.com\/danigio15\/dashboardmodern-v2\/main\/brand\/logo\.png/,
   );
   assert.doesNotMatch(readme, /main\/assets\/logo|brand\/logo@2x\.png/);
-  assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']0\.15\.24["']/);
-  assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']0\.15\.24["']/);
+  assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']0\.15\.25["']/);
+  assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']0\.15\.25["']/);
   assert.match(buildInfo, /["']?moduleVersion["']?\s*:\s*14/);
 });
 

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "0.15.24"
+  "version": "0.15.25"
 }


### PR DESCRIPTION
## Richiesta UI

- sostituire **Dispositivi accesi** con **In funzione**;
- rendere cliccabile **In funzione** con popup di dettaglio;
- rendere cliccabile **Consumo istantaneo** con popup di dettaglio Watt;
- eliminare la KPI **Avvisi** dalla sezione Elettrodomestici;
- mantenere i popup centrati anche su mobile, incluso Energia giornaliera.

## Implementazione

- `In funzione` usa il `mode === "running"` del view-model canonico e non il semplice stato ON del comando;
- il popup mostra soltanto gli apparecchi realmente in funzione, con artwork, stanza, potenza e stato;
- `Consumo istantaneo` somma i Watt misurabili e mostra il dettaglio per elettrodomestico ordinato per assorbimento con percentuale sul totale;
- Avvisi viene rimosso dal DOM a ogni sincronizzazione della sezione;
- Energia giornaliera non usa più il bottom-sheet mobile: overlay e dialog restano centrati;
- nessun nuovo MutationObserver o polling periodico.

## Test aggiunti

- Browser E2E IT/EN con un dispositivo running e uno standby;
- verifica conteggio `In funzione = 1`;
- verifica totale `Consumo istantaneo = 922 W` e dettaglio 920 W + 2 W;
- verifica assenza Avvisi;
- verifica artwork canonici nei popup;
- verifica centratura running/power/daily popup;
- contratto frontend per semantica running, rimozione Avvisi e assenza bottom-sheet.