### PR TITLE
fix: persistenza unificata single-writer e sentinella moduli (hotfix beta.24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.0.0-beta.24 — 2026-08-14
+
+### Corretto
+
+- Unificata la chiave di sincronizzazione HA tra runtime e moduli (con migrazione automatica del payload esistente): i salvataggi ora si consolidano su un unico archivio.
+- Lo store canonico non sovrascrive più le modifiche appena salvate dai flussi legacy (protezione single-writer).
+- Aggiunta sentinella nel pannello: se i moduli non si caricano compare un avviso con l'azione da fare, invece di un'interfaccia silenziosamente degradata.
+
 ## 1.0.0-beta.23 — 2026-08-14
 
 ### Manutenzione

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -7,4 +7,4 @@ import "../src/sections/beta12-real-device-polish-section.js";
 import "../src/sections/room-color-lock-section.js";
 import "../src/sections/beta14-real-device-hotfix-section.js";
 import "../src/sections/beta16-real-device-layout-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.23","dashboardVersion":"1.0.0-beta.23","moduleVersion":14,"schemaVersion":4,"date":"2026-08-12T18:17:51+00:00","commit":"6e7303980cf17c2e2931e15878eab3c4045d2c0b","assetHash":"4c9e657b79fadb14"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.24","dashboardVersion":"1.0.0-beta.24","moduleVersion":14,"schemaVersion":4,"date":"2026-08-12T18:17:51+00:00","commit":"6e7303980cf17c2e2931e15878eab3c4045d2c0b","assetHash":"4c9e657b79fadb14"});

--- a/custom_components/dashboardmodern/frontend/panel.js
+++ b/custom_components/dashboardmodern/frontend/panel.js
@@ -3,6 +3,10 @@ import { legacyVariantForLocale, mountLegacyHost } from "./src/legacy/host.js";
 
 const dashboardJobs = new Map();
 
+export function dashboardModulesActive(frameWindow) {
+  return Boolean(frameWindow?.DashboardModernModules?.store);
+}
+
 export function resolveLegacyVariant(panel, hass) {
   const variants = panel?.config?.legacy_variants;
   if (!Array.isArray(variants) || variants.length === 0) return null;
@@ -133,9 +137,38 @@ export class DashboardModernPanel extends HTMLElement {
   }
 
   resetHost() {
+    if (this.modulesTimer) clearTimeout(this.modulesTimer);
+    this.modulesTimer = null;
     this.host?.destroy();
     this.host = null;
     this.mounted = false;
+  }
+
+  showModulesWarning() {
+    if (this.shadowRoot.querySelector?.("[data-dashboardmodern-modules-warning]")) return;
+    const banner = document.createElement("aside");
+    banner.dataset.dashboardmodernModulesWarning = "";
+    banner.setAttribute("role", "alert");
+    const message = this._hass?.locale?.language?.startsWith("it")
+      ? "⚠️ Aggiornamento incompleto: i moduli della dashboard non si sono caricati. Riavvia Home Assistant e svuota la cache del browser."
+      : "⚠️ Incomplete update: the dashboard modules did not load. Restart Home Assistant and clear your browser cache.";
+    banner.innerHTML = `<span>${message}</span><button type="button" aria-label="${
+      this._hass?.locale?.language?.startsWith("it") ? "Chiudi" : "Dismiss"
+    }">×</button>`;
+    banner.style.cssText = "position:fixed;z-index:10000;top:0;left:0;right:0;display:flex;align-items:center;justify-content:center;gap:16px;padding:12px 18px;background:#b91c1c;color:#fff;font:600 14px/1.4 sans-serif;box-shadow:0 2px 8px #0005";
+    banner.querySelector("button").style.cssText = "border:0;background:transparent;color:inherit;font-size:24px;cursor:pointer";
+    banner.querySelector("button").addEventListener("click", () => banner.remove());
+    this.shadowRoot.append(banner);
+  }
+
+  scheduleModulesCheck(frame) {
+    if (this.modulesTimer) clearTimeout(this.modulesTimer);
+    this.modulesTimer = setTimeout(() => {
+      this.modulesTimer = null;
+      const active = dashboardModulesActive(frame?.contentWindow);
+      console.log(`[DashboardModern] moduli attivi: ${active ? "sì" : "no"}`);
+      if (!active) this.showModulesWarning();
+    }, 6000);
   }
 
   renderDenied() {
@@ -180,6 +213,7 @@ export class DashboardModernPanel extends HTMLElement {
         "integration",
       primary: this._panel.config?.primary !== false,
     });
+    this.host.frame.addEventListener?.("load", () => this.scheduleModulesCheck(this.host?.frame));
   }
 
   disconnectedCallback() {

--- a/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
+++ b/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
@@ -66,6 +66,7 @@ export class DashboardStore {
     this.syncAdapter = sync;
     this.onStatus = onStatus;
     this.listeners = new Set();
+    this.persistedLegacyDigests = new Map();
     this.state = { schema_version: SCHEMA_VERSION, sections: {}, visibility: {} };
   }
   migrate() {
@@ -110,22 +111,54 @@ export class DashboardStore {
     return () => this.listeners.delete(listener);
   }
   persist() {
+    const legacyKeys = ["cd_sections", ...Object.values(SECTION_KEYS)];
+    for (const key of legacyKeys) {
+      if (this.canonicalWriteKeys?.has(key)) continue;
+      if (!this.persistedLegacyDigests.has(key)) continue;
+      const current = this.storage.getItem(key);
+      if (current === this.persistedLegacyDigests.get(key)) continue;
+      let value;
+      try {
+        value = JSON.parse(current);
+      } catch {
+        continue;
+      }
+      if (key === "cd_sections") {
+        if (value && typeof value === "object" && !Array.isArray(value))
+          this.state.visibility = { ...value };
+        continue;
+      }
+      const section = Object.entries(SECTION_KEYS).find(
+        ([, storageKey]) => storageKey === key,
+      )?.[0];
+      if (section)
+        this.state.sections[section] = normalizeSection(section, value, {
+          rooms: this.state.sections.rooms || [],
+        });
+    }
     this.state.sections.entityOverrides = projectEnergySlots(
       this.state.sections.energy || {},
       this.state.sections.entityOverrides || {},
     );
     this.projecting = true;
+    this.storage.__dashboardStoreProjecting = (this.storage.__dashboardStoreProjecting || 0) + 1;
     try {
       this.storage.setItem("dm_dashboard_state", JSON.stringify(this.state));
       this.storage.setItem("dm_schema_version", String(SCHEMA_VERSION));
-      this.storage.setItem("cd_sections", JSON.stringify(this.state.visibility));
+      const writeLegacy = (key, value) => {
+        const serialized = JSON.stringify(value);
+        this.storage.setItem(key, serialized);
+        this.persistedLegacyDigests.set(key, serialized);
+      };
+      writeLegacy("cd_sections", this.state.visibility);
       for (const [section, key] of Object.entries(SECTION_KEYS)) {
         let value = this.state.sections[section] || [];
         if (section === "lights")
           value = Object.fromEntries(value.map((item) => [item.entities[0], item.name]));
-        this.storage.setItem(key, JSON.stringify(value));
+        writeLegacy(key, value);
       }
     } finally {
+      this.storage.__dashboardStoreProjecting--;
       this.projecting = false;
     }
   }
@@ -137,6 +170,7 @@ export class DashboardStore {
       const result = original(key, value);
       if (
         !store.projecting &&
+        !store.storage.__dashboardStoreProjecting &&
         !globalThis.__DASHBOARDMODERN_PERSIST_RESTORE__ &&
         (key === "cd_sections" || Object.values(SECTION_KEYS).includes(key))
       )
@@ -193,7 +227,17 @@ export class DashboardStore {
     try {
       const detail = mutate();
       visibilityChanged = this.ensureSectionVisibleForData(section);
-      this.persist();
+      this.canonicalWriteKeys = new Set(
+        [
+          section === "visibility" ? "cd_sections" : SECTION_KEYS[section],
+          ...(visibilityChanged ? ["cd_sections"] : []),
+        ].filter(Boolean),
+      );
+      try {
+        this.persist();
+      } finally {
+        this.canonicalWriteKeys = null;
+      }
       const change = {
         section,
         operation,

--- a/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
@@ -63,8 +63,32 @@ function instanceId() {
   );
 }
 
+export function integrationUserDataKey({ primary = true, instance = "" } = {}) {
+  const suffix =
+    primary === false && instance
+      ? `__${String(instance).replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 16)}`
+      : "";
+  return `dashboardmodern_integration_config${suffix}`;
+}
+
 function userDataKey() {
+  return integrationUserDataKey({
+    primary: root.__DASHBOARDMODERN_PRIMARY__ !== false,
+    instance: root.__DASHBOARDMODERN_INSTANCE__,
+  });
+}
+
+function legacyUserDataKey() {
   return `dashboardmodern_v2_config:${instanceId()}`;
+}
+
+export async function migrateLegacyUserData(fetchValue, pushValue) {
+  const current = await fetchValue(userDataKey());
+  if (current) return current;
+  const legacy = await fetchValue(legacyUserDataKey());
+  if (!legacy) return null;
+  await pushValue(userDataKey(), legacy);
+  return legacy;
 }
 
 function localValues() {
@@ -208,8 +232,10 @@ async function hydrateRemote() {
   if (state.hydrating || state.hydrated || state.resetting || !hostedBridge()) return false;
   state.hydrating = true;
   try {
-    const result = await bridgeRequest("frontend/get_user_data", { key: userDataKey() });
-    const remote = result?.value;
+    const remote = await migrateLegacyUserData(
+      async (key) => (await bridgeRequest("frontend/get_user_data", { key }))?.value,
+      (key, value) => bridgeRequest("frontend/set_user_data", { key, value }),
+    );
     if (
       !state.localWasConfigured &&
       remote &&

--- a/custom_components/dashboardmodern/frontend/tests/config-persistence-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/config-persistence-section.test.js
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+globalThis.addEventListener = () => {};
+const { integrationUserDataKey, migrateLegacyUserData } = await import(
+  "../src/sections/config-persistence-section.js"
+);
+
+test("primary persistence uses the legacy runtime key", () => {
+  assert.equal(integrationUserDataKey(), "dashboardmodern_integration_config");
+});
+
+test("secondary persistence uses the runtime instance slug", () => {
+  assert.equal(
+    integrationUserDataKey({ primary: false, instance: "Casa / mare! 123456789" }),
+    "dashboardmodern_integration_config__Casamare12345678",
+  );
+});
+
+test("empty unified storage migrates the previous payload exactly once", async () => {
+  globalThis.__DASHBOARDMODERN_PRIMARY__ = true;
+  globalThis.__DASHBOARDMODERN_INSTANCE__ = "integration";
+  const legacy = { version: 1, values: { cd_sections: '{"home":true}' } };
+  const values = new Map([["dashboardmodern_v2_config:integration", legacy]]);
+  const pushes = [];
+  const fetchValue = async (key) => values.get(key) || null;
+  const pushValue = async (key, value) => {
+    pushes.push([key, value]);
+    values.set(key, value);
+  };
+
+  assert.equal(await migrateLegacyUserData(fetchValue, pushValue), legacy);
+  assert.equal(await migrateLegacyUserData(fetchValue, pushValue), legacy);
+  assert.deepEqual(pushes, [["dashboardmodern_integration_config", legacy]]);
+});

--- a/custom_components/dashboardmodern/frontend/tests/dashboard-store.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/dashboard-store.test.js
@@ -116,6 +116,38 @@ function setup(seed = {}) {
   return { store, storage, synced };
 }
 
+test("persist imports a fresh legacy sections write instead of overwriting it", () => {
+  const { store, storage } = setup({ cd_sections: { home: false } });
+  const external = { home: true, energy: false };
+  storage.setItem("cd_sections", JSON.stringify(external));
+  store.persist();
+  assert.deepEqual(JSON.parse(storage.getItem("cd_sections")), external);
+  assert.deepEqual(store.getState().visibility, external);
+});
+
+test("persist writes canonical state normally without an external legacy write", () => {
+  const { store, storage } = setup({ cd_sections: { home: false } });
+  store.state.visibility = { home: true };
+  store.persist();
+  assert.deepEqual(JSON.parse(storage.getItem("cd_sections")), { home: true });
+});
+
+test("fresh legacy rooms round-trip Temperature display names", () => {
+  const { store, storage } = setup();
+  const rooms = [
+    {
+      id: "room-kitchen",
+      name: "Kitchen",
+      temp: "sensor.kitchen",
+      temp_name: "Sonda cucina",
+    },
+  ];
+  storage.setItem("cd_stanze", JSON.stringify(rooms));
+  store.persist();
+  assert.equal(JSON.parse(storage.getItem("cd_stanze"))[0].temp_name, "Sonda cucina");
+  assert.equal(store.getSection("rooms")[0].temp_name, "Sonda cucina");
+});
+
 test("canonical display names never concatenate category/type", () => {
   assert.equal(getDeviceDisplayName({ name: "Forno", type: "forno" }), "Forno");
   assert.equal(getDeviceDisplayName({ name: "fOrNo", device_type: "forno" }), "fOrNo");

--- a/custom_components/dashboardmodern/frontend/tests/panel.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/panel.test.js
@@ -5,7 +5,13 @@ import test from "node:test";
 globalThis.HTMLElement = class {};
 globalThis.customElements = { get: () => undefined, define: () => {} };
 
-const { resolveLegacyVariant } = await import("../panel.js");
+const { dashboardModulesActive, resolveLegacyVariant } = await import("../panel.js");
+
+test("module sentinel decision requires the canonical store", () => {
+  assert.equal(dashboardModulesActive(undefined), false);
+  assert.equal(dashboardModulesActive({ DashboardModernModules: {} }), false);
+  assert.equal(dashboardModulesActive({ DashboardModernModules: { store: {} } }), true);
+});
 
 test("the Italian locale selects the Italian dashboard", () => {
   const panel = { config: { legacy_variants: ["dashboard.html", "dashboard-en.html"] } };

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.23"
+  "version": "1.0.0-beta.24"
 }


### PR DESCRIPTION
### Motivation

- Risolvere due fonti di incongruenza che impedivano il consolidamento dei salvataggi dell'editor e causavano la perdita di modifiche recenti salvate dai flussi legacy.
- Aggiungere una sentinella diagnostica nel pannello che segnali quando i moduli della dashboard non si sono inizializzati, evitando un degrado silenzioso dell'interfaccia.
- Allineare la versione dell'integrazione alla nuova hotfix `1.0.0-beta.24` e documentare le correzioni rilevanti nel CHANGELOG.

### Description

- Panel sentinel: in `custom_components/dashboardmodern/frontend/panel.js` è stata aggiunta la funzione pura `dashboardModulesActive` e un controllo a 6s dopo il caricamento dell'iframe che logga sempre lo stato (`[DashboardModern] moduli attivi: sì|no`) e, se i moduli non sono presenti, mostra un banner dismissibile IT/EN senza altri effetti collaterali; la logica decisionale è coperta da test unitario.
- Unified persistence key + migration: in `src/sections/config-persistence-section.js` è stata introdotta la funzione `integrationUserDataKey` che replica esattamente la logica di chiave del runtime legacy (suffix sanitizzato e troncamento a 16 caratteri), è stata aggiunta una migrazione one-shot in `hydrateRemote()` che, se la chiave unificata è vuota, legge dalla vecchia chiave `dashboardmodern_v2_config:*` e ripubblica il payload sulla chiave unificata senza cancellare l'originale, ed è stato esposto `migrateLegacyUserData` con test unitari.
- Single-writer protection: in `src/core/dashboard-store.js` `persist()` ora mantiene digest per le scritture legacy gestite, e prima di sovrascrivere ogni chiave verifica se il valore in `localStorage` è cambiato rispetto all'ultimo write del store; in caso di modifica esterna fresca importa/normalizza quel valore nello stato canonico invece di sovrascriverlo, e sono state aggiunte protezioni per non confondere proiezioni concorrenti del proprio persist con scritture esterne.
- Test e regressioni: aggiunti test unitari per la logica sentinel del pannello, per la generazione della chiave unificata e migrazione one-shot, e per i casi di regressione single-writer (preservazione `cd_sections`, scrittura canonica normale, round-trip `cd_stanze` con `temp_name`).
- Metadata e release: aggiornati `custom_components/dashboardmodern/manifest.json` a `1.0.0-beta.24`, aggiornato `CHANGELOG.md` e aggiornato `frontend/legacy/build-info.js` con la versione di release generata.

### Testing

- `python scripts/generate_build_info.py` — eseguito con esito positivo.
- `npm run check:inline-syntax` — eseguito con esito positivo sui file vendored legacy.
- `npm run format:check` — Prettier: nessuna violazione riportata.
- `npm run test:frontend` — eseguiti i test frontend: `413` test passati e `0` fallimenti.
- `node --test` su singoli file di unit test rilevanti — `panel.test.js`, `config-persistence-section.test.js`, `dashboard-store.test.js`, `editor-registry.test.js` eseguiti e superati nelle verifiche locali.
- `ruff check .` e `ruff format --check .` — eseguiti con esito positivo.
- `python -m pytest` — eseguito con `5` test passati e `2` ignorati.

Tutti i controlli automatici indicati nel gate sono passati localmente e l'albero di lavoro risulta coerente con le modifiche descritte.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f4c88b550832ebf811924815eb0e5)