### PR TITLE
chore: retrigger beta.18 release

### DIFF
--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -1,7 +1,9 @@
 {
   "domain": "dashboardmodern",
   "name": "Dashboard Modern V2",
-  "codeowners": ["@danigio15"],
+  "codeowners": [
+    "@danigio15"
+  ],
   "config_flow": true,
   "dependencies": ["http"],
   "documentation": "https://github.com/danigio15/dashboardmodern-v2",


### PR DESCRIPTION
Retrigger della pipeline Release dopo il merge dei fix WebKit della PR #102.

Modifica esclusivamente la formattazione JSON di `codeowners` in `custom_components/dashboardmodern/manifest.json`; tutti i valori restano identici e la versione resta `1.0.0-beta.18`.

`release.yml` è configurato per partire su push a `main` quando cambia il manifest, quindi questo commit serve unicamente ad avviare il nuovo gate completo di release sul codice corretto.