### PR TITLE
chore: release v1.0.0-beta.9

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/beta2-persistence-ev-flow.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta2-persistence-ev-flow.spec.js
@@ -99,7 +99,7 @@ async function openEditor(page, tab) {
 }
 
 for (const variant of ["dashboard.html", "dashboard-en.html"]) {
-  test(`${variant}: beta2 saves EV appearance and keeps legacy mappings`, async ({ page }, testInfo) => {
+  test(`${variant}: beta2 saves EV brand/model and keeps legacy mappings`, async ({ page }, testInfo) => {
     test.setTimeout(testInfo.project.name === "webkit-ipad" ? 150_000 : 90_000);
     await boot(page, variant, testInfo);
 
@@ -124,17 +124,21 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     const profile = page.locator("#ev-car-picker .dm-vehicle-profile-card").first();
     await expect(profile).toBeVisible();
     await expect(profile).toContainText("Pluto");
-    const brandImage = profile.locator('.dm-vehicle-profile-icon img[data-dm-brand-image="leapmotor"]');
-    await expect(brandImage).toHaveCount(1);
-    await expect(brandImage).toHaveAttribute("src", /Leapmotor_logo_en\.svg/);
+    const brandMark = profile.locator('.dm-vehicle-profile-icon .dm-leapmotor-mark[data-brand="leapmotor"][data-brand-source="inline"]');
+    await expect(brandMark).toHaveCount(1);
+    await expect(brandMark.locator("svg")).toHaveCount(1);
+    await expect(profile.locator('.dm-vehicle-profile-icon img[data-dm-brand-image="leapmotor"]')).toHaveCount(0);
     await expect(profile.locator(".dm-vehicle-profile-icon")).not.toContainText("🚗");
 
     await openEditor(page, "sez2");
     const appearance = page.locator("#ed-body [data-ev-appearance]");
     await expect(appearance).toBeVisible();
     await appearance.locator("select[data-brand]").selectOption("BMW");
-    await appearance.locator("input[data-icon]").fill("mdi:car-sports");
+    const modelSelect = appearance.locator("select[data-model]");
+    await expect(modelSelect).toContainText("i4");
+    await modelSelect.selectOption("i4");
     await expect(appearance.locator("select[data-brand]")).toHaveValue("BMW");
+    await expect(modelSelect).toHaveValue("i4");
     await appearance.locator("button[data-save]").click();
 
     await expect.poll(() =>
@@ -142,7 +146,8 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     ).toMatchObject({
       id: "ev-pluto",
       brand: "BMW",
-      icon: "mdi:car-sports",
+      model: "i4",
+      icon: "mdi:car-electric",
       img: "/local/pluto.png",
       ov: {
         "dm.ev_batteria_auto": "sensor.pluto_soc",
@@ -162,11 +167,12 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       }),
     }));
 
-    const persistedBrand = await page.evaluate(() => {
+    const persisted = await page.evaluate(() => {
       const remote = JSON.parse(localStorage.getItem("__beta2_remote_user_data__"));
-      return JSON.parse(remote.values.cd_ev_cars)[0].brand;
+      const car = JSON.parse(remote.values.cd_ev_cars)[0];
+      return { brand: car.brand, model: car.model };
     });
-    expect(persistedBrand).toBe("BMW");
+    expect(persisted).toEqual({ brand: "BMW", model: "i4" });
   });
 
   test(`${variant}: beta2 binds daily and monthly load flow animation to displayed energy`, async ({ page }, testInfo) => {

--- a/custom_components/dashboardmodern/frontend/e2e/beta2-persistence-ev-flow.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta2-persistence-ev-flow.spec.js
@@ -133,20 +133,19 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await openEditor(page, "sez2");
     const appearance = page.locator("#ed-body [data-ev-appearance]");
     await expect(appearance).toBeVisible();
-    await appearance.locator("select[data-brand]").selectOption("BMW");
+    await expect(appearance.locator("select[data-brand]")).toHaveValue("Leapmotor");
     const modelSelect = appearance.locator("select[data-model]");
-    await expect(modelSelect).toContainText("i4");
-    await modelSelect.selectOption("i4");
-    await expect(appearance.locator("select[data-brand]")).toHaveValue("BMW");
-    await expect(modelSelect).toHaveValue("i4");
+    await expect(modelSelect).toContainText("B10");
+    await modelSelect.selectOption("B10");
+    await expect(modelSelect).toHaveValue("B10");
     await appearance.locator("button[data-save]").click();
 
     await expect.poll(() =>
       page.evaluate(() => DashboardModernModules.store.getSection("ev")[0]),
     ).toMatchObject({
       id: "ev-pluto",
-      brand: "BMW",
-      model: "i4",
+      brand: "Leapmotor",
+      model: "B10",
       icon: "mdi:car-electric",
       img: "/local/pluto.png",
       ov: {
@@ -172,7 +171,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       const car = JSON.parse(remote.values.cd_ev_cars)[0];
       return { brand: car.brand, model: car.model };
     });
-    expect(persisted).toEqual({ brand: "BMW", model: "i4" });
+    expect(persisted).toEqual({ brand: "Leapmotor", model: "B10" });
   });
 
   test(`${variant}: beta2 binds daily and monthly load flow animation to displayed energy`, async ({ page }, testInfo) => {

--- a/custom_components/dashboardmodern/frontend/e2e/beta3-editor-scope.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta3-editor-scope.spec.js
@@ -77,7 +77,7 @@ async function switchEditor(page, tab) {
 }
 
 for (const variant of ["dashboard.html", "dashboard-en.html"]) {
-  test(`${variant}: car appearance exists only in EV and car pickers are dedicated`, async ({ page }, testInfo) => {
+  test(`${variant}: car appearance exists only in EV and brand/model controls are dedicated`, async ({ page }, testInfo) => {
     test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
     await boot(page, variant, testInfo);
 
@@ -93,15 +93,19 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     const brandPicker = page.locator('#dm-visual-picker[data-kind="car"]');
     await expect(brandPicker).toBeVisible();
     await expect(brandPicker.locator(".dm-car-brand").first()).toBeVisible();
+    const leap = brandPicker.locator(".dm-picker-option", { hasText: "Leapmotor" });
+    await expect(leap.locator('.dm-leapmotor-mark[data-brand="leapmotor"][data-brand-source="inline"]')).toHaveCount(1);
     await brandPicker.locator("[data-close]").click();
 
-    await appearance.locator("[data-icon-preview]").click();
-    const carIconPicker = page.locator('#dm-visual-picker[data-kind="car-icon"]');
-    await expect(carIconPicker).toBeVisible();
-    await expect(carIconPicker.locator(".dm-car-icon-glyph")).toHaveCount(8);
-    await expect(carIconPicker).not.toContainText("Casa");
-    await expect(carIconPicker).not.toContainText("Luci");
-    await carIconPicker.locator("[data-close]").click();
+    await expect(appearance.locator("[data-icon-preview]")).toHaveCount(0);
+    await expect(page.locator('#dm-visual-picker[data-kind="car-icon"]')).toHaveCount(0);
+    const modelSelect = appearance.locator("select[data-model]");
+    await expect(modelSelect).toBeVisible();
+    await expect(modelSelect).toContainText("T03");
+    await expect(modelSelect).toContainText("B10");
+    await expect(modelSelect).toContainText("C10");
+    await modelSelect.selectOption("B10");
+    await expect(appearance.locator("[data-brand-preview]")).toContainText("B10");
 
     await switchEditor(page, "sez0");
     await expect(page.locator("#ed-body [data-ev-appearance]")).toHaveCount(0);

--- a/custom_components/dashboardmodern/frontend/e2e/beta5-root-causes.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta5-root-causes.spec.js
@@ -156,7 +156,10 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await expect(realBrandImages.first()).toHaveAttribute("src", /simple-icons@16\.27\.1/);
     expect(await realBrandImages.count()).toBeGreaterThan(20);
     const leap = picker.locator(".dm-picker-option", { hasText: "Leapmotor" });
-    await expect(leap.locator('img[data-dm-brand-image="leapmotor"]')).toHaveAttribute("src", /Leapmotor_logo_en\.svg/);
+    const leapMark = leap.locator('.dm-leapmotor-mark[data-brand="leapmotor"][data-brand-source="inline"]');
+    await expect(leapMark).toHaveCount(1);
+    await expect(leapMark.locator("svg")).toHaveCount(1);
+    await expect(leap.locator('img[data-dm-brand-image="leapmotor"]')).toHaveCount(0);
     await picker.locator("[data-close]").click();
 
     await page.locator("#editor-modal .ed-head-close").last().click();

--- a/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
@@ -23,7 +23,7 @@ const refreshUrl = new URL("../src/sections/energy-refresh-section.js", import.m
 const analysisUrl = new URL("../src/sections/energy-analysis-section.js", import.meta.url);
 const contractsUrl = new URL("../src/sections/editor-contracts-section.js", import.meta.url);
 
-const RELEASE_VERSION = "1.0.0-beta.8";
+const RELEASE_VERSION = "1.0.0-beta.9";
 
 test("the 1.0 beta release metadata is consistently versioned", async () => {
   const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
@@ -40,8 +40,8 @@ test("the 1.0 beta release metadata is consistently versioned", async () => {
     /https:\/\/raw\.githubusercontent\.com\/danigio15\/dashboardmodern-v2\/main\/brand\/logo\.png/,
   );
   assert.doesNotMatch(readme, /main\/assets\/logo|brand\/logo@2x\.png/);
-  assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']1\.0\.0-beta\.8["']/);
-  assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']1\.0\.0-beta\.8["']/);
+  assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']1\.0\.0-beta\.9["']/);
+  assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']1\.0\.0-beta\.9["']/);
   assert.match(buildInfo, /["']?moduleVersion["']?\s*:\s*14/);
 });
 

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.8"
+  "version": "1.0.0-beta.9"
 }


### PR DESCRIPTION
Release-only PR after #87. Bumps manifest from 1.0.0-beta.8 to 1.0.0-beta.9 so the Release workflow is actually triggered on main. No functional code changes.