### PR TITLE
fix: beta6 UI feedback — icons, energy chart, car brands, light controls

### DIFF
--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -3,9 +3,9 @@ import "../src/sections/beta-entry-section.js";
 
 export const BUILD_INFO = Object.freeze({
   generated: false,
-  integrationVersion: "1.0.0-beta.5",
-  dashboardVersion: "1.0.0-beta.5",
-  moduleVersion: 14,
+  integrationVersion: "1.0.0-beta.6",
+  dashboardVersion: "1.0.0-beta.6",
+  moduleVersion: 15,
   schemaVersion: 4,
   date: "UNBUILT",
   commit: "UNBUILT",

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -5,7 +5,7 @@ export const BUILD_INFO = Object.freeze({
   generated: false,
   integrationVersion: "1.0.0-beta.6",
   dashboardVersion: "1.0.0-beta.6",
-  moduleVersion: 15,
+  moduleVersion: 14,
   schemaVersion: 4,
   date: "UNBUILT",
   commit: "UNBUILT",

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -43,6 +43,32 @@ if (typeof document !== "undefined") {
       .join("");
     document.head?.append(style);
 
+    // The legacy form class is ed-form-row (not ed-qa-form-row). Lock the
+    // quick-action editor to three clean columns so the icon selector keeps a
+    // compact square footprint on phone screens instead of stretching the row.
+    const quickActionStyle = document.createElement("style");
+    quickActionStyle.id = "dm-beta6-quick-action-layout";
+    quickActionStyle.textContent = `
+      .ed-form-row[data-dm-beta6-quick-action="true"]{
+        display:grid!important;
+        grid-template-columns:minmax(0,1.15fr) 64px minmax(0,1fr)!important;
+        align-items:stretch!important;
+        gap:8px!important;
+      }
+      .ed-form-row[data-dm-beta6-quick-action="true"] #ed-qa-type,
+      .ed-form-row[data-dm-beta6-quick-action="true"] #ed-qa-name{
+        width:100%!important;
+        min-width:0!important;
+        margin:0!important;
+      }
+      .ed-form-row[data-dm-beta6-quick-action="true"] .dm-beta6-qa-icon-trigger{
+        width:64px!important;
+        min-width:64px!important;
+        max-width:64px!important;
+      }
+    `;
+    document.head?.append(quickActionStyle);
+
     // Legacy quick actions persist their icon as text and inject that value
     // directly into the Home card. The beta6 picker renders MDI artwork, so
     // convert its selected MDI token to the corresponding portable glyph before

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -6,6 +6,7 @@ import "./energy-report-polish-section.js";
 import "./personalization-section.js";
 import "./editor-polish-section.js";
 import "./beta4-mobile-polish-section.js";
+import "./beta6-feedback-section.js";
 
 // First insert keeps the new direct icon trigger, but delegates the actual
 // catalog to the mature multilingual picker already used by the legacy editor.

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -34,9 +34,176 @@ if (typeof document !== "undefined") {
     const style = document.createElement("style");
     style.id = "dm-beta5-complete-flow-links";
     style.textContent = ["day", "month"]
-      .flatMap((period) => ["boiler", "wb", "clima", "lav", "cuc"].map((load) => `#line-home-${load}-${period}`))
+      .flatMap((period) =>
+        ["boiler", "wb", "clima", "lav", "cuc"].map(
+          (load) => `#line-home-${load}-${period}`,
+        ),
+      )
       .map((selector) => `${selector}{display:block!important}`)
       .join("");
     document.head?.append(style);
+
+    // Legacy quick actions persist their icon as text and inject that value
+    // directly into the Home card. The beta6 picker renders MDI artwork, so
+    // convert its selected MDI token to the corresponding portable glyph before
+    // legacy save code runs, then render the saved glyph back as a HA icon in
+    // both the editor preview and the Home card. This avoids storing literal
+    // "mdi:..." strings while removing the generic flash fallback.
+    const quickActionGlyphByType = Object.freeze({
+      luci_group: "💡",
+      builtin_luci: "💡",
+      builtin_clima: "❄️",
+      builtin_antifurto: "🛡️",
+      builtin_lavatrice: "🧺",
+      toggle: "🔀",
+      script: "▶️",
+      scene: "🎬",
+    });
+    const quickActionMdiByType = Object.freeze({
+      luci_group: "mdi:lightbulb-group",
+      builtin_luci: "mdi:lightbulb-group",
+      builtin_clima: "mdi:snowflake",
+      builtin_antifurto: "mdi:shield-home",
+      builtin_lavatrice: "mdi:washing-machine",
+      toggle: "mdi:toggle-switch-outline",
+      script: "mdi:script-text-play",
+      scene: "mdi:movie-open",
+    });
+    const quickActionGlyphByMdi = Object.freeze({
+      "mdi:home": "🏠",
+      "mdi:lightbulb": "💡",
+      "mdi:lightbulb-group": "💡",
+      "mdi:snowflake": "❄️",
+      "mdi:radiator": "🔥",
+      "mdi:shield-home": "🛡️",
+      "mdi:gate": "🚪",
+      "mdi:window-shutter": "🪟",
+      "mdi:movie-open": "🎬",
+      "mdi:palette-outline": "🎬",
+      "mdi:script-text-play": "▶️",
+      "mdi:script-text-outline": "▶️",
+      "mdi:flash": "⚡",
+      "mdi:car-electric": "🚗",
+      "mdi:water-boiler": "♨️",
+      "mdi:water": "💧",
+      "mdi:cctv": "📷",
+      "mdi:bell": "🔔",
+      "mdi:star": "⭐",
+      "mdi:thermostat": "❄️",
+    });
+    const quickActionMdiByGlyph = Object.freeze({
+      "🏠": "mdi:home",
+      "💡": "mdi:lightbulb",
+      "❄️": "mdi:snowflake",
+      "🔥": "mdi:radiator",
+      "🛡️": "mdi:shield-home",
+      "🚪": "mdi:gate",
+      "🪟": "mdi:window-shutter",
+      "🎬": "mdi:movie-open",
+      "▶️": "mdi:script-text-play",
+      "⚡": "mdi:flash",
+      "🚗": "mdi:car-electric",
+      "♨️": "mdi:water-boiler",
+      "💧": "mdi:water",
+      "📷": "mdi:cctv",
+      "🔔": "mdi:bell",
+      "⭐": "mdi:star",
+      "🧺": "mdi:washing-machine",
+      "🔀": "mdi:toggle-switch-outline",
+    });
+
+    const quickActionDefaultGlyph = (type) => quickActionGlyphByType[type] || "⭐";
+    const quickActionGlyph = (value, type) => {
+      const icon = String(value || "").trim();
+      if (!icon || icon === "⚡") return quickActionDefaultGlyph(type);
+      if (icon.startsWith("mdi:")) return quickActionGlyphByMdi[icon] || quickActionDefaultGlyph(type);
+      return icon;
+    };
+    const quickActionMdi = (value, type) => {
+      const icon = String(value || "").trim();
+      if (icon.startsWith("mdi:")) return icon;
+      return quickActionMdiByGlyph[icon] || quickActionMdiByType[type] || "";
+    };
+    const renderQuickActionIcon = (target, value, type, size = 32) => {
+      if (!target) return;
+      const mdi = quickActionMdi(value, type);
+      if (mdi && typeof globalThis.cdIconMarkup === "function") {
+        target.innerHTML = globalThis.cdIconMarkup(mdi, size);
+        return;
+      }
+      target.textContent = quickActionGlyph(value, type);
+    };
+    const normalizeQuickActionEditor = () => {
+      const input = document.getElementById("ed-qa-icon");
+      const type = document.getElementById("ed-qa-type");
+      if (!input || !type) return;
+      const current = String(input.value || "").trim();
+      const next = quickActionGlyph(current, type.value);
+      if (next !== current) {
+        input.value = next;
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      }
+      renderQuickActionIcon(
+        input.parentElement?.querySelector?.(".dm-beta6-qa-icon-trigger"),
+        next,
+        type.value,
+        32,
+      );
+    };
+    const polishQuickActionCards = () => {
+      const actions =
+        typeof globalThis.getQuickActions === "function" ? globalThis.getQuickActions() : [];
+      document.querySelectorAll?.("#qa-grid .qa-btn").forEach((button, index) => {
+        const action = actions[index] || {};
+        const type =
+          action.type === "builtin" ? `builtin_${action.builtin || ""}` : action.type || "";
+        const icon = quickActionGlyph(action.icon, type);
+        renderQuickActionIcon(button.querySelector?.(".icon"), icon, type, 30);
+      });
+    };
+    const installQuickActionRenderer = () => {
+      const original = globalThis.buildQuickActions;
+      if (typeof original !== "function" || original.__dmBeta6Icons === true) return;
+      const wrapped = function dashboardModernQuickActionsWithIcons(...args) {
+        const result = original.apply(this, args);
+        polishQuickActionCards();
+        return result;
+      };
+      wrapped.__dmBeta6Icons = true;
+      globalThis.buildQuickActions = wrapped;
+      polishQuickActionCards();
+    };
+    const scheduleQuickActionPolish = () =>
+      globalThis.setTimeout?.(() => {
+        installQuickActionRenderer();
+        normalizeQuickActionEditor();
+        polishQuickActionCards();
+      }, 0);
+
+    document.addEventListener(
+      "change",
+      (event) => {
+        if (event.target?.id === "ed-qa-icon" || event.target?.id === "ed-qa-type") {
+          scheduleQuickActionPolish();
+        }
+      },
+      false,
+    );
+    document.addEventListener(
+      "click",
+      (event) => {
+        if (
+          event.target?.closest?.(
+            '.ed-tab,[data-tab="sez8"],.dm-beta6-qa-icon-trigger,#dm-beta6-quick-icon-picker .dm-picker-option',
+          )
+        ) {
+          scheduleQuickActionPolish();
+        }
+      },
+      false,
+    );
+    globalThis.addEventListener?.("dashboardmodern:legacy-ready", scheduleQuickActionPolish);
+    globalThis.addEventListener?.("dashboardmodern:runtime-ready", scheduleQuickActionPolish);
+    queueMicrotask(scheduleQuickActionPolish);
   }
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/beta6-feedback-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta6-feedback-section.js
@@ -1,0 +1,551 @@
+import { allStates, clean, doc, installStyle, readJson, root, t, wrapFunction } from "./shared.js";
+
+// Feedback fixes introduced after beta.5. This module intentionally layers on
+// top of the beta5 root-cause owner instead of forking its data/history logic.
+const KEY = "__DASHBOARDMODERN_BETA6_FEEDBACK__";
+const state = (root[KEY] ||= {
+  installed: false,
+  frame: 0,
+  observer: null,
+  chart: null,
+  lightSignature: "",
+});
+
+const SIMPLE_ICONS_VERSION = "16.27.1";
+const SIMPLE_ICON_SLUGS = Object.freeze({
+  abarth: "abarth",
+  "alfa-romeo": "alfaromeo",
+  audi: "audi",
+  bmw: "bmw",
+  byd: "byd",
+  citroen: "citroen",
+  cupra: "cupra",
+  dacia: "dacia",
+  ds: "dsautomobiles",
+  fiat: "fiat",
+  ford: "ford",
+  honda: "honda",
+  hyundai: "hyundai",
+  jeep: "jeep",
+  kia: "kia",
+  lancia: "lancia",
+  lexus: "lexus",
+  mazda: "mazda",
+  "mercedes-benz": "mercedesbenz",
+  mg: "mg",
+  mini: "mini",
+  nissan: "nissan",
+  opel: "opel",
+  peugeot: "peugeot",
+  polestar: "polestar",
+  porsche: "porsche",
+  renault: "renault",
+  seat: "seat",
+  skoda: "skoda",
+  smart: "smart",
+  subaru: "subaru",
+  suzuki: "suzuki",
+  tesla: "tesla",
+  toyota: "toyota",
+  volkswagen: "volkswagen",
+  volvo: "volvo",
+  xpeng: "xpeng",
+});
+
+const BRAND_IMAGE_OVERRIDES = Object.freeze({
+  // Official Leapmotor wordmark mirrored by Wikimedia Commons from Leapmotor IR.
+  leapmotor: "https://upload.wikimedia.org/wikipedia/commons/d/d8/Leapmotor_logo_en.svg",
+});
+
+const QUICK_ACTION_DEFAULTS = Object.freeze({
+  lights: "mdi:lightbulb-group",
+  script: "mdi:script-text-outline",
+  scene: "mdi:palette-outline",
+  cover: "mdi:window-shutter",
+  climate: "mdi:thermostat",
+  custom: "mdi:gesture-tap-button",
+  popup: "mdi:view-dashboard-outline",
+});
+
+const QUICK_ACTION_ICONS = Object.freeze([
+  ["mdi:lightbulb-group", "Luci", "Lights"],
+  ["mdi:lightbulb", "Lampadina", "Light"],
+  ["mdi:ceiling-light", "Plafoniera", "Ceiling light"],
+  ["mdi:led-strip-variant", "LED / RGB", "LED / RGB"],
+  ["mdi:palette-outline", "Scena", "Scene"],
+  ["mdi:script-text-outline", "Script", "Script"],
+  ["mdi:window-shutter", "Tapparella", "Cover"],
+  ["mdi:thermostat", "Clima", "Climate"],
+  ["mdi:view-dashboard-outline", "Popup", "Popup"],
+  ["mdi:power", "Accensione", "Power"],
+  ["mdi:play", "Avvia", "Start"],
+  ["mdi:stop", "Stop", "Stop"],
+  ["mdi:garage", "Garage", "Garage"],
+  ["mdi:door", "Porta", "Door"],
+  ["mdi:fan", "Ventola", "Fan"],
+  ["mdi:water", "Acqua", "Water"],
+]);
+
+const RGB_MODES = new Set(["hs", "xy", "rgb", "rgbw", "rgbww"]);
+const BRIGHTNESS_MODES = new Set(["brightness", "color_temp", "hs", "xy", "rgb", "rgbw", "rgbww"]);
+
+function escAttr(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function normalizeBrandKey(value) {
+  return clean(value)
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function brandImageSource(value) {
+  const key = normalizeBrandKey(value);
+  if (BRAND_IMAGE_OVERRIDES[key]) return BRAND_IMAGE_OVERRIDES[key];
+  const slug = SIMPLE_ICON_SLUGS[key];
+  return slug ? `https://cdn.jsdelivr.net/npm/simple-icons@${SIMPLE_ICONS_VERSION}/icons/${slug}.svg` : "";
+}
+
+function brandLabel(mark) {
+  const host = mark.closest?.(".dm-picker-option,[data-brand-preview],.dm-ev-brand-badge");
+  return clean(mark.dataset.dmBeta5Brand || mark.dataset.brand || mark.getAttribute("title") || host?.querySelector?.("b")?.textContent);
+}
+
+function polishVehicleBrandImages() {
+  doc?.querySelectorAll?.(".dm-car-brand").forEach((mark) => {
+    const brand = brandLabel(mark);
+    const key = normalizeBrandKey(brand);
+    const source = brandImageSource(key);
+    if (!brand || !source) return;
+    const current = mark.querySelector("img[data-dm-beta6-brand-image]");
+    if (current?.dataset?.dmBeta6BrandKey === key) return;
+
+    const fallback = mark.innerHTML;
+    const wrapper = doc.createElement("span");
+    wrapper.className = "dm-beta5-brand-logo dm-beta6-brand-image";
+    wrapper.dataset.brandLogo = key;
+    wrapper.title = brand;
+    const image = doc.createElement("img");
+    image.dataset.dmBeta6BrandImage = "true";
+    image.dataset.dmBeta6BrandKey = key;
+    image.alt = brand;
+    image.decoding = "async";
+    image.loading = "eager";
+    image.referrerPolicy = "no-referrer";
+    image.src = source;
+    image.addEventListener(
+      "error",
+      () => {
+        // Keep the old in-bundle SVG as an offline/error fallback.
+        mark.innerHTML = fallback;
+        mark.dataset.dmBeta6BrandImageError = key;
+      },
+      { once: true },
+    );
+    wrapper.append(image);
+    mark.replaceChildren(wrapper);
+    mark.dataset.dmBeta5Brand = brand;
+    mark.dataset.dmBeta4Brand = brand;
+    mark.dataset.dmBeta6BrandImage = key;
+  });
+}
+
+function iconMarkup(icon) {
+  const value = clean(icon) || "mdi:gesture-tap-button";
+  try {
+    const rendered = root.cdIconMarkup?.(value);
+    if (clean(rendered)) return rendered;
+  } catch (_error) {}
+  return `<ha-icon icon="${escAttr(value)}" aria-hidden="true"></ha-icon>`;
+}
+
+function closeQuickIconPicker() {
+  doc?.getElementById("dm-beta6-quick-icon-picker")?.remove();
+}
+
+function openQuickIconPicker(input, trigger) {
+  if (!input) return;
+  closeQuickIconPicker();
+  const modal = doc.createElement("div");
+  modal.id = "dm-beta6-quick-icon-picker";
+  modal.className = "dm-section-modal dm-visual-picker";
+  const english = doc.documentElement.lang === "en";
+  modal.innerHTML = `<section class="dm-section-dialog dm-picker-dialog" role="dialog" aria-modal="true" aria-labelledby="dm-beta6-quick-icon-title">
+    <header><strong id="dm-beta6-quick-icon-title">${t("Scegli icona azione", "Choose action icon")}</strong><button type="button" data-close aria-label="${t("Chiudi", "Close")}">✕</button></header>
+    <div class="dm-picker-grid dm-beta6-quick-icon-grid">${QUICK_ACTION_ICONS.map(([icon, it, en]) => `<button type="button" class="dm-picker-option dm-beta6-icon-option" data-icon="${escAttr(icon)}"><span class="dm-picker-visual">${iconMarkup(icon)}</span><b>${escAttr(english ? en : it)}</b></button>`).join("")}</div>
+  </section>`;
+  doc.body.append(modal);
+  const close = () => closeQuickIconPicker();
+  modal.querySelector("[data-close]")?.addEventListener("click", close);
+  modal.addEventListener("click", (event) => {
+    if (event.target === modal) close();
+  });
+  modal.querySelectorAll("[data-icon]").forEach((button) =>
+    button.addEventListener("click", () => {
+      input.value = button.dataset.icon;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+      if (trigger) trigger.innerHTML = iconMarkup(input.value);
+      close();
+    }),
+  );
+}
+
+function actionTypeDefault(type) {
+  return QUICK_ACTION_DEFAULTS[clean(type)] || "mdi:gesture-tap-button";
+}
+
+function polishQuickActionIcon() {
+  const input = doc?.getElementById?.("ed-qa-icon");
+  const type = doc?.getElementById?.("ed-qa-type");
+  if (!input || !type) return false;
+  const row = input.closest?.(".ed-qa-form-row") || input.parentElement;
+  if (!row) return false;
+  row.dataset.dmBeta6QuickAction = "true";
+
+  let trigger = row.querySelector(".dm-beta6-qa-icon-trigger");
+  if (!trigger) {
+    trigger = doc.createElement("button");
+    trigger.type = "button";
+    trigger.className = "dm-beta6-qa-icon-trigger";
+    trigger.setAttribute("aria-label", t("Scegli icona azione", "Choose action icon"));
+    input.insertAdjacentElement("afterend", trigger);
+    trigger.addEventListener("click", (event) => {
+      event.preventDefault();
+      openQuickIconPicker(input, trigger);
+    });
+    input.addEventListener("input", () => (trigger.innerHTML = iconMarkup(input.value)));
+    input.addEventListener("change", () => (trigger.innerHTML = iconMarkup(input.value)));
+  }
+
+  const defaults = new Set(["", "⚡", "mdi:flash", "mdi:flash-outline", ...Object.values(QUICK_ACTION_DEFAULTS)]);
+  const desired = actionTypeDefault(type.value);
+  if (defaults.has(clean(input.value)) && clean(input.value) !== desired) input.value = desired;
+  trigger.innerHTML = iconMarkup(input.value || desired);
+  input.classList.add("dm-beta6-qa-icon-value");
+
+  if (type.dataset.dmBeta6IconBound !== "true") {
+    type.dataset.dmBeta6IconBound = "true";
+    type.addEventListener("change", () => {
+      const current = clean(input.value);
+      if (!current || current === "⚡" || current.startsWith("mdi:")) {
+        input.value = actionTypeDefault(type.value);
+        input.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+      trigger.innerHTML = iconMarkup(input.value);
+    });
+  }
+  return true;
+}
+
+function polishDailyChart() {
+  const beta5 = root.__DASHBOARDMODERN_BETA5_ROOT_CAUSES__;
+  const chart = beta5?.dailyChart;
+  if (!chart?.canvas || !chart?.data?.datasets?.length) return false;
+  const canvas = chart.canvas;
+  const mobile = (root.innerWidth || doc?.documentElement?.clientWidth || 900) <= 760;
+  const first = chart.data.datasets[0];
+  const second = chart.data.datasets[1];
+
+  try {
+    const ctx = chart.ctx || canvas.getContext?.("2d");
+    if (ctx?.createLinearGradient) {
+      const gradient = ctx.createLinearGradient(0, 0, 0, Math.max(220, canvas.clientHeight || 280));
+      gradient.addColorStop(0, "rgba(22,163,74,.24)");
+      gradient.addColorStop(0.72, "rgba(22,163,74,.07)");
+      gradient.addColorStop(1, "rgba(22,163,74,0)");
+      first.backgroundColor = gradient;
+    }
+  } catch (_error) {
+    first.backgroundColor = "rgba(22,163,74,.11)";
+  }
+
+  Object.assign(first, {
+    fill: "origin",
+    tension: 0.34,
+    borderWidth: mobile ? 2.2 : 2.6,
+    pointRadius: mobile ? 2.2 : 2.8,
+    pointHoverRadius: 5,
+    pointBorderWidth: 0,
+  });
+  if (second)
+    Object.assign(second, {
+      fill: false,
+      tension: 0.34,
+      borderWidth: mobile ? 2.2 : 2.6,
+      pointRadius: mobile ? 2.2 : 2.8,
+      pointHoverRadius: 5,
+      pointBorderWidth: 0,
+      backgroundColor: "rgba(14,165,233,0)",
+    });
+
+  chart.options ||= {};
+  chart.options.maintainAspectRatio = false;
+  chart.options.animation = false;
+  chart.options.layout = { padding: { top: 10, right: 8, bottom: 2, left: 2 } };
+  chart.options.interaction = { intersect: false, mode: "index" };
+  chart.options.plugins ||= {};
+  chart.options.plugins.legend = { display: false };
+  chart.options.plugins.tooltip = {
+    ...(chart.options.plugins.tooltip || {}),
+    displayColors: true,
+    padding: 10,
+    cornerRadius: 10,
+  };
+  chart.options.scales ||= {};
+  chart.options.scales.x = {
+    ...(chart.options.scales.x || {}),
+    offset: false,
+    border: { display: false },
+    grid: { display: false, drawBorder: false },
+    ticks: {
+      ...(chart.options.scales.x?.ticks || {}),
+      autoSkip: true,
+      maxTicksLimit: mobile ? 6 : 10,
+      maxRotation: 0,
+      minRotation: 0,
+      padding: 8,
+      color: "#64748b",
+      font: { size: mobile ? 11 : 12, weight: "700" },
+    },
+  };
+  chart.options.scales.y = {
+    ...(chart.options.scales.y || {}),
+    beginAtZero: true,
+    grace: "8%",
+    border: { display: false },
+    grid: { color: "rgba(100,116,139,.16)", drawBorder: false },
+    ticks: {
+      ...(chart.options.scales.y?.ticks || {}),
+      maxTicksLimit: mobile ? 5 : 6,
+      padding: 7,
+      color: "#64748b",
+      font: { size: mobile ? 11 : 12, weight: "650" },
+    },
+    title: { display: !mobile, text: "kWh", color: "#64748b", font: { weight: "700" } },
+  };
+  canvas.dataset.dmBeta6ChartPolished = "true";
+  if (state.chart !== chart) state.chart = chart;
+  try {
+    chart.resize?.();
+    chart.update?.("none");
+  } catch (_error) {}
+  return true;
+}
+
+function lightState(entityId) {
+  const states = allStates?.() || root.STATES || root._RAW_STATES || {};
+  return states?.[entityId] || root.currentEntity?.(entityId) || root.haState?.(entityId) || null;
+}
+
+function configuredLights() {
+  const names = readJson("cd_luci", {});
+  return Object.keys(names || {})
+    .filter((id) => /^light\./i.test(id))
+    .map((id) => ({ id, name: clean(names[id]) || clean(lightState(id)?.attributes?.friendly_name) || id }));
+}
+
+function supportedModes(entity) {
+  const raw = entity?.attributes?.supported_color_modes;
+  return new Set((Array.isArray(raw) ? raw : []).map((value) => clean(value).toLowerCase()).filter(Boolean));
+}
+
+function supportsBrightness(entity) {
+  const modes = supportedModes(entity);
+  if (entity?.attributes?.brightness != null) return true;
+  return [...modes].some((mode) => BRIGHTNESS_MODES.has(mode));
+}
+
+function supportsRgb(entity) {
+  return [...supportedModes(entity)].some((mode) => RGB_MODES.has(mode));
+}
+
+function rgbToHex(rgb) {
+  const values = Array.isArray(rgb) ? rgb.slice(0, 3) : [];
+  if (values.length < 3 || values.some((value) => !Number.isFinite(Number(value)))) return "#ffffff";
+  return `#${values.map((value) => Math.max(0, Math.min(255, Number(value))).toString(16).padStart(2, "0")).join("")}`;
+}
+
+function hexToRgb(hex) {
+  const value = clean(hex).replace(/^#/, "");
+  if (!/^[0-9a-f]{6}$/i.test(value)) return [255, 255, 255];
+  return [0, 2, 4].map((offset) => Number.parseInt(value.slice(offset, offset + 2), 16));
+}
+
+function callLight(entityId, data) {
+  const payload = { entity_id: entityId, ...data };
+  try {
+    if (typeof root.cdCallServiceJson === "function") return root.cdCallServiceJson("light", "turn_on", JSON.stringify(payload));
+    if (typeof root.callService === "function") return root.callService("light", "turn_on", payload);
+    const hass = root.hass || root._hass || doc?.querySelector?.("home-assistant")?.hass;
+    if (typeof hass?.callService === "function") return hass.callService("light", "turn_on", payload);
+  } catch (error) {
+    root.console?.warn?.("[DashboardModern] light control failed", error);
+  }
+  return null;
+}
+
+function lightSignature(lights) {
+  return lights
+    .map(({ id }) => {
+      const entity = lightState(id) || {};
+      const attrs = entity.attributes || {};
+      return [id, entity.state, attrs.brightness, (attrs.rgb_color || []).join(","), (attrs.supported_color_modes || []).join(",")].join("|");
+    })
+    .join(";");
+}
+
+function renderAdvancedLightControls() {
+  const list = doc?.getElementById?.("wz-lights-list");
+  if (!list) return false;
+  const popup = list.closest?.(".wz-popup,.popup,.modal,.wz-modal") || list.parentElement;
+  if (!popup) return false;
+  const lights = configuredLights().filter(({ id }) => {
+    const entity = lightState(id);
+    return entity && (supportsBrightness(entity) || supportsRgb(entity));
+  });
+  let panel = popup.querySelector?.(".dm-beta6-light-advanced");
+  if (!lights.length) {
+    panel?.remove();
+    return false;
+  }
+
+  const signature = lightSignature(lights);
+  if (panel && state.lightSignature === signature) return true;
+  state.lightSignature = signature;
+  if (!panel) {
+    panel = doc.createElement("section");
+    panel.className = "dm-beta6-light-advanced";
+    list.insertAdjacentElement("afterend", panel);
+  }
+  panel.innerHTML = `<header><strong>${t("Dimmer e colori", "Dimmer & colors")}</strong><span>${t("Solo per luci compatibili", "Compatible lights only")}</span></header><div class="dm-beta6-light-control-list"></div>`;
+  const body = panel.querySelector(".dm-beta6-light-control-list");
+
+  lights.forEach(({ id, name }) => {
+    const entity = lightState(id) || {};
+    const attrs = entity.attributes || {};
+    const dimmable = supportsBrightness(entity);
+    const rgb = supportsRgb(entity);
+    const brightness = Math.round((Math.max(0, Math.min(255, Number(attrs.brightness) || 0)) / 255) * 100);
+    const color = rgbToHex(attrs.rgb_color);
+    const row = doc.createElement("article");
+    row.className = "dm-beta6-light-control";
+    row.dataset.entity = id;
+    row.innerHTML = `<div class="dm-beta6-light-head"><span class="dm-beta6-light-dot ${entity.state === "on" ? "is-on" : ""}"></span><div><strong>${escAttr(name)}</strong><small>${escAttr(id)}</small></div></div><div class="dm-beta6-light-tools">${dimmable ? `<label class="dm-beta6-dimmer"><span>${t("Luminosità", "Brightness")}</span><output>${brightness}%</output><input type="range" min="1" max="100" step="1" value="${Math.max(1, brightness || 1)}" data-brightness></label>` : ""}${rgb ? `<label class="dm-beta6-color"><span>RGB</span><input type="color" value="${color}" data-color aria-label="${t("Colore luce", "Light color")}"></label>` : ""}</div>`;
+    body.append(row);
+
+    const slider = row.querySelector("[data-brightness]");
+    const output = row.querySelector(".dm-beta6-dimmer output");
+    if (slider) {
+      let timer = 0;
+      slider.addEventListener("input", () => {
+        if (output) output.value = `${slider.value}%`;
+        root.clearTimeout?.(timer);
+        timer = root.setTimeout?.(() => callLight(id, { brightness_pct: Number(slider.value) }), 120) || 0;
+      });
+      slider.addEventListener("change", () => callLight(id, { brightness_pct: Number(slider.value) }));
+    }
+    row.querySelector("[data-color]")?.addEventListener("input", (event) => callLight(id, { rgb_color: hexToRgb(event.target.value) }));
+  });
+  return true;
+}
+
+function run() {
+  state.frame = 0;
+  polishQuickActionIcon();
+  polishVehicleBrandImages();
+  polishDailyChart();
+  renderAdvancedLightControls();
+}
+
+function schedule() {
+  if (state.frame) return;
+  state.frame = root.requestAnimationFrame?.(run) || root.setTimeout?.(run, 0);
+}
+
+function installOwners() {
+  wrapFunction("wzOpenLightsPopup", "__dmBeta6LightControls", () => root.setTimeout?.(schedule, 0));
+  wrapFunction("editorSwitch", "__dmBeta6QuickAction", schedule);
+  wrapFunction("render", "__dmBeta6Runtime", schedule);
+}
+
+function installStyles() {
+  installStyle("dm-beta6-feedback-style", `
+    /* Quick actions: the stored input remains for legacy save code, while the UI
+       exposes a real HA icon button instead of the old flash emoji. */
+    .ed-qa-form-row[data-dm-beta6-quick-action="true"]{align-items:stretch!important}
+    #ed-qa-icon.dm-beta6-qa-icon-value{display:none!important}
+    .dm-beta6-qa-icon-trigger{display:grid!important;place-items:center!important;box-sizing:border-box!important;width:100%!important;min-width:62px!important;min-height:52px!important;margin:0!important;padding:8px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:16px!important;background:var(--card-background-color,#fff)!important;color:var(--info-color,#0284c7)!important;cursor:pointer!important;box-shadow:none!important}
+    .dm-beta6-qa-icon-trigger ha-icon,.dm-beta6-qa-icon-trigger svg{width:30px!important;height:30px!important;font-size:30px!important}
+    .dm-beta6-quick-icon-grid .dm-picker-option{min-height:104px!important}
+    .dm-beta6-quick-icon-grid ha-icon,.dm-beta6-quick-icon-grid svg{width:38px!important;height:38px!important;font-size:38px!important;color:var(--info-color,#0284c7)!important}
+
+    /* Real manufacturer artwork. Logos are external IMG elements with the beta5
+       SVG retained as automatic offline fallback. */
+    .dm-beta6-brand-image{display:grid!important;place-items:center!important;width:88px!important;height:58px!important;padding:5px!important;box-sizing:border-box!important}
+    .dm-beta6-brand-image img{display:block!important;width:100%!important;height:100%!important;max-width:86px!important;max-height:50px!important;object-fit:contain!important;object-position:center!important;filter:none!important}
+    [data-brand-preview] .dm-beta6-brand-image{width:104px!important;height:64px!important}
+    [data-brand-preview] .dm-beta6-brand-image img{max-width:100px!important;max-height:56px!important}
+
+    /* Daily chart: compact card, restrained fill, readable axes and no canvas
+       leaking below the card on phone screens. */
+    #ed-daily-chart{overflow:hidden!important}
+    #ed-daily-chart .ed-chart-wrap{box-sizing:border-box!important;height:clamp(250px,52vw,320px)!important;min-height:0!important;max-height:320px!important;margin:8px 0 0!important;padding:0 8px 8px!important;overflow:hidden!important}
+    #ed-daily-chart .ed-chart-wrap canvas,#ed-daily-canvas[data-dm-beta5-real-history]{box-sizing:border-box!important;width:100%!important;height:100%!important;min-height:0!important;max-height:100%!important;margin:0!important}
+
+    /* Advanced controls are appended to the existing Lights popup only for
+       entities whose HA supported_color_modes expose brightness/RGB. */
+    .dm-beta6-light-advanced{display:grid!important;gap:10px!important;margin:14px 0 0!important;padding:14px!important;border:1px solid color-mix(in srgb,var(--info-color,#0ea5e9) 18%,var(--divider-color,#dbe4ee))!important;border-radius:18px!important;background:color-mix(in srgb,var(--info-color,#0ea5e9) 4%,var(--card-background-color,#fff))!important}
+    .dm-beta6-light-advanced>header{display:flex!important;align-items:baseline!important;justify-content:space-between!important;gap:12px!important}.dm-beta6-light-advanced>header strong{font-size:15px!important}.dm-beta6-light-advanced>header span{font-size:11px!important;color:var(--secondary-text-color,#64748b)!important}
+    .dm-beta6-light-control-list{display:grid!important;gap:10px!important}
+    .dm-beta6-light-control{display:grid!important;grid-template-columns:minmax(0,1fr) minmax(220px,1.4fr)!important;align-items:center!important;gap:14px!important;padding:12px!important;border-radius:15px!important;background:var(--card-background-color,#fff)!important;box-shadow:0 5px 18px rgba(15,23,42,.05)!important}
+    .dm-beta6-light-head{display:flex!important;align-items:center!important;gap:10px!important;min-width:0!important}.dm-beta6-light-head>div{min-width:0!important}.dm-beta6-light-head strong,.dm-beta6-light-head small{display:block!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important}.dm-beta6-light-head small{margin-top:3px!important;font-size:10px!important;color:var(--secondary-text-color,#64748b)!important}
+    .dm-beta6-light-dot{width:10px!important;height:10px!important;flex:0 0 10px!important;border-radius:999px!important;background:#94a3b8!important;box-shadow:0 0 0 4px rgba(148,163,184,.12)!important}.dm-beta6-light-dot.is-on{background:#f59e0b!important;box-shadow:0 0 0 4px rgba(245,158,11,.14)!important}
+    .dm-beta6-light-tools{display:grid!important;grid-template-columns:minmax(160px,1fr) auto!important;align-items:center!important;gap:12px!important}.dm-beta6-dimmer{display:grid!important;grid-template-columns:1fr auto!important;align-items:center!important;gap:6px 10px!important}.dm-beta6-dimmer span,.dm-beta6-color span{font-size:11px!important;font-weight:800!important;color:var(--secondary-text-color,#64748b)!important}.dm-beta6-dimmer output{font-size:11px!important;font-weight:900!important;color:var(--primary-text-color,#0f172a)!important}.dm-beta6-dimmer input{grid-column:1/-1!important;width:100%!important;accent-color:var(--info-color,#0ea5e9)!important}.dm-beta6-color{display:grid!important;place-items:center!important;gap:5px!important}.dm-beta6-color input{box-sizing:border-box!important;width:42px!important;height:34px!important;padding:2px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:10px!important;background:transparent!important}
+
+    @media(max-width:760px){
+      .ed-qa-form-row[data-dm-beta6-quick-action="true"]{grid-template-columns:minmax(0,1fr) 64px minmax(0,1fr)!important}
+      .dm-beta6-qa-icon-trigger{min-width:64px!important;width:64px!important;min-height:52px!important}
+      #ed-daily-chart .ed-chart-wrap{height:252px!important;min-height:252px!important;max-height:252px!important;padding:0 4px 6px!important}
+      .dm-beta6-light-control{grid-template-columns:1fr!important;gap:10px!important;padding:11px!important}.dm-beta6-light-tools{grid-template-columns:minmax(0,1fr) 48px!important}.dm-beta6-light-advanced>header{align-items:flex-start!important;flex-direction:column!important;gap:2px!important}
+      .dm-beta6-brand-image{width:80px!important;height:54px!important}.dm-beta6-brand-image img{max-width:78px!important;max-height:46px!important}
+    }
+  `);
+}
+
+export function installBeta6FeedbackSection() {
+  if (!doc || state.installed) return;
+  state.installed = true;
+  installStyles();
+  installOwners();
+
+  root.addEventListener?.("dashboardmodern:legacy-ready", () => {
+    installOwners();
+    schedule();
+  });
+  root.addEventListener?.("dashboardmodern:runtime-ready", schedule);
+  root.addEventListener?.("dashboardmodern:period-bundle", schedule);
+  root.addEventListener?.("dashboardmodern:energy-stable", schedule);
+  root.addEventListener?.("resize", schedule, { passive: true });
+  doc.addEventListener("change", schedule, true);
+  doc.addEventListener("click", (event) => {
+    if (event.target?.closest?.(".ed-tab,.sub-tab-btn,.dm-picker-option,.ed-btn-add,[data-brand-preview],#btn-lights")) root.setTimeout?.(schedule, 0);
+  }, true);
+
+  if (typeof MutationObserver !== "undefined") {
+    state.observer = new MutationObserver((mutations) => {
+      if (mutations.some((mutation) => mutation.type === "childList" || mutation.target?.id === "ed-daily-canvas" || mutation.target?.id === "ed-body")) schedule();
+    });
+    state.observer.observe(doc.documentElement, { subtree: true, childList: true, attributes: true, attributeFilter: ["data-dm-beta5-real-history", "class"] });
+  }
+  schedule();
+}
+
+installBeta6FeedbackSection();

--- a/custom_components/dashboardmodern/frontend/src/sections/beta6-feedback-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta6-feedback-section.js
@@ -1,12 +1,10 @@
-import { allStates, clean, doc, installStyle, readJson, root, t, wrapFunction } from "./shared.js";
+import { ACTION_ICON_CATALOG, actionVisual } from "../core/personalization-catalog.js";
+import { allStates, clean, doc, esc, installStyle, readJson, root, t, wrapFunction } from "./shared.js";
 
-// Feedback fixes introduced after beta.5. This module intentionally layers on
-// top of the beta5 root-cause owner instead of forking its data/history logic.
 const KEY = "__DASHBOARDMODERN_BETA6_FEEDBACK__";
 const state = (root[KEY] ||= {
   installed: false,
   frame: 0,
-  observer: null,
   chart: null,
   lightSignature: "",
 });
@@ -53,7 +51,6 @@ const SIMPLE_ICON_SLUGS = Object.freeze({
 });
 
 const BRAND_IMAGE_OVERRIDES = Object.freeze({
-  // Official Leapmotor wordmark mirrored by Wikimedia Commons from Leapmotor IR.
   leapmotor: "https://upload.wikimedia.org/wikipedia/commons/d/d8/Leapmotor_logo_en.svg",
 });
 
@@ -67,35 +64,16 @@ const QUICK_ACTION_DEFAULTS = Object.freeze({
   popup: "mdi:view-dashboard-outline",
 });
 
-const QUICK_ACTION_ICONS = Object.freeze([
-  ["mdi:lightbulb-group", "Luci", "Lights"],
-  ["mdi:lightbulb", "Lampadina", "Light"],
-  ["mdi:ceiling-light", "Plafoniera", "Ceiling light"],
-  ["mdi:led-strip-variant", "LED / RGB", "LED / RGB"],
-  ["mdi:palette-outline", "Scena", "Scene"],
-  ["mdi:script-text-outline", "Script", "Script"],
-  ["mdi:window-shutter", "Tapparella", "Cover"],
-  ["mdi:thermostat", "Clima", "Climate"],
-  ["mdi:view-dashboard-outline", "Popup", "Popup"],
-  ["mdi:power", "Accensione", "Power"],
-  ["mdi:play", "Avvia", "Start"],
-  ["mdi:stop", "Stop", "Stop"],
-  ["mdi:garage", "Garage", "Garage"],
-  ["mdi:door", "Porta", "Door"],
-  ["mdi:fan", "Ventola", "Fan"],
-  ["mdi:water", "Acqua", "Water"],
-]);
-
 const RGB_MODES = new Set(["hs", "xy", "rgb", "rgbw", "rgbww"]);
-const BRIGHTNESS_MODES = new Set(["brightness", "color_temp", "hs", "xy", "rgb", "rgbw", "rgbww"]);
-
-function escAttr(value) {
-  return String(value ?? "")
-    .replaceAll("&", "&amp;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
-}
+const BRIGHTNESS_MODES = new Set([
+  "brightness",
+  "color_temp",
+  "hs",
+  "xy",
+  "rgb",
+  "rgbw",
+  "rgbww",
+]);
 
 function normalizeBrandKey(value) {
   return clean(value)
@@ -110,12 +88,19 @@ function brandImageSource(value) {
   const key = normalizeBrandKey(value);
   if (BRAND_IMAGE_OVERRIDES[key]) return BRAND_IMAGE_OVERRIDES[key];
   const slug = SIMPLE_ICON_SLUGS[key];
-  return slug ? `https://cdn.jsdelivr.net/npm/simple-icons@${SIMPLE_ICONS_VERSION}/icons/${slug}.svg` : "";
+  return slug
+    ? `https://cdn.jsdelivr.net/npm/simple-icons@${SIMPLE_ICONS_VERSION}/icons/${slug}.svg`
+    : "";
 }
 
 function brandLabel(mark) {
   const host = mark.closest?.(".dm-picker-option,[data-brand-preview],.dm-ev-brand-badge");
-  return clean(mark.dataset.dmBeta5Brand || mark.dataset.brand || mark.getAttribute("title") || host?.querySelector?.("b")?.textContent);
+  return clean(
+    mark.dataset.dmBeta5Brand ||
+      mark.dataset.brand ||
+      mark.getAttribute("title") ||
+      host?.querySelector?.("b")?.textContent,
+  );
 }
 
 function polishVehicleBrandImages() {
@@ -132,6 +117,7 @@ function polishVehicleBrandImages() {
     wrapper.className = "dm-beta5-brand-logo dm-beta6-brand-image";
     wrapper.dataset.brandLogo = key;
     wrapper.title = brand;
+
     const image = doc.createElement("img");
     image.dataset.dmBeta6BrandImage = "true";
     image.dataset.dmBeta6BrandKey = key;
@@ -143,7 +129,6 @@ function polishVehicleBrandImages() {
     image.addEventListener(
       "error",
       () => {
-        // Keep the old in-bundle SVG as an offline/error fallback.
         mark.innerHTML = fallback;
         mark.dataset.dmBeta6BrandImageError = key;
       },
@@ -157,48 +142,57 @@ function polishVehicleBrandImages() {
   });
 }
 
-function iconMarkup(icon) {
-  const value = clean(icon) || "mdi:gesture-tap-button";
-  try {
-    const rendered = root.cdIconMarkup?.(value);
-    if (clean(rendered)) return rendered;
-  } catch (_error) {}
-  return `<ha-icon icon="${escAttr(value)}" aria-hidden="true"></ha-icon>`;
+function actionIconMarkup(value, size = 32) {
+  const icon = clean(value) || "mdi:gesture-tap-button";
+  return actionVisual(icon, size) || root.cdIconMarkup?.(icon, size) || esc(icon);
 }
 
-function closeQuickIconPicker() {
+function closeActionPicker() {
   doc?.getElementById("dm-beta6-quick-icon-picker")?.remove();
 }
 
-function openQuickIconPicker(input, trigger) {
+function openActionPicker(input, preview) {
   if (!input) return;
-  closeQuickIconPicker();
+  closeActionPicker();
   const modal = doc.createElement("div");
   modal.id = "dm-beta6-quick-icon-picker";
   modal.className = "dm-section-modal dm-visual-picker";
-  const english = doc.documentElement.lang === "en";
-  modal.innerHTML = `<section class="dm-section-dialog dm-picker-dialog" role="dialog" aria-modal="true" aria-labelledby="dm-beta6-quick-icon-title">
-    <header><strong id="dm-beta6-quick-icon-title">${t("Scegli icona azione", "Choose action icon")}</strong><button type="button" data-close aria-label="${t("Chiudi", "Close")}">✕</button></header>
-    <div class="dm-picker-grid dm-beta6-quick-icon-grid">${QUICK_ACTION_ICONS.map(([icon, it, en]) => `<button type="button" class="dm-picker-option dm-beta6-icon-option" data-icon="${escAttr(icon)}"><span class="dm-picker-visual">${iconMarkup(icon)}</span><b>${escAttr(english ? en : it)}</b></button>`).join("")}</div>
+  const english = clean(doc.documentElement?.lang).toLowerCase().startsWith("en");
+  modal.innerHTML = `<section class="dm-section-dialog dm-picker-dialog" role="dialog" aria-modal="true">
+    <header><strong>${t("Scegli icona azione", "Choose action icon")}</strong><button type="button" data-close aria-label="${t("Chiudi", "Close")}">✕</button></header>
+    <div class="dm-picker-search"><input class="ed-input" type="search" placeholder="🔎 ${t("Cerca…", "Search…")}" data-search></div>
+    <div class="dm-picker-grid dm-beta6-quick-icon-grid">${ACTION_ICON_CATALOG.map(
+      (item, index) =>
+        `<button type="button" class="dm-picker-option" data-index="${index}" data-search-text="${esc(`${item.it} ${item.en} ${item.id} ${item.mdi}`.toLowerCase())}"><span class="dm-picker-visual">${actionVisual(item.mdi, 44)}</span><b>${esc(english ? item.en : item.it)}</b></button>`,
+    ).join("")}</div>
   </section>`;
   doc.body.append(modal);
-  const close = () => closeQuickIconPicker();
+  const close = () => closeActionPicker();
   modal.querySelector("[data-close]")?.addEventListener("click", close);
   modal.addEventListener("click", (event) => {
     if (event.target === modal) close();
   });
-  modal.querySelectorAll("[data-icon]").forEach((button) =>
+  modal.querySelector("[data-search]")?.addEventListener("input", (event) => {
+    const query = clean(event.target.value).toLowerCase();
+    modal.querySelectorAll(".dm-picker-option").forEach((button) => {
+      button.hidden = Boolean(query) && !button.dataset.searchText.includes(query);
+    });
+  });
+  modal.querySelectorAll(".dm-picker-option").forEach((button) =>
     button.addEventListener("click", () => {
-      input.value = button.dataset.icon;
+      const item = ACTION_ICON_CATALOG[Number(button.dataset.index)];
+      if (!item) return;
+      input.value = item.mdi;
       input.dispatchEvent(new Event("input", { bubbles: true }));
       input.dispatchEvent(new Event("change", { bubbles: true }));
-      if (trigger) trigger.innerHTML = iconMarkup(input.value);
+      if (preview) preview.innerHTML = actionIconMarkup(item.mdi);
       close();
     }),
   );
+  root.setTimeout?.(() => modal.querySelector("[data-search]")?.focus(), 30);
 }
 
-function actionTypeDefault(type) {
+function quickActionDefault(type) {
   return QUICK_ACTION_DEFAULTS[clean(type)] || "mdi:gesture-tap-button";
 }
 
@@ -208,66 +202,71 @@ function polishQuickActionIcon() {
   if (!input || !type) return false;
   const row = input.closest?.(".ed-qa-form-row") || input.parentElement;
   if (!row) return false;
-  row.dataset.dmBeta6QuickAction = "true";
 
-  let trigger = row.querySelector(".dm-beta6-qa-icon-trigger");
-  if (!trigger) {
-    trigger = doc.createElement("button");
-    trigger.type = "button";
-    trigger.className = "dm-beta6-qa-icon-trigger";
-    trigger.setAttribute("aria-label", t("Scegli icona azione", "Choose action icon"));
-    input.insertAdjacentElement("afterend", trigger);
-    trigger.addEventListener("click", (event) => {
+  row.dataset.dmBeta6QuickAction = "true";
+  let preview = row.querySelector(".dm-beta6-qa-icon-trigger");
+  if (!preview) {
+    preview = doc.createElement("button");
+    preview.type = "button";
+    preview.className = "dm-beta6-qa-icon-trigger";
+    preview.setAttribute("aria-label", t("Scegli icona azione", "Choose action icon"));
+    input.insertAdjacentElement("afterend", preview);
+    preview.addEventListener("click", (event) => {
       event.preventDefault();
-      openQuickIconPicker(input, trigger);
+      openActionPicker(input, preview);
     });
-    input.addEventListener("input", () => (trigger.innerHTML = iconMarkup(input.value)));
-    input.addEventListener("change", () => (trigger.innerHTML = iconMarkup(input.value)));
+    input.addEventListener("input", () => {
+      preview.innerHTML = actionIconMarkup(input.value);
+    });
+    input.addEventListener("change", () => {
+      preview.innerHTML = actionIconMarkup(input.value);
+    });
   }
 
-  const defaults = new Set(["", "⚡", "mdi:flash", "mdi:flash-outline", ...Object.values(QUICK_ACTION_DEFAULTS)]);
-  const desired = actionTypeDefault(type.value);
-  if (defaults.has(clean(input.value)) && clean(input.value) !== desired) input.value = desired;
-  trigger.innerHTML = iconMarkup(input.value || desired);
+  const current = clean(input.value);
+  if (!current || current === "⚡" || current === "mdi:flash" || current === "mdi:flash-outline") {
+    input.value = quickActionDefault(type.value);
+  }
+  preview.innerHTML = actionIconMarkup(input.value || quickActionDefault(type.value));
   input.classList.add("dm-beta6-qa-icon-value");
 
   if (type.dataset.dmBeta6IconBound !== "true") {
     type.dataset.dmBeta6IconBound = "true";
     type.addEventListener("change", () => {
-      const current = clean(input.value);
-      if (!current || current === "⚡" || current.startsWith("mdi:")) {
-        input.value = actionTypeDefault(type.value);
-        input.dispatchEvent(new Event("change", { bubbles: true }));
-      }
-      trigger.innerHTML = iconMarkup(input.value);
+      const oldDefault = Object.values(QUICK_ACTION_DEFAULTS).includes(clean(input.value));
+      if (!clean(input.value) || oldDefault) input.value = quickActionDefault(type.value);
+      input.dispatchEvent(new Event("change", { bubbles: true }));
     });
   }
   return true;
 }
 
 function polishDailyChart() {
-  const beta5 = root.__DASHBOARDMODERN_BETA5_ROOT_CAUSES__;
-  const chart = beta5?.dailyChart;
+  const chart = root.__DASHBOARDMODERN_BETA5_ROOT_CAUSES__?.dailyChart;
   if (!chart?.canvas || !chart?.data?.datasets?.length) return false;
-  const canvas = chart.canvas;
-  const mobile = (root.innerWidth || doc?.documentElement?.clientWidth || 900) <= 760;
-  const first = chart.data.datasets[0];
-  const second = chart.data.datasets[1];
+  const mobile = (root.innerWidth || doc.documentElement?.clientWidth || 900) <= 760;
+  const production = chart.data.datasets[0];
+  const consumption = chart.data.datasets[1];
 
   try {
-    const ctx = chart.ctx || canvas.getContext?.("2d");
-    if (ctx?.createLinearGradient) {
-      const gradient = ctx.createLinearGradient(0, 0, 0, Math.max(220, canvas.clientHeight || 280));
+    const context = chart.ctx || chart.canvas.getContext?.("2d");
+    if (context?.createLinearGradient) {
+      const gradient = context.createLinearGradient(
+        0,
+        0,
+        0,
+        Math.max(220, chart.canvas.clientHeight || 280),
+      );
       gradient.addColorStop(0, "rgba(22,163,74,.24)");
       gradient.addColorStop(0.72, "rgba(22,163,74,.07)");
       gradient.addColorStop(1, "rgba(22,163,74,0)");
-      first.backgroundColor = gradient;
+      production.backgroundColor = gradient;
     }
   } catch (_error) {
-    first.backgroundColor = "rgba(22,163,74,.11)";
+    production.backgroundColor = "rgba(22,163,74,.11)";
   }
 
-  Object.assign(first, {
+  Object.assign(production, {
     fill: "origin",
     tension: 0.34,
     borderWidth: mobile ? 2.2 : 2.6,
@@ -275,8 +274,8 @@ function polishDailyChart() {
     pointHoverRadius: 5,
     pointBorderWidth: 0,
   });
-  if (second)
-    Object.assign(second, {
+  if (consumption)
+    Object.assign(consumption, {
       fill: false,
       tension: 0.34,
       borderWidth: mobile ? 2.2 : 2.6,
@@ -302,7 +301,6 @@ function polishDailyChart() {
   chart.options.scales ||= {};
   chart.options.scales.x = {
     ...(chart.options.scales.x || {}),
-    offset: false,
     border: { display: false },
     grid: { display: false, drawBorder: false },
     ticks: {
@@ -329,10 +327,15 @@ function polishDailyChart() {
       color: "#64748b",
       font: { size: mobile ? 11 : 12, weight: "650" },
     },
-    title: { display: !mobile, text: "kWh", color: "#64748b", font: { weight: "700" } },
+    title: {
+      display: !mobile,
+      text: "kWh",
+      color: "#64748b",
+      font: { weight: "700" },
+    },
   };
-  canvas.dataset.dmBeta6ChartPolished = "true";
-  if (state.chart !== chart) state.chart = chart;
+  chart.canvas.dataset.dmBeta6ChartPolished = "true";
+  state.chart = chart;
   try {
     chart.resize?.();
     chart.update?.("none");
@@ -341,20 +344,26 @@ function polishDailyChart() {
 }
 
 function lightState(entityId) {
-  const states = allStates?.() || root.STATES || root._RAW_STATES || {};
-  return states?.[entityId] || root.currentEntity?.(entityId) || root.haState?.(entityId) || null;
+  return allStates()?.[entityId] || root.currentEntity?.(entityId) || root.haState?.(entityId) || null;
 }
 
 function configuredLights() {
   const names = readJson("cd_luci", {});
   return Object.keys(names || {})
     .filter((id) => /^light\./i.test(id))
-    .map((id) => ({ id, name: clean(names[id]) || clean(lightState(id)?.attributes?.friendly_name) || id }));
+    .map((id) => ({
+      id,
+      name: clean(names[id]) || clean(lightState(id)?.attributes?.friendly_name) || id,
+    }));
 }
 
 function supportedModes(entity) {
   const raw = entity?.attributes?.supported_color_modes;
-  return new Set((Array.isArray(raw) ? raw : []).map((value) => clean(value).toLowerCase()).filter(Boolean));
+  return new Set(
+    (Array.isArray(raw) ? raw : [])
+      .map((value) => clean(value).toLowerCase())
+      .filter(Boolean),
+  );
 }
 
 function supportsBrightness(entity) {
@@ -370,7 +379,9 @@ function supportsRgb(entity) {
 function rgbToHex(rgb) {
   const values = Array.isArray(rgb) ? rgb.slice(0, 3) : [];
   if (values.length < 3 || values.some((value) => !Number.isFinite(Number(value)))) return "#ffffff";
-  return `#${values.map((value) => Math.max(0, Math.min(255, Number(value))).toString(16).padStart(2, "0")).join("")}`;
+  return `#${values
+    .map((value) => Math.max(0, Math.min(255, Number(value))).toString(16).padStart(2, "0"))
+    .join("")}`;
 }
 
 function hexToRgb(hex) {
@@ -382,7 +393,8 @@ function hexToRgb(hex) {
 function callLight(entityId, data) {
   const payload = { entity_id: entityId, ...data };
   try {
-    if (typeof root.cdCallServiceJson === "function") return root.cdCallServiceJson("light", "turn_on", JSON.stringify(payload));
+    if (typeof root.cdCallServiceJson === "function")
+      return root.cdCallServiceJson("light", "turn_on", JSON.stringify(payload));
     if (typeof root.callService === "function") return root.callService("light", "turn_on", payload);
     const hass = root.hass || root._hass || doc?.querySelector?.("home-assistant")?.hass;
     if (typeof hass?.callService === "function") return hass.callService("light", "turn_on", payload);
@@ -396,8 +408,14 @@ function lightSignature(lights) {
   return lights
     .map(({ id }) => {
       const entity = lightState(id) || {};
-      const attrs = entity.attributes || {};
-      return [id, entity.state, attrs.brightness, (attrs.rgb_color || []).join(","), (attrs.supported_color_modes || []).join(",")].join("|");
+      const attributes = entity.attributes || {};
+      return [
+        id,
+        entity.state,
+        attributes.brightness,
+        (attributes.rgb_color || []).join(","),
+        (attributes.supported_color_modes || []).join(","),
+      ].join("|");
     })
     .join(";");
 }
@@ -430,15 +448,24 @@ function renderAdvancedLightControls() {
 
   lights.forEach(({ id, name }) => {
     const entity = lightState(id) || {};
-    const attrs = entity.attributes || {};
+    const attributes = entity.attributes || {};
     const dimmable = supportsBrightness(entity);
     const rgb = supportsRgb(entity);
-    const brightness = Math.round((Math.max(0, Math.min(255, Number(attrs.brightness) || 0)) / 255) * 100);
-    const color = rgbToHex(attrs.rgb_color);
+    const brightness = Math.round(
+      (Math.max(0, Math.min(255, Number(attributes.brightness) || 0)) / 255) * 100,
+    );
     const row = doc.createElement("article");
     row.className = "dm-beta6-light-control";
     row.dataset.entity = id;
-    row.innerHTML = `<div class="dm-beta6-light-head"><span class="dm-beta6-light-dot ${entity.state === "on" ? "is-on" : ""}"></span><div><strong>${escAttr(name)}</strong><small>${escAttr(id)}</small></div></div><div class="dm-beta6-light-tools">${dimmable ? `<label class="dm-beta6-dimmer"><span>${t("Luminosità", "Brightness")}</span><output>${brightness}%</output><input type="range" min="1" max="100" step="1" value="${Math.max(1, brightness || 1)}" data-brightness></label>` : ""}${rgb ? `<label class="dm-beta6-color"><span>RGB</span><input type="color" value="${color}" data-color aria-label="${t("Colore luce", "Light color")}"></label>` : ""}</div>`;
+    row.innerHTML = `<div class="dm-beta6-light-head"><span class="dm-beta6-light-dot ${entity.state === "on" ? "is-on" : ""}"></span><div><strong>${esc(name)}</strong><small>${esc(id)}</small></div></div><div class="dm-beta6-light-tools">${
+      dimmable
+        ? `<label class="dm-beta6-dimmer"><span>${t("Luminosità", "Brightness")}</span><output>${brightness}%</output><input type="range" min="1" max="100" step="1" value="${Math.max(1, brightness || 1)}" data-brightness></label>`
+        : ""
+    }${
+      rgb
+        ? `<label class="dm-beta6-color"><span>RGB</span><input type="color" value="${rgbToHex(attributes.rgb_color)}" data-color aria-label="${t("Colore luce", "Light color")}"></label>`
+        : ""
+    }</div>`;
     body.append(row);
 
     const slider = row.querySelector("[data-brightness]");
@@ -448,11 +475,20 @@ function renderAdvancedLightControls() {
       slider.addEventListener("input", () => {
         if (output) output.value = `${slider.value}%`;
         root.clearTimeout?.(timer);
-        timer = root.setTimeout?.(() => callLight(id, { brightness_pct: Number(slider.value) }), 120) || 0;
+        timer =
+          root.setTimeout?.(
+            () => callLight(id, { brightness_pct: Number(slider.value) }),
+            120,
+          ) || 0;
       });
-      slider.addEventListener("change", () => callLight(id, { brightness_pct: Number(slider.value) }));
+      slider.addEventListener("change", () => {
+        root.clearTimeout?.(timer);
+        callLight(id, { brightness_pct: Number(slider.value) });
+      });
     }
-    row.querySelector("[data-color]")?.addEventListener("input", (event) => callLight(id, { rgb_color: hexToRgb(event.target.value) }));
+    row.querySelector("[data-color]")?.addEventListener("change", (event) =>
+      callLight(id, { rgb_color: hexToRgb(event.target.value) }),
+    );
   });
   return true;
 }
@@ -471,53 +507,49 @@ function schedule() {
 }
 
 function installOwners() {
-  wrapFunction("wzOpenLightsPopup", "__dmBeta6LightControls", () => root.setTimeout?.(schedule, 0));
+  wrapFunction("wzOpenLightsPopup", "__dmBeta6LightControls", schedule);
   wrapFunction("editorSwitch", "__dmBeta6QuickAction", schedule);
+  wrapFunction("renderEdDailyChart", "__dmBeta6DailyChart", schedule);
   wrapFunction("render", "__dmBeta6Runtime", schedule);
 }
 
 function installStyles() {
-  installStyle("dm-beta6-feedback-style", `
-    /* Quick actions: the stored input remains for legacy save code, while the UI
-       exposes a real HA icon button instead of the old flash emoji. */
-    .ed-qa-form-row[data-dm-beta6-quick-action="true"]{align-items:stretch!important}
-    #ed-qa-icon.dm-beta6-qa-icon-value{display:none!important}
-    .dm-beta6-qa-icon-trigger{display:grid!important;place-items:center!important;box-sizing:border-box!important;width:100%!important;min-width:62px!important;min-height:52px!important;margin:0!important;padding:8px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:16px!important;background:var(--card-background-color,#fff)!important;color:var(--info-color,#0284c7)!important;cursor:pointer!important;box-shadow:none!important}
-    .dm-beta6-qa-icon-trigger ha-icon,.dm-beta6-qa-icon-trigger svg{width:30px!important;height:30px!important;font-size:30px!important}
-    .dm-beta6-quick-icon-grid .dm-picker-option{min-height:104px!important}
-    .dm-beta6-quick-icon-grid ha-icon,.dm-beta6-quick-icon-grid svg{width:38px!important;height:38px!important;font-size:38px!important;color:var(--info-color,#0284c7)!important}
+  installStyle(
+    "dm-beta6-feedback-style",
+    `
+      .ed-qa-form-row[data-dm-beta6-quick-action="true"]{align-items:stretch!important}
+      #ed-qa-icon.dm-beta6-qa-icon-value{display:none!important}
+      .dm-beta6-qa-icon-trigger{display:grid!important;place-items:center!important;box-sizing:border-box!important;width:100%!important;min-width:62px!important;min-height:52px!important;margin:0!important;padding:8px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:16px!important;background:var(--card-background-color,#fff)!important;color:var(--info-color,#0284c7)!important;cursor:pointer!important;box-shadow:none!important}
+      .dm-beta6-qa-icon-trigger svg{width:34px!important;height:34px!important;max-width:34px!important;max-height:34px!important}
+      .dm-beta6-quick-icon-grid .dm-picker-option{min-height:104px!important}
+      .dm-beta6-quick-icon-grid .dm-picker-visual svg{width:40px!important;height:40px!important;max-width:40px!important;max-height:40px!important}
 
-    /* Real manufacturer artwork. Logos are external IMG elements with the beta5
-       SVG retained as automatic offline fallback. */
-    .dm-beta6-brand-image{display:grid!important;place-items:center!important;width:88px!important;height:58px!important;padding:5px!important;box-sizing:border-box!important}
-    .dm-beta6-brand-image img{display:block!important;width:100%!important;height:100%!important;max-width:86px!important;max-height:50px!important;object-fit:contain!important;object-position:center!important;filter:none!important}
-    [data-brand-preview] .dm-beta6-brand-image{width:104px!important;height:64px!important}
-    [data-brand-preview] .dm-beta6-brand-image img{max-width:100px!important;max-height:56px!important}
+      .dm-beta6-brand-image{display:grid!important;place-items:center!important;width:88px!important;height:58px!important;padding:5px!important;box-sizing:border-box!important}
+      .dm-beta6-brand-image img{display:block!important;width:100%!important;height:100%!important;max-width:86px!important;max-height:50px!important;object-fit:contain!important;object-position:center!important;filter:none!important}
+      [data-brand-preview] .dm-beta6-brand-image{width:104px!important;height:64px!important}
+      [data-brand-preview] .dm-beta6-brand-image img{max-width:100px!important;max-height:56px!important}
 
-    /* Daily chart: compact card, restrained fill, readable axes and no canvas
-       leaking below the card on phone screens. */
-    #ed-daily-chart{overflow:hidden!important}
-    #ed-daily-chart .ed-chart-wrap{box-sizing:border-box!important;height:clamp(250px,52vw,320px)!important;min-height:0!important;max-height:320px!important;margin:8px 0 0!important;padding:0 8px 8px!important;overflow:hidden!important}
-    #ed-daily-chart .ed-chart-wrap canvas,#ed-daily-canvas[data-dm-beta5-real-history]{box-sizing:border-box!important;width:100%!important;height:100%!important;min-height:0!important;max-height:100%!important;margin:0!important}
+      #ed-daily-chart{overflow:hidden!important}
+      #ed-daily-chart .ed-chart-wrap{box-sizing:border-box!important;height:clamp(250px,52vw,320px)!important;min-height:0!important;max-height:320px!important;margin:8px 0 0!important;padding:0 8px 8px!important;overflow:hidden!important}
+      #ed-daily-chart .ed-chart-wrap canvas,#ed-daily-canvas[data-dm-beta5-real-history]{box-sizing:border-box!important;width:100%!important;height:100%!important;min-height:0!important;max-height:100%!important;margin:0!important}
 
-    /* Advanced controls are appended to the existing Lights popup only for
-       entities whose HA supported_color_modes expose brightness/RGB. */
-    .dm-beta6-light-advanced{display:grid!important;gap:10px!important;margin:14px 0 0!important;padding:14px!important;border:1px solid color-mix(in srgb,var(--info-color,#0ea5e9) 18%,var(--divider-color,#dbe4ee))!important;border-radius:18px!important;background:color-mix(in srgb,var(--info-color,#0ea5e9) 4%,var(--card-background-color,#fff))!important}
-    .dm-beta6-light-advanced>header{display:flex!important;align-items:baseline!important;justify-content:space-between!important;gap:12px!important}.dm-beta6-light-advanced>header strong{font-size:15px!important}.dm-beta6-light-advanced>header span{font-size:11px!important;color:var(--secondary-text-color,#64748b)!important}
-    .dm-beta6-light-control-list{display:grid!important;gap:10px!important}
-    .dm-beta6-light-control{display:grid!important;grid-template-columns:minmax(0,1fr) minmax(220px,1.4fr)!important;align-items:center!important;gap:14px!important;padding:12px!important;border-radius:15px!important;background:var(--card-background-color,#fff)!important;box-shadow:0 5px 18px rgba(15,23,42,.05)!important}
-    .dm-beta6-light-head{display:flex!important;align-items:center!important;gap:10px!important;min-width:0!important}.dm-beta6-light-head>div{min-width:0!important}.dm-beta6-light-head strong,.dm-beta6-light-head small{display:block!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important}.dm-beta6-light-head small{margin-top:3px!important;font-size:10px!important;color:var(--secondary-text-color,#64748b)!important}
-    .dm-beta6-light-dot{width:10px!important;height:10px!important;flex:0 0 10px!important;border-radius:999px!important;background:#94a3b8!important;box-shadow:0 0 0 4px rgba(148,163,184,.12)!important}.dm-beta6-light-dot.is-on{background:#f59e0b!important;box-shadow:0 0 0 4px rgba(245,158,11,.14)!important}
-    .dm-beta6-light-tools{display:grid!important;grid-template-columns:minmax(160px,1fr) auto!important;align-items:center!important;gap:12px!important}.dm-beta6-dimmer{display:grid!important;grid-template-columns:1fr auto!important;align-items:center!important;gap:6px 10px!important}.dm-beta6-dimmer span,.dm-beta6-color span{font-size:11px!important;font-weight:800!important;color:var(--secondary-text-color,#64748b)!important}.dm-beta6-dimmer output{font-size:11px!important;font-weight:900!important;color:var(--primary-text-color,#0f172a)!important}.dm-beta6-dimmer input{grid-column:1/-1!important;width:100%!important;accent-color:var(--info-color,#0ea5e9)!important}.dm-beta6-color{display:grid!important;place-items:center!important;gap:5px!important}.dm-beta6-color input{box-sizing:border-box!important;width:42px!important;height:34px!important;padding:2px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:10px!important;background:transparent!important}
+      .dm-beta6-light-advanced{display:grid!important;gap:10px!important;margin:14px 0 0!important;padding:14px!important;border:1px solid color-mix(in srgb,var(--info-color,#0ea5e9) 18%,var(--divider-color,#dbe4ee))!important;border-radius:18px!important;background:color-mix(in srgb,var(--info-color,#0ea5e9) 4%,var(--card-background-color,#fff))!important}
+      .dm-beta6-light-advanced>header{display:flex!important;align-items:baseline!important;justify-content:space-between!important;gap:12px!important}.dm-beta6-light-advanced>header strong{font-size:15px!important}.dm-beta6-light-advanced>header span{font-size:11px!important;color:var(--secondary-text-color,#64748b)!important}
+      .dm-beta6-light-control-list{display:grid!important;gap:10px!important}
+      .dm-beta6-light-control{display:grid!important;grid-template-columns:minmax(0,1fr) minmax(220px,1.4fr)!important;align-items:center!important;gap:14px!important;padding:12px!important;border-radius:15px!important;background:var(--card-background-color,#fff)!important;box-shadow:0 5px 18px rgba(15,23,42,.05)!important}
+      .dm-beta6-light-head{display:flex!important;align-items:center!important;gap:10px!important;min-width:0!important}.dm-beta6-light-head>div{min-width:0!important}.dm-beta6-light-head strong,.dm-beta6-light-head small{display:block!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important}.dm-beta6-light-head small{margin-top:3px!important;font-size:10px!important;color:var(--secondary-text-color,#64748b)!important}
+      .dm-beta6-light-dot{width:10px!important;height:10px!important;flex:0 0 10px!important;border-radius:999px!important;background:#94a3b8!important;box-shadow:0 0 0 4px rgba(148,163,184,.12)!important}.dm-beta6-light-dot.is-on{background:#f59e0b!important;box-shadow:0 0 0 4px rgba(245,158,11,.14)!important}
+      .dm-beta6-light-tools{display:grid!important;grid-template-columns:minmax(160px,1fr) auto!important;align-items:center!important;gap:12px!important}.dm-beta6-dimmer{display:grid!important;grid-template-columns:1fr auto!important;align-items:center!important;gap:6px 10px!important}.dm-beta6-dimmer span,.dm-beta6-color span{font-size:11px!important;font-weight:800!important;color:var(--secondary-text-color,#64748b)!important}.dm-beta6-dimmer output{font-size:11px!important;font-weight:900!important;color:var(--primary-text-color,#0f172a)!important}.dm-beta6-dimmer input{grid-column:1/-1!important;width:100%!important;accent-color:var(--info-color,#0ea5e9)!important}.dm-beta6-color{display:grid!important;place-items:center!important;gap:5px!important}.dm-beta6-color input{box-sizing:border-box!important;width:42px!important;height:34px!important;padding:2px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:10px!important;background:transparent!important}
 
-    @media(max-width:760px){
-      .ed-qa-form-row[data-dm-beta6-quick-action="true"]{grid-template-columns:minmax(0,1fr) 64px minmax(0,1fr)!important}
-      .dm-beta6-qa-icon-trigger{min-width:64px!important;width:64px!important;min-height:52px!important}
-      #ed-daily-chart .ed-chart-wrap{height:252px!important;min-height:252px!important;max-height:252px!important;padding:0 4px 6px!important}
-      .dm-beta6-light-control{grid-template-columns:1fr!important;gap:10px!important;padding:11px!important}.dm-beta6-light-tools{grid-template-columns:minmax(0,1fr) 48px!important}.dm-beta6-light-advanced>header{align-items:flex-start!important;flex-direction:column!important;gap:2px!important}
-      .dm-beta6-brand-image{width:80px!important;height:54px!important}.dm-beta6-brand-image img{max-width:78px!important;max-height:46px!important}
-    }
-  `);
+      @media(max-width:760px){
+        .ed-qa-form-row[data-dm-beta6-quick-action="true"]{grid-template-columns:minmax(0,1fr) 64px minmax(0,1fr)!important}
+        .dm-beta6-qa-icon-trigger{min-width:64px!important;width:64px!important;min-height:52px!important}
+        #ed-daily-chart .ed-chart-wrap{height:252px!important;min-height:252px!important;max-height:252px!important;padding:0 4px 6px!important}
+        .dm-beta6-light-control{grid-template-columns:1fr!important;gap:10px!important;padding:11px!important}.dm-beta6-light-tools{grid-template-columns:minmax(0,1fr) 48px!important}.dm-beta6-light-advanced>header{align-items:flex-start!important;flex-direction:column!important;gap:2px!important}
+        .dm-beta6-brand-image{width:80px!important;height:54px!important}.dm-beta6-brand-image img{max-width:78px!important;max-height:46px!important}
+      }
+    `,
+  );
 }
 
 export function installBeta6FeedbackSection() {
@@ -530,21 +562,26 @@ export function installBeta6FeedbackSection() {
     installOwners();
     schedule();
   });
-  root.addEventListener?.("dashboardmodern:runtime-ready", schedule);
+  root.addEventListener?.("dashboardmodern:runtime-ready", () => {
+    installOwners();
+    schedule();
+  });
   root.addEventListener?.("dashboardmodern:period-bundle", schedule);
   root.addEventListener?.("dashboardmodern:energy-stable", schedule);
   root.addEventListener?.("resize", schedule, { passive: true });
   doc.addEventListener("change", schedule, true);
-  doc.addEventListener("click", (event) => {
-    if (event.target?.closest?.(".ed-tab,.sub-tab-btn,.dm-picker-option,.ed-btn-add,[data-brand-preview],#btn-lights")) root.setTimeout?.(schedule, 0);
-  }, true);
-
-  if (typeof MutationObserver !== "undefined") {
-    state.observer = new MutationObserver((mutations) => {
-      if (mutations.some((mutation) => mutation.type === "childList" || mutation.target?.id === "ed-daily-canvas" || mutation.target?.id === "ed-body")) schedule();
-    });
-    state.observer.observe(doc.documentElement, { subtree: true, childList: true, attributes: true, attributeFilter: ["data-dm-beta5-real-history", "class"] });
-  }
+  doc.addEventListener(
+    "click",
+    (event) => {
+      if (
+        event.target?.closest?.(
+          ".ed-tab,.sub-tab-btn,.dm-picker-option,.ed-btn-add,[data-brand-preview],#btn-lights",
+        )
+      )
+        root.setTimeout?.(schedule, 0);
+    },
+    true,
+  );
   schedule();
 }
 

--- a/custom_components/dashboardmodern/frontend/tests/beta6-feedback.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta6-feedback.test.js
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const ROOT = new URL("../", import.meta.url);
+const read = (path) => readFile(new URL(path, ROOT), "utf8");
+
+test("beta6 feedback layer loads after the beta5 root-cause owner", async () => {
+  const entry = await read("src/sections/beta-entry-section.js");
+  assert.match(entry, /beta4-mobile-polish-section\.js";\nimport "\.\/beta6-feedback-section\.js";/);
+});
+
+test("quick action editor replaces the flash field with a real icon trigger", async () => {
+  const source = await read("src/sections/beta6-feedback-section.js");
+  assert.match(source, /lights: "mdi:lightbulb-group"/);
+  assert.match(source, /input\.insertAdjacentElement\("afterend", trigger\)/);
+  assert.match(source, /dm-beta6-qa-icon-trigger/);
+  assert.match(source, /#ed-qa-icon\.dm-beta6-qa-icon-value\{display:none!important\}/);
+  assert.match(source, /openQuickIconPicker\(input, trigger\)/);
+});
+
+test("car brand picker uses real pinned brand images and the official Leapmotor wordmark", async () => {
+  const source = await read("src/sections/beta6-feedback-section.js");
+  assert.match(source, /SIMPLE_ICONS_VERSION = "16\.27\.1"/);
+  assert.match(source, /simple-icons@\$\{SIMPLE_ICONS_VERSION\}\/icons\/\$\{slug\}\.svg/);
+  assert.match(source, /upload\.wikimedia\.org\/wikipedia\/commons\/d\/d8\/Leapmotor_logo_en\.svg/);
+  assert.match(source, /img\[data-dm-beta6-brand-image\]/);
+  assert.match(source, /mark\.innerHTML = fallback/);
+});
+
+test("daily chart polish changes presentation only and stays inside the mobile card", async () => {
+  const source = await read("src/sections/beta6-feedback-section.js");
+  assert.match(source, /const chart = beta5\?\.dailyChart/);
+  assert.match(source, /second[\s\S]*fill: false/);
+  assert.match(source, /maxTicksLimit: mobile \? 6 : 10/);
+  assert.match(source, /#ed-daily-chart \.ed-chart-wrap\{[\s\S]*overflow:hidden!important/);
+  assert.match(source, /height:252px!important;min-height:252px!important;max-height:252px!important/);
+  assert.doesNotMatch(source, /Math\.random|Math\.sin|Math\.cos/);
+});
+
+test("Lights popup exposes dimmer and RGB controls only from HA capabilities", async () => {
+  const source = await read("src/sections/beta6-feedback-section.js");
+  assert.match(source, /supported_color_modes/);
+  assert.match(source, /BRIGHTNESS_MODES/);
+  assert.match(source, /RGB_MODES/);
+  assert.match(source, /brightness_pct: Number\(slider\.value\)/);
+  assert.match(source, /rgb_color: hexToRgb\(event\.target\.value\)/);
+  assert.match(source, /cdCallServiceJson\("light", "turn_on"/);
+  assert.match(source, /wz-lights-list/);
+  assert.match(source, /Dimmer e colori/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/beta6-feedback.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta6-feedback.test.js
@@ -20,6 +20,20 @@ test("quick action editor replaces the flash field with a real icon trigger", as
   assert.match(source, /ACTION_ICON_CATALOG/);
 });
 
+test("quick action bridge stores portable glyphs and renders real HA icons", async () => {
+  const entry = await read("src/sections/beta-entry-section.js");
+  assert.match(entry, /luci_group: "💡"/);
+  assert.match(entry, /builtin_clima: "❄️"/);
+  assert.match(entry, /builtin_antifurto: "🛡️"/);
+  assert.match(entry, /builtin_lavatrice: "🧺"/);
+  assert.match(entry, /toggle: "🔀"/);
+  assert.match(entry, /script: "▶️"/);
+  assert.match(entry, /scene: "🎬"/);
+  assert.match(entry, /quickActionGlyphByMdi/);
+  assert.match(entry, /globalThis\.cdIconMarkup\(mdi, size\)/);
+  assert.match(entry, /buildQuickActions/);
+});
+
 test("car brand picker uses real pinned brand images and the official Leapmotor wordmark", async () => {
   const source = await read("src/sections/beta6-feedback-section.js");
   assert.match(source, /SIMPLE_ICONS_VERSION = "16\.27\.1"/);

--- a/custom_components/dashboardmodern/frontend/tests/beta6-feedback.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta6-feedback.test.js
@@ -13,10 +13,11 @@ test("beta6 feedback layer loads after the beta5 root-cause owner", async () => 
 test("quick action editor replaces the flash field with a real icon trigger", async () => {
   const source = await read("src/sections/beta6-feedback-section.js");
   assert.match(source, /lights: "mdi:lightbulb-group"/);
-  assert.match(source, /input\.insertAdjacentElement\("afterend", trigger\)/);
+  assert.match(source, /input\.insertAdjacentElement\("afterend", preview\)/);
   assert.match(source, /dm-beta6-qa-icon-trigger/);
   assert.match(source, /#ed-qa-icon\.dm-beta6-qa-icon-value\{display:none!important\}/);
-  assert.match(source, /openQuickIconPicker\(input, trigger\)/);
+  assert.match(source, /openActionPicker\(input, preview\)/);
+  assert.match(source, /ACTION_ICON_CATALOG/);
 });
 
 test("car brand picker uses real pinned brand images and the official Leapmotor wordmark", async () => {
@@ -30,8 +31,8 @@ test("car brand picker uses real pinned brand images and the official Leapmotor 
 
 test("daily chart polish changes presentation only and stays inside the mobile card", async () => {
   const source = await read("src/sections/beta6-feedback-section.js");
-  assert.match(source, /const chart = beta5\?\.dailyChart/);
-  assert.match(source, /second[\s\S]*fill: false/);
+  assert.match(source, /const chart = root\.__DASHBOARDMODERN_BETA5_ROOT_CAUSES__\?\.dailyChart/);
+  assert.match(source, /consumption[\s\S]*fill: false/);
   assert.match(source, /maxTicksLimit: mobile \? 6 : 10/);
   assert.match(source, /#ed-daily-chart \.ed-chart-wrap\{[\s\S]*overflow:hidden!important/);
   assert.match(source, /height:252px!important;min-height:252px!important;max-height:252px!important/);

--- a/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
@@ -42,7 +42,7 @@ test("the 1.0 beta release metadata is consistently versioned", async () => {
   assert.doesNotMatch(readme, /main\/assets\/logo|brand\/logo@2x\.png/);
   assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']1\.0\.0-beta\.6["']/);
   assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']1\.0\.0-beta\.6["']/);
-  assert.match(buildInfo, /["']?moduleVersion["']?\s*:\s*15/);
+  assert.match(buildInfo, /["']?moduleVersion["']?\s*:\s*14/);
 });
 
 test("weekly Analysis uses authenticated Recorder statistics and the canonical Home balance", async () => {

--- a/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
@@ -23,7 +23,7 @@ const refreshUrl = new URL("../src/sections/energy-refresh-section.js", import.m
 const analysisUrl = new URL("../src/sections/energy-analysis-section.js", import.meta.url);
 const contractsUrl = new URL("../src/sections/editor-contracts-section.js", import.meta.url);
 
-const RELEASE_VERSION = "1.0.0-beta.5";
+const RELEASE_VERSION = "1.0.0-beta.6";
 
 test("the 1.0 beta release metadata is consistently versioned", async () => {
   const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
@@ -40,9 +40,9 @@ test("the 1.0 beta release metadata is consistently versioned", async () => {
     /https:\/\/raw\.githubusercontent\.com\/danigio15\/dashboardmodern-v2\/main\/brand\/logo\.png/,
   );
   assert.doesNotMatch(readme, /main\/assets\/logo|brand\/logo@2x\.png/);
-  assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']1\.0\.0-beta\.5["']/);
-  assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']1\.0\.0-beta\.5["']/);
-  assert.match(buildInfo, /["']?moduleVersion["']?\s*:\s*14/);
+  assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']1\.0\.0-beta\.6["']/);
+  assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']1\.0\.0-beta\.6["']/);
+  assert.match(buildInfo, /["']?moduleVersion["']?\s*:\s*15/);
 });
 
 test("weekly Analysis uses authenticated Recorder statistics and the canonical Home balance", async () => {

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -108,9 +108,10 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
     ),
     [],
   );
-  // v1 beta adds the persistence owner plus substantive UI owners. Beta4 adds
-  // one scoped mobile-polish owner rather than reopening the vendored runtime.
-  assert.ok(relative.length <= 61, `production graph unexpectedly grew to ${relative.length} modules`);
+  // v1 beta adds the persistence owner plus substantive UI owners. Beta4/Beta5
+  // keep one scoped mobile-polish owner; Beta6 adds one event-driven feedback
+  // owner for quick-action icons, car artwork, chart presentation and light controls.
+  assert.ok(relative.length <= 62, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.5"
+  "version": "1.0.0-beta.6"
 }


### PR DESCRIPTION
Correzioni richieste dai test reali su mobile dopo beta.5:

- sostituisce il flash dell'editor Azioni rapide con un vero selettore di icone MDI;
- rifinisce il grafico Andamento giornaliero senza cambiare i dati reali Recorder;
- sostituisce i loghi auto disegnati a mano con immagini reali di marca (Simple Icons pin 16.27.1) e wordmark Leapmotor ufficiale via Wikimedia, con fallback locale;
- aggiunge nel popup Luci i controlli dimmer e RGB solo quando `supported_color_modes` dell'entità HA li supporta;
- aggiunge test di contratto dedicati beta6.

Non modifica la logica dei dati energia introdotta in beta.5.