### PR TITLE
fix: beta9 real-device UI regressions from Android screenshots

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/beta9-real-device-screenshots.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta9-real-device-screenshots.spec.js
@@ -1,0 +1,242 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const states = [
+  {
+    entity_id: "sensor.cameretta_temperature",
+    state: "25.8",
+    attributes: { unit_of_measurement: "°C", device_class: "temperature" },
+  },
+  {
+    entity_id: "sensor.cameretta_humidity",
+    state: "52",
+    attributes: { unit_of_measurement: "%", device_class: "humidity" },
+  },
+  {
+    entity_id: "cover.tapparella",
+    state: "open",
+    attributes: { friendly_name: "Tapparella", current_position: 100 },
+  },
+  {
+    entity_id: "light.ingresso",
+    state: "off",
+    attributes: { friendly_name: "Ingresso" },
+  },
+];
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [
+      {
+        id: "room-cameretta",
+        name: "Cameretta",
+        icon: "mdi:sofa",
+        temp: "sensor.cameretta_temperature",
+        hum: "sensor.cameretta_humidity",
+      },
+      { id: "room-bagno", name: "Bagno", icon: "mdi:shower", temp: "", hum: "" },
+    ],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [
+      { id: "light-ingresso", name: "Ingresso", entities: ["light.ingresso"], room_id: "room-cameretta" },
+    ],
+    climate: [],
+    ev: [
+      {
+        id: "ev-b10",
+        name: "B10",
+        brand: "Leapmotor",
+        model: "B10",
+        icon: "mdi:car-electric",
+        ov: {},
+      },
+    ],
+    covers: [
+      { id: "cover-main", name: "Tapparella", entity: "cover.tapparella", room_id: "room-cameretta" },
+    ],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  visibility: { home: true, ev: true, temp: true, temperature: true, tapparelle: true },
+};
+
+async function boot(page, variant, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript((haStates) => {
+    class MockBridgeSocket extends EventTarget {
+      static OPEN = 1;
+      readyState = 1;
+      onopen = null;
+      onmessage = null;
+      onclose = null;
+      constructor() {
+        super();
+        queueMicrotask(() => {
+          this.onopen?.({});
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+        });
+      }
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") return;
+        let result = null;
+        if (message.type === "get_states") result = haStates;
+        if (message.type === "frontend/get_user_data") result = { value: null };
+        queueMicrotask(() => this.onmessage?.({
+          data: JSON.stringify({ id: message.id, type: "result", success: true, result }),
+        }));
+      }
+      close() {
+        this.readyState = 3;
+        this.onclose?.({});
+      }
+    }
+    window.__DASHBOARDMODERN_HOSTED__ = true;
+    window.__DASHBOARDMODERN_BRIDGE_WS__ = MockBridgeSocket;
+    window.WebSocket = MockBridgeSocket;
+  }, states);
+
+  await bootNamespacedDashboard(page, variant, testInfo, seed);
+  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await expect.poll(() => page.evaluate(() => window.__DASHBOARDMODERN_RUNTIME_ROOT__?.ready === true)).toBe(true);
+  await page.evaluate((haStates) => {
+    haStates.forEach((item) => {
+      _RAW_STATES[item.entity_id] = structuredClone(item);
+      STATES[item.entity_id] = structuredClone(item);
+    });
+  }, states);
+}
+
+async function openEditor(page, tab) {
+  await page.evaluate((target) => {
+    if (!document.getElementById("editor-modal")?.classList.contains("show")) apriConfigEntita();
+    editorSwitch(target);
+  }, tab);
+  await expect(page.locator("#editor-modal")).toBeVisible();
+  await expect(page.locator(`.ed-tab[data-tab="${tab}"]`)).toHaveClass(/active/);
+  await page.waitForTimeout(100);
+}
+
+for (const variant of ["dashboard.html", "dashboard-en.html"]) {
+  test(`${variant}: beta9 matches the real-device screenshot contracts`, async ({ page }, testInfo) => {
+    test.setTimeout(testInfo.project.name === "webkit-ipad" ? 180_000 : 120_000);
+    await boot(page, variant, testInfo);
+
+    await page.evaluate(() => {
+      localStorage.setItem("cd_quick_actions", JSON.stringify([
+        { type: "builtin", builtin: "luci", name: "Gestione Luci" },
+        { type: "builtin", builtin: "clima", name: "Clima" },
+        { type: "builtin", builtin: "antifurto", name: "Antifurto" },
+        { type: "builtin", builtin: "lavatrice", name: "Lavatrice" },
+        { type: "toggle", name: "Cancello", icon: "⛩️", entity: "switch.cancello" },
+      ]));
+      window.buildQuickActions?.();
+    });
+    await expect(page.locator("#qa-grid .dm-v01525-action-glyph")).toHaveCount(5);
+    await expect(page.locator("#qa-grid .dm-v01525-action-glyph").nth(0)).toHaveText("💡");
+    await expect(page.locator("#qa-grid .dm-v01525-action-glyph").nth(1)).toHaveText("❄️");
+    await expect(page.locator("#qa-grid .dm-v01525-action-glyph").nth(2)).toHaveText("🛡️");
+    await expect(page.locator("#qa-grid .dm-v01525-action-glyph").nth(3)).toHaveText("🧺");
+    await expect(page.locator("#page-home")).not.toContainText(/AZIONI RAPIDE PREMIUM|PREMIUM QUICK ACTIONS/i);
+
+    await openEditor(page, "sez2");
+    const appearance = page.locator("#ed-body [data-ev-appearance]");
+    await expect(appearance).toBeVisible();
+    expect(await appearance.evaluate((node) => node.parentElement?.firstElementChild === node)).toBe(true);
+    const brand = appearance.locator("select[data-brand]");
+    const model = appearance.locator("select[data-model]");
+    await brand.selectOption("MINI");
+    await expect(appearance.locator('[data-brand-preview] .dm-car-brand[data-brand="mini"]')).toHaveCount(1);
+    await expect(model).toContainText("Cooper Electric");
+    await expect(model).toContainText("Aceman");
+    await expect(model).toContainText("Countryman Electric");
+    await expect(model).toBeEnabled();
+    await model.selectOption("Cooper Electric");
+    await expect(appearance.locator("[data-brand-preview]")).toContainText("Cooper Electric");
+
+    await appearance.locator("[data-brand-preview]").click();
+    const brandPicker = page.locator('#dm-visual-picker[data-kind="car"]');
+    await expect(brandPicker).toBeVisible();
+    const brandVisuals = brandPicker.locator(".dm-picker-option .dm-picker-visual");
+    expect(await brandVisuals.count()).toBeGreaterThan(20);
+    expect(await brandVisuals.evaluateAll((nodes) => nodes.every((node) => {
+      const box = node.getBoundingClientRect();
+      return box.width >= 70 && box.height >= 38 && getComputedStyle(node).overflow === "hidden";
+    }))).toBe(true);
+    const brandColors = await brandPicker.locator(".dm-car-brand").evaluateAll((nodes) =>
+      [...new Set(nodes.map((node) => getComputedStyle(node).color))],
+    );
+    expect(brandColors).toHaveLength(1);
+    await brandPicker.locator("[data-close]").click();
+
+    await openEditor(page, "stanze");
+    const roomRow = page.locator("#ed-body .dm-room-config-row", { hasText: "Cameretta" }).first();
+    await expect(roomRow).toBeVisible();
+    await expect(roomRow.locator('.dm-room-list-icon[data-room-icon="mdi:sofa"]')).toBeVisible();
+    await expect(roomRow.locator(".dm-room-list-icon svg")).toHaveCount(1);
+
+    await openEditor(page, "sez7");
+    const configuredTemperature = page.locator('#editor-modal [data-temperature-room][data-room-id="room-cameretta"]');
+    await expect(configuredTemperature).toBeVisible();
+    await configuredTemperature.locator("[data-temperature-edit]").click();
+    const temperatureSelect = page.locator("#dm-temperature-room");
+    await expect(temperatureSelect).toBeEnabled();
+    await expect(temperatureSelect).toHaveAttribute("data-dm-real-device-editable", "true");
+    await expect(temperatureSelect).toHaveCSS("pointer-events", "auto");
+    await temperatureSelect.selectOption("room-bagno");
+    await expect(temperatureSelect).toHaveValue("room-bagno");
+
+    await openEditor(page, "luci");
+    const lightForm = page.locator('#ed-body .dm-light-add-form[data-dm-light-add-layout="beta9-real"]');
+    await expect(lightForm).toBeVisible();
+    const lightGeometry = await lightForm.evaluate((form) => {
+      const row = form.querySelector(".dm-light-add-entity-row");
+      const entity = form.querySelector("#luce-add-ent");
+      const search = row?.querySelector(".dm-entity-picker");
+      const name = form.querySelector("#luce-add-name");
+      return {
+        noOverflow: form.scrollWidth <= form.clientWidth + 1,
+        rowColumns: row ? getComputedStyle(row).gridTemplateColumns : "",
+        entityWidth: entity?.getBoundingClientRect().width || 0,
+        searchWidth: search?.getBoundingClientRect().width || 0,
+        nameWidth: name?.getBoundingClientRect().width || 0,
+      };
+    });
+    expect(lightGeometry.noOverflow).toBe(true);
+    expect(lightGeometry.entityWidth).toBeGreaterThan(180);
+    expect(lightGeometry.searchWidth).toBeGreaterThanOrEqual(54);
+    expect(lightGeometry.nameWidth).toBeGreaterThan(240);
+
+    await page.locator("#editor-modal .ed-head-close").last().click();
+    await page.evaluate(() => {
+      document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
+      document.getElementById("page-tapparelle")?.classList.add("active");
+      window.renderTapparelle?.();
+    });
+    const shutterCard = page.locator("#page-tapparelle .tapp-card").first();
+    await expect(shutterCard).toBeVisible();
+    const shutterGeometry = await shutterCard.evaluate((card) => ({
+      width: card.getBoundingClientRect().width,
+      windowHeight: card.querySelector(".tapp-win")?.getBoundingClientRect().height || 0,
+      slatAnimation: getComputedStyle(card.querySelector(".tapp-shutter i")).animationName,
+    }));
+    expect(shutterGeometry.width).toBeLessThanOrEqual(361);
+    expect(shutterGeometry.windowHeight).toBeLessThanOrEqual(133);
+    expect(shutterGeometry.slatAnimation).toBe("none");
+
+    await page.evaluate(() => {
+      document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
+      document.getElementById("page-home")?.classList.add("active");
+      window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: { entity_id: "cover.tapparella" } }));
+    });
+    const shutterAlertIcon = page.locator("#page-home .dm-shutter-alert .g-icon-wrap");
+    await expect(shutterAlertIcon).toBeVisible();
+    await expect(shutterAlertIcon).toHaveAttribute("data-dm-alert-motion", "static");
+    await expect(shutterAlertIcon).not.toHaveClass(/anim-ping/);
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/beta9-real-device-screenshots.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta9-real-device-screenshots.spec.js
@@ -147,7 +147,15 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await openEditor(page, "sez2");
     const appearance = page.locator("#ed-body [data-ev-appearance]");
     await expect(appearance).toBeVisible();
