### PR TITLE
fix: ripristina comportamento Temperatura beta.20 e release beta.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.0.0-beta.22 — 2026-08-14
+
+### Corretto
+
+- Ripristinato integralmente il comportamento Temperatura della beta.20 (nomi personalizzati al posto delle etichette sulla card, righe editor originali): la riscrittura della beta.21 causava il collasso della catena dei moduli sezione su dispositivi reali, facendo regredire visivamente tutte le sezioni al rendering legacy.
+- Reincluso `build-info.js` nell'hash asset runtime per garantire l'invalidazione della cache anche nelle release solo-metadata.
+
+### Manutenzione
+
+- Conservate tutte le correzioni di release della beta.21 (guard versione build-info, documentazione HACS, policy di sicurezza, template bug, validator).
+
 ## 1.0.0-beta.21 — 2026-08-14
 
 ### Corretto

--- a/custom_components/dashboardmodern/frontend.py
+++ b/custom_components/dashboardmodern/frontend.py
@@ -40,7 +40,8 @@ ASSET_SUFFIXES = frozenset(
 RUNTIME_ROOT_FILES = frozenset({"panel.js", "dashboard-card.js"})
 RUNTIME_DIRECTORIES = ("legacy", "src")
 IGNORED_RUNTIME_PARTS = frozenset({"e2e", "tests", "__pycache__"})
-IGNORED_RUNTIME_FILES = frozenset({"legacy/build-info.js", "legacy/VENDOR.json"})
+# Include build-info.js so metadata-only releases invalidate immutable client caches.
+IGNORED_RUNTIME_FILES = frozenset({"legacy/VENDOR.json"})
 
 
 def _runtime_assets() -> Iterator[Path]:

--- a/custom_components/dashboardmodern/frontend/e2e/temperature-labels-real-device.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/temperature-labels-real-device.spec.js
@@ -33,11 +33,14 @@ const states = [
   },
 ];
 
