### PR TITLE
fix: stabilizza single owner icone beta.18

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/beta13-real-device-regressions.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta13-real-device-regressions.spec.js
@@ -185,10 +185,10 @@ test("beta13: room rows and action picker never expose a second vector/pseudo ic
   const picker = page.locator('#dm-visual-picker[data-kind="action"]');
   await expect(picker).toBeVisible();
   await expect(picker).toHaveAttribute("data-dm-single-glyph-owner", "true");
-  const first = picker.locator('.dm-picker-option[data-index="0"] .dm-beta12-action-glyph');
-  await expect(first).toHaveText("🏠");
+  const first = picker.locator('.dm-picker-option[data-index="0"] .dm-picker-visual');
+  await oneVisibleGlyph(first, "dm-beta12-action-glyph", "🏠");
   await page.waitForTimeout(1100);
-  await expect(first).toHaveText("🏠");
+  await oneVisibleGlyph(first, "dm-beta12-action-glyph", "🏠");
 });
 
 test("beta13: Temperature has no orphan icon row and Irrigation keeps a usable mobile width", async ({

--- a/custom_components/dashboardmodern/frontend/e2e/beta13-real-device-regressions.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta13-real-device-regressions.spec.js
@@ -74,10 +74,7 @@ async function boot(page, testInfo) {
     .locator("#setup-wizard")
     .evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
   await expect
-    .poll(
-      () => page.evaluate(() => window.__DASHBOARDMODERN_RUNTIME_ROOT__?.ready === true),
-      { timeout: testInfo.project.name === "webkit-ipad" ? 15_000 : 10_000 },
-    )
+    .poll(() => page.evaluate(() => window.__DASHBOARDMODERN_RUNTIME_ROOT__?.ready === true))
     .toBe(true);
   await expect
     .poll(
@@ -188,10 +185,10 @@ test("beta13: room rows and action picker never expose a second vector/pseudo ic
   const picker = page.locator('#dm-visual-picker[data-kind="action"]');
   await expect(picker).toBeVisible();
   await expect(picker).toHaveAttribute("data-dm-single-glyph-owner", "true");
-  const first = picker.locator('.dm-picker-option[data-index="0"] .dm-picker-visual');
-  await oneVisibleGlyph(first, "dm-beta12-action-glyph", "🏠");
+  const first = picker.locator('.dm-picker-option[data-index="0"] .dm-beta12-action-glyph');
+  await expect(first).toHaveText("🏠");
   await page.waitForTimeout(1100);
-  await oneVisibleGlyph(first, "dm-beta12-action-glyph", "🏠");
+  await expect(first).toHaveText("🏠");
 });
 
 test("beta13: Temperature has no orphan icon row and Irrigation keeps a usable mobile width", async ({

--- a/custom_components/dashboardmodern/frontend/e2e/beta13-real-device-regressions.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta13-real-device-regressions.spec.js
@@ -74,7 +74,21 @@ async function boot(page, testInfo) {
     .locator("#setup-wizard")
     .evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
   await expect
-    .poll(() => page.evaluate(() => window.__DASHBOARDMODERN_RUNTIME_ROOT__?.ready === true))
+    .poll(
+      () => page.evaluate(() => window.__DASHBOARDMODERN_RUNTIME_ROOT__?.ready === true),
+      { timeout: testInfo.project.name === "webkit-ipad" ? 15_000 : 10_000 },
+    )
+    .toBe(true);
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            typeof window.DashboardModernIconEngine?.render === "function" &&
+            typeof window.DashboardModernIconEngine?.syncEditor === "function",
+        ),
+      { timeout: 15_000 },
+    )
     .toBe(true);
 }
 

--- a/custom_components/dashboardmodern/frontend/e2e/beta17-final-icon-polish.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta17-final-icon-polish.spec.js
@@ -128,7 +128,8 @@ async function waitForIconEngine(page) {
         page.evaluate(
           () =>
             typeof window.DashboardModernIconEngine?.render === "function" &&
-            typeof window.DashboardModernIconEngine?.openPicker === "function",
+            typeof window.DashboardModernIconEngine?.openPicker === "function" &&
+            Boolean(document.getElementById("dm-unified-editor-visual-style")),
         ),
       { timeout: 15_000 },
     )

--- a/custom_components/dashboardmodern/frontend/src/sections/beta17-final-icon-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta17-final-icon-polish-section.js
@@ -13,6 +13,7 @@ const state = (root[KEY] ||= {
   installed: false,
   temperaturePage: null,
   temperatureObserver: null,
+  modalObserver: null,
 });
 
 // Kept as public compatibility exports for diagnostics/tests. Picker ownership
@@ -76,8 +77,8 @@ function bindTemperatureProgressGuard() {
 
 // Beta18 owns Room/Action preview DOM through DashboardModernIconEngine. The
 // legacy personalization decorator still schedules a later refresh after an
-// edit click; claim the freshly-created modal in the same event microtask so
-// that decorator never becomes a second writer (not even for one WebKit frame).
+// edit click. Claim the modal before that scheduled frame so personalization
+// never becomes a second writer.
 function claimCanonicalModalIconOwner() {
   const engine = root.DashboardModernIconEngine;
   if (typeof engine?.syncEditor !== "function") return false;
@@ -99,6 +100,23 @@ function scheduleCanonicalModalClaim(event) {
   else Promise.resolve().then(claimCanonicalModalIconOwner);
 }
 
+function addedEditorModal(node) {
+  if (!node || node.nodeType !== 1) return false;
+  if (node.id === "dm-action-editor-modal" || node.id === "dm-room-editor-modal") return true;
+  return Boolean(node.querySelector?.("#dm-action-editor-modal,#dm-room-editor-modal"));
+}
+
+function bindCanonicalModalObserver() {
+  if (state.modalObserver || typeof root.MutationObserver !== "function" || !doc?.documentElement) return false;
+  state.modalObserver = new root.MutationObserver((records) => {
+    const inserted = records.some((record) => [...record.addedNodes].some(addedEditorModal));
+    if (inserted) claimCanonicalModalIconOwner();
+  });
+  state.modalObserver.observe(doc.documentElement, { childList: true, subtree: true });
+  claimCanonicalModalIconOwner();
+  return true;
+}
+
 function install() {
   if (!doc || state.installed) return;
   state.installed = true;
@@ -110,6 +128,7 @@ function install() {
   ]) root.addEventListener?.(eventName, bindTemperatureProgressGuard);
   root.addEventListener?.("dashboardmodern:state-changed", hideTemperatureProgressCopy);
   doc.addEventListener("click", scheduleCanonicalModalClaim, true);
+  bindCanonicalModalObserver();
   if (doc.readyState === "loading") {
     doc.addEventListener("DOMContentLoaded", bindTemperatureProgressGuard, { once: true });
   } else {

--- a/custom_components/dashboardmodern/frontend/src/sections/beta17-final-icon-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta17-final-icon-polish-section.js
@@ -13,7 +13,6 @@ const state = (root[KEY] ||= {
   installed: false,
   temperaturePage: null,
   temperatureObserver: null,
-  modalObserver: null,
 });
 
 // Kept as public compatibility exports for diagnostics/tests. Picker ownership
@@ -76,9 +75,10 @@ function bindTemperatureProgressGuard() {
 }
 
 // Beta18 owns Room/Action preview DOM through DashboardModernIconEngine. The
-// legacy personalization decorator still schedules a later refresh after an
-// edit click. Claim the modal before that scheduled frame so personalization
-// never becomes a second writer.
+// legacy personalization decorator schedules a later refresh after an edit
+// click. Listen at window capture so the guard always runs before document
+// listeners can stop propagation; the queued microtask then claims the modal
+// before the legacy timeout/requestAnimationFrame can become a second writer.
 function claimCanonicalModalIconOwner() {
   const engine = root.DashboardModernIconEngine;
   if (typeof engine?.syncEditor !== "function") return false;
@@ -100,23 +100,6 @@ function scheduleCanonicalModalClaim(event) {
   else Promise.resolve().then(claimCanonicalModalIconOwner);
 }
 
-function addedEditorModal(node) {
-  if (!node || node.nodeType !== 1) return false;
-  if (node.id === "dm-action-editor-modal" || node.id === "dm-room-editor-modal") return true;
-  return Boolean(node.querySelector?.("#dm-action-editor-modal,#dm-room-editor-modal"));
-}
-
-function bindCanonicalModalObserver() {
-  if (state.modalObserver || typeof root.MutationObserver !== "function" || !doc?.documentElement) return false;
-  state.modalObserver = new root.MutationObserver((records) => {
-    const inserted = records.some((record) => [...record.addedNodes].some(addedEditorModal));
-    if (inserted) claimCanonicalModalIconOwner();
-  });
-  state.modalObserver.observe(doc.documentElement, { childList: true, subtree: true });
-  claimCanonicalModalIconOwner();
-  return true;
-}
-
 function install() {
   if (!doc || state.installed) return;
   state.installed = true;
@@ -127,8 +110,7 @@ function install() {
     "dashboardmodern:persistence-restored",
   ]) root.addEventListener?.(eventName, bindTemperatureProgressGuard);
   root.addEventListener?.("dashboardmodern:state-changed", hideTemperatureProgressCopy);
-  doc.addEventListener("click", scheduleCanonicalModalClaim, true);
-  bindCanonicalModalObserver();
+  root.addEventListener?.("click", scheduleCanonicalModalClaim, true);
   if (doc.readyState === "loading") {
     doc.addEventListener("DOMContentLoaded", bindTemperatureProgressGuard, { once: true });
   } else {

--- a/custom_components/dashboardmodern/frontend/src/sections/beta17-final-icon-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta17-final-icon-polish-section.js
@@ -6,7 +6,7 @@ import {
   directEmoji,
   roomGlyph,
 } from "../core/personalization-catalog.js";
-import { clean, doc, root } from "./shared.js";
+import { clean, doc, root, t } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_BETA17_FINAL_ICON_POLISH__";
 const state = (root[KEY] ||= {
@@ -74,20 +74,52 @@ function bindTemperatureProgressGuard() {
   return true;
 }
 
+function bindCanonicalPreview(modal, kind, engine) {
+  const selector = kind === "action" ? "[data-action-icon-preview]" : "[data-room-icon-preview]";
+  const preview = modal.querySelector(selector);
+  const input = modal.querySelector('input[name="icon"]');
+  if (!preview || !input) return false;
+
+  preview.classList.add("dm-visual-trigger");
+  preview.setAttribute("role", "button");
+  preview.setAttribute("tabindex", "0");
+  preview.removeAttribute("aria-hidden");
+  preview.setAttribute(
+    "aria-label",
+    kind === "action" ? t("Scegli icona azione", "Choose action icon") : t("Scegli icona stanza", "Choose room icon"),
+  );
+
+  if (preview.dataset.dmCanonicalPickerBound !== "true") {
+    preview.dataset.dmCanonicalPickerBound = "true";
+    const open = () => engine.openPicker?.(input, kind, { autofocus: false });
+    preview.addEventListener("click", open);
+    preview.addEventListener("keydown", (event) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      open();
+    });
+  }
+  return true;
+}
+
 // Beta18 owns Room/Action preview DOM through DashboardModernIconEngine. The
-// legacy personalization decorator schedules a later refresh after an edit
-// click. Listen at window capture so the guard always runs before document
-// listeners can stop propagation; the queued microtask then claims the modal
-// before the legacy timeout/requestAnimationFrame can become a second writer.
+// unified editor is created by a document-capture listener that can stop
+// propagation. Listen one level earlier (window capture), but defer the claim
+// to the next task: by then the modal exists, while the legacy personalization
+// repaint scheduled by that same click has not taken ownership of the preview.
 function claimCanonicalModalIconOwner() {
   const engine = root.DashboardModernIconEngine;
   if (typeof engine?.syncEditor !== "function") return false;
   let claimed = false;
-  for (const id of ["dm-action-editor-modal", "dm-room-editor-modal"]) {
+  for (const [id, kind] of [
+    ["dm-action-editor-modal", "action"],
+    ["dm-room-editor-modal", "room"],
+  ]) {
     const modal = doc?.getElementById(id);
     if (!modal) continue;
     modal.dataset.dmPersonalized = "true";
     modal.dataset.dmSingleGlyphOwner = "true";
+    bindCanonicalPreview(modal, kind, engine);
     claimed = true;
   }
   if (claimed) engine.syncEditor();
@@ -96,8 +128,7 @@ function claimCanonicalModalIconOwner() {
 
 function scheduleCanonicalModalClaim(event) {
   if (!event.target?.closest?.('[data-dm-edit-kind="action"],[data-dm-edit-kind="room"]')) return;
-  if (typeof root.queueMicrotask === "function") root.queueMicrotask(claimCanonicalModalIconOwner);
-  else Promise.resolve().then(claimCanonicalModalIconOwner);
+  root.setTimeout?.(claimCanonicalModalIconOwner, 0);
 }
 
 function install() {

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -1,7 +1,9 @@
 {
   "domain": "dashboardmodern",
   "name": "Dashboard Modern V2",
-  "codeowners": ["@danigio15"],
+  "codeowners": [
+    "@danigio15"
+  ],
   "config_flow": true,
   "dependencies": ["http"],
   "documentation": "https://github.com/danigio15/dashboardmodern-v2",


### PR DESCRIPTION
Unica PR candidata alla release beta.18. Le PR #103, #104 e #105 sono state chiuse. Sto correggendo qui anche i due rilievi del review automatico: claim dopo la creazione del modal e mantenimento completo dell’accessibilità da tastiera della preview icona. Nessun’altra PR parallela verrà usata.