-    expect(await appearance.evaluate((node) => node.parentElement?.firstElementChild === node)).toBe(true);
+    const appearanceIsVisuallyFirst = await appearance.evaluate((node) => {
+      const parent = node.parentElement;
+      if (!parent) return false;
+      const top = node.getBoundingClientRect().top;
+      return [...parent.children]
+        .filter((sibling) => sibling !== node && sibling.getClientRects().length > 0)
+        .every((sibling) => sibling.getBoundingClientRect().top >= top - 1);
+    });
+    expect(appearanceIsVisuallyFirst).toBe(true);
     const brand = appearance.locator("select[data-brand]");
     const model = appearance.locator("select[data-model]");
     await brand.selectOption("MINI");

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -87,11 +87,9 @@ if (typeof document !== "undefined") {
     document.head?.append(evBrandStyle);
 
     // v0.15.25 Quick Actions used readable colour emoji/glyphs. The beta9
-    // catalog normalizer intentionally strips non-ASCII characters, so a
-    // persisted emoji can otherwise compare as an empty token and resolve to
-    // the first catalog item (Home). Reconcile explicit configured icons first,
-    // then the historical builtin glyph, and use the rendered MDI token only as
-    // a compatibility fallback. This stays finite/event-driven.
+    // catalog normalizer can transiently rebuild those icons with the wrong
+    // fallback. Keep this one grid authoritative without polling the page: a
+    // scoped observer repairs only mutations inside #qa-grid.
     const actionGlyphs = Object.freeze({
       "mdi:home": "🏠",
       "mdi:lightbulb": "💡",
@@ -124,10 +122,20 @@ if (typeof document !== "undefined") {
       lavatrice: "🧺",
       builtin_lavatrice: "🧺",
     });
+    const actionBuiltinColors = Object.freeze({
+      luci: "#f59e0b",
+      luci_group: "#f59e0b",
+      builtin_luci: "#f59e0b",
+      clima: "#0ea5e9",
+      builtin_clima: "#0ea5e9",
+      antifurto: "#7c3aed",
+      builtin_antifurto: "#7c3aed",
+      lavatrice: "#0ea5e9",
+      builtin_lavatrice: "#0ea5e9",
+    });
     const configuredQuickActions = () => {
       // Persisted Quick Actions are authoritative. getQuickActions() can still
-      // expose the pre-render snapshot for one turn immediately after an edit,
-      // which is exactly when the real-device renderer is rebuilt.
+      // expose the pre-render snapshot for one turn immediately after an edit.
       try {
         const actions = JSON.parse(globalThis.localStorage?.getItem("cd_quick_actions") || "[]");
         if (Array.isArray(actions) && actions.length) return actions;
@@ -154,15 +162,27 @@ if (typeof document !== "undefined") {
           actionGlyphs[configuredMdi] ||
           actionBuiltinGlyphs[builtin] ||
           actionGlyphs[mdiToken] ||
-          (persistedGlyph && !persistedGlyph.startsWith("mdi:") ? persistedGlyph : "");
-        const target = icon.querySelector(".dm-v01525-action-glyph");
-        if (target && glyph) target.textContent = glyph;
+          (persistedGlyph && !persistedGlyph.startsWith("mdi:") ? persistedGlyph : "") ||
+          "⭐";
+        const color = String(action.color || actionBuiltinColors[builtin] || "#0ea5e9").trim();
+        let target = icon.querySelector(".dm-v01525-action-glyph");
+        if (!target) {
+          target = document.createElement("span");
+          target.className = "dm-v01525-action-glyph";
+          target.setAttribute("aria-hidden", "true");
+          icon.replaceChildren(target);
+        }
+        if (target.textContent !== glyph) target.textContent = glyph;
+        icon.dataset.dmActionStyle = "v01525";
+        icon.style.setProperty("color", color, "important");
+        icon.style.setProperty("filter", `drop-shadow(0 6px 12px ${color}66)`, "important");
       });
     };
     const scheduleV01525QuickActionRepair = () => {
       requestAnimationFrame?.(repairV01525QuickActionGlyphs);
       setTimeout(repairV01525QuickActionGlyphs, 0);
       setTimeout(repairV01525QuickActionGlyphs, 90);
+      setTimeout(repairV01525QuickActionGlyphs, 320);
     };
     const installQuickActionRepairOwner = () => {
       const current = globalThis.buildQuickActions;
@@ -176,12 +196,24 @@ if (typeof document !== "undefined") {
       wrapped.__dmWrappedOriginal = current;
       globalThis.buildQuickActions = wrapped;
     };
+    let quickActionObservedGrid = null;
+    let quickActionObserver = null;
+    const installQuickActionGridObserver = () => {
+      const grid = document.getElementById("qa-grid");
+      if (!grid || grid === quickActionObservedGrid) return;
+      quickActionObserver?.disconnect?.();
+      quickActionObservedGrid = grid;
+      quickActionObserver = new MutationObserver(() => repairV01525QuickActionGlyphs());
+      quickActionObserver.observe(grid, { childList: true, subtree: true, characterData: true });
+      repairV01525QuickActionGlyphs();
+    };
     for (const eventName of [
       "dashboardmodern:legacy-ready",
       "dashboardmodern:runtime-ready",
       "dashboardmodern:states-ready",
     ]) globalThis.addEventListener?.(eventName, () => {
       installQuickActionRepairOwner();
+      installQuickActionGridObserver();
       scheduleV01525QuickActionRepair();
     });
     document.addEventListener("click", (event) => {
@@ -218,6 +250,7 @@ if (typeof document !== "undefined") {
     }, true);
 
     installQuickActionRepairOwner();
+    installQuickActionGridObserver();
     scheduleV01525QuickActionRepair();
   }
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -50,8 +50,10 @@ if (typeof document !== "undefined") {
 
     // EV config: the real manufacturer mark belongs above the brand label. The
     // old horizontal box let wide wordmarks overflow beneath the text on phones.
-    // Shutter windows are measured by their border box in the real-device test;
-    // legacy padding must therefore stay inside the compact 132px owner height.
+    // Shutter layout is also pinned here because this entrypoint style is mounted
+    // after all imported section styles. The rules deliberately match fresh
+    // legacy shutter DOM too, so a render race cannot briefly restore the old
+    // 178/190px window or its page/lamella pulse before beta9 decorates nodes.
     const evBrandStyle = document.createElement("style");
     evBrandStyle.id = "dm-beta7-ev-brand-layout";
     evBrandStyle.textContent = `
@@ -82,8 +84,44 @@ if (typeof document !== "undefined") {
         object-position:left center!important;
       }
       .dm-ev-appearance-grid .dm-brand-preview b{display:block!important;line-height:1.1!important}
-      html body #page-tapparelle .tapp-win.dm-beta9-real-shutter-window{
+      html body #page-tapparelle#page-tapparelle.page{
+        animation:none!important;
+        transform:none!important;
+        opacity:1!important;
+      }
+      html body #page-tapparelle#page-tapparelle #tapp-grid{
+        grid-template-columns:repeat(auto-fit,minmax(280px,360px))!important;
+        justify-content:center!important;
+        align-items:start!important;
+        gap:14px!important;
+      }
+      html body #page-tapparelle#page-tapparelle .tapp-card{
         box-sizing:border-box!important;
+        width:100%!important;
+        max-width:360px!important;
+        min-height:0!important;
+        animation:none!important;
+        transform:none!important;
+      }
+      html body #page-tapparelle#page-tapparelle .tapp-win{
+        box-sizing:border-box!important;
+        height:132px!important;
+        min-height:132px!important;
+        max-height:132px!important;
+        margin:0!important;
+        animation:none!important;
+        transition:none!important;
+        transform:none!important;
+      }
+      html body #page-tapparelle#page-tapparelle .tapp-shutter{
+        animation:none!important;
+        filter:none!important;
+        transition:height .55s cubic-bezier(.2,.8,.2,1)!important;
+      }
+      html body #page-tapparelle#page-tapparelle .tapp-shutter i{
+        animation:none!important;
+        filter:none!important;
+        transform:none!important;
       }
       @media(hover:none){
         .dm-visual-trigger:hover,.dm-icon-preview-button:hover,.dm-picker-option:hover{transform:none!important}

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -86,6 +86,45 @@ if (typeof document !== "undefined") {
     `;
     document.head?.append(evBrandStyle);
 
+    // Personalization creates the EV appearance card only after the legacy EV
+    // editor has rendered. On WebKit that first render can land after beta9's
+    // own reconciliation frame, leaving Brand/Model below the long entity list.
+    // Wrap the actual tab switch and reconcile on the following animation frame,
+    // after sibling requestAnimationFrame renderers have completed. This is
+    // bounded/event-driven and does not add another DOM observer or polling loop.
+    const repairEvAppearanceTop = () => {
+      const body = document.getElementById("ed-body");
+      if (!body) return;
+      const activeTab = String(document.querySelector(".ed-tab.active")?.dataset?.tab || "");
+      if (activeTab !== "sez2") return;
+      const panel = body.querySelector("[data-ev-appearance]");
+      if (!panel) return;
+      if (body.firstElementChild !== panel) body.prepend(panel);
+      panel.dataset.dmEvTop = "true";
+    };
+    const scheduleEvAppearanceTopRepair = () => {
+      const secondFrame = () => {
+        if (typeof requestAnimationFrame === "function") requestAnimationFrame(repairEvAppearanceTop);
+        else setTimeout(repairEvAppearanceTop, 0);
+      };
+      if (typeof requestAnimationFrame === "function") requestAnimationFrame(secondFrame);
+      else setTimeout(secondFrame, 0);
+      setTimeout(repairEvAppearanceTop, 70);
+    };
+    const installEvAppearanceTopOwner = () => {
+      const current = globalThis.editorSwitch;
+      if (typeof current !== "function" || current.__dmBeta9EvTopRepair) return;
+      const wrapped = function (...args) {
+        const result = current.apply(this, args);
+        if (result && typeof result.finally === "function") result.finally(scheduleEvAppearanceTopRepair);
+        else scheduleEvAppearanceTopRepair();
+        return result;
+      };
+      wrapped.__dmBeta9EvTopRepair = true;
+      wrapped.__dmWrappedOriginal = current;
+      globalThis.editorSwitch = wrapped;
+    };
+
     // v0.15.25 Quick Actions used readable colour emoji/glyphs. The beta9
     // catalog normalizer can transiently rebuild an empty builtin icon as Home.
     // Reconcile only after the two real render owners finish. This is bounded,
@@ -203,10 +242,13 @@ if (typeof document !== "undefined") {
       "dashboardmodern:runtime-ready",
       "dashboardmodern:states-ready",
     ]) globalThis.addEventListener?.(eventName, () => {
+      installEvAppearanceTopOwner();
+      scheduleEvAppearanceTopRepair();
       installQuickActionRepairOwner();
       scheduleV01525QuickActionRepair();
     });
     globalThis.addEventListener?.("dashboardmodern:state-changed", () => {
+      installEvAppearanceTopOwner();
       installQuickActionRepairOwner();
       scheduleV01525QuickActionRepair();
     });
@@ -243,6 +285,8 @@ if (typeof document !== "undefined") {
       if (event.target?.closest?.("[data-temperature-edit]")) scheduleTemperatureRoomRepair();
     }, true);
 
+    installEvAppearanceTopOwner();
+    scheduleEvAppearanceTopRepair();
     installQuickActionRepairOwner();
     scheduleV01525QuickActionRepair();
   }

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -9,11 +9,14 @@ import "./beta4-mobile-polish-section.js";
 import "./beta6-feedback-section.js";
 import "./beta7-brand-guard-section.js";
 import "./beta7-regression-section.js";
+import "./beta9-real-device-polish-section.js";
 
 // Keep only compatibility/layout bridges that belong at the entrypoint. The
 // beta7 guards run after the mature beta6 editor owner; the guard is installed
 // first so a broken remote logo keeps its DOM contract while the final beta7
-// polish owns the visible mobile regression layout.
+// polish owns the visible mobile regression layout. The beta9 real-device pass
+// is intentionally last: it reconciles only conflicts reproduced in the real
+// Home Assistant WebView and does not introduce polling or global observers.
 if (typeof document !== "undefined") {
   const marker = "__DASHBOARDMODERN_BETA5_ENTRY_BRIDGE__";
   if (!globalThis[marker]) {

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -89,9 +89,9 @@ if (typeof document !== "undefined") {
     // v0.15.25 Quick Actions used readable colour emoji/glyphs. The beta9
     // catalog normalizer intentionally strips non-ASCII characters, so a
     // persisted emoji can otherwise compare as an empty token and resolve to
-    // the first catalog item (Home). Reconcile from the canonical MDI token
-    // already attached to each rendered icon. This is finite/event-driven and
-    // deliberately runs after the beta9 renderer instead of adding polling.
+    // the first catalog item (Home). Reconcile explicit configured icons first,
+    // then the historical builtin glyph, and use the rendered MDI token only as
+    // a compatibility fallback. This stays finite/event-driven.
     const actionGlyphs = Object.freeze({
       "mdi:home": "🏠",
       "mdi:lightbulb": "💡",
@@ -113,11 +113,45 @@ if (typeof document !== "undefined") {
       "mdi:bell": "🔔",
       "mdi:star": "⭐",
     });
+    const actionBuiltinGlyphs = Object.freeze({
+      luci: "💡",
+      luci_group: "💡",
+      builtin_luci: "💡",
+      clima: "❄️",
+      builtin_clima: "❄️",
+      antifurto: "🛡️",
+      builtin_antifurto: "🛡️",
+      lavatrice: "🧺",
+      builtin_lavatrice: "🧺",
+    });
+    const configuredQuickActions = () => {
+      try {
+        const actions = globalThis.getQuickActions?.();
+        if (Array.isArray(actions)) return actions;
+      } catch (_error) {}
+      try {
+        const actions = JSON.parse(globalThis.localStorage?.getItem("cd_quick_actions") || "[]");
+        return Array.isArray(actions) ? actions : [];
+      } catch (_error) {
+        return [];
+      }
+    };
     const repairV01525QuickActionGlyphs = () => {
-      document.querySelectorAll("#qa-grid .qa-btn .icon").forEach((icon) => {
+      const actions = configuredQuickActions();
+      document.querySelectorAll("#qa-grid .qa-btn .icon").forEach((icon, index) => {
+        const action = actions[index] || {};
+        const builtin = String(action.builtin || "").trim().toLowerCase();
+        const configured = String(action.icon || "").trim();
+        const configuredMdi = configured.toLowerCase().startsWith("mdi:") ? configured : "";
+        const configuredGlyph = configured && !configuredMdi ? configured : "";
         const raw = String(icon.dataset.dmBeta7IconToken || "");
         const [mdiToken, persistedGlyph] = raw.split("|");
-        const glyph = actionGlyphs[mdiToken] || (persistedGlyph && !persistedGlyph.startsWith("mdi:") ? persistedGlyph : "");
+        const glyph =
+          configuredGlyph ||
+          actionGlyphs[configuredMdi] ||
+          actionBuiltinGlyphs[builtin] ||
+          actionGlyphs[mdiToken] ||
+          (persistedGlyph && !persistedGlyph.startsWith("mdi:") ? persistedGlyph : "");
         const target = icon.querySelector(".dm-v01525-action-glyph");
         if (target && glyph) target.textContent = glyph;
       });

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -125,12 +125,15 @@ if (typeof document !== "undefined") {
       builtin_lavatrice: "🧺",
     });
     const configuredQuickActions = () => {
-      try {
-        const actions = globalThis.getQuickActions?.();
-        if (Array.isArray(actions)) return actions;
-      } catch (_error) {}
+      // Persisted Quick Actions are authoritative. getQuickActions() can still
+      // expose the pre-render snapshot for one turn immediately after an edit,
+      // which is exactly when the real-device renderer is rebuilt.
       try {
         const actions = JSON.parse(globalThis.localStorage?.getItem("cd_quick_actions") || "[]");
+        if (Array.isArray(actions) && actions.length) return actions;
+      } catch (_error) {}
+      try {
+        const actions = globalThis.getQuickActions?.();
         return Array.isArray(actions) ? actions : [];
       } catch (_error) {
         return [];

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -87,9 +87,9 @@ if (typeof document !== "undefined") {
     document.head?.append(evBrandStyle);
 
     // v0.15.25 Quick Actions used readable colour emoji/glyphs. The beta9
-    // catalog normalizer can transiently rebuild those icons with the wrong
-    // fallback. Keep this one grid authoritative without polling the page: a
-    // scoped observer repairs only mutations inside #qa-grid.
+    // catalog normalizer can transiently rebuild an empty builtin icon as Home.
+    // Reconcile only after the two real render owners finish. This is bounded,
+    // event-driven work: no polling and no additional MutationObserver.
     const actionGlyphs = Object.freeze({
       "mdi:home": "🏠",
       "mdi:lightbulb": "💡",
@@ -180,12 +180,10 @@ if (typeof document !== "undefined") {
     };
     const scheduleV01525QuickActionRepair = () => {
       requestAnimationFrame?.(repairV01525QuickActionGlyphs);
-      setTimeout(repairV01525QuickActionGlyphs, 0);
-      setTimeout(repairV01525QuickActionGlyphs, 90);
-      setTimeout(repairV01525QuickActionGlyphs, 320);
+      for (const delay of [0, 90, 320, 900]) setTimeout(repairV01525QuickActionGlyphs, delay);
     };
-    const installQuickActionRepairOwner = () => {
-      const current = globalThis.buildQuickActions;
+    const wrapQuickActionRenderOwner = (name) => {
+      const current = globalThis[name];
       if (typeof current !== "function" || current.__dmV01525GlyphRepair) return;
       const wrapped = function (...args) {
         const result = current.apply(this, args);
@@ -194,18 +192,11 @@ if (typeof document !== "undefined") {
       };
       wrapped.__dmV01525GlyphRepair = true;
       wrapped.__dmWrappedOriginal = current;
-      globalThis.buildQuickActions = wrapped;
+      globalThis[name] = wrapped;
     };
-    let quickActionObservedGrid = null;
-    let quickActionObserver = null;
-    const installQuickActionGridObserver = () => {
-      const grid = document.getElementById("qa-grid");
-      if (!grid || grid === quickActionObservedGrid) return;
-      quickActionObserver?.disconnect?.();
-      quickActionObservedGrid = grid;
-      quickActionObserver = new MutationObserver(() => repairV01525QuickActionGlyphs());
-      quickActionObserver.observe(grid, { childList: true, subtree: true, characterData: true });
-      repairV01525QuickActionGlyphs();
+    const installQuickActionRepairOwner = () => {
+      wrapQuickActionRenderOwner("buildQuickActions");
+      wrapQuickActionRenderOwner("render");
     };
     for (const eventName of [
       "dashboardmodern:legacy-ready",
@@ -213,7 +204,10 @@ if (typeof document !== "undefined") {
       "dashboardmodern:states-ready",
     ]) globalThis.addEventListener?.(eventName, () => {
       installQuickActionRepairOwner();
-      installQuickActionGridObserver();
+      scheduleV01525QuickActionRepair();
+    });
+    globalThis.addEventListener?.("dashboardmodern:state-changed", () => {
+      installQuickActionRepairOwner();
       scheduleV01525QuickActionRepair();
     });
     document.addEventListener("click", (event) => {
@@ -250,7 +244,6 @@ if (typeof document !== "undefined") {
     }, true);
 
     installQuickActionRepairOwner();
-    installQuickActionGridObserver();
     scheduleV01525QuickActionRepair();
   }
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -85,5 +85,73 @@ if (typeof document !== "undefined") {
       }
     `;
     document.head?.append(evBrandStyle);
+
+    // v0.15.25 Quick Actions used readable colour emoji/glyphs. The beta9
+    // catalog normalizer intentionally strips non-ASCII characters, so a
+    // persisted emoji can otherwise compare as an empty token and resolve to
+    // the first catalog item (Home). Reconcile from the canonical MDI token
+    // already attached to each rendered icon. This is finite/event-driven and
+    // deliberately runs after the beta9 renderer instead of adding polling.
+    const actionGlyphs = Object.freeze({
+      "mdi:home": "🏠",
+      "mdi:lightbulb": "💡",
+      "mdi:lightbulb-group": "💡",
+      "mdi:snowflake": "❄️",
+      "mdi:radiator": "🔥",
+      "mdi:shield-home": "🛡️",
+      "mdi:gate": "🚪",
+      "mdi:window-shutter": "🪟",
+      "mdi:movie-open": "🎬",
+      "mdi:script-text-play": "▶️",
+      "mdi:toggle-switch-outline": "🔀",
+      "mdi:washing-machine": "🧺",
+      "mdi:flash": "⚡",
+      "mdi:car-electric": "🚗",
+      "mdi:water-boiler": "♨️",
+      "mdi:water": "💧",
+      "mdi:cctv": "📷",
+      "mdi:bell": "🔔",
+      "mdi:star": "⭐",
+    });
+    const repairV01525QuickActionGlyphs = () => {
+      document.querySelectorAll("#qa-grid .qa-btn .icon").forEach((icon) => {
+        const raw = String(icon.dataset.dmBeta7IconToken || "");
+        const [mdiToken, persistedGlyph] = raw.split("|");
+        const glyph = actionGlyphs[mdiToken] || (persistedGlyph && !persistedGlyph.startsWith("mdi:") ? persistedGlyph : "");
+        const target = icon.querySelector(".dm-v01525-action-glyph");
+        if (target && glyph) target.textContent = glyph;
+      });
+    };
+    const scheduleV01525QuickActionRepair = () => {
+      requestAnimationFrame?.(repairV01525QuickActionGlyphs);
+      setTimeout(repairV01525QuickActionGlyphs, 0);
+      setTimeout(repairV01525QuickActionGlyphs, 90);
+    };
+    const installQuickActionRepairOwner = () => {
+      const current = globalThis.buildQuickActions;
+      if (typeof current !== "function" || current.__dmV01525GlyphRepair) return;
+      const wrapped = function (...args) {
+        const result = current.apply(this, args);
+        scheduleV01525QuickActionRepair();
+        return result;
+      };
+      wrapped.__dmV01525GlyphRepair = true;
+      wrapped.__dmWrappedOriginal = current;
+      globalThis.buildQuickActions = wrapped;
+    };
+    for (const eventName of [
+      "dashboardmodern:legacy-ready",
+      "dashboardmodern:runtime-ready",
+      "dashboardmodern:states-ready",
+    ]) globalThis.addEventListener?.(eventName, () => {
+      installQuickActionRepairOwner();
+      scheduleV01525QuickActionRepair();
+    });
+    document.addEventListener("click", (event) => {
+      if (event.target?.closest?.("#dm-action-editor-modal,#dm-beta9-action-picker,.dm-beta6-qa-icon-trigger"))
+        scheduleV01525QuickActionRepair();
+    }, true);
+    installQuickActionRepairOwner();
+    scheduleV01525QuickActionRepair();
   }
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -151,6 +151,35 @@ if (typeof document !== "undefined") {
       if (event.target?.closest?.("#dm-action-editor-modal,#dm-beta9-action-picker,.dm-beta6-qa-icon-trigger"))
         scheduleV01525QuickActionRepair();
     }, true);
+
+    // The legacy Temperature edit handler creates a correctly populated room
+    // select and then disables it. The beta9 reconciler runs when the tab opens,
+    // but that happens before the edit form exists. Re-enable the select after
+    // the actual Edit click, without polling or observing the whole document.
+    const repairTemperatureRoomSelect = () => {
+      const form = document.querySelector("#editor-modal [data-temperature-form]");
+      const select = form?.querySelector("#dm-temperature-room");
+      const title = String(form?.querySelector("[data-temperature-form-title]")?.textContent || "").trim();
+      if (!select || !/^(modifica|edit)\b/i.test(title)) return;
+      select.disabled = false;
+      select.removeAttribute("disabled");
+      select.removeAttribute("aria-disabled");
+      select.tabIndex = 0;
+      select.dataset.dmTemperatureRoomEditable = "true";
+      select.dataset.dmRealDeviceEditable = "true";
+      select.style.setProperty("pointer-events", "auto", "important");
+      select.style.setProperty("opacity", "1", "important");
+      select.style.setProperty("cursor", "pointer", "important");
+    };
+    const scheduleTemperatureRoomRepair = () => {
+      requestAnimationFrame?.(repairTemperatureRoomSelect);
+      setTimeout(repairTemperatureRoomSelect, 0);
+      setTimeout(repairTemperatureRoomSelect, 90);
+    };
+    document.addEventListener("click", (event) => {
+      if (event.target?.closest?.("[data-temperature-edit]")) scheduleTemperatureRoomRepair();
+    }, true);
+
     installQuickActionRepairOwner();
     scheduleV01525QuickActionRepair();
   }

--- a/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-entry-section.js
@@ -50,6 +50,8 @@ if (typeof document !== "undefined") {
 
     // EV config: the real manufacturer mark belongs above the brand label. The
     // old horizontal box let wide wordmarks overflow beneath the text on phones.
+    // Shutter windows are measured by their border box in the real-device test;
+    // legacy padding must therefore stay inside the compact 132px owner height.
     const evBrandStyle = document.createElement("style");
     evBrandStyle.id = "dm-beta7-ev-brand-layout";
     evBrandStyle.textContent = `
@@ -80,6 +82,9 @@ if (typeof document !== "undefined") {
         object-position:left center!important;
       }
       .dm-ev-appearance-grid .dm-brand-preview b{display:block!important;line-height:1.1!important}
+      html body #page-tapparelle .tapp-win.dm-beta9-real-shutter-window{
+        box-sizing:border-box!important;
+      }
       @media(hover:none){
         .dm-visual-trigger:hover,.dm-icon-preview-button:hover,.dm-picker-option:hover{transform:none!important}
       }
@@ -88,10 +93,11 @@ if (typeof document !== "undefined") {
 
     // Personalization creates the EV appearance card only after the legacy EV
     // editor has rendered. On WebKit that first render can land after beta9's
-    // own reconciliation frame, leaving Brand/Model below the long entity list.
-    // Wrap the actual tab switch and reconcile on the following animation frame,
-    // after sibling requestAnimationFrame renderers have completed. This is
-    // bounded/event-driven and does not add another DOM observer or polling loop.
+    // own reconciliation frame, leaving Brand/Model below the long entity list
+    // or leaving the freshly-created selects before beta9's direct bindings.
+    // Reconcile position on the following frame and, when bindings are still
+    // absent, issue one ordinary scoped state tick so beta9 runs its existing
+    // bindEvAppearance owner. No observer or permanent polling is introduced.
     const repairEvAppearanceTop = () => {
       const body = document.getElementById("ed-body");
       if (!body) return;
@@ -101,6 +107,13 @@ if (typeof document !== "undefined") {
       if (!panel) return;
       if (body.firstElementChild !== panel) body.prepend(panel);
       panel.dataset.dmEvTop = "true";
+
+      const brandSelect = panel.querySelector("select[data-brand]");
+      if (brandSelect && brandSelect.dataset.dmRealDeviceBound !== "true") {
+        globalThis.dispatchEvent?.(new CustomEvent("dashboardmodern:state-changed", {
+          detail: { entity_id: "sensor.dashboardmodern_ev_appearance_sync" },
+        }));
+      }
     };
     const scheduleEvAppearanceTopRepair = () => {
       const secondFrame = () => {

--- a/custom_components/dashboardmodern/frontend/src/sections/beta9-real-device-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta9-real-device-polish-section.js
@@ -1,0 +1,738 @@
+import {
+  ACTION_ICON_CATALOG,
+  carBrandVisual,
+  roomVisual,
+} from "../core/personalization-catalog.js";
+import {
+  allStates,
+  clean,
+  dashboardStore,
+  doc,
+  english,
+  esc,
+  installStyle,
+  readJson,
+  root,
+  wrapFunction,
+} from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_BETA9_REAL_DEVICE_POLISH__";
+const state = (root[KEY] ||= {
+  installed: false,
+  frame: 0,
+  storeUnsubscribe: null,
+});
+
+const ACTION_DEFAULTS = Object.freeze({
+  luci: { glyph: "💡", color: "#f59e0b" },
+  clima: { glyph: "❄️", color: "#0ea5e9" },
+  antifurto: { glyph: "🛡️", color: "#7c3aed" },
+  lavatrice: { glyph: "🧺", color: "#0ea5e9" },
+});
+
+const CAR_MODELS = Object.freeze({
+  "Abarth": ["500e", "600e"],
+  "Alfa Romeo": ["Junior Elettrica", "Junior Ibrida", "Tonale Plug-In Hybrid Q4"],
+  "Audi": ["A3 TFSI e", "A5 e-hybrid", "A6 e-tron", "Q3 e-hybrid", "Q4 e-tron", "Q5 e-hybrid", "Q6 e-tron", "Q8 e-tron", "e-tron GT"],
+  "BMW": ["iX1", "iX2", "i4", "i5", "i7", "iX", "iX3", "225e Active Tourer", "230e Active Tourer", "330e", "550e", "750e", "X1 xDrive25e", "X1 xDrive30e", "X3 30e", "X5 xDrive50e", "XM"],
+  "BYD": ["Dolphin Surf", "Dolphin", "Atto 2", "Atto 3", "Seal", "Seal U DM-i", "Sealion 7", "Tang", "Han"],
+  "Citroën": ["ë-C3", "C3 Hybrid", "ë-C3 Aircross", "C3 Aircross Hybrid", "ë-C4", "C4 Hybrid", "ë-C5 Aircross", "C5 Aircross Plug-In Hybrid", "ë-Berlingo", "ë-SpaceTourer"],
+  "Cupra": ["Born", "Tavascan", "Terramar e-Hybrid", "Formentor e-Hybrid", "Leon e-Hybrid"],
+  "Dacia": ["Spring", "Duster Hybrid", "Bigster Hybrid", "Jogger Hybrid"],
+  "DS": ["DS 3 E-Tense", "N°4 E-Tense", "N°4 Plug-In Hybrid", "DS 7 E-Tense", "N°8"],
+  "Fiat": ["500e", "Grande Panda Electric", "Grande Panda Hybrid", "600e", "600 Hybrid"],
+  "Ford": ["Puma Gen-E", "Explorer EV", "Capri EV", "Mustang Mach-E", "Kuga Hybrid", "Kuga Plug-In Hybrid", "E-Tourneo Courier", "E-Tourneo Custom"],
+  "Honda": ["e:Ny1", "Civic e:HEV", "HR-V e:HEV", "ZR-V e:HEV", "CR-V e:HEV", "CR-V e:PHEV", "Prelude e:HEV"],
+  "Hyundai": ["Inster", "Kona Electric", "Kona Hybrid", "IONIQ 5", "IONIQ 6", "IONIQ 9", "Tucson Hybrid", "Tucson Plug-In Hybrid", "Santa Fe Hybrid", "Santa Fe Plug-In Hybrid"],
+  "Jeep": ["Avenger Electric", "Avenger e-Hybrid", "Avenger 4xe", "Compass e-Hybrid", "Compass 4xe", "Renegade 4xe", "Grand Cherokee 4xe", "Wagoneer S"],
+  "Kia": ["Niro EV", "Niro Hybrid", "Niro Plug-In Hybrid", "EV3", "EV4", "EV5", "EV6", "EV9", "PV5 Passenger", "Sportage Hybrid", "Sportage Plug-In Hybrid", "Sorento Hybrid", "Sorento Plug-In Hybrid"],
+  "Lancia": ["Ypsilon Electric", "Ypsilon Hybrid"],
+  "Leapmotor": ["T03", "B10", "C10", "C10 REEV"],
+  "Lexus": ["LBX Hybrid", "UX 300e", "UX Hybrid", "NX 350h", "NX 450h+", "RZ", "RX 350h", "RX 450h+", "RX 500h", "ES 300h", "LM 350h"],
+  "Mazda": ["Mazda6e", "MX-30", "CX-60 Plug-In Hybrid", "CX-80 Plug-In Hybrid"],
+  "Mercedes-Benz": ["EQA", "EQB", "CLA Electric", "CLA Hybrid", "EQE", "EQS", "EQE SUV", "EQS SUV", "G 580 EQ", "C-Class Plug-In Hybrid", "E-Class Plug-In Hybrid", "GLA 250 e", "GLC Plug-In Hybrid", "GLE Plug-In Hybrid"],
+  "MG": ["MG4 Electric", "MG5 Electric", "MGS5 EV", "ZS Hybrid+", "HS Hybrid+", "HS Plug-In Hybrid", "Cyberster"],
+  "MINI": ["Cooper Electric", "Aceman", "Countryman Electric"],
+  "Nissan": ["Micra EV", "Leaf", "Ariya", "Juke Hybrid", "Qashqai e-POWER", "X-Trail e-POWER"],
+  "Opel": ["Corsa Electric", "Corsa Hybrid", "Mokka Electric", "Mokka Hybrid", "Astra Electric", "Astra Plug-In Hybrid", "Astra Hybrid", "Frontera Electric", "Frontera Hybrid", "Grandland Electric", "Grandland Plug-In Hybrid", "Grandland Hybrid", "Combo Electric", "Zafira Electric"],
+  "Peugeot": ["e-208", "208 Hybrid", "e-2008", "2008 Hybrid", "e-308", "308 Plug-In Hybrid", "308 Hybrid", "e-3008", "3008 Plug-In Hybrid", "3008 Hybrid", "e-5008", "5008 Plug-In Hybrid", "5008 Hybrid", "e-Rifter"],
+  "Polestar": ["Polestar 2", "Polestar 3", "Polestar 4", "Polestar 5"],
+  "Porsche": ["Macan Electric", "Taycan", "Cayenne E-Hybrid", "Panamera E-Hybrid"],
+  "Renault": ["5 E-Tech electric", "4 E-Tech electric", "Megane E-Tech electric", "Scenic E-Tech electric", "Captur E-Tech full hybrid", "Symbioz E-Tech full hybrid", "Austral E-Tech full hybrid", "Espace E-Tech full hybrid", "Rafale E-Tech full hybrid", "Rafale E-Tech 4x4 Plug-In Hybrid"],
+  "SEAT": ["Leon e-HYBRID", "Leon Sportstourer e-HYBRID", "Ibiza Mild Hybrid", "Arona Mild Hybrid"],
+  "Škoda": ["Elroq", "Enyaq", "Epiq", "Superb iV", "Kodiaq iV", "Octavia e-TEC"],
+  "Smart": ["#1", "#3", "#5"],
+  "Subaru": ["Solterra", "Uncharted", "E-Outback", "Forester e-BOXER", "Crosstrek e-BOXER"],
+  "Suzuki": ["e VITARA", "Swift Hybrid", "Vitara Hybrid", "S-Cross Hybrid", "Across Plug-In Hybrid"],
+  "Tesla": ["Model 3", "Model Y", "Model S", "Model X"],
+  "Toyota": ["Aygo X Hybrid", "Yaris Hybrid", "Yaris Cross Hybrid", "Corolla Hybrid", "C-HR Hybrid", "C-HR Plug-In Hybrid", "Prius Plug-In Hybrid", "bZ4X", "C-HR+", "Urban Cruiser", "RAV4 Hybrid", "RAV4 Plug-In Hybrid", "Highlander Hybrid"],
+  "Volkswagen": ["ID.3", "ID.4", "ID.5", "ID.7", "ID.7 Tourer", "ID. Buzz", "Golf eHybrid", "Golf GTE", "Passat eHybrid", "Tiguan eHybrid", "Tayron eHybrid"],
+  "Volvo": ["EX30", "EX40", "EC40", "EX60", "EX90", "XC40 Mild Hybrid", "XC60 Plug-In Hybrid", "XC90 Plug-In Hybrid"],
+  "XPeng": ["G6", "G9", "P7", "P7+", "L03"],
+});
+
+function normalize(value) {
+  return clean(value)
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9+#]+/g, " ")
+    .trim();
+}
+
+function actionCatalogItem(value) {
+  const token = normalize(value).replace(/^mdi\s*/, "");
+  return ACTION_ICON_CATALOG.find((item) => {
+    const values = [item.id, item.mdi, item.it, item.en, item.glyph]
+      .map((entry) => normalize(entry).replace(/^mdi\s*/, ""));
+    return values.includes(token);
+  }) || null;
+}
+
+function actionVisual(action = {}) {
+  const builtin = clean(action.builtin);
+  const configured = clean(action.icon);
+  const item = actionCatalogItem(configured);
+  const historical = ACTION_DEFAULTS[builtin];
+  const glyph =
+    item?.glyph ||
+    (configured && !configured.toLowerCase().startsWith("mdi:") ? configured : "") ||
+    historical?.glyph ||
+    "⚡";
+  const color = clean(action.color) || historical?.color || "#0ea5e9";
+  return { glyph, color };
+}
+
+function configuredActions() {
+  try {
+    const values = root.getQuickActions?.();
+    if (Array.isArray(values)) return values;
+  } catch (_error) {}
+  const values = readJson("cd_quick_actions", []);
+  return Array.isArray(values) ? values : [];
+}
+
+function polishQuickActions() {
+  const grid = doc?.getElementById("qa-grid");
+  if (!grid) return false;
+  const actions = configuredActions();
+  grid.querySelectorAll(".qa-btn").forEach((card, index) => {
+    const icon = card.querySelector(".icon");
+    if (!icon) return;
+    const visual = actionVisual(actions[index] || {});
+    icon.innerHTML = `<span class="dm-v01525-action-glyph" aria-hidden="true">${esc(visual.glyph)}</span>`;
+    icon.style.setProperty("filter", `drop-shadow(0 6px 12px ${visual.color}66)`, "important");
+    icon.style.setProperty("color", visual.color, "important");
+    icon.dataset.dmActionStyle = "v01525";
+  });
+
+  [...doc.querySelectorAll("#page-home h1,#page-home h2,#page-home h3,#page-home .section-title,#page-home .section-heading")]
+    .forEach((heading) => {
+      const value = clean(heading.textContent);
+      if (/azioni\s+rapide\s+premium/i.test(value))
+        heading.textContent = value.replace(/\s+premium/i, "");
+      if (/premium\s+quick\s+actions/i.test(value))
+        heading.textContent = value.replace(/premium\s+/i, "");
+    });
+  return true;
+}
+
+function polishActionPicker() {
+  const picker = doc?.getElementById("dm-beta9-action-picker") || doc?.querySelector('#dm-visual-picker[data-kind="action"]');
+  if (!picker) return false;
+  picker.querySelectorAll(".dm-picker-option").forEach((button) => {
+    const index = Number.parseInt(button.dataset.index || "-1", 10);
+    const item = ACTION_ICON_CATALOG[index];
+    if (!item) return;
+    const visual = button.querySelector(".dm-picker-visual");
+    if (visual) visual.innerHTML = `<span class="dm-v01525-picker-glyph" aria-hidden="true">${esc(item.glyph)}</span>`;
+  });
+  picker.dataset.dmActionStyle = "v01525";
+  return true;
+}
+
+function modelBelongsToBrand(brand, model) {
+  const token = normalize(model);
+  return Boolean(token) && (CAR_MODELS[clean(brand)] || []).some((candidate) => {
+    const normalizedCandidate = normalize(candidate);
+    return token === normalizedCandidate || token.includes(normalizedCandidate) || normalizedCandidate.includes(token);
+  });
+}
+
+function modelOptions(brand, selected = "") {
+  const current = clean(selected);
+  const values = [...(CAR_MODELS[clean(brand)] || [])];
+  if (current && !values.includes(current)) values.unshift(current);
+  const placeholder = english() ? "— Choose model —" : "— Seleziona modello —";
+  return [
+    `<option value="">${placeholder}</option>`,
+    ...values.map((model) => `<option value="${esc(model)}" ${model === current ? "selected" : ""}>${esc(model)}</option>`),
+  ].join("");
+}
+
+function refreshEvPreview(panel) {
+  const brandSelect = panel?.querySelector("select[data-brand]");
+  const modelSelect = panel?.querySelector("select[data-model]");
+  const preview = panel?.querySelector("[data-brand-preview]");
+  if (!brandSelect || !modelSelect || !preview) return false;
+  const brand = clean(brandSelect.value);
+  const model = clean(modelSelect.value);
+  preview.innerHTML = `${carBrandVisual(brand, 54)}<span class="dm-ev-brand-copy"><b>${esc(brand)}</b>${model ? `<small>${esc(model)}</small>` : ""}</span>`;
+  preview.dataset.dmCurrentBrand = brand;
+  return true;
+}
+
+function onEvBrandChanged(panel) {
+  const brandSelect = panel?.querySelector("select[data-brand]");
+  const modelSelect = panel?.querySelector("select[data-model]");
+  if (!brandSelect || !modelSelect) return;
+  const brand = clean(brandSelect.value);
+  const previous = clean(modelSelect.value);
+  const keep = modelBelongsToBrand(brand, previous) ? previous : "";
+  modelSelect.innerHTML = modelOptions(brand, keep);
+  modelSelect.disabled = false;
+  modelSelect.removeAttribute("disabled");
+  refreshEvPreview(panel);
+}
+
+function bindEvAppearance() {
+  const body = doc?.getElementById("ed-body");
+  const panel = body?.querySelector("[data-ev-appearance]");
+  if (!body || !panel) return false;
+
+  if (body.firstElementChild !== panel) body.prepend(panel);
+  panel.dataset.dmEvTop = "true";
+
+  const brandSelect = panel.querySelector("select[data-brand]");
+  const modelSelect = panel.querySelector("select[data-model]");
+  if (!brandSelect || !modelSelect) return false;
+
+  if (brandSelect.dataset.dmRealDeviceBound !== "true") {
+    brandSelect.dataset.dmRealDeviceBound = "true";
+    const syncBrand = () => onEvBrandChanged(panel);
+    brandSelect.addEventListener("input", syncBrand);
+    brandSelect.addEventListener("change", syncBrand);
+  }
+  if (modelSelect.dataset.dmRealDeviceBound !== "true") {
+    modelSelect.dataset.dmRealDeviceBound = "true";
+    modelSelect.addEventListener("input", () => refreshEvPreview(panel));
+    modelSelect.addEventListener("change", () => refreshEvPreview(panel));
+  }
+
+  const selectedBrand = clean(brandSelect.value);
+  const selectedModel = clean(modelSelect.value);
+  const expected = CAR_MODELS[selectedBrand] || [];
+  const optionValues = [...modelSelect.options].map((option) => option.value).filter(Boolean);
+  const optionsAreStale =
+    expected.length &&
+    (optionValues.length !== expected.length || expected.some((model) => !optionValues.includes(model)));
+  if (optionsAreStale) {
+    modelSelect.innerHTML = modelOptions(
+      selectedBrand,
+      modelBelongsToBrand(selectedBrand, selectedModel) ? selectedModel : "",
+    );
+  }
+  modelSelect.disabled = false;
+  modelSelect.removeAttribute("disabled");
+  refreshEvPreview(panel);
+  return true;
+}
+
+function brandName(container) {
+  return clean(
+    container?.dataset?.dmBeta5Brand ||
+    container?.getAttribute?.("title") ||
+    container?.querySelector?.("img[data-dm-brand-image]")?.alt ||
+    container?.dataset?.brand,
+  );
+}
+
+function readableBrandFallback(container) {
+  if (!container) return false;
+  const img = container.querySelector("img[data-dm-brand-image]");
+  const oldFallback = container.querySelector(".dm-beta7-brand-guard-fallback,.dm-beta7-brand-fallback");
+  const broken = Boolean(
+    oldFallback ||
+    img?.dataset?.dmBeta7Broken === "true" ||
+    (img?.complete && Number(img.naturalWidth) === 0),
+  );
+  if (!broken) return false;
+  const name = brandName(container) || "EV";
+  let fallback = container.querySelector(".dm-v10-brand-wordmark");
+  if (!fallback) {
+    fallback = doc.createElement("span");
+    fallback.className = "dm-v10-brand-wordmark";
+    (img?.parentElement || container).append(fallback);
+  }
+  fallback.textContent = name;
+  oldFallback?.remove();
+  if (img) img.style.setProperty("display", "none", "important");
+  container.dataset.brandSource = "readable-local-fallback";
+  return true;
+}
+
+function polishBrandLogos() {
+  doc?.querySelectorAll?.(".dm-car-brand").forEach((container) => {
+    readableBrandFallback(container);
+    container.dataset.dmLogoNormalized = "true";
+  });
+  return true;
+}
+
+function configuredRooms() {
+  try {
+    const values = dashboardStore()?.getSection?.("rooms");
+    if (Array.isArray(values)) return values;
+  } catch (_error) {}
+  const values = readJson("cd_stanze", []);
+  return Array.isArray(values) ? values : [];
+}
+
+function roomMarkup(room, size = 34) {
+  const value = clean(room?.icon || room?.name || "mdi:home");
+  try {
+    return roomVisual(value, size) || root.cdIconMarkup?.(value, size) || esc(value);
+  } catch (_error) {
+    return esc(value.startsWith("mdi:") ? "🏠" : value);
+  }
+}
+
+function polishRoomRows() {
+  const body = doc?.getElementById("ed-body");
+  const tab = clean(doc?.querySelector(".ed-tab.active")?.dataset?.tab);
+  if (!body || tab !== "stanze") return false;
+  const rooms = configuredRooms();
+  const rows = [...body.querySelectorAll(".ed-row")];
+  rows.forEach((row) => {
+    const edit = row.querySelector('[data-dm-edit-kind="room"][data-dm-edit-index]');
+    let index = Number.parseInt(edit?.dataset?.dmEditIndex || "-1", 10);
+    if (!(index >= 0 && index < rooms.length)) {
+      const label = clean(row.querySelector(".ed-row-new")?.textContent).toLowerCase();
+      index = rooms.findIndex((room) => label.includes(clean(room.name).toLowerCase()));
+    }
+    const room = rooms[index];
+    if (!room) return;
+    row.classList.add("dm-room-config-row");
+    let visual = row.querySelector(".dm-room-list-icon");
+    if (!visual) {
+      visual = doc.createElement("span");
+      visual.className = "dm-room-list-icon";
+      row.prepend(visual);
+    }
+    visual.innerHTML = roomMarkup(room, 34);
+    visual.dataset.roomIcon = clean(room.icon || "mdi:home");
+    visual.setAttribute("title", clean(room.name));
+  });
+  return true;
+}
+
+function temperatureForm() {
+  return doc?.querySelector("#editor-modal [data-temperature-form]") || null;
+}
+
+function isTemperatureEdit(form) {
+  return /^(modifica|edit)\b/i.test(clean(form?.querySelector("[data-temperature-form-title]")?.textContent));
+}
+
+function rebuildTemperatureRoomOptions(form, select) {
+  const rooms = configuredRooms();
+  if (!rooms.length) return;
+  const current = clean(select.value || form.dataset.dmOriginalRoom);
+  const options = rooms.map((room) => {
+    const id = clean(room.id || room.name);
+    const icon = clean(room.icon);
+    const marker = (clean(room.temp) || clean(room.hum)) && id !== current
+      ? (english() ? " — configured" : " — configurata")
+      : "";
+    const labelIcon = icon && !icon.startsWith("mdi:") ? `${icon} ` : "";
+    return `<option value="${esc(id)}" ${id === current ? "selected" : ""}>${labelIcon}${esc(room.name || id)}${marker}</option>`;
+  }).join("");
+  if (select.dataset.dmRoomOptionsSignature !== options) {
+    select.innerHTML = options;
+    select.dataset.dmRoomOptionsSignature = options;
+  }
+  if ([...select.options].some((option) => option.value === current)) select.value = current;
+}
+
+function repairTemperatureRoomSelect() {
+  const form = temperatureForm();
+  const select = form?.querySelector("#dm-temperature-room");
+  if (!form || !select || !isTemperatureEdit(form)) return false;
+
+  form.dataset.dmOriginalRoom ||= clean(select.value);
+  select.disabled = false;
+  select.removeAttribute("disabled");
+  select.removeAttribute("aria-disabled");
+  select.tabIndex = 0;
+  select.dataset.dmTemperatureRoomEditable = "true";
+  select.dataset.dmRealDeviceEditable = "true";
+  select.style.setProperty("pointer-events", "auto", "important");
+  select.style.setProperty("opacity", "1", "important");
+  select.style.setProperty("cursor", "pointer", "important");
+  select.style.setProperty("position", "relative", "important");
+  select.style.setProperty("z-index", "8", "important");
+  rebuildTemperatureRoomOptions(form, select);
+
+  if (select.dataset.dmPreOpenGuard !== "true") {
+    select.dataset.dmPreOpenGuard = "true";
+    for (const eventName of ["pointerdown", "touchstart", "mousedown", "focus"]) {
+      select.addEventListener(eventName, () => {
+        select.disabled = false;
+        select.removeAttribute("disabled");
+        select.style.setProperty("pointer-events", "auto", "important");
+      }, true);
+    }
+  }
+  return true;
+}
+
+function polishShutters() {
+  const page = doc?.getElementById("page-tapparelle");
+  if (!page) return false;
+  page.dataset.dmShutterDesign = "beta9-compact-real";
+
+  const grid = page.querySelector("#tapp-grid");
+  if (grid) {
+    grid.style.setProperty("display", "grid", "important");
+    grid.style.setProperty("grid-template-columns", "repeat(auto-fit,minmax(280px,360px))", "important");
+    grid.style.setProperty("justify-content", "center", "important");
+    grid.style.setProperty("align-items", "start", "important");
+    grid.style.setProperty("gap", "14px", "important");
+  }
+
+  page.querySelectorAll(".tapp-card").forEach((card) => {
+    card.classList.add("dm-beta9-real-shutter-card");
+    card.style.setProperty("width", "100%", "important");
+    card.style.setProperty("max-width", "360px", "important");
+    card.style.setProperty("min-height", "0", "important");
+    card.style.setProperty("padding", "14px", "important");
+    card.style.setProperty("gap", "10px", "important");
+    card.style.setProperty("border-radius", "20px", "important");
+    card.style.setProperty("animation", "none", "important");
+    card.style.setProperty("transform", "none", "important");
+  });
+
+  page.querySelectorAll(".tapp-win").forEach((windowNode) => {
+    windowNode.classList.add("dm-beta9-real-shutter-window");
+    windowNode.style.setProperty("height", "132px", "important");
+    windowNode.style.setProperty("min-height", "132px", "important");
+    windowNode.style.setProperty("max-height", "132px", "important");
+    windowNode.style.setProperty("margin", "0", "important");
+    windowNode.style.setProperty("animation", "none", "important");
+  });
+
+  page.querySelectorAll(".tapp-shutter").forEach((shutter) => {
+    shutter.style.setProperty("transition", "height .55s cubic-bezier(.2,.8,.2,1)", "important");
+    shutter.style.setProperty("filter", "none", "important");
+    shutter.style.setProperty("animation", "none", "important");
+  });
+  page.querySelectorAll(".tapp-shutter i").forEach((slat) => {
+    slat.style.setProperty("animation", "none", "important");
+    slat.style.setProperty("filter", "none", "important");
+    slat.style.setProperty("transform", "none", "important");
+  });
+  page.querySelectorAll(".tapp-btn").forEach((button) => {
+    button.style.setProperty("height", "40px", "important");
+    button.style.setProperty("min-height", "40px", "important");
+    button.style.setProperty("font-size", "12px", "important");
+    button.style.setProperty("border-radius", "12px", "important");
+  });
+  return true;
+}
+
+function shutterMoving() {
+  const storeCovers = dashboardStore()?.getSection?.("covers") || [];
+  const covers = Array.isArray(storeCovers) ? storeCovers : [];
+  const states = allStates();
+  return covers.some((cover) => {
+    const entity = clean(cover.entity || cover.entities?.[0]);
+    return ["opening", "closing"].includes(clean(states[entity]?.state).toLowerCase());
+  });
+}
+
+function classifyAlert(card) {
+  const name = clean(card.querySelector(".g-name")?.textContent || card.textContent).toLowerCase();
+  if (/tapparell|shutter/.test(name)) return shutterMoving() ? "shutter-moving" : "static";
+  if (/apertur|porta|finestr|door|window/.test(name)) return "opening";
+  if (/batt|battery/.test(name)) return "battery";
+  if (/antifurto|allarme|alarm|security|sicurezza/.test(name)) return "security";
+  if (/luce|light/.test(name)) return "light";
+  return "static";
+}
+
+function polishAlertAnimations() {
+  doc?.querySelectorAll?.("#page-home .glance-card").forEach((card) => {
+    const icon = card.querySelector(".g-icon-wrap");
+    if (!icon) return;
+    icon.classList.remove(
+      "anim-ping",
+      "dm-alert-opening",
+      "dm-alert-battery",
+      "dm-alert-security",
+      "dm-alert-light",
+      "dm-alert-shutter-moving",
+      "dm-alert-static",
+    );
+    const kind = classifyAlert(card);
+    icon.classList.add(`dm-alert-${kind}`);
+    icon.dataset.dmAlertMotion = kind;
+  });
+  return true;
+}
+
+function polishLightAddForm() {
+  const form = doc?.querySelector("#ed-body .dm-light-add-form[data-light-add-form]");
+  if (!form) return false;
+  form.dataset.dmLightAddLayout = "beta9-real";
+  const row = form.querySelector(":scope > .ed-form-row");
+  if (row) row.classList.add("dm-light-add-entity-row");
+  const entity = form.querySelector("#luce-add-ent");
+  const search = row?.querySelector(".dm-entity-picker");
+  const name = form.querySelector("#luce-add-name");
+  const add = form.querySelector(".ed-btn-add");
+  for (const input of [entity, name]) {
+    input?.style?.setProperty("width", "100%", "important");
+    input?.style?.setProperty("min-width", "0", "important");
+    input?.style?.setProperty("max-width", "100%", "important");
+  }
+  if (search) {
+    search.style.setProperty("position", "static", "important");
+    search.style.setProperty("transform", "none", "important");
+    search.style.setProperty("margin", "0", "important");
+  }
+  add?.style?.setProperty("width", "100%", "important");
+  return true;
+}
+
+function ensureStyleLast() {
+  const style = doc?.getElementById("dm-beta9-real-device-polish-style");
+  if (style && style.parentElement === doc.head && style !== doc.head.lastElementChild) doc.head.append(style);
+}
+
+function run() {
+  state.frame = 0;
+  installOwners();
+  ensureStyleLast();
+  polishQuickActions();
+  polishActionPicker();
+  bindEvAppearance();
+  polishBrandLogos();
+  polishRoomRows();
+  repairTemperatureRoomSelect();
+  polishShutters();
+  polishAlertAnimations();
+  polishLightAddForm();
+}
+
+function schedule() {
+  if (state.frame) return;
+  state.frame = root.requestAnimationFrame?.(run) || root.setTimeout?.(run, 0) || 0;
+}
+
+function scheduleAfterLegacyWork() {
+  schedule();
+  root.setTimeout?.(schedule, 0);
+  root.setTimeout?.(schedule, 70);
+}
+
+function installOwners() {
+  for (const name of [
+    "editorSwitch",
+    "buildQuickActions",
+    "renderTapparelle",
+    "buildTempCards",
+    "render",
+    "cdFillRoomSelects",
+  ]) wrapFunction(name, "__dmBeta9RealDevicePolish", scheduleAfterLegacyWork);
+}
+
+function subscribeStore() {
+  if (state.storeUnsubscribe) return;
+  const store = dashboardStore();
+  if (typeof store?.subscribe !== "function") return;
+  state.storeUnsubscribe = store.subscribe((change) => {
+    if (["rooms", "ev", "lights", "covers", "snapshot"].includes(change?.section))
+      scheduleAfterLegacyWork();
+  });
+}
+
+function installStyles() {
+  installStyle("dm-beta9-real-device-polish-style", `
+    html body #page-home #qa-grid .qa-btn .icon{
+      display:grid!important;place-items:center!important;width:58px!important;height:58px!important;
+      min-width:58px!important;min-height:58px!important;padding:0!important;border-radius:0!important;
+      background:transparent!important;box-shadow:none!important;line-height:1!important;overflow:visible!important
+    }
+    html body #page-home #qa-grid .qa-btn .icon .dm-v01525-action-glyph{
+      display:block!important;font-family:Apple Color Emoji,Segoe UI Emoji,Noto Color Emoji,sans-serif!important;
+      font-size:42px!important;line-height:1!important;filter:none!important
+    }
+    #dm-beta9-action-picker .dm-picker-visual,
+    #dm-visual-picker[data-kind="action"] .dm-picker-visual{
+      background:transparent!important;color:inherit!important
+    }
+    #dm-beta9-action-picker .dm-v01525-picker-glyph,
+    #dm-visual-picker[data-kind="action"] .dm-v01525-picker-glyph{
+      display:block!important;font-family:Apple Color Emoji,Segoe UI Emoji,Noto Color Emoji,sans-serif!important;
+      font-size:38px!important;line-height:1!important
+    }
+
+    #ed-body>[data-ev-appearance][data-dm-ev-top="true"]{order:-1000!important;margin-top:0!important}
+    [data-ev-appearance] .dm-brand-preview,
+    #dm-visual-picker[data-kind="car"] .dm-picker-visual{
+      background:#fff!important;color:#111827!important
+    }
+    [data-ev-appearance] .dm-car-brand,
+    #dm-visual-picker[data-kind="car"] .dm-car-brand,
+    #ev-car-picker .dm-car-brand{
+      color:#111827!important
+    }
+    [data-ev-appearance] img[data-dm-brand-image],
+    #dm-visual-picker[data-kind="car"] img[data-dm-brand-image],
+    #ev-car-picker img[data-dm-brand-image]{
+      display:block!important;width:100%!important;height:100%!important;max-width:100%!important;max-height:100%!important;
+      object-fit:contain!important;object-position:center!important;filter:grayscale(1) brightness(0)!important;opacity:1!important
+    }
+    #dm-visual-picker[data-kind="car"] .dm-picker-option{
+      min-height:116px!important;padding:12px 9px!important;overflow:hidden!important
+    }
+    #dm-visual-picker[data-kind="car"] .dm-picker-visual{
+      width:96px!important;height:58px!important;min-width:0!important;min-height:0!important;padding:7px!important;
+      border-radius:13px!important;overflow:hidden!important
+    }
+    #dm-visual-picker[data-kind="car"] .dm-picker-visual .dm-car-brand{
+      width:82px!important;max-width:82px!important;height:44px!important;max-height:44px!important;
+      padding:0!important;overflow:hidden!important
+    }
+    .dm-v10-brand-wordmark{
+      display:grid!important;place-items:center!important;width:100%!important;height:100%!important;padding:2px 4px!important;
+      color:#111827!important;font:900 clamp(9px,2.4vw,14px)/1 system-ui,sans-serif!important;
+      letter-spacing:-.3px!important;text-align:center!important;white-space:normal!important;overflow-wrap:anywhere!important
+    }
+
+    #ed-body .ed-row.dm-room-config-row{
+      display:grid!important;grid-template-columns:48px minmax(0,1fr) 44px 44px!important;
+      gap:9px!important;align-items:center!important;min-width:0!important;overflow:visible!important
+    }
+    #ed-body .dm-room-config-row>.dm-room-list-icon{
+      display:grid!important;grid-column:1!important;place-items:center!important;width:46px!important;height:46px!important;
+      min-width:46px!important;visibility:visible!important;opacity:1!important;border-radius:14px!important;
+      background:color-mix(in srgb,var(--primary-color,#0ea5e9) 10%,transparent)!important;
+      color:var(--primary-color,#0ea5e9)!important;overflow:hidden!important
+    }
+    #ed-body .dm-room-config-row>.ed-row-main{grid-column:2!important;display:block!important;min-width:0!important}
+
+    #editor-modal [data-temperature-form] #dm-temperature-room[data-dm-real-device-editable="true"]{
+      display:block!important;visibility:visible!important;opacity:1!important;pointer-events:auto!important;
+      position:relative!important;z-index:8!important;width:100%!important;min-height:54px!important;
+      cursor:pointer!important;touch-action:manipulation!important
+    }
+
+    html body #page-tapparelle[data-dm-shutter-design="beta9-compact-real"] #tapp-grid{
+      grid-template-columns:repeat(auto-fit,minmax(280px,360px))!important;
+      justify-content:center!important;align-items:start!important;gap:14px!important
+    }
+    html body #page-tapparelle[data-dm-shutter-design="beta9-compact-real"] .tapp-card.dm-beta9-real-shutter-card{
+      width:100%!important;max-width:360px!important;min-height:0!important;padding:14px!important;gap:10px!important;
+      border-radius:20px!important;animation:none!important;transform:none!important
+    }
+    html body #page-tapparelle[data-dm-shutter-design="beta9-compact-real"] .tapp-win.dm-beta9-real-shutter-window{
+      height:132px!important;min-height:132px!important;max-height:132px!important;margin:0!important;
+      border-radius:17px!important;animation:none!important
+    }
+    html body #page-tapparelle[data-dm-shutter-design="beta9-compact-real"] .tapp-shutter.opening i,
+    html body #page-tapparelle[data-dm-shutter-design="beta9-compact-real"] .tapp-shutter.closing i,
+    html body #page-tapparelle[data-dm-shutter-design="beta9-compact-real"] .tapp-shutter i{
+      animation:none!important;filter:none!important;transform:none!important
+    }
+    html body #page-tapparelle[data-dm-shutter-design="beta9-compact-real"] .tapp-shutter{
+      animation:none!important;filter:none!important;transition:height .55s cubic-bezier(.2,.8,.2,1)!important
+    }
+
+    #page-home .g-icon-wrap.dm-alert-static{animation:none!important;transform:none!important}
+    #page-home .g-icon-wrap.dm-alert-opening{animation:dmAlertOpening 1.8s ease-in-out infinite!important}
+    #page-home .g-icon-wrap.dm-alert-battery{animation:dmAlertBattery 2.4s ease-in-out infinite!important}
+    #page-home .g-icon-wrap.dm-alert-security{animation:dmAlertSecurity 1.6s ease-in-out infinite!important}
+    #page-home .g-icon-wrap.dm-alert-light{animation:dmAlertLight 2.2s ease-in-out infinite!important}
+    #page-home .g-icon-wrap.dm-alert-shutter-moving{animation:dmAlertShutterMove 1.25s ease-in-out infinite!important}
+    @keyframes dmAlertOpening{0%,100%{transform:rotate(-3deg)}50%{transform:rotate(3deg)}}
+    @keyframes dmAlertBattery{0%,100%{opacity:1}50%{opacity:.72}}
+    @keyframes dmAlertSecurity{0%,100%{transform:scale(1)}50%{transform:scale(1.055)}}
+    @keyframes dmAlertLight{0%,100%{filter:drop-shadow(0 0 0 transparent)}50%{filter:drop-shadow(0 0 7px rgba(245,158,11,.38))}}
+    @keyframes dmAlertShutterMove{0%,100%{transform:translateY(-2px)}50%{transform:translateY(2px)}}
+
+    #ed-body .dm-light-add-form[data-dm-light-add-layout="beta9-real"]{
+      display:grid!important;grid-template-columns:minmax(0,1fr)!important;gap:12px!important;
+      width:100%!important;max-width:100%!important;min-width:0!important;overflow:hidden!important
+    }
+    #ed-body .dm-light-add-form[data-dm-light-add-layout="beta9-real"]>.dm-light-add-entity-row{
+      display:grid!important;grid-template-columns:minmax(0,1fr) 58px!important;gap:9px!important;
+      width:100%!important;max-width:100%!important;min-width:0!important;align-items:stretch!important
+    }
+    #ed-body .dm-light-add-form[data-dm-light-add-layout="beta9-real"] #luce-add-ent,
+    #ed-body .dm-light-add-form[data-dm-light-add-layout="beta9-real"] #luce-add-name{
+      display:block!important;width:100%!important;min-width:0!important;max-width:100%!important;min-height:54px!important;margin:0!important
+    }
+    #ed-body .dm-light-add-form[data-dm-light-add-layout="beta9-real"] .dm-light-add-entity-row>.dm-entity-picker{
+      position:static!important;display:grid!important;place-items:center!important;width:58px!important;height:54px!important;
+      min-width:58px!important;max-width:58px!important;margin:0!important;padding:0!important;transform:none!important
+    }
+    #ed-body .dm-light-add-form[data-dm-light-add-layout="beta9-real"]>.ed-btn-add{
+      display:flex!important;width:100%!important;max-width:100%!important;min-height:54px!important;margin:0!important
+    }
+
+    @media(max-width:560px){
+      html body #page-home #qa-grid .qa-btn .icon{width:54px!important;height:54px!important;min-width:54px!important;min-height:54px!important}
+      html body #page-home #qa-grid .qa-btn .icon .dm-v01525-action-glyph{font-size:40px!important}
+      #dm-visual-picker[data-kind="car"] .dm-picker-grid{grid-template-columns:repeat(3,minmax(0,1fr))!important}
+      #dm-visual-picker[data-kind="car"] .dm-picker-visual{width:82px!important;height:52px!important}
+      #dm-visual-picker[data-kind="car"] .dm-picker-visual .dm-car-brand{width:70px!important;height:39px!important}
+      html body #page-tapparelle[data-dm-shutter-design="beta9-compact-real"] #tapp-grid{
+        grid-template-columns:minmax(0,360px)!important;justify-content:center!important
+      }
+      html body #page-tapparelle[data-dm-shutter-design="beta9-compact-real"] .tapp-card.dm-beta9-real-shutter-card{
+        max-width:360px!important
+      }
+    }
+    @media(prefers-reduced-motion:reduce){
+      #page-home .g-icon-wrap[class*="dm-alert-"]{animation:none!important}
+    }
+  `);
+}
+
+export function installBeta9RealDevicePolishSection() {
+  if (!doc || state.installed) return;
+  state.installed = true;
+  installStyles();
+  installOwners();
+  subscribeStore();
+
+  for (const name of [
+    "dashboardmodern:legacy-ready",
+    "dashboardmodern:runtime-ready",
+    "dashboardmodern:states-ready",
+  ]) root.addEventListener?.(name, () => {
+    installOwners();
+    subscribeStore();
+    scheduleAfterLegacyWork();
+  });
+
+  root.addEventListener?.("dashboardmodern:state-changed", (event) => {
+    const id = clean(event?.detail?.entity_id);
+    if (/^(cover|binary_sensor|sensor|light)\./.test(id)) schedule();
+  });
+
+  doc.addEventListener("click", (event) => {
+    if (event.target?.closest?.(
+      '.ed-tab[data-tab="sez2"],.ed-tab[data-tab="stanze"],.ed-tab[data-tab="sez7"],.ed-tab[data-tab="luci"],.tab[data-tab="tapparelle"],.dm-beta6-qa-icon-trigger,[data-brand-preview]',
+    )) scheduleAfterLegacyWork();
+  }, true);
+
+  doc.addEventListener("error", (event) => {
+    if (event.target?.matches?.("img[data-dm-brand-image]")) scheduleAfterLegacyWork();
+  }, true);
+
+  scheduleAfterLegacyWork();
+}
+
+installBeta9RealDevicePolishSection();

--- a/custom_components/dashboardmodern/frontend/tests/beta6-feedback.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta6-feedback.test.js
@@ -10,7 +10,13 @@ test("feedback layer keeps legacy quick-action defaults while beta9 owns stable 
   const feedback = await read("src/sections/beta6-feedback-section.js");
   const guard = await read("src/sections/beta7-brand-guard-section.js");
   assert.match(entry, /beta4-mobile-polish-section\.js";\nimport "\.\/beta6-feedback-section\.js";/);
-  assert.doesNotMatch(entry, /quickActionGlyphByType|buildQuickActions|dm-beta6-quick-action-layout/);
+  assert.doesNotMatch(entry, /quickActionGlyphByType|dm-beta6-quick-action-layout/);
+  assert.match(entry, /__dmV01525GlyphRepair/);
+  assert.match(entry, /dmBeta7IconToken/);
+  assert.match(entry, /"mdi:lightbulb": "💡"/);
+  assert.match(entry, /"mdi:snowflake": "❄️"/);
+  assert.match(entry, /"mdi:shield-home": "🛡️"/);
+  assert.match(entry, /"mdi:washing-machine": "🧺"/);
   assert.match(feedback, /luci_group:\{glyph:"💡",mdi:"mdi:lightbulb-group"\}/);
   assert.match(feedback, /builtin_clima:\{glyph:"❄️",mdi:"mdi:snowflake"\}/);
   assert.match(feedback, /builtin_antifurto:\{glyph:"🛡️",mdi:"mdi:shield-home"\}/);

--- a/custom_components/dashboardmodern/frontend/tests/beta9-real-device-polish.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta9-real-device-polish.test.js
@@ -63,5 +63,5 @@ test("add-light layout cannot collapse its entity field", async () => {
   assert.match(source, /dm-light-add-entity-row/);
   assert.match(source, /grid-template-columns:minmax\(0,1fr\) 58px!important/);
   assert.match(source, /#luce-add-ent/);
-  assert.match(source, /position","static","important"/);
+  assert.match(source, /setProperty\("position", "static", "important"\)/);
 });

--- a/custom_components/dashboardmodern/frontend/tests/beta9-real-device-polish.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta9-real-device-polish.test.js
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const entryUrl = new URL("../src/sections/beta-entry-section.js", import.meta.url);
+const polishUrl = new URL("../src/sections/beta9-real-device-polish-section.js", import.meta.url);
+
+test("beta9 real-device polish loads after the older beta7 compatibility layers", async () => {
+  const entry = await readFile(entryUrl, "utf8");
+  const regression = entry.indexOf('import "./beta7-regression-section.js"');
+  const finalPolish = entry.indexOf('import "./beta9-real-device-polish-section.js"');
+  assert.ok(regression >= 0);
+  assert.ok(finalPolish > regression);
+});
+
+test("quick actions restore the v0.15.25 colorful glyph contract", async () => {
+  const source = await readFile(polishUrl, "utf8");
+  assert.match(source, /luci: \{ glyph: "💡", color: "#f59e0b" \}/);
+  assert.match(source, /clima: \{ glyph: "❄️", color: "#0ea5e9" \}/);
+  assert.match(source, /antifurto: \{ glyph: "🛡️", color: "#7c3aed" \}/);
+  assert.match(source, /lavatrice: \{ glyph: "🧺", color: "#0ea5e9" \}/);
+  assert.match(source, /dm-v01525-action-glyph/);
+  assert.match(source, /drop-shadow\(0 6px 12px/);
+  assert.match(source, /azioni\\s\+rapide\\s\+premium/);
+});
+
+test("EV brand dropdown owns logo preview and model options and stays at the top", async () => {
+  const source = await readFile(polishUrl, "utf8");
+  assert.match(source, /body\.prepend\(panel\)/);
+  assert.match(source, /brandSelect\.addEventListener\("input", syncBrand\)/);
+  assert.match(source, /brandSelect\.addEventListener\("change", syncBrand\)/);
+  assert.match(source, /modelSelect\.innerHTML = modelOptions\(brand, keep\)/);
+  assert.match(source, /"Leapmotor": \["T03", "B10", "C10", "C10 REEV"\]/);
+  assert.match(source, /"MINI": \["Cooper Electric", "Aceman", "Countryman Electric"\]/);
+  assert.match(source, /filter:grayscale\(1\) brightness\(0\)!important/);
+  assert.match(source, /dm-v10-brand-wordmark/);
+});
+
+test("room and temperature editors are repaired without a global observer", async () => {
+  const source = await readFile(polishUrl, "utf8");
+  assert.match(source, /dm-room-config-row/);
+  assert.match(source, /visual\.innerHTML = roomMarkup\(room, 34\)/);
+  assert.match(source, /select\.disabled = false/);
+  assert.match(source, /select\.removeAttribute\("disabled"\)/);
+  assert.match(source, /pointer-events", "auto", "important"/);
+  assert.doesNotMatch(source, /MutationObserver/);
+  assert.doesNotMatch(source, /setInterval\s*\(/);
+});
+
+test("shutters are compact and alert animations follow the alert kind", async () => {
+  const source = await readFile(polishUrl, "utf8");
+  assert.match(source, /max-width", "360px", "important"/);
+  assert.match(source, /height", "132px", "important"/);
+  assert.match(source, /slat\.style\.setProperty\("animation", "none", "important"\)/);
+  assert.match(source, /shutterMoving\(\) \? "shutter-moving" : "static"/);
+  assert.match(source, /dmAlertOpening/);
+  assert.match(source, /dmAlertBattery/);
+  assert.match(source, /dmAlertSecurity/);
+});
+
+test("add-light layout cannot collapse its entity field", async () => {
+  const source = await readFile(polishUrl, "utf8");
+  assert.match(source, /dm-light-add-entity-row/);
+  assert.match(source, /grid-template-columns:minmax\(0,1fr\) 58px!important/);
+  assert.match(source, /#luce-add-ent/);
+  assert.match(source, /position","static","important"/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -1,87 +1,82 @@
 import assert from "node:assert/strict";
+import { access, readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { readFile, readdir } from "node:fs/promises";
+import test from "node:test";
 
-const here = path.dirname(fileURLToPath(import.meta.url));
-const frontendRoot = path.resolve(here, "..");
-const repoRoot = path.resolve(frontendRoot, "../../../..");
-
-async function exists(file) {
-  try {
-    await readFile(file);
-    return true;
-  } catch {
-    return false;
-  }
-}
+const frontendRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const staticImportPattern = /(?:import|export)\s+(?:[^"']*?\s+from\s+)?["']([^"']+)["']/g;
+const dynamicImportPattern = /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g;
+const productionEntries = Object.freeze([
+  "legacy/config.js",
+  "legacy/modules-entry.js",
+  "panel.js",
+  "dashboard-card.js",
+]);
+const obsoleteFacades = Object.freeze([
+  "src/sections/home-section.js",
+  "src/sections/climate-section.js",
+  "src/sections/security-section.js",
+  "src/sections/solar-thermal-section.js",
+  "src/sections/pool-section.js",
+  "src/sections/irrigation-section.js",
+  "src/sections/minipc-section.js",
+  "src/sections/legacy-section-adapter.js",
+  "legacy/report-mobile-fixes.js",
+]);
 
 async function filesBelow(directory) {
-  const out = [];
+  const output = [];
   for (const entry of await readdir(directory, { withFileTypes: true })) {
-    const file = path.join(directory, entry.name);
-    if (entry.isDirectory()) out.push(...(await filesBelow(file)));
-    else out.push(file);
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) output.push(...(await filesBelow(absolute)));
+    else output.push(absolute);
   }
-  return out;
+  return output;
 }
 
-function importTargets(source) {
-  const values = new Set();
-  for (const match of source.matchAll(/(?:import\s+(?:[^"']+?\s+from\s+)?|import\s*\()\s*["']([^"']+)["']/g))
-    values.add(match[1]);
-  return [...values];
-}
-
-async function productionGraph() {
-  const roots = [
-    path.join(frontendRoot, "legacy", "dashboard.html"),
-    path.join(frontendRoot, "legacy", "dashboard-en.html"),
-    path.join(frontendRoot, "dashboard-card.js"),
-    path.join(frontendRoot, "panel.js"),
+function importSpecifiers(source) {
+  return [
+    ...[...source.matchAll(staticImportPattern)].map((match) => match[1]),
+    ...[...source.matchAll(dynamicImportPattern)].map((match) => match[1]),
   ];
-  const queue = [...roots];
+}
+
+async function productionGraph(entries = productionEntries) {
   const seen = new Map();
   const edges = new Map();
-  while (queue.length) {
-    const file = path.resolve(queue.shift());
-    if (seen.has(file) || !(await exists(file))) continue;
-    const source = await readFile(file, "utf8");
-    seen.set(file, source);
-    const deps = [];
-    for (const specifier of importTargets(source)) {
+
+  async function visit(file) {
+    const normalized = path.normalize(file);
+    if (seen.has(normalized)) return;
+    const source = await readFile(normalized, "utf8");
+    seen.set(normalized, source);
+    const dependencies = [];
+    edges.set(normalized, dependencies);
+    for (const specifier of importSpecifiers(source)) {
       if (!specifier.startsWith(".")) continue;
-      const resolved = path.resolve(path.dirname(file), specifier);
-      const candidates = [resolved, `${resolved}.js`, path.join(resolved, "index.js")];
-      const dependency = candidates.find((candidate) => path.extname(candidate) === ".js" && path.relative(frontendRoot, candidate).startsWith("..") === false)
-        || candidates.find((candidate) => path.extname(candidate) === ".html" && path.relative(frontendRoot, candidate).startsWith("..") === false);
-      if (!dependency || !(await exists(dependency))) continue;
-      deps.push(dependency);
-      queue.push(dependency);
+      let next = path.resolve(path.dirname(normalized), specifier);
+      if (!path.extname(next)) next += ".js";
+      next = path.normalize(next);
+      dependencies.push(next);
+      await visit(next);
     }
-    if (file.endsWith(".html")) {
-      for (const match of source.matchAll(/<script\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi)) {
-        const specifier = match[1].split(/[?#]/, 1)[0];
-        if (!specifier.startsWith(".")) continue;
-        const dependency = path.resolve(path.dirname(file), specifier);
-        if (path.relative(frontendRoot, dependency).startsWith("..") === false && await exists(dependency)) {
-          deps.push(dependency);
-          queue.push(dependency);
-        }
-      }
-    }
-    edges.set(file, deps);
   }
+
+  for (const entry of entries) await visit(path.resolve(frontendRoot, entry));
   return { seen, edges };
 }
 
 function assertAcyclic(edges) {
-  const complete = new Set();
   const active = new Set();
+  const complete = new Set();
   function visit(file, chain = []) {
     if (complete.has(file)) return;
     if (active.has(file)) {
-      assert.fail(`production import cycle: ${[...chain, file].map((value) => path.basename(value)).join(" -> ")}`);
+      const cycle = [...chain, file]
+        .map((item) => path.relative(frontendRoot, item).replaceAll("\\", "/"))
+        .join(" -> ");
+      assert.fail(`production import cycle: ${cycle}`);
     }
     active.add(file);
     for (const dependency of edges.get(file) || []) visit(dependency, [...chain, file]);
@@ -116,9 +111,9 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // v1 beta adds the persistence owner plus substantive UI owners. Beta4/Beta5
   // keep one scoped mobile-polish owner; Beta6 adds one event-driven feedback
   // owner. Beta7 adds exactly two scoped, event-driven guards for real WebView
-  // failures. Beta9 adds one final event-driven real-device reconciler for the
-  // screenshot-proven EV/editor/shutter conflicts; it adds no polling or global
-  // observer and is intentionally the last visual authority in beta-entry.
+  // failures: brand-image fallback and the final mobile regression polish.
+  // Beta9 adds one final scoped event-driven real-device reconciler for the
+  // screenshot-proven EV/editor/shutter conflicts, with no polling or observer.
   assert.ok(relative.length <= 65, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
@@ -135,14 +130,15 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
 
   const srcRoot = path.join(frontendRoot, "src");
   const srcFiles = (await filesBelow(srcRoot)).filter((file) => file.endsWith(".js"));
-  const orphaned = srcFiles
-    .filter((file) => !graph.has(path.resolve(file)))
-    .map((file) => path.relative(frontendRoot, file).replaceAll("\\", "/"));
-  assert.deepEqual(orphaned, [], `orphan production modules: ${orphaned.join(", ")}`);
-
-  const forbiddenArtifacts = (await filesBelow(repoRoot))
-    .map((file) => path.relative(repoRoot, file).replaceAll("\\", "/"))
-    .filter((file) => /(?:^|\/)(?:playwright-report|test-results|node_modules)(?:\/|$)|\.(?:bak|orig|tmp|old)$/.test(file))
-    .filter((file) => !file.startsWith(".git/"));
-  assert.deepEqual(forbiddenArtifacts, []);
+  const srcOrphans = srcFiles
+    .filter((file) => !graph.has(path.normalize(file)))
+    .map((file) => path.relative(frontendRoot, file).replaceAll("\\", "/"))
+    .sort();
+  assert.deepEqual(srcOrphans, [], `orphan src modules:\n${srcOrphans.join("\n")}`);
 });
+
+for (const relative of obsoleteFacades) {
+  test(`${relative} is physically absent`, async () => {
+    await assert.rejects(access(path.join(frontendRoot, relative)));
+  });
+}

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -1,82 +1,87 @@
 import assert from "node:assert/strict";
-import { access, readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import test from "node:test";
+import { readFile, readdir } from "node:fs/promises";
 
-const frontendRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const staticImportPattern = /(?:import|export)\s+(?:[^"']*?\s+from\s+)?["']([^"']+)["']/g;
-const dynamicImportPattern = /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g;
-const productionEntries = Object.freeze([
-  "legacy/config.js",
-  "legacy/modules-entry.js",
-  "panel.js",
-  "dashboard-card.js",
-]);
-const obsoleteFacades = Object.freeze([
-  "src/sections/home-section.js",
-  "src/sections/climate-section.js",
-  "src/sections/security-section.js",
-  "src/sections/solar-thermal-section.js",
-  "src/sections/pool-section.js",
-  "src/sections/irrigation-section.js",
-  "src/sections/minipc-section.js",
-  "src/sections/legacy-section-adapter.js",
-  "legacy/report-mobile-fixes.js",
-]);
+const here = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(here, "..");
+const repoRoot = path.resolve(frontendRoot, "../../../..");
+
+async function exists(file) {
+  try {
+    await readFile(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 async function filesBelow(directory) {
-  const output = [];
+  const out = [];
   for (const entry of await readdir(directory, { withFileTypes: true })) {
-    const absolute = path.join(directory, entry.name);
-    if (entry.isDirectory()) output.push(...(await filesBelow(absolute)));
-    else output.push(absolute);
+    const file = path.join(directory, entry.name);
+    if (entry.isDirectory()) out.push(...(await filesBelow(file)));
+    else out.push(file);
   }
-  return output;
+  return out;
 }
 
-function importSpecifiers(source) {
-  return [
-    ...[...source.matchAll(staticImportPattern)].map((match) => match[1]),
-    ...[...source.matchAll(dynamicImportPattern)].map((match) => match[1]),
+function importTargets(source) {
+  const values = new Set();
+  for (const match of source.matchAll(/(?:import\s+(?:[^"']+?\s+from\s+)?|import\s*\()\s*["']([^"']+)["']/g))
+    values.add(match[1]);
+  return [...values];
+}
+
+async function productionGraph() {
+  const roots = [
+    path.join(frontendRoot, "legacy", "dashboard.html"),
+    path.join(frontendRoot, "legacy", "dashboard-en.html"),
+    path.join(frontendRoot, "dashboard-card.js"),
+    path.join(frontendRoot, "panel.js"),
   ];
-}
-
-async function productionGraph(entries = productionEntries) {
+  const queue = [...roots];
   const seen = new Map();
   const edges = new Map();
-
-  async function visit(file) {
-    const normalized = path.normalize(file);
-    if (seen.has(normalized)) return;
-    const source = await readFile(normalized, "utf8");
-    seen.set(normalized, source);
-    const dependencies = [];
-    edges.set(normalized, dependencies);
-    for (const specifier of importSpecifiers(source)) {
+  while (queue.length) {
+    const file = path.resolve(queue.shift());
+    if (seen.has(file) || !(await exists(file))) continue;
+    const source = await readFile(file, "utf8");
+    seen.set(file, source);
+    const deps = [];
+    for (const specifier of importTargets(source)) {
       if (!specifier.startsWith(".")) continue;
-      let next = path.resolve(path.dirname(normalized), specifier);
-      if (!path.extname(next)) next += ".js";
-      next = path.normalize(next);
-      dependencies.push(next);
-      await visit(next);
+      const resolved = path.resolve(path.dirname(file), specifier);
+      const candidates = [resolved, `${resolved}.js`, path.join(resolved, "index.js")];
+      const dependency = candidates.find((candidate) => path.extname(candidate) === ".js" && path.relative(frontendRoot, candidate).startsWith("..") === false)
+        || candidates.find((candidate) => path.extname(candidate) === ".html" && path.relative(frontendRoot, candidate).startsWith("..") === false);
+      if (!dependency || !(await exists(dependency))) continue;
+      deps.push(dependency);
+      queue.push(dependency);
     }
+    if (file.endsWith(".html")) {
+      for (const match of source.matchAll(/<script\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi)) {
+        const specifier = match[1].split(/[?#]/, 1)[0];
+        if (!specifier.startsWith(".")) continue;
+        const dependency = path.resolve(path.dirname(file), specifier);
+        if (path.relative(frontendRoot, dependency).startsWith("..") === false && await exists(dependency)) {
+          deps.push(dependency);
+          queue.push(dependency);
+        }
+      }
+    }
+    edges.set(file, deps);
   }
-
-  for (const entry of entries) await visit(path.resolve(frontendRoot, entry));
   return { seen, edges };
 }
 
 function assertAcyclic(edges) {
-  const active = new Set();
   const complete = new Set();
+  const active = new Set();
   function visit(file, chain = []) {
     if (complete.has(file)) return;
     if (active.has(file)) {
-      const cycle = [...chain, file]
-        .map((item) => path.relative(frontendRoot, item).replaceAll("\\", "/"))
-        .join(" -> ");
-      assert.fail(`production import cycle: ${cycle}`);
+      assert.fail(`production import cycle: ${[...chain, file].map((value) => path.basename(value)).join(" -> ")}`);
     }
     active.add(file);
     for (const dependency of edges.get(file) || []) visit(dependency, [...chain, file]);
@@ -111,8 +116,10 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // v1 beta adds the persistence owner plus substantive UI owners. Beta4/Beta5
   // keep one scoped mobile-polish owner; Beta6 adds one event-driven feedback
   // owner. Beta7 adds exactly two scoped, event-driven guards for real WebView
-  // failures: brand-image fallback and the final mobile regression polish.
-  assert.ok(relative.length <= 64, `production graph unexpectedly grew to ${relative.length} modules`);
+  // failures. Beta9 adds one final event-driven real-device reconciler for the
+  // screenshot-proven EV/editor/shutter conflicts; it adds no polling or global
+  // observer and is intentionally the last visual authority in beta-entry.
+  assert.ok(relative.length <= 65, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 
@@ -128,15 +135,14 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
 
   const srcRoot = path.join(frontendRoot, "src");
   const srcFiles = (await filesBelow(srcRoot)).filter((file) => file.endsWith(".js"));
-  const srcOrphans = srcFiles
-    .filter((file) => !graph.has(path.normalize(file)))
-    .map((file) => path.relative(frontendRoot, file).replaceAll("\\", "/"))
-    .sort();
-  assert.deepEqual(srcOrphans, [], `orphan src modules:\n${srcOrphans.join("\n")}`);
-});
+  const orphaned = srcFiles
+    .filter((file) => !graph.has(path.resolve(file)))
+    .map((file) => path.relative(frontendRoot, file).replaceAll("\\", "/"));
+  assert.deepEqual(orphaned, [], `orphan production modules: ${orphaned.join(", ")}`);
 
-for (const relative of obsoleteFacades) {
-  test(`${relative} is physically absent`, async () => {
-    await assert.rejects(access(path.join(frontendRoot, relative)));
-  });
-}
+  const forbiddenArtifacts = (await filesBelow(repoRoot))
+    .map((file) => path.relative(repoRoot, file).replaceAll("\\", "/"))
+    .filter((file) => /(?:^|\/)(?:playwright-report|test-results|node_modules)(?:\/|$)|\.(?:bak|orig|tmp|old)$/.test(file))
+    .filter((file) => !file.startsWith(".git/"));
+  assert.deepEqual(forbiddenArtifacts, []);
+});


### PR DESCRIPTION
Correzione mirata ai difetti ancora riprodotti sulla vera installazione Home Assistant dopo #87/#88.

Include:
- Azioni rapide: ripristino della tipologia visiva della v0.15.25 (glifi/emoji a colori con ombra), rimozione del residuo “Premium” e picker coerente.
- EV: blocco brand/modello spostato in cima alla configurazione vettura; il cambio del menu Marchio aggiorna direttamente logo e catalogo modelli; fallback logo leggibile; marchi normalizzati a un unico colore/viewport per evitare clipping e loghi invisibili.
- Stanze: icona persistita resa visibile nella lista configurata senza dipendere da `:has()`.
- Temperatura: select Stanza realmente abilitato in modifica, opzioni canoniche ricostruite e pointer interaction protetta dai reset legacy.
- Tapparelle: card mobile limitata a 360 px, finestra 132 px, rimosso il vecchio pulse/brightness delle lamelle; resta solo la transizione dell’avvolgibile.
- Avvisi: niente ping generico; movimento coerente per aperture, batteria, sicurezza, luci e tapparella in movimento; tapparella semplicemente aperta resta statica.
- Luci: form Aggiungi luce ricomposto con entità + lente su due colonne e nome/CTA a larghezza piena.
- Nuovi contract test e Browser E2E basati sui difetti esatti degli screenshot reali.

Nessun polling permanente, nessun MutationObserver globale. Questa PR va unita nella branch release beta.9 solo con tutti i gate verdi.