### PR TITLE
test: chiude la race editor/icon engine della beta.18

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/beta17-final-icon-polish.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta17-final-icon-polish.spec.js
@@ -128,7 +128,8 @@ async function waitForIconEngine(page) {
         page.evaluate(
           () =>
             typeof window.DashboardModernIconEngine?.render === "function" &&
-            typeof window.DashboardModernIconEngine?.openPicker === "function",
+            typeof window.DashboardModernIconEngine?.openPicker === "function" &&
+            Boolean(document.getElementById("dm-unified-editor-visual-style")),
         ),
       { timeout: 15_000 },
     )

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -1,7 +1,9 @@
 {
   "domain": "dashboardmodern",
   "name": "Dashboard Modern V2",
-  "codeowners": ["@danigio15"],
+  "codeowners": [
+    "@danigio15"
+  ],
   "config_flow": true,
   "dependencies": ["http"],
   "documentation": "https://github.com/danigio15/dashboardmodern-v2",


### PR DESCRIPTION
Sostituisce la #103 e mantiene il retrigger del manifest necessario ad avviare `release.yml`.

Correzione aggiuntiva: il test Beta17 attende non solo `DashboardModernIconEngine`, ma anche l'installazione dell'editor unificato (`#dm-unified-editor-visual-style`) prima di cliccare una riga azione/stanza. Questo elimina la finestra in cui il legacy editor può aprirsi prima che il listener capture canonico sia registrato.

Le asserzioni restano invariate: zero SVG/ha-icon, glyph canonico già presente e picker colorato dalla prima mutation. Nessuna soglia allentata e nessuna modifica al runtime applicativo.

Il manifest conserva `1.0.0-beta.18`; cambia solo whitespace per retriggerare la pipeline Release dopo il merge.