### PR TITLE
test: stabilizza i gate WebKit della beta.18

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/beta13-real-device-regressions.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta13-real-device-regressions.spec.js
@@ -285,7 +285,11 @@ test("beta13: Pool uses equal mobile controls and keeps temperature copy clear o
     renderPiscina();
   });
 
-  const layout = await page.locator("#page-piscina .pool-hero").evaluate((hero) => {
+  const hero = page.locator("#page-piscina .pool-hero");
+  await expect(hero).toBeVisible();
+  await expect(hero).toHaveAttribute("data-dm-beta16-pool", "true");
+
+  const layout = await hero.evaluate((hero) => {
     const controls = [...hero.querySelectorAll(".pool-tg[data-act]")].map((node) =>
       node.getBoundingClientRect(),
     );

--- a/custom_components/dashboardmodern/frontend/e2e/beta17-final-icon-polish.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta17-final-icon-polish.spec.js
@@ -121,6 +121,20 @@ async function openEditor(page, tab) {
   await expect(page.locator(`.ed-tab[data-tab="${tab}"]`)).toHaveClass(/active/);
 }
 
+async function waitForIconEngine(page) {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            typeof window.DashboardModernIconEngine?.render === "function" &&
+            typeof window.DashboardModernIconEngine?.openPicker === "function",
+        ),
+      { timeout: 15_000 },
+    )
+    .toBe(true);
+}
+
 async function pickerPalette(page) {
   return page
     .locator('#dm-visual-picker[data-kind="room"] .dm-picker-option')
@@ -172,6 +186,7 @@ test("beta17: Temperature hides progress copy", async ({ page }, testInfo) => {
 test("beta17: Action picker is colored from first mutation", async ({ page }, testInfo) => {
   test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
   await boot(page, testInfo);
+  await waitForIconEngine(page);
   await page.evaluate(() => {
     localStorage.setItem(
       "cd_quick_actions",
@@ -234,6 +249,7 @@ test("beta17: Action picker is colored from first mutation", async ({ page }, te
 test("beta17: room add/edit share one color picker", async ({ page }, testInfo) => {
   test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
   await boot(page, testInfo);
+  await waitForIconEngine(page);
   await openEditor(page, "stanze");
 
   const firstInsert = page.locator("#ed-body .dm-beta5-room-icon-trigger");


### PR DESCRIPTION
Sostituisce la #101 e contiene entrambe le sincronizzazioni necessarie ai gate WebKit della beta.18.

1. Piscina: attende che l'owner Beta16 abbia applicato il layout finale (`data-dm-beta16-pool="true"`) prima di misurare i tre controlli. Tutte le soglie su larghezza, uniformità, separazione e overflow restano invariate.
2. Icon picker Beta17: attende che `DashboardModernIconEngine` esponga `render` e `openPicker` prima di eseguire le asserzioni specifiche del motore. Restano invariate le verifiche zero SVG/ha-icon e first-mutation già colorata.

Nessuna modifica al runtime applicativo e nessun indebolimento delle verifiche funzionali.