+// prettier-ignore
 for (const variant of ["dashboard.html", "dashboard-en.html"]) {
-  test(`${variant}: Temperature shows room and entity display names on a real-device layout`, async ({
+  test(`${variant}: configured Temperature keeps room name and custom entity names`, async ({
     page,
   }, testInfo) => {
-    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await page.route("https://**", (route) =>
+      route.fulfill({ status: 200, body: "" }),
+    );
     await page.addInitScript((haStates) => {
       window.WebSocket = class extends EventTarget {
         static OPEN = 1;
@@ -80,30 +83,23 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       editorSwitch("sez7");
     }, states);
 
-    const row = page.locator('[data-temperature-room][data-room-id="room-cameretta"]');
+    const row = page.locator(
+      '[data-temperature-room][data-room-id="room-cameretta"]',
+    );
     await expect(row).toBeVisible();
-    const rowName = row.locator(":scope > .ed-row-main > .ed-row-new");
-    await expect(rowName).toBeVisible();
-    await expect(rowName).toHaveText("Cameretta");
-    await expect(row.locator(":scope > .ed-row-main > .ed-row-old")).toContainText(
-      "Temperatura cameretta",
-    );
-    await expect(row.locator(":scope > .ed-row-main > .ed-row-old")).toContainText(
-      "Umidità cameretta",
-    );
-    expect((await rowName.boundingBox())?.width || 0).toBeGreaterThan(20);
+    await expect(
+      row.locator(":scope > .ed-row-main > .ed-row-new"),
+    ).toHaveText("Cameretta");
 
     await row.locator("[data-temperature-edit]").click();
     const tempName = page.locator("#dm-temperature-name");
     const humName = page.locator("#dm-humidity-name");
-    await expect(tempName).toBeVisible();
-    await expect(humName).toBeVisible();
     await expect(tempName).toHaveValue("Temperatura cameretta");
     await expect(humName).toHaveValue("Umidità cameretta");
+
     await tempName.fill("Temperatura Camera");
     await humName.fill("Umidità Camera");
     await page.locator("[data-temperature-submit]").click();
-
     await expect
       .poll(() =>
         page.evaluate(() =>
@@ -119,16 +115,15 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
 
     await page.locator("#editor-modal .ed-head-close").last().click();
     await clickBottomTab(page, "temp", testInfo);
-    const card = page.locator('#temp-grid .temp-card[data-room-id="room-cameretta"]');
-    await expect(card.locator(".temp-room-name")).toHaveText("Cameretta");
-    await expect(card.locator(".temp-room-entity-name")).toHaveText(
-      "Temperatura Camera · Umidità Camera",
+    const card = page.locator(
+      '#temp-grid .temp-card[data-room-id="room-cameretta"]',
     );
+    await expect(card).toContainText("Cameretta");
     await expect(card.locator(".cp-temp-current-lbl")).toHaveText(
-      variant === "dashboard-en.html" ? "Temperature" : "Temperatura",
+      "Temperatura Camera",
     );
     await expect(card.locator(".cp-temp-target .lbl")).toContainText(
-      variant === "dashboard-en.html" ? "Humidity" : "Umidità",
+      "Umidità Camera",
     );
   });
 }

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -7,4 +7,4 @@ import "../src/sections/beta12-real-device-polish-section.js";
 import "../src/sections/beta12-room-color-lock-section.js";
 import "../src/sections/beta14-real-device-hotfix-section.js";
 import "../src/sections/beta16-real-device-layout-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.21","dashboardVersion":"1.0.0-beta.21","moduleVersion":14,"schemaVersion":4,"date":"2026-08-12T18:17:51+00:00","commit":"6e7303980cf17c2e2931e15878eab3c4045d2c0b","assetHash":"4c9e657b79fadb14"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.22","dashboardVersion":"1.0.0-beta.22","moduleVersion":14,"schemaVersion":4,"date":"2026-08-12T18:17:51+00:00","commit":"6e7303980cf17c2e2931e15878eab3c4045d2c0b","assetHash":"4c9e657b79fadb14"});

--- a/custom_components/dashboardmodern/frontend/src/sections/beta16-real-device-layout-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta16-real-device-layout-section.js
@@ -166,14 +166,9 @@ function repairTemperatureEditorRows() {
     if (!nodes) return;
     const name = clean(room.name) || clean(room.id) || (english() ? "Room" : "Stanza");
     const sensors = [clean(room.temp), clean(room.hum)].filter(Boolean).join(" · ");
-    const labels = [];
-    if (clean(room.temp))
-      labels.push(clean(room.temp_name || room.temperature_name) || clean(room.temp));
-    if (clean(room.hum))
-      labels.push(clean(room.hum_name || room.humidity_name) || clean(room.hum));
     nodes.primary.textContent = name;
     nodes.primary.title = name;
-    nodes.secondary.textContent = labels.join(" · ");
+    nodes.secondary.textContent = sensors;
     nodes.secondary.title = sensors;
     row.dataset.dmBeta16TemperatureName = "true";
   });

--- a/custom_components/dashboardmodern/frontend/src/sections/beta17-final-icon-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta17-final-icon-polish-section.js
@@ -246,9 +246,26 @@ function repairTemperatureEditor() {
 }
 
 function repairTemperatureDashboardLabels() {
-  // The canonical Temperature card owns metric labels. Optional sensor display
-  // names are rendered as a subtitle beneath the room by temperature-section.
-  return false;
+  const grid = doc?.getElementById("temp-grid");
+  if (!grid) return false;
+  let repaired = false;
+  grid.querySelectorAll(".temp-card[data-room-id]").forEach((card) => {
+    const room = temperatureRoom(card.dataset.roomId);
+    if (!room) return;
+    const temp = card.querySelector(".cp-temp-current-lbl");
+    const hum = card.querySelector(".cp-temp-target .lbl");
+    if (temp) {
+      temp.textContent = temperatureLabel(room);
+      temp.title = temperatureLabel(room);
+    }
+    if (hum) {
+      hum.textContent = `💧 ${humidityLabel(room)}`;
+      hum.title = humidityLabel(room);
+    }
+    card.dataset.dmBeta20TemperatureEntityLabels = "true";
+    repaired = true;
+  });
+  return repaired;
 }
 
 function runTemperatureRepair() {

--- a/custom_components/dashboardmodern/frontend/src/sections/temperature-layout-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/temperature-layout-section.js
@@ -1,253 +1,27 @@
-// DM-FIX-20260814D
-// Targeted Temperature editor companion. The canonical card/row renderer stays
-// in temperature-section.js; this module only owns optional display-name fields
-// and their persistence lifecycle.
-import {
-  clean,
-  dashboardStore,
-  doc,
-  english,
-  installStyle,
-  root,
-  wrapFunction,
-} from "./shared.js";
+// Compatibility shim retained while section-runtime still imports this module.
+// Temperature layout and rendering are now owned entirely by temperature-section.js.
+// This shim only preserves the two optional Temperature display-name fields
+// through the canonical room normalizer; it does not render, style or observe DOM.
+import { clean, dashboardStore, root } from "./shared.js";
 
-const KEY = "__DASHBOARDMODERN_TEMPERATURE_LABEL_EDITOR__";
-const state = (root[KEY] ||= {
-  installed: false,
-  frame: 0,
-  storeUnsubscribe: null,
-  pendingLabels: new Map(),
-  flushing: false,
-  clearing: false,
-});
+const KEY = "__DASHBOARDMODERN_TEMPERATURE_LABEL_MODEL_COMPAT__";
+const state = (root[KEY] ||= { patched: false });
 
-function rooms() {
-  try {
-    const values = dashboardStore()?.getSection?.("rooms");
-    return Array.isArray(values) ? values : [];
-  } catch (_error) {
-    return [];
-  }
-}
-
-function roomById(id) {
-  const token = clean(id);
-  return rooms().find((room) => clean(room?.id) === token) || null;
-}
-
-function createNameField(id, label) {
-  const field = doc.createElement("label");
-  field.className = "ed-slot dm-temperature-name-field";
-  field.dataset.temperatureNameField = id;
-  const title = doc.createElement("span");
-  title.className = "ed-slot-lbl";
-  title.textContent = label;
-  const input = doc.createElement("input");
-  input.id = id;
-  input.type = "text";
-  input.autocomplete = "off";
-  input.className = "ed-input ed-slot-in";
-  input.placeholder = english() ? "Optional display name" : "Nome visualizzato facoltativo";
-  field.append(title, input);
-  return field;
-}
-
-function formMode(form) {
-  if (clean(form?.dataset?.dmOriginalRoom)) return "edit";
-  if (form?.dataset?.dmTemperatureMode) return form.dataset.dmTemperatureMode;
-  const title = clean(form?.querySelector("[data-temperature-form-title]")?.textContent);
-  return /^(modifica|edit)\b/i.test(title) ? "edit" : "add";
-}
-
-export function ensureTemperatureNameFields(
-  form = doc?.querySelector?.("#editor-modal [data-temperature-form]"),
-) {
-  if (!form) return false;
-  let temp = form.querySelector("#dm-temperature-name");
-  if (!temp) {
-    const field = createNameField(
-      "dm-temperature-name",
-      english() ? "Temperature display name" : "Nome visualizzato temperatura",
-    );
-    const anchor = form.querySelector("#ed-pl-temp")?.closest("[data-entity-field],label.ed-slot");
-    if (anchor) anchor.before(field);
-    else form.append(field);
-    temp = field.querySelector("input");
-  }
-  let hum = form.querySelector("#dm-humidity-name");
-  if (!hum) {
-    const field = createNameField(
-      "dm-humidity-name",
-      english() ? "Humidity display name" : "Nome visualizzato umidità",
-    );
-    const anchor = form
-      .querySelector("#dm-humidity-new")
-      ?.closest("[data-entity-field],label.ed-slot");
-    if (anchor) anchor.before(field);
-    else form.append(field);
-    hum = field.querySelector("input");
-  }
-
-  const roomId = clean(form.querySelector("#dm-temperature-room")?.value);
-  const context = `${formMode(form)}|${roomId}`;
-  if (form.dataset.dmTemperatureLabelContext !== context) {
-    const room = roomById(roomId);
-    temp.value = room ? clean(room.temp_name || room.temperature_name) : "";
-    hum.value = room ? clean(room.hum_name || room.humidity_name) : "";
-    form.dataset.dmTemperatureLabelContext = context;
-  }
-  form.dataset.dmTemperatureDisplayNames = "true";
-  return true;
-}
-
-function captureSubmit(event) {
-  const form = event.target?.closest?.("[data-temperature-form]");
-  if (!form) return;
-  const id = clean(form.querySelector("#dm-temperature-room")?.value);
-  if (!id) return;
-  state.pendingLabels.set(id, {
-    temp_name: clean(form.querySelector("#dm-temperature-name")?.value),
-    hum_name: clean(form.querySelector("#dm-humidity-name")?.value),
-  });
-  root.queueMicrotask?.(flushPendingLabels);
-  root.setTimeout?.(flushPendingLabels, 0);
-}
-
-async function flushPendingLabels() {
-  if (state.flushing || !state.pendingLabels.size) return;
-  const store = dashboardStore();
-  if (!store?.updateItem) return;
-  state.flushing = true;
-  try {
-    for (const [id, labels] of [...state.pendingLabels.entries()]) {
-      const room = roomById(id);
-      if (!room || (!clean(room.temp) && !clean(room.hum))) continue;
-      state.pendingLabels.delete(id);
-      const patch = {
-        temp_name: clean(labels.temp_name),
-        hum_name: clean(labels.hum_name),
-      };
-      if (
-        clean(room.temp_name) === patch.temp_name &&
-        clean(room.hum_name) === patch.hum_name
-      ) {
-        continue;
-      }
-      await store.updateItem("rooms", id, patch);
-    }
-  } catch (error) {
-    root.console?.error?.("[DashboardModern] Temperature display names", error);
-  } finally {
-    state.flushing = false;
-  }
-}
-
-async function clearOrphanLabels() {
-  if (state.clearing) return;
-  const store = dashboardStore();
-  if (!store?.updateItem) return;
-  const orphan = rooms().find(
-    (room) =>
-      !clean(room.temp) &&
-      !clean(room.hum) &&
-      (clean(room.temp_name) || clean(room.hum_name)),
-  );
-  if (!orphan) return;
-  state.clearing = true;
-  try {
-    await store.updateItem("rooms", orphan.id, { temp_name: "", hum_name: "" });
-  } catch (error) {
-    root.console?.error?.("[DashboardModern] clear Temperature display names", error);
-  } finally {
-    state.clearing = false;
-  }
-}
-
-function run() {
-  state.frame = 0;
-  ensureTemperatureNameFields();
-  flushPendingLabels();
-  clearOrphanLabels();
-}
-
-function schedule() {
-  if (state.frame) return;
-  const execute = () => {
-    run();
-    root.requestAnimationFrame?.(() => ensureTemperatureNameFields());
+function preserveTemperatureLabels(store) {
+  if (!store || state.patched || typeof store._normalizeItem !== "function") return false;
+  const current = store._normalizeItem.bind(store);
+  store._normalizeItem = function normalizeItemWithTemperatureLabels(section, item, index) {
+    const normalized = current(section, item, index);
+    if (section !== "rooms" || !normalized) return normalized;
+    normalized.temp_name = clean(item?.temp_name || item?.temperature_name);
+    normalized.hum_name = clean(item?.hum_name || item?.humidity_name);
+    return normalized;
   };
-  state.frame = root.requestAnimationFrame?.(execute) || root.setTimeout?.(execute, 0) || 0;
-}
-
-function installOwners() {
-  wrapFunction("editorSwitch", "__dmTemperatureDisplayNamesEditor", schedule);
-}
-
-function subscribeStore() {
-  if (state.storeUnsubscribe) return;
-  const store = dashboardStore();
-  if (typeof store?.subscribe !== "function") return;
-  state.storeUnsubscribe = store.subscribe((change) => {
-    if (change?.section !== "rooms" && change?.section !== "snapshot") return;
-    flushPendingLabels();
-    clearOrphanLabels();
-    schedule();
-  });
-}
-
-function installStyles() {
-  installStyle(
-    "dm-temperature-display-name-fields",
-    `
-      #editor-modal [data-temperature-form] .dm-temperature-name-field{
-        display:grid!important;gap:6px!important;min-width:0!important
-      }
-      #editor-modal [data-temperature-form] .dm-temperature-name-field>.ed-input{
-        box-sizing:border-box!important;width:100%!important;min-width:0!important
-      }
-    `,
-  );
+  state.patched = true;
+  return true;
 }
 
 export function installTemperatureLayoutSection() {
-  installOwners();
-  subscribeStore();
-  if (!doc || state.installed) return false;
-  state.installed = true;
-  installStyles();
-  doc.addEventListener("submit", captureSubmit, true);
-  doc.addEventListener(
-    "click",
-    (event) => {
-      if (
-        event.target?.closest?.(
-          "[data-temperature-edit],.ed-tab[data-tab='sez7'],[data-tab='temp'],[data-tab='temperature']",
-        )
-      ) {
-        root.queueMicrotask?.(schedule);
-      }
-    },
-    true,
-  );
-  doc.addEventListener(
-    "change",
-    (event) => {
-      if (event.target?.closest?.("[data-temperature-form]")) schedule();
-    },
-    true,
-  );
-  for (const eventName of [
-    "dashboardmodern:legacy-ready",
-    "dashboardmodern:runtime-ready",
-    "dashboardmodern:persistence-restored",
-  ]) {
-    root.addEventListener?.(eventName, () => {
-      installOwners();
-      subscribeStore();
-      schedule();
-    });
-  }
-  schedule();
-  return true;
+  preserveTemperatureLabels(dashboardStore());
+  return false;
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/temperature-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/temperature-section.js
@@ -90,8 +90,6 @@ function cardSignature(values = configuredRooms()) {
         clean(room.floor),
         clean(room.temp),
         roomHumidity(room),
-        clean(room.temp_name || room.temperature_name),
-        clean(room.hum_name || room.humidity_name),
       ].join("|"),
     )
     .join(";");
@@ -130,15 +128,10 @@ function createTemperatureCard(room) {
   icon.className = "cp-icon temp-room-icon";
   icon.dataset.roomIcon = clean(room.icon || "mdi:home");
   icon.append(makeText("dm-temperature-icon-fallback", glyph(room.icon)));
-  const roomCopy = doc.createElement("div");
-  roomCopy.className = "dm-temperature-room-copy";
   const name = doc.createElement("div");
   name.className = "cp-name temp-room-name";
   name.textContent = clean(room.name) || (english() ? "Room" : "Stanza");
-  const entityName = doc.createElement("small");
-  entityName.className = "temp-room-entity-name";
-  roomCopy.append(name, entityName);
-  title.append(icon, roomCopy);
+  title.append(icon, name);
   const badge = doc.createElement("div");
   badge.className = "cp-badge temp-comfort-badge";
   badge.id = `tc_${tid}`;
@@ -179,7 +172,6 @@ function updateCard(card, room) {
   const comfort = card.querySelector(".temp-comfort-badge");
   const icon = card.querySelector(".cp-icon,.temp-room-icon");
   const name = card.querySelector(".cp-name,.temp-room-name");
-  const entityName = card.querySelector(".temp-room-entity-name");
 
   if (value) value.textContent = temperature == null ? "—" : temperature.toFixed(1);
   if (humidityValue)
@@ -200,15 +192,6 @@ function updateCard(card, room) {
     if (!fallback.parentElement) icon.replaceChildren(fallback);
   }
   if (name) name.textContent = clean(room.name) || (english() ? "Room" : "Stanza");
-  if (entityName) {
-    const labels = [
-      clean(room.temp_name || room.temperature_name),
-      clean(room.hum_name || room.humidity_name),
-    ].filter(Boolean);
-    entityName.textContent = labels.join(" · ");
-    entityName.hidden = labels.length === 0;
-    entityName.title = labels.join(" · ");
-  }
 }
 
 export function normalizeTemperatureCards() {
@@ -372,40 +355,23 @@ function normalizeTemperatureConfiguredRows() {
     ?.querySelectorAll?.("#editor-modal [data-temperature-room][data-room-id]")
     .forEach((row) => {
       const room = values.find((item) => clean(item?.id) === clean(row.dataset.roomId));
-      if (!room) return;
-      const icon = row.querySelector(":scope > .dm-temperature-card-icon");
-      let main = row.querySelector(":scope > .ed-row-main");
-      if (!main) {
-        main = doc.createElement("div");
-        main.className = "ed-row-main";
-        if (icon?.parentElement === row) icon.after(main);
-        else row.prepend(main);
-      }
-      let primary = main.querySelector(":scope > .ed-row-new");
-      if (!primary) {
-        primary = doc.createElement("div");
-        primary.className = "ed-row-new";
-        main.prepend(primary);
-      }
-      let secondary = main.querySelector(":scope > .ed-row-old");
-      if (!secondary) {
-        secondary = doc.createElement("div");
-        secondary.className = "ed-row-old";
-        main.append(secondary);
-      }
       const name =
-        clean(room.name) || clean(row.dataset.roomId) || (english() ? "Room" : "Stanza");
-      const labels = [];
-      if (clean(room.temp))
-        labels.push(clean(room.temp_name || room.temperature_name) || clean(room.temp));
-      if (clean(room.hum))
-        labels.push(clean(room.hum_name || room.humidity_name) || clean(room.hum));
-      primary.textContent = name;
-      primary.title = name;
-      secondary.textContent = labels.join(" · ");
-      secondary.title = [clean(room.temp), clean(room.hum)].filter(Boolean).join(" · ");
+        clean(room?.name) || clean(row.dataset.roomId) || (english() ? "Room" : "Stanza");
+      const primary = row.querySelector(".ed-row-new");
+      const secondary = row.querySelector(".ed-row-old");
+      if (primary) {
+        primary.textContent = name;
+        primary.title = name;
+        normalized = true;
+      }
+      if (secondary && room) {
+        const sensors = [clean(room.temp), clean(room.hum)].filter(Boolean).join(" · ");
+        if (sensors) {
+          secondary.textContent = sensors;
+          secondary.title = sensors;
+        }
+      }
       row.dataset.dmTemperatureNameVisible = "true";
-      normalized = true;
     });
   return normalized;
 }
@@ -502,8 +468,6 @@ function installStyles() {
     #page-temp .cp-title-wrap,#temp-grid .cp-title-wrap{display:flex!important;align-items:center!important;gap:9px!important;min-width:0!important;flex:1 1 auto!important}
     #page-temp .cp-icon,#temp-grid .cp-icon{display:grid!important;place-items:center!important;flex:0 0 36px!important;width:36px!important;height:36px!important;margin:0!important;border:1px solid color-mix(in srgb,var(--primary-color,#0ea5e9) 12%,transparent)!important;border-radius:12px!important;background:color-mix(in srgb,var(--primary-color,#0ea5e9) 8%,var(--ha-card-background,#fff))!important;box-shadow:0 4px 12px rgba(15,23,42,.05)!important;font-family:Apple Color Emoji,Segoe UI Emoji,Noto Color Emoji,sans-serif!important}
     #page-temp .cp-name,#temp-grid .cp-name{min-width:0!important;margin:0!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important;font-size:16px!important;font-weight:900!important;line-height:1.15!important;color:var(--primary-text-color,var(--text,#0f172a))!important}
-    #page-temp .dm-temperature-room-copy,#temp-grid .dm-temperature-room-copy{display:grid!important;gap:2px!important;min-width:0!important;flex:1 1 auto!important}
-    #page-temp .temp-room-entity-name,#temp-grid .temp-room-entity-name{display:block!important;min-width:0!important;margin:0!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important;color:var(--secondary-text-color,var(--text-dim,#64748b))!important;font-size:9px!important;font-weight:800!important;line-height:1.2!important;text-transform:none!important;letter-spacing:0!important}
     #page-temp .temp-comfort-badge,#temp-grid .temp-comfort-badge{position:static!important;display:inline-flex!important;align-items:center!important;justify-content:center!important;flex:0 0 auto!important;min-width:48px!important;max-width:82px!important;min-height:24px!important;padding:4px 8px!important;border-radius:999px!important;font-size:8.5px!important;font-weight:900!important;line-height:1!important;white-space:nowrap!important;transform:none!important}
     #temp-grid .temp-comfort-badge[data-comfort="freddo"],#temp-grid .temp-comfort-badge[data-comfort="cold"]{background:color-mix(in srgb,var(--info-color,#0ea5e9) 16%,transparent)!important;color:var(--info-color,#0284c7)!important}
     #temp-grid .temp-comfort-badge[data-comfort="comfort"]{background:color-mix(in srgb,var(--success-color,#10b981) 16%,transparent)!important;color:var(--success-color,#047857)!important}
@@ -514,10 +478,9 @@ function installStyles() {
     #page-temp .cp-temp-target,#temp-grid .cp-temp-target{display:grid!important;align-content:end!important;gap:4px!important;min-width:0!important;margin:0!important;padding:5px 0 1px 11px!important;border-left:1px solid color-mix(in srgb,var(--primary-color,#0ea5e9) 18%,var(--divider-color,#dbe4ee))!important;text-align:left!important}.cp-temp-target .lbl{font-size:8px!important;font-weight:900!important;letter-spacing:.05em!important;text-transform:uppercase!important;white-space:nowrap!important;color:var(--secondary-text-color,var(--text-dim,#64748b))!important}.cp-temp-target .val{font-size:22px!important;font-weight:850!important;line-height:1!important;white-space:nowrap!important;color:var(--secondary-text-color,var(--text-dim,#64748b))!important}
     #temp-grid .dm-temperature-icon-fallback{display:block!important;font-size:23px!important;line-height:1!important}
     #temp-grid .dm-temperature-empty{grid-column:1/-1!important;box-sizing:border-box!important;width:100%!important;padding:28px 20px!important;border:1px dashed var(--divider-color,#dbe4ee)!important;border-radius:20px!important;background:var(--ha-card-background,var(--card-bg,#fff))!important;color:var(--secondary-text-color,#64748b)!important;text-align:center!important;font-weight:750!important}
-    #editor-modal [data-temperature-room][data-dm-temperature-name-visible="true"]>.ed-row-main{display:block!important;visibility:visible!important;opacity:1!important;width:auto!important;min-width:0!important;max-width:none!important;flex:1 1 auto!important;align-self:center!important;overflow:hidden!important}
+    #editor-modal [data-temperature-room][data-dm-temperature-name-visible="true"]>.ed-row-main{display:block!important;visibility:visible!important;opacity:1!important;min-width:0!important;align-self:center!important;overflow:hidden!important}
     #editor-modal [data-temperature-room][data-dm-temperature-name-visible="true"]>.ed-row-main>.ed-row-new{display:block!important;visibility:visible!important;opacity:1!important;color:var(--primary-text-color,var(--text,#0f172a))!important;font-weight:900!important;line-height:1.25!important;white-space:nowrap!important;overflow:hidden!important;text-overflow:ellipsis!important}
     #editor-modal [data-temperature-room][data-dm-temperature-name-visible="true"]>.ed-row-main>.ed-row-old{display:block!important;visibility:visible!important;opacity:1!important;margin-top:3px!important;color:var(--secondary-text-color,var(--text-dim,#64748b))!important;line-height:1.25!important;white-space:nowrap!important;overflow:hidden!important;text-overflow:ellipsis!important}
-    #editor-modal #ed-body [data-temperature-room][data-room-id]{display:grid!important;grid-template-columns:56px minmax(0,1fr) 48px 48px!important;align-items:center!important;gap:10px!important}
     #editor-modal [data-temperature-form] #dm-temperature-icon,#editor-modal [data-temperature-form] [data-icon-field],#editor-modal [data-temperature-form] label.ed-slot:has(#dm-temperature-icon){display:none!important}
     #editor-modal [data-temperature-form] .dm-temperature-actions button{min-height:44px!important}
     #editor-modal [data-temperature-form] #dm-temperature-room[data-dm-temperature-room-editable="true"]{border-color:var(--primary-color,#0ea5e9)!important;box-shadow:0 0 0 3px color-mix(in srgb,var(--primary-color,#0ea5e9) 10%,transparent)!important}

--- a/custom_components/dashboardmodern/frontend/tests/temperature-labels-regression.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/temperature-labels-regression.test.js
@@ -2,48 +2,42 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-const temperatureUrl = new URL("../src/sections/temperature-section.js", import.meta.url);
+const guardUrl = new URL("../src/sections/beta17-final-icon-polish-section.js", import.meta.url);
 const layoutUrl = new URL("../src/sections/temperature-layout-section.js", import.meta.url);
-const migrationsUrl = new URL("../src/core/migrations.js", import.meta.url);
 
-test("Temperature configured rows keep a visible room name beside the icon", async () => {
-  const source = await readFile(temperatureUrl, "utf8");
-  assert.match(source, /function normalizeTemperatureConfiguredRows\(\)/);
+test("configured Temperature rows restore the canonical room name beside the icon", async () => {
+  const source = await readFile(guardUrl, "utf8");
+  assert.match(source, /function ensureTemperatureRowMain\(row, room\)/);
   assert.match(source, /primary\.textContent = name/);
-  assert.match(source, /width:auto!important/);
-  assert.match(source, /grid-template-columns:56px minmax\(0,1fr\) 48px 48px/);
+  assert.match(source, /data-temperature-room\]\[data-room-id\]/);
+  assert.match(source, /dmTemperatureNameVisible/);
+  assert.match(source, /style\.setProperty\("display", "block", "important"\)/);
 });
 
-test("Temperature optional entity names are canonical room fields", async () => {
-  const source = await readFile(migrationsUrl, "utf8");
-  assert.match(source, /temp_name: String\(room\.temp_name \|\| room\.temperature_name \|\| ""\)/);
-  assert.match(source, /hum_name: String\(room\.hum_name \|\| room\.humidity_name \|\| ""\)/);
-});
-
-test("Temperature editor exposes and persists both optional display names", async () => {
-  const source = await readFile(layoutUrl, "utf8");
+test("Temperature editor exposes and persists custom display names for both entities", async () => {
+  const source = await readFile(guardUrl, "utf8");
   assert.match(source, /dm-temperature-name/);
   assert.match(source, /dm-humidity-name/);
+  assert.match(source, /temp_name/);
+  assert.match(source, /hum_name/);
   assert.match(source, /pendingLabels/);
   assert.match(source, /store\.updateItem\("rooms", id, patch\)/);
-  assert.doesNotMatch(source, /MutationObserver|setInterval\s*\(/);
 });
 
-test("legacy real-device row repair cannot overwrite custom Temperature names with raw entity ids", async () => {
-  const source = await readFile(
-    new URL("../src/sections/beta16-real-device-layout-section.js", import.meta.url),
-    "utf8",
-  );
-  assert.match(source, /room\.temp_name \|\| room\.temperature_name/);
-  assert.match(source, /room\.hum_name \|\| room\.humidity_name/);
-  assert.match(source, /nodes\.secondary\.textContent = labels\.join\(" · "\)/);
+test("custom Temperature entity names are projected onto live dashboard labels", async () => {
+  const source = await readFile(guardUrl, "utf8");
+  assert.match(source, /function repairTemperatureDashboardLabels\(\)/);
+  assert.match(source, /\.cp-temp-current-lbl/);
+  assert.match(source, /\.cp-temp-target \.lbl/);
+  assert.match(source, /dmBeta20TemperatureEntityLabels/);
 });
 
-test("Temperature card renders optional entity names below the room and preserves generic metric labels", async () => {
-  const source = await readFile(temperatureUrl, "utf8");
-  assert.match(source, /temp-room-entity-name/);
-  assert.match(source, /roomCopy\.append\(name, entityName\)/);
-  assert.match(source, /entityName\.textContent = labels\.join\(" · "\)/);
-  assert.match(source, /cp-temp-current-lbl/);
-  assert.match(source, /cp-temp-target/);
+test("Beta20 label hardening reuses an existing scoped owner and keeps the layout shim passive", async () => {
+  const source = await readFile(guardUrl, "utf8");
+  const layout = await readFile(layoutUrl, "utf8");
+  assert.doesNotMatch(source, /setInterval\s*\(/);
+  assert.match(source, /store\.subscribe/);
+  assert.match(source, /requestAnimationFrame/);
+  assert.match(layout, /return false/);
+  assert.doesNotMatch(layout, /installStyle|setInterval|MutationObserver|querySelector|innerHTML/);
 });

--- a/custom_components/dashboardmodern/frontend/tests/ui-regressions-01514.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/ui-regressions-01514.test.js
@@ -74,9 +74,7 @@ test("temperature mobile card is owned by the canonical temperature renderer", a
   assert.match(source, /font-size:21px!important/);
   assert.doesNotMatch(source, /setInterval|MutationObserver/);
 
-  // The companion may own the two optional editor-name fields, but never
-  // the Temperature card renderer or a global polling/observer loop.
-  assert.match(legacyLayout, /ensureTemperatureNameFields/);
-  assert.doesNotMatch(legacyLayout, /renderTemperatureCards|replaceChildren/);
-  assert.doesNotMatch(legacyLayout, /setInterval|MutationObserver/);
+  // Temporary import compatibility only: it must not render, style or observe.
+  assert.match(legacyLayout, /return false/);
+  assert.doesNotMatch(legacyLayout, /installStyle|setInterval|MutationObserver|querySelector|innerHTML/);
 });

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.21"
+  "version": "1.0.0-beta.22"
 }


### PR DESCRIPTION
### Motivation

- Ripristinare esattamente il comportamento frontend della `v1.0.0-beta.20` per la card/ editor Temperatura, perché la riscrittura introdotta in `v1.0.0-beta.21` rompe la catena dei moduli su dispositivi reali e causa il fallback al rendering legacy. Riferimento fixpack: `DM-FIX-20260814E`.
- Mantenere le correzioni di igiene della release già presenti in beta.21 (build-info guard, documentazione, security template, validator) senza alterare i file vendored o altre parti non richieste.

### Description

- Ripristinati byte-per-byte dal tag `v1.0.0-beta.20` i seguenti file: `custom_components/dashboardmodern/frontend/src/sections/temperature-section.js`, `custom_components/dashboardmodern/frontend/src/sections/temperature-layout-section.js`, `custom_components/dashboardmodern/frontend/src/sections/beta16-real-device-layout-section.js`, `custom_components/dashboardmodern/frontend/src/sections/beta17-final-icon-polish-section.js`, `custom_components/dashboardmodern/frontend/tests/temperature-labels-regression.test.js`, `custom_components/dashboardmodern/frontend/tests/ui-regressions-01514.test.js`, `custom_components/dashboardmodern/frontend/e2e/temperature-labels-real-device.spec.js`.
- Modifica mirata in `custom_components/dashboardmodern/frontend.py` per rimuovere solo `"legacy/build-info.js"` da `IGNORED_RUNTIME_FILES` lasciando `"legacy/VENDOR.json"`, con commento per motivazione: build-info deve essere incluso nell'hash runtime per invalidare la cache client su release metadata-only.
- Bump versione in `custom_components/dashboardmodern/manifest.json` a `"1.0.0-beta.22"` e aggiornamento committato di `custom_components/dashboardmodern/frontend/legacy/build-info.js` modificando solamente i campi `"integrationVersion"` e `"dashboardVersion"` a `1.0.0-beta.22` (senza rigenerare gli altri metadata o rimuovere il marker esistente).
- Aggiunta voce iniziale a `CHANGELOG.md` per `1.0.0-beta.22` con motivazione del ripristino e note di manutenzione.

### Testing

- Eseguiti i gate disponibili; risultati principali: `npm ci` non completabile per HTTP 403 sul registry (prettier / playwright) e mismatch engine Node (ambiente Node v20 vs richiesta >=22), quindi installazione completa delle dipendenze di dev non possibile in questo ambiente; questo ha impedito lanciare gli spec E2E locali con Playwright.
- `python scripts/generate_build_info.py` eseguito con successo e il file `frontend/legacy/build-info.js` è stato adattato per mantenere il marker richiesto e aggiornare solo i campi di versione (committato).
- `npm run check:inline-syntax` — verde.
- `npm run format:check` — verde (Prettier OK).
- `npm run test:frontend` — verde; tutti i test frontend sono passati (406/406) e incluso il controllo critico `committed build info cannot lag behind the manifest version` è passato dopo l'aggiornamento del `build-info.js`.
- `ruff check .` e `ruff format --check .` — verdi.
- `python -m pytest` — verdi (5 passed, 2 skipped).
- Spec E2E Chromium/WebKit: tentati ma non eseguibili a causa del fallimento di `npm ci` e dell'impossibilità di installare Playwright dal registry (HTTP 403).

Criterio richiesto (1) verificato: il confronto richiesto contro `v1.0.0-beta.20` per i quattro moduli Temperature ha prodotto output vuoto (nessuna differenza):

`$ git diff v1.0.0-beta.20 -- custom_components/dashboardmodern/frontend/src/sections/temperature-section.js custom_components/dashboardmodern/frontend/src/sections/temperature-layout-section.js custom_components/dashboardmodern/frontend/src/sections/beta16-real-device-layout-section.js custom_components/dashboardmodern/frontend/src/sections/beta17-final-icon-polish-section.js`

<output vuoto>

Esiti addizionali: il working tree è stato committato in un unico commit di preparazione sul branch di lavoro, gli unici file modificati sono quelli elencati sopra più `custom_components/dashboardmodern/frontend.py`, `custom_components/dashboardmodern/manifest.json`, `custom_components/dashboardmodern/frontend/legacy/build-info.js`, e `CHANGELOG.md`, e tutti i gate eseguibili sono verdi. Spec E2E non eseguiti per limiti ambientali (HTTP 403 dal registry).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f121b8230832e8bd54a1b7584cee7)