### PR TITLE
fix: beta5 root-cause mobile UI and real Energy history

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/beta5-root-causes.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta5-root-causes.spec.js
@@ -167,7 +167,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     if (testInfo.project.name === "mobile") {
       const climateHeight = await page.locator("#page-clima.active .cp-card").first().evaluate((card) => card.getBoundingClientRect().height);
       expect(climateHeight).toBeLessThan(260);
-      await expect(page.locator("#page-clima.active .clima-premium-grid")).toHaveCSS("grid-template-columns", /.+/);
+      await expect(page.locator("#page-clima.active .clima-premium-grid").first()).toHaveCSS("grid-template-columns", /.+/);
     }
   });
 

--- a/custom_components/dashboardmodern/frontend/e2e/beta5-root-causes.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta5-root-causes.spec.js
@@ -1,0 +1,239 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const states = [
+  ...[1, 2, 3, 4].map((index) => ({
+    entity_id: `light.cucina_${index}`,
+    state: index % 2 ? "on" : "off",
+    attributes: { friendly_name: `Luce cucina ${index}` },
+  })),
+  {
+    entity_id: "climate.cucina",
+    state: "off",
+    attributes: { friendly_name: "Cucina", current_temperature: 31.8, temperature: 18 },
+  },
+  {
+    entity_id: "climate.salone",
+    state: "off",
+    attributes: { friendly_name: "Salone", current_temperature: 31.7, temperature: 18 },
+  },
+];
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [{ id: "room-cucina", name: "Cucina", icon: "mdi:stove" }],
+    lights: [
+      { id: "light-cucina-1", name: "Luce cucina 1", entities: ["light.cucina_1"], room_id: "room-cucina" },
+      { id: "light-cucina-2", name: "Luce cucina 2", entities: ["light.cucina_2"], room_id: "room-cucina" },
+      { id: "light-cucina-3", name: "Luce cucina 3", entities: ["light.cucina_3"], room_id: "room-cucina" },
+      { id: "light-cucina-4", name: "Luce cucina 4", entities: ["light.cucina_4"], room_id: "room-cucina" },
+    ],
+    appliances: [],
+    loads: [],
+    climate: [],
+    ev: [{ id: "ev-b10", name: "B10", brand: "Leapmotor", icon: "mdi:car", ov: {} }],
+    energy: {},
+  },
+  visibility: { home: true, energy: true, ev: true, clima: true },
+};
+
+async function boot(page, variant, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript((haStates) => {
+    class MockBridgeSocket extends EventTarget {
+      static OPEN = 1;
+      readyState = 1;
+      onopen = null;
+      onmessage = null;
+      onclose = null;
+      constructor() {
+        super();
+        queueMicrotask(() => {
+          this.onopen?.({});
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+        });
+      }
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") return;
+        const result = message.type === "get_states" ? haStates : message.type === "frontend/get_user_data" ? { value: null } : null;
+        queueMicrotask(() => this.onmessage?.({ data: JSON.stringify({ id: message.id, type: "result", success: true, result }) }));
+      }
+      close() {
+        this.readyState = 3;
+        this.onclose?.({});
+      }
+    }
+    window.__DASHBOARDMODERN_BRIDGE_WS__ = MockBridgeSocket;
+    window.WebSocket = MockBridgeSocket;
+  }, states);
+
+  await bootNamespacedDashboard(page, variant, testInfo, seed);
+  await page.evaluate(() => {
+    localStorage.setItem("cd_luci", JSON.stringify({
+      "light.cucina_1": "Luce cucina 1",
+      "light.cucina_2": "Luce cucina 2",
+      "light.cucina_3": "Luce cucina 3",
+      "light.cucina_4": "Luce cucina 4",
+    }));
+    localStorage.setItem("cd_luci_rooms", JSON.stringify({
+      "light.cucina_1": "room-cucina",
+      "light.cucina_2": "room-cucina",
+      "light.cucina_3": "room-cucina",
+      "light.cucina_4": "room-cucina",
+    }));
+    localStorage.setItem("cd_clima_units", JSON.stringify([
+      { entity: "climate.cucina", name: "Cucina", type: "clima", room: "Cucina" },
+      { entity: "climate.salone", name: "Salone", type: "clima", room: "Cucina" },
+    ]));
+  });
+  await page.reload();
+  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await expect.poll(() => page.evaluate(() => window.__DASHBOARDMODERN_RUNTIME_ROOT__?.ready === true)).toBe(true);
+  await page.evaluate((haStates) => {
+    haStates.forEach((item) => {
+      _RAW_STATES[item.entity_id] = structuredClone(item);
+      STATES[item.entity_id] = structuredClone(item);
+    });
+    window.render?.();
+    window.buildClimaCards?.();
+  }, states);
+}
+
+async function openEditor(page, tab) {
+  await page.evaluate(() => {
+    if (!document.getElementById("editor-modal")?.classList.contains("show")) apriConfigEntita();
+    editorSwitch(arguments[0]);
+  }, tab);
+  await expect(page.locator("#editor-modal")).toBeVisible();
+  await expect(page.locator(`.ed-tab[data-tab="${tab}"]`)).toHaveClass(/active/);
+  await page.waitForTimeout(40);
+}
+
+for (const variant of ["dashboard.html", "dashboard-en.html"]) {
+  test(`${variant}: beta5 fixes the exact mobile editor regressions`, async ({ page }, testInfo) => {
+    test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
+    await boot(page, variant, testInfo);
+
+    await openEditor(page, "visib");
+    const renameRows = page.locator("#ed-body .ed-row[data-section-key]");
+    await expect(renameRows.first()).toBeVisible();
+    const renameCounts = await renameRows.evaluateAll((rows) => rows.map((row) => ({
+      total: row.querySelectorAll(".dm-inline-rename[data-rename]").length,
+      visible: [...row.querySelectorAll(".dm-inline-rename[data-rename]")].filter((button) => getComputedStyle(button).display !== "none").length,
+    })));
+    expect(renameCounts.length).toBeGreaterThan(3);
+    expect(renameCounts.every((count) => count.total === 1 && count.visible === 1)).toBe(true);
+
+    await openEditor(page, "luci");
+    const lightRows = page.locator("#ed-body .dm-light-row");
+    await expect(lightRows).toHaveCount(4);
+    await expect(lightRows.first().locator(".ed-row-new")).toContainText(/Luce cucina 1/i);
+    await expect(lightRows.first().locator(".ed-row-old")).toContainText("light.cucina_1");
+    await expect(lightRows.first().locator(".dm-light-room")).toBeVisible();
+    if (testInfo.project.name === "mobile") {
+      const height = await lightRows.first().evaluate((row) => row.getBoundingClientRect().height);
+      expect(height).toBeLessThan(150);
+    }
+
+    await openEditor(page, "avvisi");
+    await expect(page.locator("#ed-avv-custom")).toBeHidden();
+    await expect(page.locator('#ed-body button', { hasText: /^⚡$/ })).toHaveCount(0);
+    await page.locator("#ed-avv-grp").selectOption("custom");
+    await expect(page.locator("#ed-avv-custom")).toBeVisible();
+    await page.locator("#ed-avv-grp").selectOption("win");
+    await expect(page.locator("#ed-avv-custom")).toBeHidden();
+    await expect(page.locator('#ed-body button', { hasText: /^⚡$/ })).toHaveCount(0);
+
+    await openEditor(page, "sez2");
+    const brandPreview = page.locator("#ed-body [data-brand-preview]");
+    await expect(brandPreview).toBeVisible();
+    await brandPreview.click();
+    const picker = page.locator('#dm-visual-picker[data-kind="car"]');
+    await expect(picker).toBeVisible();
+    await expect(picker.locator(".dm-beta5-brand-logo svg").first()).toBeVisible();
+    expect(await picker.locator(".dm-beta5-brand-logo svg").count()).toBeGreaterThan(20);
+    const leap = picker.locator(".dm-picker-option", { hasText: "Leapmotor" });
+    await expect(leap.locator('[data-brand-logo="leapmotor"] svg')).toBeVisible();
+    await picker.locator("[data-close]").click();
+
+    await page.locator("#editor-modal .ed-head-close").last().click();
+    await page.locator('.tab[data-tab="clima"]').click();
+    await expect(page.locator("#page-clima.active .cp-card").first()).toBeVisible();
+    if (testInfo.project.name === "mobile") {
+      const climateHeight = await page.locator("#page-clima.active .cp-card").first().evaluate((card) => card.getBoundingClientRect().height);
+      expect(climateHeight).toBeLessThan(260);
+      await expect(page.locator("#page-clima.active .clima-premium-grid")).toHaveCSS("grid-template-columns", /.+/);
+    }
+  });
+
+  test(`${variant}: beta5 Energy chart never invents future days and keeps Wallbox in the flow`, async ({ page }, testInfo) => {
+    test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
+    await boot(page, variant, testInfo);
+
+    await page.evaluate(async () => {
+      window.render?.();
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    });
+    await expect(page.locator("#n-wb-day")).toHaveAttribute("data-dm-beta5-flow-complete", "true");
+    await expect(page.locator("#n-wb-day")).not.toHaveCSS("display", "none");
+
+    const result = await page.evaluate(async () => {
+      let loading = document.getElementById("ed-chart-loading");
+      let canvas = document.getElementById("ed-daily-canvas");
+      if (!loading) {
+        loading = document.createElement("div");
+        loading.id = "ed-chart-loading";
+        document.body.append(loading);
+      }
+      if (!canvas) {
+        canvas = document.createElement("canvas");
+        canvas.id = "ed-daily-canvas";
+        document.body.append(canvas);
+      }
+      class MockChart {
+        static getChart() { return null; }
+        constructor(_context, config) { window.__BETA5_CHART_CONFIG__ = structuredClone(config); }
+        destroy() {}
+      }
+      window.Chart = MockChart;
+      const today = new Date();
+      window.__DASHBOARDMODERN_RUNTIME_ROOT__.bundle = {
+        ...(window.__DASHBOARDMODERN_RUNTIME_ROOT__.bundle || {}),
+        day: {
+          solar: 3.4,
+          house: 3.1,
+          gridImport: 0.1,
+          gridExport: 0,
+          batteryCharged: 2.4,
+          batteryDischarged: 2.0,
+        },
+      };
+      window.DashboardModernEnergyService.statisticsWithGrowth = async () => ({});
+      const ok = await window.renderEdDailyChart(
+        new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate(),
+        today.getMonth() + 1,
+        today.getFullYear(),
+        true,
+        314,
+        165,
+      );
+      const config = window.__BETA5_CHART_CONFIG__;
+      return {
+        ok,
+        today: today.getDate(),
+        labels: config?.data?.labels || [],
+        production: config?.data?.datasets?.[0]?.data || [],
+        consumption: config?.data?.datasets?.[1]?.data || [],
+        marker: canvas.dataset.dmBeta5RealHistory || "",
+      };
+    });
+    expect(result.ok).toBe(true);
+    expect(result.labels).toHaveLength(result.today);
+    expect(result.labels.at(-1)).toBe(String(result.today));
+    expect(result.production.at(-1)).toBeCloseTo(3.4, 4);
+    expect(result.consumption.at(-1)).toBeCloseTo(3.1, 4);
+    expect(result.marker).toMatch(/^\d{4}-\d{2}$/);
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/beta5-root-causes.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta5-root-causes.spec.js
@@ -102,9 +102,9 @@ async function boot(page, variant, testInfo) {
 }
 
 async function openEditor(page, tab) {
-  await page.evaluate(() => {
+  await page.evaluate((target) => {
     if (!document.getElementById("editor-modal")?.classList.contains("show")) apriConfigEntita();
-    editorSwitch(arguments[0]);
+    editorSwitch(target);
   }, tab);
   await expect(page.locator("#editor-modal")).toBeVisible();
   await expect(page.locator(`.ed-tab[data-tab="${tab}"]`)).toHaveClass(/active/);

--- a/custom_components/dashboardmodern/frontend/e2e/beta5-root-causes.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta5-root-causes.spec.js
@@ -159,7 +159,10 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await picker.locator("[data-close]").click();
 
     await page.locator("#editor-modal .ed-head-close").last().click();
-    await page.locator('.tab[data-tab="clima"]').click();
+    // On narrow hosted frames the horizontal navbar can live outside the
+    // physical viewport. DOM click exercises the same application handler
+    // without turning navbar scrolling into a prerequisite for this layout test.
+    await page.locator('.tab[data-tab="clima"]').evaluate((button) => button.click());
     await expect(page.locator("#page-clima.active .cp-card").first()).toBeVisible();
     if (testInfo.project.name === "mobile") {
       const climateHeight = await page.locator("#page-clima.active .cp-card").first().evaluate((card) => card.getBoundingClientRect().height);
@@ -178,6 +181,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     });
     await expect(page.locator("#n-wb-day")).toHaveAttribute("data-dm-beta5-flow-complete", "true");
     await expect(page.locator("#n-wb-day")).not.toHaveCSS("display", "none");
+    await expect(page.locator("#line-home-wb-day")).not.toHaveCSS("display", "none");
 
     const result = await page.evaluate(async () => {
       let loading = document.getElementById("ed-chart-loading");
@@ -194,7 +198,13 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       }
       class MockChart {
         static getChart() { return null; }
-        constructor(_context, config) { window.__BETA5_CHART_CONFIG__ = structuredClone(config); }
+        constructor(_context, config) {
+          window.__BETA5_CHART_CONFIG__ = {
+            labels: [...(config?.data?.labels || [])],
+            production: [...(config?.data?.datasets?.[0]?.data || [])],
+            consumption: [...(config?.data?.datasets?.[1]?.data || [])],
+          };
+        }
         destroy() {}
       }
       window.Chart = MockChart;
@@ -219,13 +229,13 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
         314,
         165,
       );
-      const config = window.__BETA5_CHART_CONFIG__;
+      const config = window.__BETA5_CHART_CONFIG__ || {};
       return {
         ok,
         today: today.getDate(),
-        labels: config?.data?.labels || [],
-        production: config?.data?.datasets?.[0]?.data || [],
-        consumption: config?.data?.datasets?.[1]?.data || [],
+        labels: config.labels || [],
+        production: config.production || [],
+        consumption: config.consumption || [],
         marker: canvas.dataset.dmBeta5RealHistory || "",
       };
     });

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -3,8 +3,8 @@ import "../src/sections/beta-entry-section.js";
 
 export const BUILD_INFO = Object.freeze({
   generated: false,
-  integrationVersion: "1.0.0-beta.4",
-  dashboardVersion: "1.0.0-beta.4",
+  integrationVersion: "1.0.0-beta.5",
+  dashboardVersion: "1.0.0-beta.5",
   moduleVersion: 14,
   schemaVersion: 4,
   date: "UNBUILT",

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -6,20 +6,3 @@ import "./energy-report-polish-section.js";
 import "./personalization-section.js";
 import "./editor-polish-section.js";
 import "./beta4-mobile-polish-section.js";
-
-// The first-insert Rooms control is now the icon itself, not a separate palette.
-// Keep the mature searchable room catalog behind that direct trigger so the
-// existing multilingual icon set and search semantics remain unchanged.
-if (typeof document !== "undefined") {
-  document.addEventListener(
-    "click",
-    (event) => {
-      const trigger = event.target?.closest?.(".dm-beta4-room-icon-trigger");
-      if (!trigger || typeof globalThis.dmIconPicker !== "function") return;
-      event.preventDefault();
-      event.stopImmediatePropagation();
-      globalThis.dmIconPicker("#ed-room-icon", "rooms");
-    },
-    true,
-  );
-}

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -6,3 +6,36 @@ import "./energy-report-polish-section.js";
 import "./personalization-section.js";
 import "./editor-polish-section.js";
 import "./beta4-mobile-polish-section.js";
+
+// First insert keeps the new direct icon trigger, but delegates the actual
+// catalog to the mature multilingual picker already used by the legacy editor.
+// Capture phase prevents the superseded beta picker from opening as a second
+// modal without reintroducing a visible palette button.
+if (typeof document !== "undefined") {
+  const marker = "__DASHBOARDMODERN_BETA5_ENTRY_BRIDGE__";
+  if (!globalThis[marker]) {
+    globalThis[marker] = true;
+    document.addEventListener(
+      "click",
+      (event) => {
+        const trigger = event.target?.closest?.(".dm-beta5-room-icon-trigger");
+        if (!trigger || typeof globalThis.dmIconPicker !== "function") return;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        globalThis.dmIconPicker("#ed-room-icon", "rooms");
+      },
+      true,
+    );
+
+    // The canonical period renderer may mark a secondary load as unmapped and
+    // hide its SVG connector inline. Keep the topology complete: a load with no
+    // current sample is still represented and its value remains zero/blank.
+    const style = document.createElement("style");
+    style.id = "dm-beta5-complete-flow-links";
+    style.textContent = ["day", "month"]
+      .flatMap((period) => ["boiler", "wb", "clima", "lav", "cuc"].map((load) => `#line-home-${load}-${period}`))
+      .map((selector) => `${selector}{display:block!important}`)
+      .join("");
+    document.head?.append(style);
+  }
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/beta4-mobile-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta4-mobile-polish-section.js
@@ -1,8 +1,10 @@
 import { ROOM_CATALOG, roomVisual } from "../core/personalization-catalog.js";
-import { clean, doc, esc, installStyle, root, t, wrapFunction } from "./shared.js";
+import { clean, doc, esc, formatNumber, installStyle, root, t, wrapFunction } from "./shared.js";
 
-const KEY = "__DASHBOARDMODERN_BETA4_MOBILE_POLISH__";
-const state = (root[KEY] ||= { installed: false, frame: 0, listeners: false });
+// Kept in the beta4 entry filename for release compatibility, but this module is
+// now the final root-cause owner for the regressions reported after beta.4.
+const KEY = "__DASHBOARDMODERN_BETA5_ROOT_CAUSES__";
+const state = (root[KEY] ||= { installed: false, frame: 0, listeners: false, dailyChart: null });
 
 const TAB_ICONS = Object.freeze({
   visib: "⚙️",
@@ -24,43 +26,53 @@ const TAB_ICONS = Object.freeze({
   pool: "🏊",
 });
 
-const BRAND_SIGNS = Object.freeze({
-  abarth: "♏",
-  "alfa romeo": "AR",
-  audi: "○○○○",
-  bmw: "BMW",
-  byd: "BYD",
-  citroen: "⌃⌃",
-  "citroën": "⌃⌃",
-  cupra: "◇",
-  dacia: "DACIA",
-  ds: "DS",
-  fiat: "FIAT",
-  ford: "Ford",
-  honda: "H",
-  hyundai: "H",
-  jeep: "Jeep",
-  kia: "KIA",
-  leapmotor: "LEAP",
-  lexus: "L",
-  mazda: "M",
-  mercedes: "✦",
-  "mercedes-benz": "✦",
-  mini: "MINI",
-  nissan: "NISSAN",
-  opel: "⚡",
-  peugeot: "♌",
-  polestar: "✦",
-  porsche: "PORSCHE",
-  renault: "◇",
-  seat: "S",
-  skoda: "Š",
-  "škoda": "Š",
-  smart: "smart",
-  tesla: "T",
-  toyota: "TOYOTA",
-  volkswagen: "VW",
-  volvo: "VOLVO",
+const FLOW_LOADS = Object.freeze({
+  boiler: { day: "dm.energy_boiler_oggi", month: "dm.energy_boiler_mese" },
+  wb: { day: "dm.ev_energia_wallbox_oggi", month: "dm.ev_energia_wallbox_mese" },
+  clima: { day: "dm.energy_condizionatori_oggi", month: "dm.energy_condizionatori_mese" },
+  lav: { day: "dm.energy_somma_lavanderia_oggi", month: "dm.energy_somma_lavanderia_mese" },
+  cuc: { day: "dm.energy_somma_cucina_oggi", month: "dm.energy_somma_cucina_mese" },
+});
+
+const BRAND_LOGOS = Object.freeze({
+  abarth: "<path d='M20 5h24l-3 9-9 4 6 5-4 12-8 5-8-5-4-12 6-5-9-4z' fill='none' stroke='currentColor' stroke-width='2.8'/><path d='M27 13l-5 8 6 1-4 8 11-11-7-1 4-5z' fill='currentColor'/>",
+  "alfa-romeo": "<circle cx='32' cy='22' r='16' fill='none' stroke='currentColor' stroke-width='2.7'/><path d='M24 10v24M17 17h14' stroke='currentColor' stroke-width='2.3'/><path d='M38 11c-7 6-2 9-7 13 8 0 10 5 5 11 9-4 12-13 2-24z' fill='currentColor' opacity='.78'/>",
+  audi: "<g fill='none' stroke='currentColor' stroke-width='3'><circle cx='17' cy='22' r='9'/><circle cx='27' cy='22' r='9'/><circle cx='37' cy='22' r='9'/><circle cx='47' cy='22' r='9'/></g>",
+  bmw: "<circle cx='32' cy='22' r='18' fill='none' stroke='currentColor' stroke-width='3'/><circle cx='32' cy='22' r='11' fill='none' stroke='currentColor' stroke-width='2'/><path d='M32 11v11H21A11 11 0 0 1 32 11zm0 11h11a11 11 0 0 1-11 11z' fill='currentColor' opacity='.8'/>",
+  byd: "<ellipse cx='32' cy='22' rx='25' ry='13' fill='none' stroke='currentColor' stroke-width='2.6'/><text x='32' y='27' text-anchor='middle' font-size='14' font-weight='900' font-family='system-ui'>BYD</text>",
+  citroen: "<path d='M17 24l15-10 15 10M17 33l15-10 15 10' fill='none' stroke='currentColor' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'/>",
+  cupra: "<path d='M12 15l13 4 7 12 7-12 13-4-9 11 7 8-14-5-4 8-4-8-14 5 7-8z' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linejoin='round'/>",
+  dacia: "<path d='M10 11h44v10c0 11-9 18-22 18S10 32 10 21z' fill='none' stroke='currentColor' stroke-width='2.8'/><path d='M20 18h24M25 18v11h14V18' fill='none' stroke='currentColor' stroke-width='3'/>",
+  ds: "<path d='M11 30l14-17 8 9-8 8H11zm42-16H37l-7 8 8 8h15l-8-8z' fill='none' stroke='currentColor' stroke-width='2.6' stroke-linejoin='round'/>",
+  fiat: "<circle cx='32' cy='22' r='18' fill='none' stroke='currentColor' stroke-width='3'/><text x='32' y='27' text-anchor='middle' font-size='14' font-weight='900' font-family='system-ui'>FIAT</text>",
+  ford: "<ellipse cx='32' cy='22' rx='27' ry='14' fill='none' stroke='currentColor' stroke-width='3'/><text x='32' y='27' text-anchor='middle' font-size='14' font-weight='800' font-style='italic' font-family='serif'>Ford</text>",
+  honda: "<rect x='10' y='6' width='44' height='32' rx='10' fill='none' stroke='currentColor' stroke-width='2.7'/><path d='M21 13l3 18M43 13l-3 18M23 24h18' fill='none' stroke='currentColor' stroke-width='4' stroke-linecap='round'/>",
+  hyundai: "<ellipse cx='32' cy='22' rx='25' ry='15' fill='none' stroke='currentColor' stroke-width='2.8'/><path d='M20 30l8-17M36 31l8-18M26 24l12-4' fill='none' stroke='currentColor' stroke-width='3.5' stroke-linecap='round'/>",
+  jeep: "<text x='32' y='27' text-anchor='middle' font-size='18' font-weight='900' font-family='system-ui'>Jeep</text><path d='M16 31h32' stroke='currentColor' stroke-width='2'/>",
+  kia: "<ellipse cx='32' cy='22' rx='27' ry='14' fill='none' stroke='currentColor' stroke-width='2.4'/><path d='M15 28V16m0 6l9-6m-9 6l10 6M29 28l6-12 6 12m-9-5h6M45 28V16' fill='none' stroke='currentColor' stroke-width='2.8' stroke-linecap='round' stroke-linejoin='round'/>",
+  lancia: "<path d='M32 4l20 8-4 20-16 8-16-8-4-20z' fill='none' stroke='currentColor' stroke-width='2.5'/><path d='M22 25h20M32 11v22M27 14h10' stroke='currentColor' stroke-width='2.5'/>",
+  leapmotor: "<circle cx='32' cy='22' r='17' fill='none' stroke='currentColor' stroke-width='3'/><path d='M21 25c6-1 10-5 12-13 2 8 5 12 11 14-6 0-10 3-12 7-2-4-5-7-11-8z' fill='currentColor'/>",
+  lexus: "<ellipse cx='32' cy='22' rx='25' ry='15' fill='none' stroke='currentColor' stroke-width='2.7'/><path d='M34 10L22 32h22' fill='none' stroke='currentColor' stroke-width='3.2' stroke-linecap='round' stroke-linejoin='round'/>",
+  mazda: "<ellipse cx='32' cy='22' rx='25' ry='15' fill='none' stroke='currentColor' stroke-width='2.7'/><path d='M15 17c7 0 12 3 17 10 5-7 10-10 17-10-4 9-9 14-17 14s-13-5-17-14z' fill='none' stroke='currentColor' stroke-width='2.8'/>",
+  "mercedes-benz": "<circle cx='32' cy='22' r='18' fill='none' stroke='currentColor' stroke-width='2.5'/><path d='M32 7v15L17 31M32 22l15 9' fill='none' stroke='currentColor' stroke-width='2.8' stroke-linejoin='round'/>",
+  mg: "<path d='M20 5h24l12 12v10L44 39H20L8 27V17z' fill='none' stroke='currentColor' stroke-width='2.6'/><text x='32' y='28' text-anchor='middle' font-size='16' font-weight='900' font-family='system-ui'>MG</text>",
+  mini: "<circle cx='32' cy='22' r='11' fill='none' stroke='currentColor' stroke-width='2.6'/><path d='M21 15H5m16 5H9m12 5H5m38-10h16m-16 5h12m-12 5h16' stroke='currentColor' stroke-width='2.5'/><text x='32' y='25' text-anchor='middle' font-size='6' font-weight='900' font-family='system-ui'>MINI</text>",
+  nissan: "<circle cx='32' cy='22' r='17' fill='none' stroke='currentColor' stroke-width='2.5'/><rect x='8' y='17' width='48' height='10' rx='2' fill='var(--card-background-color,#fff)' stroke='currentColor' stroke-width='2'/><text x='32' y='24.5' text-anchor='middle' font-size='8' font-weight='900' font-family='system-ui'>NISSAN</text>",
+  opel: "<circle cx='32' cy='22' r='18' fill='none' stroke='currentColor' stroke-width='2.5'/><path d='M8 24h20l-4 7 32-12H36l4-7z' fill='currentColor'/>",
+  peugeot: "<path d='M16 6h32v28L32 40 16 34z' fill='none' stroke='currentColor' stroke-width='2.6'/><path d='M35 12c-7 1-11 5-9 10-5 2-5 8 1 10l5-5 5 4 5-6-5-4 3-6z' fill='none' stroke='currentColor' stroke-width='2.4' stroke-linejoin='round'/>",
+  polestar: "<path d='M32 4l5 13 13 5-13 5-5 13-5-13-13-5 13-5z' fill='none' stroke='currentColor' stroke-width='2.3'/><path d='M32 10v24M20 22h24' stroke='currentColor' stroke-width='1.6' opacity='.55'/>",
+  porsche: "<path d='M17 4h30l4 12-5 17-14 8-14-8-5-17z' fill='none' stroke='currentColor' stroke-width='2.5'/><path d='M22 8v27M42 8v27M18 17h28M18 27h28' stroke='currentColor' stroke-width='1.8'/><path d='M28 13h8l4 8-8 9-8-9z' fill='currentColor' opacity='.7'/>",
+  renault: "<path d='M32 3l17 19-17 19-17-19zM32 9L22 22l10 13 10-13z' fill='none' stroke='currentColor' stroke-width='3'/>",
+  seat: "<path d='M19 8h31L44 15H25l-4 5h24l-5 7H16l-5 6h30l-5 7H8l-4-7 7-8-4-7z' fill='currentColor'/>",
+  skoda: "<circle cx='32' cy='22' r='18' fill='none' stroke='currentColor' stroke-width='2.6'/><path d='M19 24c9-11 19-12 27-7l-6 4 5 4-9 1-5 8-3-8z' fill='currentColor'/><circle cx='25' cy='18' r='2.5' fill='var(--card-background-color,#fff)'/>",
+  smart: "<circle cx='23' cy='22' r='14' fill='none' stroke='currentColor' stroke-width='4'/><path d='M34 12h20v20M34 12l20 20' fill='none' stroke='currentColor' stroke-width='3.5' stroke-linecap='round'/>",
+  subaru: "<ellipse cx='32' cy='22' rx='25' ry='15' fill='none' stroke='currentColor' stroke-width='2.5'/><g fill='currentColor'><path d='M18 22l2-2 2 2-2 2z'/><path d='M28 15l3-3 3 3-3 3z'/><path d='M39 19l2-2 2 2-2 2z'/><path d='M32 27l2-2 2 2-2 2z'/><path d='M44 27l1.5-1.5L47 27l-1.5 1.5z'/><path d='M25 31l1.5-1.5L28 31l-1.5 1.5z'/></g>",
+  suzuki: "<path d='M40 7L20 7l-7 8 17 8-11 7 6 7h21l7-8-17-8 11-7z' fill='none' stroke='currentColor' stroke-width='3' stroke-linejoin='round'/>",
+  tesla: "<path d='M13 11c13-6 25-6 38 0l-5 5c-6-2-10-3-14-3v24l-5-6V13c-4 0-8 1-14 3z' fill='currentColor'/>",
+  toyota: "<ellipse cx='32' cy='22' rx='25' ry='15' fill='none' stroke='currentColor' stroke-width='2.5'/><ellipse cx='32' cy='18' rx='10' ry='14' fill='none' stroke='currentColor' stroke-width='2.2'/><ellipse cx='32' cy='17' rx='18' ry='7' fill='none' stroke='currentColor' stroke-width='2.2'/>",
+  volkswagen: "<circle cx='32' cy='22' r='18' fill='none' stroke='currentColor' stroke-width='2.8'/><path d='M17 10l15 24 15-24M22 10l10 15 10-15M17 28h30' fill='none' stroke='currentColor' stroke-width='2.6' stroke-linejoin='round'/>",
+  volvo: "<circle cx='29' cy='24' r='14' fill='none' stroke='currentColor' stroke-width='3'/><path d='M39 14L54 3m-9 1h9v9' fill='none' stroke='currentColor' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'/><path d='M16 24h26' stroke='currentColor' stroke-width='2'/>",
+  xpeng: "<path d='M8 11l17 6 7 10 7-10 17-6-12 14 11 8-17-4-6 10-6-10-17 4 11-8z' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linejoin='round'/>",
 });
 
 function activeTab() {
@@ -69,6 +81,21 @@ function activeTab() {
 
 function stripLeadingIcon(value) {
   return clean(value).replace(/^[^\p{L}\p{N}]+/u, "").trim();
+}
+
+function normalizeBrandKey(value) {
+  return clean(value)
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function brandLogo(brand) {
+  const key = normalizeBrandKey(brand);
+  const body = BRAND_LOGOS[key] || `<path d='M10 10h44v24H10z' fill='none' stroke='currentColor' stroke-width='2.5'/><text x='32' y='27' text-anchor='middle' font-size='10' font-weight='900' font-family='system-ui'>${esc(clean(brand).slice(0, 8).toUpperCase())}</text>`;
+  return `<span class="dm-beta5-brand-logo" data-brand-logo="${esc(key)}" title="${esc(brand)}"><svg viewBox="0 0 64 44" role="img" aria-label="${esc(brand)}">${body}</svg></span>`;
 }
 
 function syncConfigTabIcons() {
@@ -81,6 +108,7 @@ function syncConfigTabIcons() {
     let iconNode = button.querySelector(":scope > .dm-beta4-tab-icon");
     let labelNode = existingLabel;
     if (!iconNode || !labelNode) {
+      const current = labelText;
       button.replaceChildren();
       iconNode = doc.createElement("span");
       iconNode.className = "dm-beta4-tab-icon";
@@ -88,6 +116,7 @@ function syncConfigTabIcons() {
       labelNode = doc.createElement("span");
       labelNode.dataset.dmConfigName = "true";
       labelNode.className = "dm-beta4-tab-label";
+      labelNode.textContent = current;
       button.append(iconNode, labelNode);
     }
     iconNode.textContent = icon;
@@ -95,55 +124,50 @@ function syncConfigTabIcons() {
   });
 }
 
-function fixSectionRenameButtons() {
+function normalizeSectionRenameButtons() {
   const body = doc?.getElementById("ed-body");
-  if (!body) return;
+  if (!body) return false;
   body.querySelectorAll(".ed-row[data-section-key]").forEach((row) => {
-    const button = row.querySelector(".dm-inline-rename");
-    if (!button) return;
-    button.classList.add("dm-beta4-section-rename");
-    button.removeAttribute("style");
-    if (button.parentElement !== row) row.append(button);
-    const main = row.querySelector(".ed-row-main");
-    if (main) main.style.paddingRight = "0";
+    const buttons = [...row.querySelectorAll(".dm-inline-rename[data-rename]")];
+    if (!buttons.length) return;
+    const primary = buttons.find((button) => button.parentElement?.classList?.contains("ed-row-main")) || buttons[0];
+    buttons.forEach((button) => {
+      if (button !== primary) button.remove();
+    });
+    primary.classList.add("dm-beta5-section-rename");
+    primary.dataset.dmBeta5Primary = "true";
+    primary.removeAttribute("style");
   });
-}
-
-function brandWordmark(brand) {
-  const name = clean(brand);
-  const key = name.toLowerCase();
-  const sign = BRAND_SIGNS[key] || name.toUpperCase();
-  const compact = sign.length > 8 ? `${sign.slice(0, 8)}…` : sign;
-  return `<span class="dm-beta4-brand-symbol">${esc(compact)}</span>`;
+  return true;
 }
 
 function polishCarBrandMarks() {
-  const picker = doc?.querySelector?.('#dm-visual-picker[data-kind="car"]');
-  picker?.querySelectorAll?.(".dm-picker-option").forEach((option) => {
-    const brand = clean(option.querySelector("b")?.textContent);
-    const mark = option.querySelector(".dm-car-brand");
-    if (!brand || !mark || mark.dataset.dmBeta4Brand === brand) return;
-    mark.dataset.dmBeta4Brand = brand;
-    mark.innerHTML = brandWordmark(brand);
-  });
-  doc?.querySelectorAll?.("[data-brand-preview],.dm-ev-brand-badge").forEach((host) => {
-    const brand = clean(host.querySelector("b")?.textContent);
+  const hosts = [
+    ...(doc?.querySelectorAll?.('#dm-visual-picker[data-kind="car"] .dm-picker-option') || []),
+    ...(doc?.querySelectorAll?.("[data-brand-preview],.dm-ev-brand-badge") || []),
+  ];
+  hosts.forEach((host) => {
+    const brand = clean(host.querySelector("b")?.textContent || host.querySelector(".dm-car-brand")?.getAttribute("title"));
     const mark = host.querySelector(".dm-car-brand");
-    if (!brand || !mark || mark.dataset.dmBeta4Brand === brand) return;
+    if (!brand || !mark) return;
+    if (mark.dataset.dmBeta5Brand === brand && mark.querySelector("[data-brand-logo]")) return;
+    mark.dataset.dmBeta5Brand = brand;
+    // This marker also stops the old beta4 wordmark decorator if a stale copy is
+    // still in memory during a hot reload.
     mark.dataset.dmBeta4Brand = brand;
-    mark.innerHTML = brandWordmark(brand);
+    mark.innerHTML = brandLogo(brand);
   });
 }
 
 function closeRoomPicker() {
-  doc?.getElementById("dm-beta4-room-picker")?.remove();
+  doc?.getElementById("dm-beta5-room-picker")?.remove();
 }
 
 function openRoomPicker(input) {
   if (!input) return;
   closeRoomPicker();
   const modal = doc.createElement("div");
-  modal.id = "dm-beta4-room-picker";
+  modal.id = "dm-beta5-room-picker";
   modal.className = "dm-section-modal dm-visual-picker";
   const english = doc.documentElement.lang === "en";
   modal.innerHTML = `<section class="dm-section-dialog dm-picker-dialog" role="dialog" aria-modal="true"><header><strong>🏠 ${t("Scegli l'icona stanza", "Choose room icon")}</strong><button type="button" data-close aria-label="${t("Chiudi", "Close")}">✕</button></header><div class="dm-picker-search"><input class="ed-input" type="search" placeholder="🔎 ${t("Cerca…", "Search…")}" data-search></div><div class="dm-picker-grid">${ROOM_CATALOG.map((item, index) => `<button type="button" class="dm-picker-option" data-index="${index}" data-search-text="${esc(`${item.it} ${item.en} ${item.keywords || ""}`.toLowerCase())}"><span class="dm-picker-visual">${roomVisual(item.mdi, 46)}</span><b>${esc(english ? item.en : item.it)}</b></button>`).join("")}</div></section>`;
@@ -151,9 +175,9 @@ function openRoomPicker(input) {
   modal.querySelector("[data-close]")?.addEventListener("click", closeRoomPicker);
   modal.addEventListener("click", (event) => { if (event.target === modal) closeRoomPicker(); });
   modal.querySelector("[data-search]")?.addEventListener("input", (event) => {
-    const q = clean(event.target.value).toLowerCase();
+    const query = clean(event.target.value).toLowerCase();
     modal.querySelectorAll(".dm-picker-option").forEach((button) => {
-      button.hidden = Boolean(q) && !button.dataset.searchText.includes(q);
+      button.hidden = Boolean(query) && !button.dataset.searchText.includes(query);
     });
   });
   modal.querySelectorAll(".dm-picker-option").forEach((button) => button.addEventListener("click", () => {
@@ -171,35 +195,48 @@ function openRoomPicker(input) {
 function polishRoomFirstInsert() {
   const body = doc?.getElementById("ed-body");
   if (!body || activeTab() !== "stanze") return false;
-  body.dataset.dmBeta4Rooms = "true";
+  body.dataset.dmBeta5Rooms = "true";
   const input = body.querySelector("#ed-room-icon");
   const name = body.querySelector("#ed-room-name");
   if (!input || !name) return false;
   const row = input.parentElement;
   if (!row) return false;
-  row.classList.add("dm-beta4-room-add-row");
+  row.classList.add("dm-beta5-room-add-row");
   const legacyPreview = body.querySelector("#ed-room-icon-preview");
   if (legacyPreview) legacyPreview.hidden = true;
-  const legacyPalette = [...row.querySelectorAll("button")].find((button) => /dmIconPicker|wzPickIcon/i.test(button.getAttribute("onclick") || "") || clean(button.textContent) === "🎨");
-  if (!legacyPalette) return false;
-  legacyPalette.removeAttribute("onclick");
-  legacyPalette.removeAttribute("style");
-  legacyPalette.className = "dm-beta4-room-icon-trigger";
-  legacyPalette.type = "button";
-  legacyPalette.setAttribute("aria-label", t("Scegli icona stanza", "Choose room icon"));
+  const trigger = [...row.querySelectorAll("button")].find((button) => /dmIconPicker|wzPickIcon/i.test(button.getAttribute("onclick") || "") || clean(button.textContent) === "🎨" || button.classList.contains("dm-beta4-room-icon-trigger"));
+  if (!trigger) return false;
+  trigger.removeAttribute("onclick");
+  trigger.removeAttribute("style");
+  trigger.className = "dm-beta5-room-icon-trigger";
+  trigger.type = "button";
+  trigger.setAttribute("aria-label", t("Scegli icona stanza", "Choose room icon"));
   const refresh = () => {
     const value = clean(input.value) || "mdi:home";
-    legacyPalette.innerHTML = roomVisual(value, 46) || `<span class="dm-beta4-room-fallback">${esc(value.startsWith("mdi:") ? "🏠" : value)}</span>`;
+    trigger.innerHTML = roomVisual(value, 46) || `<span aria-hidden="true">🏠</span>`;
   };
-  if (legacyPalette.dataset.dmBeta4Bound !== "true") {
-    legacyPalette.dataset.dmBeta4Bound = "true";
-    legacyPalette.addEventListener("click", () => openRoomPicker(input));
+  if (trigger.dataset.dmBeta5Bound !== "true") {
+    trigger.dataset.dmBeta5Bound = "true";
+    trigger.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      openRoomPicker(input);
+    });
     input.addEventListener("input", refresh);
     input.addEventListener("change", refresh);
   }
-  if (row.firstElementChild !== legacyPalette) row.prepend(legacyPalette);
+  if (row.firstElementChild !== trigger) row.prepend(trigger);
   refresh();
   return true;
+}
+
+function removeAlertFlash(form, customMode) {
+  if (!form || customMode) return;
+  form.querySelectorAll("button,.dm-action-glyph").forEach((node) => {
+    const text = clean(node.textContent);
+    const powerGlyph = node.matches?.('.dm-action-glyph[data-action="power"]') || node.querySelector?.('.dm-action-glyph[data-action="power"]');
+    if ((text === "⚡" || powerGlyph) && !node.closest(".ed-row")) node.remove();
+  });
 }
 
 function polishAlertIconField(custom) {
@@ -207,94 +244,295 @@ function polishAlertIconField(custom) {
   if (!input) return;
   const row = input.parentElement;
   if (!row) return;
-  row.classList.add("dm-beta4-alert-icon-row");
+  row.classList.add("dm-beta5-alert-icon-row");
   const button = [...row.querySelectorAll("button")].at(-1);
   if (!button) return;
   button.removeAttribute("style");
-  button.classList.add("dm-beta4-alert-icon-trigger");
+  button.classList.add("dm-beta5-alert-icon-trigger");
   button.setAttribute("aria-label", t("Scegli icona avviso", "Choose alert icon"));
-  const refresh = () => {
-    const value = clean(input.value) || "⚠️";
-    button.textContent = value.startsWith("mdi:") ? "⚠️" : value;
-  };
-  if (button.dataset.dmBeta4Bound !== "true") {
-    button.dataset.dmBeta4Bound = "true";
-    input.addEventListener("input", refresh);
-    input.addEventListener("change", refresh);
-  }
-  refresh();
 }
 
 function polishAlertsFirstInsert() {
   const body = doc?.getElementById("ed-body");
   if (!body || activeTab() !== "avvisi") return false;
-  body.dataset.dmBeta4Alerts = "true";
+  body.dataset.dmBeta5Alerts = "true";
   const group = body.querySelector("#ed-avv-grp");
   const entity = body.querySelector("#ed-avv-ent");
   const custom = body.querySelector("#ed-avv-custom");
   if (!group || !entity) return false;
-  const entityRow = entity.parentElement;
-  entityRow?.classList.add("dm-beta4-alert-entity-row");
+  const form = group.closest(".ed-form") || group.parentElement;
+  entity.parentElement?.classList.add("dm-beta5-alert-entity-row");
   const syncCustom = () => {
-    if (!custom) return;
     const visible = clean(group.value) === "custom";
-    custom.style.display = visible ? "grid" : "none";
-    custom.hidden = !visible;
-    if (visible) polishAlertIconField(custom);
+    if (custom) {
+      custom.hidden = !visible;
+      custom.style.display = visible ? "grid" : "none";
+      custom.setAttribute("aria-hidden", String(!visible));
+      if (visible) polishAlertIconField(custom);
+    }
+    removeAlertFlash(form, visible);
   };
-  if (group.dataset.dmBeta4Bound !== "true") {
-    group.dataset.dmBeta4Bound = "true";
+  if (group.dataset.dmBeta5Bound !== "true") {
+    group.dataset.dmBeta5Bound = "true";
     group.addEventListener("change", () => root.queueMicrotask?.(syncCustom));
   }
   syncCustom();
-  body.querySelectorAll("button").forEach((button) => {
-    if (clean(button.textContent) === "⚡" && !button.closest(".ed-row")) button.hidden = true;
-  });
   return true;
 }
 
 function polishLightsEditor() {
   const body = doc?.getElementById("ed-body");
   if (!body || activeTab() !== "luci") return false;
-  body.dataset.dmBeta4Lights = "true";
-  const input = body.querySelector("#luce-add-ent,[data-light-add-entity]");
-  input?.parentElement?.classList.add("dm-beta4-light-entity-row");
-  const form = input?.closest("form,.ed-form") || body.querySelector(".dm-light-add-form");
-  form?.classList.add("dm-beta4-light-add-form");
-  return true;
-}
-
-function restoreCasaSolarDailyChart() {
-  const polish = root.__DASHBOARDMODERN_ENERGY_REPORT_POLISH__;
-  const legacy = polish?.legacyDailyChart;
-  if (typeof legacy !== "function") return false;
-  if (root.renderEdDailyChart?.__dmBeta4CasaSolar === true) return true;
-  const render = async (...args) => legacy(...args);
-  render.__dmBeta4CasaSolar = true;
-  // energy-report-polish treats this marker as already owned, so it cannot
-  // wrap this function again and lose prodMese/consMese for the legacy fallback.
-  render.__dmActualHistory = true;
-  root.renderEdDailyChart = render;
+  body.dataset.dmBeta5Lights = "true";
+  body.querySelectorAll(".dm-light-row").forEach((row) => {
+    row.dataset.dmBeta5LightRow = "true";
+    row.querySelector(".ed-row-main")?.setAttribute("data-dm-light-main", "true");
+    const deleteButton = [...row.children].find((node) => node.matches?.("button.ed-del:not(.dm-light-edit)"));
+    deleteButton?.classList.add("dm-light-delete");
+  });
+  const addEntity = body.querySelector("#luce-add-ent,[data-light-add-entity]");
+  addEntity?.parentElement?.classList.add("dm-beta5-light-entity-row");
   return true;
 }
 
 function polishClimateCards() {
   const page = doc?.getElementById("page-clima");
   if (!page) return false;
-  page.dataset.dmBeta4Climate = "compact";
+  page.dataset.dmBeta5Climate = "canonical";
+  page.querySelectorAll(".cp-card").forEach((card) => card.dataset.dmBeta5ClimateCard = "true");
+  return true;
+}
+
+function numericState(reference) {
+  const id = clean(reference);
+  if (!id) return null;
+  const resolved = clean(root.resolveEntity?.(id) || id);
+  const registries = [root.STATES, root._RAW_STATES];
+  for (const registry of registries) {
+    const raw = registry?.[resolved]?.state ?? registry?.[id]?.state;
+    const value = Number(raw);
+    if (Number.isFinite(value)) return Math.max(0, value);
+  }
+  const projected = Number(root.CD_PERIOD?.[id]);
+  return Number.isFinite(projected) ? Math.max(0, projected) : null;
+}
+
+function keepSecondaryEnergyFlowsComplete() {
+  for (const [load, references] of Object.entries(FLOW_LOADS)) {
+    for (const period of ["day", "month"]) {
+      const node = doc?.getElementById(`n-${load}-${period}`);
+      const valueNode = doc?.getElementById(`v-${load}-${period}`);
+      if (node) {
+        node.hidden = false;
+        node.style.display = "";
+        node.dataset.dmBeta5FlowComplete = "true";
+      }
+      if (valueNode) {
+        const value = numericState(references[period]);
+        if (value != null) valueNode.textContent = `${formatNumber(value, value < 10 ? 2 : 1)} kWh`;
+        else if (!clean(valueNode.textContent)) valueNode.textContent = "—";
+      }
+    }
+  }
+  return true;
+}
+
+function energyModel() {
+  try { return root.DashboardModernModules?.store?.getSection?.("energy") || {}; } catch (_error) { return {}; }
+}
+
+function resolved(reference) {
+  const value = clean(reference);
+  if (!value) return "";
+  try { return clean(root.resolveEntity?.(value) || value); } catch (_error) { return value; }
+}
+
+function energyHistoryRefs() {
+  const energy = energyModel();
+  return Object.freeze({
+    solar: resolved(energy.solar?.total_energy),
+    house: resolved(energy.house?.total_energy),
+    gridImport: resolved(energy.grid?.total_import_energy),
+    gridExport: resolved(energy.grid?.total_export_energy),
+    batteryCharged: resolved(energy.battery?.total_charged_energy),
+    batteryDischarged: resolved(energy.battery?.total_discharged_energy),
+  });
+}
+
+function bucketChanges(rows, days) {
+  const result = Array.from({ length: days }, () => null);
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const when = new Date(row?.start || row?.end || 0);
+    const day = when.getDate();
+    const change = Number(row?.change);
+    if (!Number.isFinite(change) || day < 1 || day > days) continue;
+    if (result[day - 1] == null) result[day - 1] = 0;
+    result[day - 1] += Math.max(0, change);
+  }
+  return result;
+}
+
+function currentBundleDay() {
+  const day = root.__DASHBOARDMODERN_RUNTIME_ROOT__?.bundle?.day || {};
+  const read = (key, slot) => {
+    const value = Number(day?.[key]);
+    if (Number.isFinite(value)) return Math.max(0, value);
+    return numericState(slot);
+  };
+  return {
+    solar: read("solar", "dm.energy_produzione_solare_oggi"),
+    house: read("house", "dm.energy_consumo_casa_oggi"),
+    gridImport: read("gridImport", "dm.energy_energia_prelevata_oggi"),
+    gridExport: read("gridExport", "dm.energy_energia_immessa_oggi"),
+    batteryCharged: read("batteryCharged", "dm.energy_batteria_caricata_oggi"),
+    batteryDischarged: read("batteryDischarged", "dm.energy_batteria_scaricata_oggi"),
+  };
+}
+
+function balancedHouse(values, index, refs) {
+  const solar = values.solar[index];
+  const gridImport = refs.gridImport ? values.gridImport[index] : 0;
+  const gridExport = refs.gridExport ? values.gridExport[index] : 0;
+  const charged = refs.batteryCharged ? values.batteryCharged[index] : 0;
+  const discharged = refs.batteryDischarged ? values.batteryDischarged[index] : 0;
+  const hasCore = solar != null && (!refs.gridImport || gridImport != null) && (!refs.gridExport || gridExport != null);
+  const hasBattery = (!refs.batteryCharged || charged != null) && (!refs.batteryDischarged || discharged != null);
+  if (!hasCore || !hasBattery) return null;
+  return Math.max(0, solar - (gridExport || 0) + (gridImport || 0) + (discharged || 0) - (charged || 0));
+}
+
+function chartMessage(message) {
+  const loading = doc?.getElementById("ed-chart-loading");
+  const canvas = doc?.getElementById("ed-daily-canvas");
+  if (canvas) canvas.style.display = "none";
+  if (loading) {
+    loading.style.display = "flex";
+    loading.innerHTML = `<span aria-hidden="true">ℹ️</span> ${message}`;
+  }
+}
+
+function destroyDailyChart(canvas) {
+  try { root.Chart?.getChart?.(canvas)?.destroy?.(); } catch (_error) {}
+  try { state.dailyChart?.destroy?.(); } catch (_error) {}
+  state.dailyChart = null;
+}
+
+async function renderRealDailyChart(daysInMonth, selMonth, selYear) {
+  const loading = doc?.getElementById("ed-chart-loading");
+  const canvas = doc?.getElementById("ed-daily-canvas");
+  if (!loading || !canvas) return false;
+  destroyDailyChart(canvas);
+  loading.style.display = "flex";
+  loading.textContent = t("Carico i dati reali di Home Assistant…", "Loading real Home Assistant data…");
+  canvas.style.display = "none";
+
+  const now = new Date();
+  const year = Number(selYear) || now.getFullYear();
+  const month = Math.max(1, Math.min(12, Number(selMonth) || now.getMonth() + 1));
+  const currentMonth = year === now.getFullYear() && month === now.getMonth() + 1;
+  const monthDays = Number(daysInMonth) || new Date(year, month, 0).getDate();
+  const visibleDays = currentMonth ? Math.min(now.getDate(), monthDays) : monthDays;
+  const start = new Date(year, month - 1, 1);
+  const next = new Date(year, month, 1);
+  const end = currentMonth ? now : next;
+  const refs = energyHistoryRefs();
+  const ids = [...new Set(Object.values(refs).filter(Boolean))];
+  const service = root.DashboardModernEnergyService;
+  const values = Object.fromEntries(Object.keys(refs).map((key) => [key, Array.from({ length: visibleDays }, () => null)]));
+
+  if (ids.length && typeof service?.statisticsWithGrowth === "function") {
+    try {
+      const stats = await service.statisticsWithGrowth(ids, start.toISOString(), end.toISOString(), "day");
+      Object.entries(refs).forEach(([key, entity]) => {
+        if (entity) values[key] = bucketChanges(stats?.[entity] || [], visibleDays);
+      });
+    } catch (error) {
+      root.console?.warn?.("[DashboardModern] Recorder daily chart unavailable", error);
+    }
+  }
+
+  const production = values.solar.slice();
+  const consumption = values.house.slice();
+  for (let index = 0; index < visibleDays; index += 1) {
+    const balanced = balancedHouse(values, index, refs);
+    if (balanced != null) consumption[index] = balanced;
+  }
+
+  // Recorder can omit the still-open current bucket. Fill only TODAY from the
+  // already committed canonical bundle; never synthesize previous/future days.
+  if (currentMonth && visibleDays > 0) {
+    const today = currentBundleDay();
+    const index = visibleDays - 1;
+    if (today.solar != null) production[index] = today.solar;
+    if (today.house != null) consumption[index] = today.house;
+    if (today.solar != null && today.gridImport != null && today.gridExport != null) {
+      consumption[index] = Math.max(
+        0,
+        today.solar - today.gridExport + today.gridImport + (today.batteryDischarged || 0) - (today.batteryCharged || 0),
+      );
+    }
+  }
+
+  const hasReal = production.some((value) => value != null) || consumption.some((value) => value != null);
+  if (!hasReal) {
+    chartMessage(t("Nessun dato giornaliero reale disponibile per questo periodo.", "No real daily data is available for this period."));
+    return false;
+  }
+  if (!root.Chart) {
+    chartMessage(t("Grafico non disponibile: Chart.js non è caricato.", "Chart unavailable: Chart.js is not loaded."));
+    return false;
+  }
+
+  const labels = Array.from({ length: visibleDays }, (_, index) => String(index + 1));
+  loading.style.display = "none";
+  canvas.style.display = "block";
+  canvas.dataset.dmBeta5RealHistory = `${year}-${String(month).padStart(2, "0")}`;
+  canvas.dataset.dmBeta5LastDay = String(visibleDays);
+  state.dailyChart = new root.Chart(canvas.getContext("2d"), {
+    type: "line",
+    data: {
+      labels,
+      datasets: [
+        { label: t("Produzione", "Production"), data: production, borderColor: "#16a34a", backgroundColor: "rgba(22,163,74,.14)", fill: true, tension: .25, pointRadius: 2, pointHoverRadius: 5, borderWidth: 2.5, spanGaps: false },
+        { label: t("Consumo", "Consumption"), data: consumption, borderColor: "#0ea5e9", backgroundColor: "rgba(14,165,233,.08)", fill: true, tension: .25, pointRadius: 2, pointHoverRadius: 5, borderWidth: 2.2, spanGaps: false },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: false,
+      interaction: { intersect: false, mode: "index" },
+      plugins: {
+        legend: { display: false },
+        tooltip: { callbacks: { label: (context) => `${context.dataset.label}: ${formatNumber(context.parsed.y, 2)} kWh` } },
+      },
+      scales: { y: { beginAtZero: true, title: { display: true, text: "kWh" } }, x: { grid: { display: false } } },
+    },
+  });
+  return true;
+}
+renderRealDailyChart.__dmActualHistory = true;
+renderRealDailyChart.__dmBeta4CasaSolar = true;
+renderRealDailyChart.__dmBeta5RealOnly = true;
+
+function installRealDailyChartOwner() {
+  const reportState = root.__DASHBOARDMODERN_ENERGY_REPORT_POLISH__;
+  if (reportState) reportState.legacyDailyChart = null;
+  if (root.renderEdDailyChart !== renderRealDailyChart) root.renderEdDailyChart = renderRealDailyChart;
   return true;
 }
 
 function run() {
   state.frame = 0;
   syncConfigTabIcons();
-  fixSectionRenameButtons();
+  normalizeSectionRenameButtons();
   polishCarBrandMarks();
   polishRoomFirstInsert();
   polishAlertsFirstInsert();
   polishLightsEditor();
   polishClimateCards();
-  restoreCasaSolarDailyChart();
+  keepSecondaryEnergyFlowsComplete();
+  installRealDailyChartOwner();
 }
 
 function schedule() {
@@ -303,63 +541,75 @@ function schedule() {
 }
 
 function installStyles() {
-  installStyle("dm-beta4-mobile-polish-style", `
+  installStyle("dm-beta5-root-causes-style", `
     .ed-tab[data-tab]>.dm-beta4-tab-icon{display:inline-grid!important;place-items:center!important;flex:0 0 auto!important;min-width:1.2em!important;margin-right:5px!important;visibility:visible!important;opacity:1!important}
     .ed-tab[data-tab]>.dm-beta4-tab-label{display:inline!important;white-space:nowrap!important}
 
-    #ed-body .ed-row[data-section-key] .ed-row-main{padding-right:0!important;min-width:0!important}
-    #ed-body .ed-row[data-section-key]>.dm-inline-rename.dm-beta4-section-rename{position:static!important;inset:auto!important;transform:none!important;display:grid!important;place-items:center!important;flex:0 0 44px!important;width:44px!important;min-width:44px!important;height:44px!important;min-height:44px!important;margin:0 2px 0 8px!important;padding:0!important;border:1px solid color-mix(in srgb,var(--info-color,#0ea5e9) 28%,var(--divider-color,#dbe4ee))!important;border-radius:13px!important;background:color-mix(in srgb,var(--info-color,#0ea5e9) 10%,var(--card-background-color,#fff))!important;color:var(--primary-text-color,#0f172a)!important;font-size:19px!important;line-height:1!important;box-shadow:none!important;overflow:visible!important;clip:auto!important}
+    #ed-body .ed-row[data-section-key] .ed-row-main{display:grid!important;grid-template-columns:minmax(0,1fr) 44px!important;grid-template-rows:auto!important;align-items:center!important;gap:8px!important;min-width:0!important;padding-right:0!important;position:relative!important}
+    #ed-body .ed-row[data-section-key] .ed-row-main>.ed-row-new{grid-column:1!important;grid-row:1!important;min-width:0!important}
+    #ed-body .ed-row[data-section-key] .dm-inline-rename[data-dm-beta5-primary="true"]{grid-column:2!important;grid-row:1!important;position:static!important;inset:auto!important;transform:none!important;display:grid!important;place-items:center!important;width:44px!important;min-width:44px!important;height:44px!important;min-height:44px!important;margin:0!important;padding:0!important;border:1px solid color-mix(in srgb,var(--info-color,#0ea5e9) 28%,var(--divider-color,#dbe4ee))!important;border-radius:13px!important;background:color-mix(in srgb,var(--info-color,#0ea5e9) 10%,var(--card-background-color,#fff))!important;color:var(--primary-text-color,#0f172a)!important;font-size:19px!important;line-height:1!important;box-shadow:none!important;overflow:visible!important}
+    #ed-body .ed-row[data-section-key] .dm-inline-rename[data-rename]:not([data-dm-beta5-primary="true"]){display:none!important}
 
-    .dm-car-brand[data-dm-beta4-brand]{display:grid!important;place-items:center!important;width:76px!important;min-width:76px!important;height:48px!important;border-radius:14px!important;background:linear-gradient(145deg,color-mix(in srgb,var(--info-color,#0ea5e9) 11%,#fff),color-mix(in srgb,var(--info-color,#0ea5e9) 4%,#fff))!important;border:1px solid color-mix(in srgb,var(--info-color,#0ea5e9) 24%,transparent)!important;color:var(--info-color,#0284c7)!important;overflow:hidden!important}
-    .dm-beta4-brand-symbol{display:block!important;max-width:68px!important;padding:0 4px!important;font:900 11px/1.05 Inter,system-ui,sans-serif!important;letter-spacing:-.02em!important;text-align:center!important;white-space:nowrap!important;overflow:hidden!important;text-overflow:ellipsis!important}
-    #dm-visual-picker[data-kind="car"] .dm-picker-option{min-height:112px!important}
+    .dm-car-brand{display:grid!important;place-items:center!important;color:var(--info-color,#0284c7)!important;background:transparent!important}
+    .dm-beta5-brand-logo{display:grid!important;place-items:center!important;width:82px!important;height:54px!important;color:currentColor!important}
+    .dm-beta5-brand-logo svg{display:block!important;width:78px!important;height:50px!important;max-width:100%!important;overflow:visible!important}
+    #dm-visual-picker[data-kind="car"] .dm-picker-option{min-height:126px!important;padding:12px 8px!important}
+    #dm-visual-picker[data-kind="car"] .dm-picker-visual{min-height:58px!important}
+    [data-brand-preview] .dm-beta5-brand-logo{width:86px!important;height:56px!important}
 
-    #ed-body[data-dm-beta4-rooms="true"] .dm-beta4-room-add-row{display:grid!important;grid-template-columns:58px 138px minmax(0,1fr)!important;gap:10px!important;align-items:center!important;margin-bottom:10px!important}
-    #ed-body[data-dm-beta4-rooms="true"] #ed-room-icon-preview{display:none!important}
-    #ed-body[data-dm-beta4-rooms="true"] .dm-beta4-room-icon-trigger{display:grid!important;place-items:center!important;width:58px!important;height:58px!important;min-width:58px!important;padding:0!important;border:1px solid color-mix(in srgb,var(--info-color,#0ea5e9) 24%,var(--divider-color,#dbe4ee))!important;border-radius:16px!important;background:color-mix(in srgb,var(--info-color,#0ea5e9) 8%,var(--card-background-color,#fff))!important;cursor:pointer!important;overflow:hidden!important}
-    #ed-body[data-dm-beta4-rooms="true"] .dm-beta4-room-icon-trigger .dm-room-visual{max-width:46px!important;max-height:46px!important}
-    #ed-body[data-dm-beta4-rooms="true"] #ed-room-icon,#ed-body[data-dm-beta4-rooms="true"] #ed-room-name{margin:0!important;min-width:0!important;width:100%!important}
+    #ed-body[data-dm-beta5-rooms="true"] .dm-beta5-room-add-row{display:grid!important;grid-template-columns:58px 138px minmax(0,1fr)!important;gap:10px!important;align-items:center!important;margin-bottom:10px!important}
+    #ed-body[data-dm-beta5-rooms="true"] #ed-room-icon-preview{display:none!important}
+    #ed-body[data-dm-beta5-rooms="true"] .dm-beta5-room-icon-trigger{display:grid!important;place-items:center!important;width:58px!important;height:58px!important;min-width:58px!important;padding:0!important;border:1px solid color-mix(in srgb,var(--info-color,#0ea5e9) 24%,var(--divider-color,#dbe4ee))!important;border-radius:16px!important;background:color-mix(in srgb,var(--info-color,#0ea5e9) 8%,var(--card-background-color,#fff))!important;cursor:pointer!important;overflow:hidden!important}
 
-    #ed-body[data-dm-beta4-alerts="true"]{display:grid!important;gap:14px!important}
-    #ed-body[data-dm-beta4-alerts="true"] #ed-avv-grp,#ed-body[data-dm-beta4-alerts="true"] #ed-avv-name,#ed-body[data-dm-beta4-alerts="true"] #ed-avv-cond,#ed-body[data-dm-beta4-alerts="true"] #ed-avv-val{width:100%!important;min-width:0!important;margin:0!important}
-    #ed-body[data-dm-beta4-alerts="true"] .dm-beta4-alert-entity-row{display:grid!important;grid-template-columns:minmax(0,1fr) 50px!important;gap:8px!important;width:100%!important;min-width:0!important;margin:0!important}
-    #ed-body[data-dm-beta4-alerts="true"] .dm-beta4-alert-entity-row>#ed-avv-ent{width:100%!important;min-width:0!important;margin:0!important}
-    #ed-body[data-dm-beta4-alerts="true"] #ed-avv-custom{grid-template-columns:1fr!important;gap:10px!important;width:100%!important;min-width:0!important;margin-top:10px!important}
-    #ed-body[data-dm-beta4-alerts="true"] #ed-avv-custom>.ed-btn-add{display:block!important;width:100%!important;min-height:48px!important;height:auto!important;margin:0!important;padding:12px 16px!important;white-space:normal!important;line-height:1.25!important}
-    #ed-body[data-dm-beta4-alerts="true"] #ed-avv-ents{width:100%!important;min-width:0!important;margin:0!important;line-height:1.4!important}
-    #ed-body[data-dm-beta4-alerts="true"] .dm-beta4-alert-icon-row{display:grid!important;grid-template-columns:minmax(0,1fr) 54px!important;gap:8px!important;width:100%!important;min-width:0!important}
-    #ed-body[data-dm-beta4-alerts="true"] .dm-beta4-alert-icon-row>#ed-avv-icon{width:100%!important;min-width:0!important;margin:0!important}
-    #ed-body[data-dm-beta4-alerts="true"] .dm-beta4-alert-icon-trigger{display:grid!important;place-items:center!important;width:54px!important;height:50px!important;min-width:54px!important;padding:0!important;border:1px solid color-mix(in srgb,var(--info-color,#0ea5e9) 24%,var(--divider-color,#dbe4ee))!important;border-radius:14px!important;background:color-mix(in srgb,var(--info-color,#0ea5e9) 9%,var(--card-background-color,#fff))!important;color:var(--primary-text-color,#0f172a)!important;font-size:24px!important;box-shadow:none!important}
+    #ed-body[data-dm-beta5-alerts="true"]{display:grid!important;gap:14px!important}
+    #ed-body[data-dm-beta5-alerts="true"] #ed-avv-custom[hidden],#ed-body[data-dm-beta5-alerts="true"] #ed-avv-custom[aria-hidden="true"]{display:none!important}
+    #ed-body[data-dm-beta5-alerts="true"] #ed-avv-grp,#ed-body[data-dm-beta5-alerts="true"] #ed-avv-name,#ed-body[data-dm-beta5-alerts="true"] #ed-avv-cond,#ed-body[data-dm-beta5-alerts="true"] #ed-avv-val{box-sizing:border-box!important;width:100%!important;min-width:0!important;margin:0!important}
+    #ed-body[data-dm-beta5-alerts="true"] .dm-beta5-alert-entity-row{display:grid!important;grid-template-columns:minmax(0,1fr) 52px!important;gap:8px!important;width:100%!important;min-width:0!important;margin:0!important}
+    #ed-body[data-dm-beta5-alerts="true"] .dm-beta5-alert-entity-row>#ed-avv-ent{width:100%!important;min-width:0!important;margin:0!important}
+    #ed-body[data-dm-beta5-alerts="true"] #ed-avv-custom{grid-template-columns:1fr!important;gap:10px!important;width:100%!important;min-width:0!important;margin-top:10px!important}
+    #ed-body[data-dm-beta5-alerts="true"] #ed-avv-custom>.ed-btn-add{display:block!important;width:100%!important;min-height:48px!important;height:auto!important;margin:0!important;padding:12px 16px!important;white-space:normal!important;line-height:1.25!important}
+    #ed-body[data-dm-beta5-alerts="true"] #ed-avv-ents{width:100%!important;min-width:0!important;margin:0!important;line-height:1.4!important}
+    #ed-body[data-dm-beta5-alerts="true"] .dm-beta5-alert-icon-row{display:grid!important;grid-template-columns:minmax(0,1fr) 54px!important;gap:8px!important;width:100%!important;min-width:0!important}
+    #ed-body[data-dm-beta5-alerts="true"] .dm-beta5-alert-icon-row>#ed-avv-icon{width:100%!important;min-width:0!important;margin:0!important}
+    #ed-body[data-dm-beta5-alerts="true"] .dm-beta5-alert-icon-trigger{display:grid!important;place-items:center!important;width:54px!important;height:50px!important;min-width:54px!important;padding:0!important;border-radius:14px!important;box-shadow:none!important}
 
-    #ed-body[data-dm-beta4-lights="true"] .dm-light-group{overflow:visible!important}
-    #ed-body[data-dm-beta4-lights="true"] .dm-light-row{min-height:0!important;padding:12px!important}
-    #ed-body[data-dm-beta4-lights="true"] .dm-beta4-light-entity-row{display:grid!important;grid-template-columns:minmax(0,1fr) 50px!important;gap:8px!important;width:100%!important;min-width:0!important}
-    #ed-body[data-dm-beta4-lights="true"] .dm-beta4-light-add-form{display:grid!important;grid-template-columns:1fr!important;gap:10px!important;width:100%!important;min-width:0!important}
-    #ed-body[data-dm-beta4-lights="true"] .ed-input,#ed-body[data-dm-beta4-lights="true"] select{min-width:0!important;max-width:100%!important}
+    #page-clima[data-dm-beta5-climate="canonical"] .clima-premium-grid{display:grid!important;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))!important;gap:16px!important;align-items:start!important}
+    #page-clima[data-dm-beta5-climate="canonical"] .cp-card{box-sizing:border-box!important;aspect-ratio:auto!important;min-height:0!important;height:auto!important;max-height:none!important;justify-content:flex-start!important;padding:16px!important;gap:14px!important;overflow:hidden!important}
+    #page-clima[data-dm-beta5-climate="canonical"] .cp-header{flex:0 0 auto!important}
+    #page-clima[data-dm-beta5-climate="canonical"] .cp-body{display:grid!important;grid-template-columns:minmax(0,1fr) minmax(0,1fr)!important;align-items:end!important;gap:18px!important;flex:0 0 auto!important;min-height:0!important;padding:8px 4px!important;margin:0!important}
+    #page-clima[data-dm-beta5-climate="canonical"] .cp-temp-current-wrap{align-items:flex-end!important;text-align:right!important}
+    #page-clima[data-dm-beta5-climate="canonical"] .cp-controls{flex:0 0 auto!important;margin:0!important;min-height:54px!important;height:54px!important;padding:5px!important}
+    #page-clima[data-dm-beta5-climate="canonical"] .cp-btn{height:42px!important}
+    #page-clima[data-dm-beta5-climate="canonical"] .cp-temp-target .val{font-size:38px!important;line-height:1!important}
 
-    #page-clima[data-dm-beta4-climate="compact"] .clima-premium-grid{align-items:start!important}
-    #page-clima[data-dm-beta4-climate="compact"] .cp-card{aspect-ratio:auto!important;min-height:0!important;height:auto!important;max-height:none!important;justify-content:flex-start!important;gap:14px!important;padding:16px!important;overflow:hidden!important}
-    #page-clima[data-dm-beta4-climate="compact"] .cp-header{flex:0 0 auto!important}
-    #page-clima[data-dm-beta4-climate="compact"] .cp-body{flex:0 0 auto!important;min-height:0!important;padding:8px 2px!important;align-items:center!important}
-    #page-clima[data-dm-beta4-climate="compact"] .cp-controls{flex:0 0 auto!important;margin-top:0!important}
-    #page-clima[data-dm-beta4-climate="compact"] .cp-temp-target .val{font-size:34px!important;line-height:1!important}
+    #ed-daily-canvas[data-dm-beta5-real-history]{min-height:250px!important}
 
     @media(max-width:760px){
-      #ed-body .ed-row[data-section-key]>.dm-inline-rename.dm-beta4-section-rename{flex-basis:42px!important;width:42px!important;min-width:42px!important;height:42px!important;min-height:42px!important;margin-left:7px!important}
-      #ed-body[data-dm-beta4-rooms="true"] .dm-beta4-room-add-row{grid-template-columns:56px minmax(0,1fr)!important;gap:9px!important}
-      #ed-body[data-dm-beta4-rooms="true"] #ed-room-icon{display:none!important}
-      #ed-body[data-dm-beta4-rooms="true"] #ed-room-name{grid-column:2!important}
-      #ed-body[data-dm-beta4-alerts="true"] .ed-form,#ed-body[data-dm-beta4-alerts="true"] .ed-form-row{min-width:0!important;max-width:100%!important}
-      #ed-body[data-dm-beta4-lights="true"] .dm-light-row{grid-template-areas:"main edit delete" "room room room"!important;grid-template-columns:minmax(0,1fr) 44px 44px!important;gap:8px!important}
-      #ed-body[data-dm-beta4-lights="true"] .dm-light-row .dm-light-order{display:none!important}
-      #ed-body[data-dm-beta4-lights="true"] .dm-light-row .ed-row-main{grid-area:main!important;min-width:0!important}
-      #ed-body[data-dm-beta4-lights="true"] .dm-light-row .dm-light-room{grid-area:room!important;width:100%!important;min-width:0!important}
-      #ed-body[data-dm-beta4-lights="true"] .dm-light-row .dm-light-edit{grid-area:edit!important}
-      #ed-body[data-dm-beta4-lights="true"] .dm-light-row .dm-light-delete{grid-area:delete!important}
-      #page-clima[data-dm-beta4-climate="compact"] .clima-premium-grid{grid-template-columns:1fr!important;gap:12px!important}
-      #page-clima[data-dm-beta4-climate="compact"] .cp-card{min-height:0!important;height:auto!important;max-height:none!important;padding:14px!important;gap:11px!important;border-radius:20px!important}
-      #page-clima[data-dm-beta4-climate="compact"] .cp-body{padding:4px 2px!important}
-      #page-clima[data-dm-beta4-climate="compact"] .cp-controls{min-height:52px!important}
+      #ed-body .ed-row[data-section-key] .ed-row-main{grid-template-columns:minmax(0,1fr) 42px!important}
+      #ed-body .ed-row[data-section-key] .dm-inline-rename[data-dm-beta5-primary="true"]{width:42px!important;min-width:42px!important;height:42px!important;min-height:42px!important}
+
+      #ed-body[data-dm-beta5-rooms="true"] .dm-beta5-room-add-row{grid-template-columns:56px minmax(0,1fr)!important;gap:9px!important}
+      #ed-body[data-dm-beta5-rooms="true"] #ed-room-icon{display:none!important}
+      #ed-body[data-dm-beta5-rooms="true"] #ed-room-name{grid-column:2!important;min-width:0!important;width:100%!important}
+
+      #ed-body[data-dm-beta5-lights="true"] .dm-light-group>.ed-list{display:grid!important;gap:10px!important}
+      #ed-body[data-dm-beta5-lights="true"] .dm-light-row[data-dm-beta5-light-row="true"]{box-sizing:border-box!important;display:grid!important;grid-template-columns:minmax(0,1fr) 44px 44px!important;grid-template-areas:"main edit delete" "room room room"!important;grid-template-rows:auto auto!important;grid-auto-rows:auto!important;align-items:center!important;gap:8px!important;width:100%!important;min-width:0!important;min-height:0!important;height:auto!important;padding:12px!important;overflow:visible!important}
+      #ed-body[data-dm-beta5-lights="true"] .dm-light-row>.dm-light-order{display:none!important}
+      #ed-body[data-dm-beta5-lights="true"] .dm-light-row>[data-dm-light-main="true"]{grid-area:main!important;display:block!important;position:static!important;width:auto!important;min-width:0!important;min-height:48px!important;padding:3px 4px!important;visibility:visible!important;opacity:1!important;overflow:hidden!important}
+      #ed-body[data-dm-beta5-lights="true"] .dm-light-row>[data-dm-light-main="true"]>.ed-row-new{display:block!important;position:static!important;visibility:visible!important;opacity:1!important;font-size:15px!important;line-height:1.3!important;white-space:nowrap!important;overflow:hidden!important;text-overflow:ellipsis!important}
+      #ed-body[data-dm-beta5-lights="true"] .dm-light-row>[data-dm-light-main="true"]>.ed-row-old{display:block!important;position:static!important;visibility:visible!important;opacity:1!important;margin-top:4px!important;font-size:11px!important;line-height:1.25!important;white-space:nowrap!important;overflow:hidden!important;text-overflow:ellipsis!important}
+      #ed-body[data-dm-beta5-lights="true"] .dm-light-row>.dm-light-room{grid-area:room!important;grid-column:auto!important;grid-row:auto!important;box-sizing:border-box!important;width:100%!important;min-width:0!important;height:48px!important;margin:0!important}
+      #ed-body[data-dm-beta5-lights="true"] .dm-light-row>.dm-light-edit{grid-area:edit!important;display:grid!important;place-items:center!important;position:static!important;width:44px!important;height:44px!important;margin:0!important}
+      #ed-body[data-dm-beta5-lights="true"] .dm-light-row>.dm-light-delete{grid-area:delete!important;display:grid!important;place-items:center!important;position:static!important;width:44px!important;height:44px!important;margin:0!important}
+      #ed-body[data-dm-beta5-lights="true"] .dm-light-add-form{display:grid!important;grid-template-columns:1fr!important;gap:10px!important;width:100%!important;min-width:0!important}
+      #ed-body[data-dm-beta5-lights="true"] .dm-beta5-light-entity-row{display:grid!important;grid-template-columns:minmax(0,1fr) 52px!important;gap:8px!important;width:100%!important;min-width:0!important}
+
+      #page-clima[data-dm-beta5-climate="canonical"] .clima-premium-grid{grid-template-columns:1fr!important;gap:12px!important}
+      #page-clima[data-dm-beta5-climate="canonical"] .cp-card{min-height:0!important;height:auto!important;max-height:none!important;padding:14px!important;gap:11px!important;border-radius:20px!important}
+      #page-clima[data-dm-beta5-climate="canonical"] .cp-body{padding:6px 3px!important;gap:12px!important}
+      #page-clima[data-dm-beta5-climate="canonical"] .cp-temp-target .val{font-size:34px!important}
+      #page-clima[data-dm-beta5-climate="canonical"] .cp-controls{min-height:52px!important;height:52px!important}
+      #page-clima[data-dm-beta5-climate="canonical"] .cp-btn{height:40px!important}
     }
   `);
 }
@@ -368,25 +618,37 @@ export function installBeta4MobilePolishSection() {
   if (!doc || state.installed) return;
   state.installed = true;
   installStyles();
-  root.addEventListener?.("dashboardmodern:legacy-ready", () => {
-    for (const name of ["editorSwitch", "edNavMove", "editorRenderStanze", "editorRenderLuci", "editorRenderAvvisi", "dmIconChoose", "renderEnergyDashboard"]) {
-      wrapFunction(name, `__dmBeta4_${name}`, schedule);
-    }
-    restoreCasaSolarDailyChart();
+  const afterLegacy = () => {
+    installRealDailyChartOwner();
+    for (const name of [
+      "editorSwitch",
+      "edNavMove",
+      "editorRenderStanze",
+      "editorRenderLuci",
+      "editorRenderAvvisi",
+      "renderEnergyDashboard",
+      "render",
+      "buildClimaCards",
+    ]) wrapFunction(name, `__dmBeta5_${name}`, schedule);
     schedule();
-  });
-  root.addEventListener?.("dashboardmodern:runtime-ready", schedule);
+  };
+  root.addEventListener?.("dashboardmodern:legacy-ready", afterLegacy);
+  root.addEventListener?.("dashboardmodern:runtime-ready", () => { installRealDailyChartOwner(); schedule(); });
   root.addEventListener?.("dashboardmodern:period-bundle", schedule);
+  root.addEventListener?.("dashboardmodern:energy-stable", schedule);
   if (!state.listeners) {
     state.listeners = true;
     doc.addEventListener("click", (event) => {
-      if (event.target?.closest?.(".ed-tab,.dm-inline-rename,[data-brand-preview],.dm-picker-option,.ed-btn-add,.dm-entity-picker")) root.setTimeout?.(schedule, 0);
+      if (event.target?.closest?.(".ed-tab,.dm-inline-rename,[data-brand-preview],.dm-picker-option,.ed-btn-add,.dm-entity-picker,.sub-tab-btn")) root.setTimeout?.(schedule, 0);
     }, true);
     doc.addEventListener("change", (event) => {
-      if (event.target?.closest?.("#editor-modal,#ed-body,#dm-visual-picker")) root.setTimeout?.(schedule, 0);
+      if (event.target?.closest?.("#editor-modal,#ed-body,#dm-visual-picker,#page-energy")) root.setTimeout?.(schedule, 0);
     }, true);
   }
+  installRealDailyChartOwner();
   schedule();
 }
+
+export const installBeta5RootCauseFixes = installBeta4MobilePolishSection;
 
 installBeta4MobilePolishSection();

--- a/custom_components/dashboardmodern/frontend/tests/beta4-mobile-polish.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta4-mobile-polish.test.js
@@ -5,50 +5,94 @@ import test from "node:test";
 const ROOT = new URL("../", import.meta.url);
 const read = (path) => readFile(new URL(path, ROOT), "utf8");
 
-test("beta4 polish is loaded last so it can repair legacy editor markup", async () => {
+test("final mobile owner is loaded last without a second room click interceptor", async () => {
   const entry = await read("src/sections/beta-entry-section.js");
   assert.match(entry, /editor-polish-section\.js";\nimport "\.\/beta4-mobile-polish-section\.js";/);
+  assert.doesNotMatch(entry, /dm-beta4-room-icon-trigger|stopImmediatePropagation/);
 });
 
-test("section rename button is moved out of the label and config icons have dedicated nodes", async () => {
+test("section rename keeps exactly one button inside its canonical row owner", async () => {
   const source = await read("src/sections/beta4-mobile-polish-section.js");
-  assert.match(source, /if \(button\.parentElement !== row\) row\.append\(button\)/);
+  assert.match(source, /buttons\.forEach\(\(button\) => \{\s*if \(button !== primary\) button\.remove\(\)/s);
+  assert.match(source, /primary\.dataset\.dmBeta5Primary = "true"/);
+  assert.doesNotMatch(source, /button\.parentElement !== row\) row\.append\(button\)/);
+  assert.match(source, /dm-inline-rename\[data-rename\]:not\(\[data-dm-beta5-primary/);
+});
+
+test("config tab names preserve their dedicated icon nodes", async () => {
+  const source = await read("src/sections/beta4-mobile-polish-section.js");
   assert.match(source, /labelNode\.dataset\.dmConfigName = "true"/);
   assert.match(source, /dm-beta4-tab-icon/);
-  assert.match(source, />\.dm-inline-rename\.dm-beta4-section-rename/);
+  assert.match(source, /iconNode\.textContent = icon/);
 });
 
-test("room first insert uses its icon as the picker trigger and removes palette semantics", async () => {
+test("room first insert uses its icon as the only picker trigger", async () => {
   const source = await read("src/sections/beta4-mobile-polish-section.js");
   assert.match(source, /openRoomPicker\(input\)/);
-  assert.match(source, /legacyPalette\.removeAttribute\("onclick"\)/);
-  assert.match(source, /legacyPalette\.className = "dm-beta4-room-icon-trigger"/);
+  assert.match(source, /trigger\.removeAttribute\("onclick"\)/);
+  assert.match(source, /trigger\.className = "dm-beta5-room-icon-trigger"/);
   assert.match(source, /#ed-room-icon-preview\{display:none!important\}/);
 });
 
-test("alerts keep custom controls hidden for predefined groups and stack entity controls", async () => {
+test("alerts hide custom-only controls and physically remove the orphan flash", async () => {
   const source = await read("src/sections/beta4-mobile-polish-section.js");
   assert.match(source, /const visible = clean\(group\.value\) === "custom"/);
   assert.match(source, /custom\.hidden = !visible/);
-  assert.match(source, /dm-beta4-alert-entity-row/);
-  assert.match(source, /grid-template-columns:minmax\(0,1fr\) 50px/);
+  assert.match(source, /removeAlertFlash\(form, visible\)/);
+  assert.match(source, /text === "⚡" \|\| powerGlyph/);
+  assert.match(source, /dm-beta5-alert-entity-row/);
+  assert.match(source, /grid-template-columns:minmax\(0,1fr\) 52px/);
 });
 
-test("daily Energy chart restores the Casa and Fotovoltaico legacy path with all arguments", async () => {
+test("lights have one explicit compact mobile grid with visible name and entity", async () => {
+  const source = await read("src/sections/beta4-mobile-polish-section.js");
+  assert.match(source, /grid-template-areas:"main edit delete" "room room room"/);
+  assert.match(source, /data-dm-light-main/);
+  assert.match(source, />\.ed-row-new\{display:block!important/s);
+  assert.match(source, />\.ed-row-old\{display:block!important/s);
+  assert.match(source, /\.dm-light-order\{display:none!important\}/);
+});
+
+test("brand picker renders local vector brand graphics instead of initial badges", async () => {
+  const source = await read("src/sections/beta4-mobile-polish-section.js");
+  assert.match(source, /const BRAND_LOGOS/);
+  assert.match(source, /leapmotor:/);
+  assert.match(source, /audi:/);
+  assert.match(source, /volkswagen:/);
+  assert.match(source, /data-brand-logo/);
+  assert.match(source, /dm-beta5-brand-logo/);
+  assert.doesNotMatch(source, /BRAND_SIGNS|dm-beta4-brand-symbol/);
+});
+
+test("daily Energy chart is real-only, stops at today and never calls the synthetic legacy renderer", async () => {
   const source = await read("src/sections/beta4-mobile-polish-section.js");
   const legacy = await read("legacy/dashboard-runtime-it.js");
-  assert.match(source, /const render = async \(\.\.\.args\) => legacy\(\.\.\.args\)/);
-  assert.match(source, /render\.__dmBeta4CasaSolar = true/);
-  assert.match(source, /render\.__dmActualHistory = true/);
-  assert.match(legacy, /dm\.energy_produzione_solare_oggi/);
-  assert.match(legacy, /dm\.energy_consumo_casa_oggi/);
+  assert.match(source, /async function renderRealDailyChart/);
+  assert.match(source, /statisticsWithGrowth\(ids, start\.toISOString\(\), end\.toISOString\(\), "day"\)/);
+  assert.match(source, /visibleDays = currentMonth \? Math\.min\(now\.getDate\(\), monthDays\) : monthDays/);
+  assert.match(source, /currentBundleDay\(\)/);
+  assert.match(source, /balancedHouse\(values, index, refs\)/);
+  assert.match(source, /reportState\.legacyDailyChart = null/);
+  assert.match(source, /renderRealDailyChart\.__dmBeta5RealOnly = true/);
+  assert.doesNotMatch(source, /legacy\(\.\.\.args\)|Math\.sin|Math\.cos/);
+  // The old vendored fallback may remain for backwards compatibility, but the
+  // beta owner must explicitly make it unreachable.
   assert.match(legacy, /if \(!fetchOk && prodMese > 0\)/);
 });
 
-test("climate cards are truly natural-height on mobile and brand marks are readable locally", async () => {
+test("day and month Energy maps keep every secondary load node visible", async () => {
   const source = await read("src/sections/beta4-mobile-polish-section.js");
-  assert.match(source, /\.cp-card\{aspect-ratio:auto!important;min-height:0!important;height:auto!important/);
+  assert.match(source, /wb: \{ day: "dm\.ev_energia_wallbox_oggi", month: "dm\.ev_energia_wallbox_mese" \}/);
+  assert.match(source, /for \(const period of \["day", "month"\]\)/);
+  assert.match(source, /node\.style\.display = ""/);
+  assert.match(source, /node\.dataset\.dmBeta5FlowComplete = "true"/);
+});
+
+test("climate cards have one-column natural compact geometry on mobile", async () => {
+  const source = await read("src/sections/beta4-mobile-polish-section.js");
+  assert.match(source, /data-dm-beta5-climate/);
   assert.match(source, /\.clima-premium-grid\{grid-template-columns:1fr!important/);
-  assert.match(source, /BRAND_SIGNS/);
-  assert.match(source, /dm-beta4-brand-symbol/);
+  assert.match(source, /\.cp-card\{min-height:0!important;height:auto!important;max-height:none!important/);
+  assert.match(source, /\.cp-body\{display:grid!important;grid-template-columns:minmax\(0,1fr\) minmax\(0,1fr\)/);
+  assert.match(source, /\.cp-controls\{min-height:52px!important;height:52px!important/);
 });

--- a/custom_components/dashboardmodern/frontend/tests/beta4-mobile-polish.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta4-mobile-polish.test.js
@@ -5,10 +5,13 @@ import test from "node:test";
 const ROOT = new URL("../", import.meta.url);
 const read = (path) => readFile(new URL(path, ROOT), "utf8");
 
-test("final mobile owner is loaded last without a second room click interceptor", async () => {
+test("final mobile owner is loaded last and the room icon delegates to the mature picker", async () => {
   const entry = await read("src/sections/beta-entry-section.js");
   assert.match(entry, /editor-polish-section\.js";\nimport "\.\/beta4-mobile-polish-section\.js";/);
-  assert.doesNotMatch(entry, /dm-beta4-room-icon-trigger|stopImmediatePropagation/);
+  assert.match(entry, /dm-beta5-room-icon-trigger/);
+  assert.match(entry, /globalThis\.dmIconPicker\("#ed-room-icon", "rooms"\)/);
+  assert.match(entry, /event\.stopImmediatePropagation\(\)/);
+  assert.doesNotMatch(entry, /dm-beta4-room-icon-trigger/);
 });
 
 test("section rename keeps exactly one button inside its canonical row owner", async () => {
@@ -26,12 +29,13 @@ test("config tab names preserve their dedicated icon nodes", async () => {
   assert.match(source, /iconNode\.textContent = icon/);
 });
 
-test("room first insert uses its icon as the only picker trigger", async () => {
+test("room first insert uses its icon as the only visible picker trigger", async () => {
   const source = await read("src/sections/beta4-mobile-polish-section.js");
-  assert.match(source, /openRoomPicker\(input\)/);
+  const entry = await read("src/sections/beta-entry-section.js");
   assert.match(source, /trigger\.removeAttribute\("onclick"\)/);
   assert.match(source, /trigger\.className = "dm-beta5-room-icon-trigger"/);
   assert.match(source, /#ed-room-icon-preview\{display:none!important\}/);
+  assert.match(entry, /dmIconPicker\("#ed-room-icon", "rooms"\)/);
 });
 
 test("alerts hide custom-only controls and physically remove the orphan flash", async () => {
@@ -75,17 +79,18 @@ test("daily Energy chart is real-only, stops at today and never calls the synthe
   assert.match(source, /reportState\.legacyDailyChart = null/);
   assert.match(source, /renderRealDailyChart\.__dmBeta5RealOnly = true/);
   assert.doesNotMatch(source, /legacy\(\.\.\.args\)|Math\.sin|Math\.cos/);
-  // The old vendored fallback may remain for backwards compatibility, but the
-  // beta owner must explicitly make it unreachable.
   assert.match(legacy, /if \(!fetchOk && prodMese > 0\)/);
 });
 
-test("day and month Energy maps keep every secondary load node visible", async () => {
+test("day and month Energy maps keep every secondary load node and connector visible", async () => {
   const source = await read("src/sections/beta4-mobile-polish-section.js");
+  const entry = await read("src/sections/beta-entry-section.js");
   assert.match(source, /wb: \{ day: "dm\.ev_energia_wallbox_oggi", month: "dm\.ev_energia_wallbox_mese" \}/);
   assert.match(source, /for \(const period of \["day", "month"\]\)/);
   assert.match(source, /node\.style\.display = ""/);
   assert.match(source, /node\.dataset\.dmBeta5FlowComplete = "true"/);
+  assert.match(entry, /line-home-\$\{load\}-\$\{period\}/);
+  assert.match(entry, /display:block!important/);
 });
 
 test("climate cards have one-column natural compact geometry on mobile", async () => {

--- a/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
@@ -23,7 +23,7 @@ const refreshUrl = new URL("../src/sections/energy-refresh-section.js", import.m
 const analysisUrl = new URL("../src/sections/energy-analysis-section.js", import.meta.url);
 const contractsUrl = new URL("../src/sections/editor-contracts-section.js", import.meta.url);
 
-const RELEASE_VERSION = "1.0.0-beta.4";
+const RELEASE_VERSION = "1.0.0-beta.5";
 
 test("the 1.0 beta release metadata is consistently versioned", async () => {
   const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
@@ -40,8 +40,8 @@ test("the 1.0 beta release metadata is consistently versioned", async () => {
     /https:\/\/raw\.githubusercontent\.com\/danigio15\/dashboardmodern-v2\/main\/brand\/logo\.png/,
   );
   assert.doesNotMatch(readme, /main\/assets\/logo|brand\/logo@2x\.png/);
-  assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']1\.0\.0-beta\.4["']/);
-  assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']1\.0\.0-beta\.4["']/);
+  assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']1\.0\.0-beta\.5["']/);
+  assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']1\.0\.0-beta\.5["']/);
   assert.match(buildInfo, /["']?moduleVersion["']?\s*:\s*14/);
 });
 

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.4"
+  "version": "1.0.0-beta.5"
 }


### PR DESCRIPTION
## DashboardModern V2 — v1.0.0-beta.5

Questa PR corregge le cause reali riprodotte dagli screenshot Android della beta.4, non aggiunge un altro layer cosmetico.

### Energia
- Rimosso il ripristino del vecchio grafico sintetico: il fallback legacy che costruiva curve con `Math.sin`/`Math.cos` viene reso irraggiungibile.
- L'Andamento giornaliero usa soltanto Recorder sui contatori cumulativi configurati e il bilancio Casa coerente con Solare/Rete/Batteria.
- Per il mese corrente, se Recorder non ha ancora chiuso il bucket di oggi, viene usato soltanto il bundle reale già mostrato nel flow; non vengono inventati giorni passati o futuri.
- Il mese corrente termina al giorno odierno, non al giorno 31.
- Wallbox, Boiler, Clima, Lavanderia e Cucina restano presenti nei flow Giorno/Mese anche a 0 o senza campione corrente, evitando nodi mancanti.

### Config mobile
- Rimosso il conflitto che spostava la matita fuori dalla sua riga e faceva ricreare il controllo: ogni sezione ha una sola matita visibile e una sola istanza DOM.
- Luci: layout mobile esplicito `nome+entità / modifica / elimina` e selettore stanza sotto, senza righe vuote sovradimensionate.
- Avvisi: i controlli Personalizzato sono realmente nascosti per i gruppi standard e l'eventuale pulsante Flash orfano viene rimosso dal form.
- Clima: card a una colonna su mobile, altezza naturale compatta, body a due colonne e barra comandi fissa senza grande vuoto centrale.

### EV
- Il picker brand non usa più iniziali/wordmark generici. I marchi sono resi come SVG vettoriali locali e distinti (incluso Leapmotor), senza CDN.

### Verifica
- Aggiornati i contratti unitari per impedire il ritorno del fallback sintetico e dei duplicati matita.
- Aggiunto Browser E2E dedicato ai regressi esatti degli screenshot: matita unica, Luci, Avvisi/Flash, brand SVG, Clima compatto, Wallbox nel flow e grafico che termina a oggi con valori reali.
- Versione preparata come `1.0.0-beta.5`.
