### PR TITLE
chore: release v1.0.0-beta.10

### DIFF
--- a/custom_components/dashboardmodern/frontend/src/sections/beta-compat-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta-compat-section.js
@@ -84,7 +84,7 @@ function install() {
 
   const style = doc.createElement("style");
   style.id = "dm-beta-room-picker-style";
-  style.textContent = `.dm-beta-room-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(70px,1fr));gap:10px;padding:12px 18px 20px;max-height:55vh;overflow:auto}.dm-beta-room-grid button{min-height:62px;border:1px solid var(--divider-color,#dbe4ee);border-radius:15px;background:var(--card-background-color,#fff);font-size:28px;cursor:pointer}.dm-beta-room-grid button:hover{border-color:var(--primary-color,#0ea5e9);transform:translateY(-1px)}.dm-beta-room-grid button[hidden]{display:none!important}`;
+  style.textContent = `.dm-beta-room-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(70px,1fr));gap:10px;padding:12px 18px 20px;max-height:55vh;overflow:auto}.dm-beta-room-grid button{min-height:62px;border:1px solid var(--divider-color,#dbe4ee);border-radius:15px;background:var(--card-background-color,#fff);font-size:28px;cursor:pointer}.dm-beta-room-grid button:hover{border-color:var(--primary-color,#0ea5e9);transform:translateY(-1px)}.dm-beta-room-grid button[hidden]{display:none!important}#ed-body:has(>[data-ev-appearance]){display:flex!important;flex-direction:column!important}#ed-body:has(>[data-ev-appearance])>[data-ev-appearance]{order:-10000!important}`;
   doc.head?.append(style);
 }
 

--- a/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
@@ -23,7 +23,7 @@ const refreshUrl = new URL("../src/sections/energy-refresh-section.js", import.m
 const analysisUrl = new URL("../src/sections/energy-analysis-section.js", import.meta.url);
 const contractsUrl = new URL("../src/sections/editor-contracts-section.js", import.meta.url);
 
-const RELEASE_VERSION = "1.0.0-beta.9";
+const RELEASE_VERSION = "1.0.0-beta.10";
 
 test("the 1.0 beta release metadata is consistently versioned", async () => {
   const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
@@ -40,8 +40,8 @@ test("the 1.0 beta release metadata is consistently versioned", async () => {
     /https:\/\/raw\.githubusercontent\.com\/danigio15\/dashboardmodern-v2\/main\/brand\/logo\.png/,
   );
   assert.doesNotMatch(readme, /main\/assets\/logo|brand\/logo@2x\.png/);
-  assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']1\.0\.0-beta\.9["']/);
-  assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']1\.0\.0-beta\.9["']/);
+  assert.match(buildInfo, /["']?integrationVersion["']?\s*:\s*["']1\.0\.0-beta\.10["']/);
+  assert.match(buildInfo, /["']?dashboardVersion["']?\s*:\s*["']1\.0\.0-beta\.10["']/);
   assert.match(buildInfo, /["']?moduleVersion["']?\s*:\s*14/);
 });
 

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.9"
+  "version": "1.0.0-beta.10"
 }


### PR DESCRIPTION
Nuova prerelease necessaria perché v1.0.0-beta.9 era già stata pubblicata prima delle correzioni real-device poi mergiate in main. Questa PR porta il manifest a 1.0.0-beta.10 e aggiorna il contract test di versione; il codice funzionale incluso è quello già validato e mergiato tramite #89/#90.