### PR TITLE
test: elimina race WebKit nel gate piscina beta.18

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/beta13-real-device-regressions.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta13-real-device-regressions.spec.js
@@ -285,7 +285,11 @@ test("beta13: Pool uses equal mobile controls and keeps temperature copy clear o
     renderPiscina();
   });
 
-  const layout = await page.locator("#page-piscina .pool-hero").evaluate((hero) => {
+  const hero = page.locator("#page-piscina .pool-hero");
+  await expect(hero).toBeVisible();
+  await expect(hero).toHaveAttribute("data-dm-beta16-pool", "true");
+
+  const layout = await hero.evaluate((hero) => {
     const controls = [...hero.querySelectorAll(".pool-tg[data-act]")].map((node) =>
       node.getBoundingClientRect(),
     );


### PR DESCRIPTION
Corregge l'unico fallimento del workflow Release #69 su WebKit/iPad.

Causa: il test della piscina misurava `getBoundingClientRect()` nello stesso turno di `renderPiscina()`, mentre l'owner Beta16 applica il layout finale al frame successivo. Su WebKit il test poteva quindi leggere temporaneamente larghezze pari a 0.

Modifica:
- attende che `.pool-hero` sia visibile;
- attende `data-dm-beta16-pool="true"`, cioè l'owner finale Beta16;
- mantiene intatte tutte le soglie reali su larghezza dei 3 controlli, uniformità, copy, separazione e overflow.

Nessuna modifica al runtime e nessun indebolimento delle verifiche funzionali.