### PR TITLE
fix: ripristina salvataggi affidabili su base beta.20

### DIFF
--- a/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
+++ b/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
@@ -66,6 +66,7 @@ export class DashboardStore {
     this.syncAdapter = sync;
     this.onStatus = onStatus;
     this.listeners = new Set();
+    this.persistedLegacyDigests = new Map();
     this.state = { schema_version: SCHEMA_VERSION, sections: {}, visibility: {} };
   }
   migrate() {
@@ -110,22 +111,54 @@ export class DashboardStore {
     return () => this.listeners.delete(listener);
   }
   persist() {
+    const legacyKeys = ["cd_sections", ...Object.values(SECTION_KEYS)];
+    for (const key of legacyKeys) {
+      if (this.canonicalWriteKeys?.has(key)) continue;
+      if (!this.persistedLegacyDigests.has(key)) continue;
+      const current = this.storage.getItem(key);
+      if (current === this.persistedLegacyDigests.get(key)) continue;
+      let value;
+      try {
+        value = JSON.parse(current);
+      } catch {
+        continue;
+      }
+      if (key === "cd_sections") {
+        if (value && typeof value === "object" && !Array.isArray(value))
+          this.state.visibility = { ...value };
+        continue;
+      }
+      const section = Object.entries(SECTION_KEYS).find(
+        ([, storageKey]) => storageKey === key,
+      )?.[0];
+      if (section)
+        this.state.sections[section] = normalizeSection(section, value, {
+          rooms: this.state.sections.rooms || [],
+        });
+    }
     this.state.sections.entityOverrides = projectEnergySlots(
       this.state.sections.energy || {},
       this.state.sections.entityOverrides || {},
     );
     this.projecting = true;
+    this.storage.__dashboardStoreProjecting = (this.storage.__dashboardStoreProjecting || 0) + 1;
     try {
       this.storage.setItem("dm_dashboard_state", JSON.stringify(this.state));
       this.storage.setItem("dm_schema_version", String(SCHEMA_VERSION));
-      this.storage.setItem("cd_sections", JSON.stringify(this.state.visibility));
+      const writeLegacy = (key, value) => {
+        const serialized = JSON.stringify(value);
+        this.storage.setItem(key, serialized);
+        this.persistedLegacyDigests.set(key, serialized);
+      };
+      writeLegacy("cd_sections", this.state.visibility);
       for (const [section, key] of Object.entries(SECTION_KEYS)) {
         let value = this.state.sections[section] || [];
         if (section === "lights")
           value = Object.fromEntries(value.map((item) => [item.entities[0], item.name]));
-        this.storage.setItem(key, JSON.stringify(value));
+        writeLegacy(key, value);
       }
     } finally {
+      this.storage.__dashboardStoreProjecting--;
       this.projecting = false;
     }
   }
@@ -137,6 +170,7 @@ export class DashboardStore {
       const result = original(key, value);
       if (
         !store.projecting &&
+        !store.storage.__dashboardStoreProjecting &&
         !globalThis.__DASHBOARDMODERN_PERSIST_RESTORE__ &&
         (key === "cd_sections" || Object.values(SECTION_KEYS).includes(key))
       )
@@ -193,7 +227,17 @@ export class DashboardStore {
     try {
       const detail = mutate();
       visibilityChanged = this.ensureSectionVisibleForData(section);
-      this.persist();
+      this.canonicalWriteKeys = new Set(
+        [
+          section === "visibility" ? "cd_sections" : SECTION_KEYS[section],
+          ...(visibilityChanged ? ["cd_sections"] : []),
+        ].filter(Boolean),
+      );
+      try {
+        this.persist();
+      } finally {
+        this.canonicalWriteKeys = null;
+      }
       const change = {
         section,
         operation,

--- a/custom_components/dashboardmodern/frontend/src/core/migrations.js
+++ b/custom_components/dashboardmodern/frontend/src/core/migrations.js
@@ -46,6 +46,8 @@ export function migrateRooms(input = []) {
       // DashboardStore.persist() destructively rewrite cd_stanze.
       temp: String(room.temp || room.temperature_entity || ""),
       hum: String(room.hum || room.humidity_entity || ""),
+      temp_name: String(room.temp_name || room.temperature_name || ""),
+      hum_name: String(room.hum_name || room.humidity_name || ""),
       rgb: room.rgb || "",
       order: Number.isFinite(+room.order) ? +room.order : index,
       metadata: { ...(room.metadata || {}) },

--- a/custom_components/dashboardmodern/frontend/src/core/migrations.js
+++ b/custom_components/dashboardmodern/frontend/src/core/migrations.js
@@ -36,6 +36,8 @@ export function migrateRooms(input = []) {
     let collision = 2;
     while (used.has(id)) id = `${base}-${collision++}`;
     used.add(id);
+    const tempName = String(room.temp_name || room.temperature_name || "");
+    const humName = String(room.hum_name || room.humidity_name || "");
     return {
       id,
       name: String(room.name || `Room ${index + 1}`),
@@ -46,8 +48,8 @@ export function migrateRooms(input = []) {
       // DashboardStore.persist() destructively rewrite cd_stanze.
       temp: String(room.temp || room.temperature_entity || ""),
       hum: String(room.hum || room.humidity_entity || ""),
-      temp_name: String(room.temp_name || room.temperature_name || ""),
-      hum_name: String(room.hum_name || room.humidity_name || ""),
+      ...(tempName ? { temp_name: tempName } : {}),
+      ...(humName ? { hum_name: humName } : {}),
       rgb: room.rgb || "",
       order: Number.isFinite(+room.order) ? +room.order : index,
       metadata: { ...(room.metadata || {}) },

--- a/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
@@ -63,8 +63,32 @@ function instanceId() {
   );
 }
 
+export function integrationUserDataKey({ primary = true, instance = "" } = {}) {
+  const suffix =
+    primary === false && instance
+      ? `__${String(instance).replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 16)}`
+      : "";
+  return `dashboardmodern_integration_config${suffix}`;
+}
+
 function userDataKey() {
+  return integrationUserDataKey({
+    primary: root.__DASHBOARDMODERN_PRIMARY__ !== false,
+    instance: root.__DASHBOARDMODERN_INSTANCE__,
+  });
+}
+
+function legacyUserDataKey() {
   return `dashboardmodern_v2_config:${instanceId()}`;
+}
+
+export async function migrateLegacyUserData(fetchValue, pushValue) {
+  const current = await fetchValue(userDataKey());
+  if (current) return current;
+  const legacy = await fetchValue(legacyUserDataKey());
+  if (!legacy) return null;
+  await pushValue(userDataKey(), legacy);
+  return legacy;
 }
 
 function localValues() {
@@ -208,8 +232,10 @@ async function hydrateRemote() {
   if (state.hydrating || state.hydrated || state.resetting || !hostedBridge()) return false;
   state.hydrating = true;
   try {
-    const result = await bridgeRequest("frontend/get_user_data", { key: userDataKey() });
-    const remote = result?.value;
+    const remote = await migrateLegacyUserData(
+      async (key) => (await bridgeRequest("frontend/get_user_data", { key }))?.value,
+      (key, value) => bridgeRequest("frontend/set_user_data", { key, value }),
+    );
     if (
       !state.localWasConfigured &&
       remote &&

--- a/custom_components/dashboardmodern/frontend/tests/persistence-hotfix.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/persistence-hotfix.test.js
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DashboardStore } from "../src/core/dashboard-store.js";
+
+globalThis.addEventListener = () => {};
+const { integrationUserDataKey, migrateLegacyUserData } = await import(
+  "../src/sections/config-persistence-section.js"
+);
+
+class MemoryStorage {
+  values = new Map();
+  getItem(key) {
+    return this.values.get(key) ?? null;
+  }
+  setItem(key, value) {
+    this.values.set(key, String(value));
+  }
+  removeItem(key) {
+    this.values.delete(key);
+  }
+}
+
+function setup(seed = {}) {
+  const storage = new MemoryStorage();
+  for (const [key, value] of Object.entries(seed)) storage.setItem(key, JSON.stringify(value));
+  const store = new DashboardStore({ storage, sync: async () => {} });
+  store.migrate();
+  return { store, storage };
+}
+
+test("primary persistence uses the integration runtime key", () => {
+  assert.equal(integrationUserDataKey(), "dashboardmodern_integration_config");
+});
+
+test("secondary persistence uses the sanitized runtime instance suffix", () => {
+  assert.equal(
+    integrationUserDataKey({ primary: false, instance: "Casa / mare! 123456789" }),
+    "dashboardmodern_integration_config__Casamare12345678",
+  );
+});
+
+test("legacy remote payload migrates once to the unified key", async () => {
+  globalThis.__DASHBOARDMODERN_PRIMARY__ = true;
+  globalThis.__DASHBOARDMODERN_INSTANCE__ = "integration";
+  const legacy = { version: 1, values: { cd_sections: '{"home":true}' } };
+  const values = new Map([["dashboardmodern_v2_config:integration", legacy]]);
+  const pushes = [];
+  const fetchValue = async (key) => values.get(key) || null;
+  const pushValue = async (key, value) => {
+    pushes.push([key, value]);
+    values.set(key, value);
+  };
+  assert.equal(await migrateLegacyUserData(fetchValue, pushValue), legacy);
+  assert.equal(await migrateLegacyUserData(fetchValue, pushValue), legacy);
+  assert.deepEqual(pushes, [["dashboardmodern_integration_config", legacy]]);
+});
+
+test("store preserves a fresh legacy visibility write instead of overwriting it", () => {
+  const { store, storage } = setup({ cd_sections: { home: false } });
+  const external = { home: true, energy: false };
+  storage.setItem("cd_sections", JSON.stringify(external));
+  store.persist();
+  assert.deepEqual(JSON.parse(storage.getItem("cd_sections")), external);
+  assert.deepEqual(store.getState().visibility, external);
+});
+
+test("store preserves fresh room edits including Temperature display names", () => {
+  const { store, storage } = setup();
+  const rooms = [
+    {
+      id: "room-kitchen",
+      name: "Kitchen",
+      temp: "sensor.kitchen",
+      temp_name: "Sonda cucina",
+      hum: "sensor.kitchen_humidity",
+      hum_name: "Umidità cucina",
+    },
+  ];
+  storage.setItem("cd_stanze", JSON.stringify(rooms));
+  store.persist();
+  const saved = JSON.parse(storage.getItem("cd_stanze"))[0];
+  assert.equal(saved.temp_name, "Sonda cucina");
+  assert.equal(saved.hum_name, "Umidità cucina");
+  assert.equal(store.getSection("rooms")[0].temp_name, "Sonda cucina");
+});

--- a/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-01520-version.test.js
@@ -30,7 +30,7 @@ test("the 1.0 beta release metadata is consistently versioned", async () => {
   const buildInfo = await readFile(buildInfoUrl, "utf8");
   const releaseVersion = String(manifest.version || "").trim();
 
-  assert.match(releaseVersion, /^1\.0\.0-beta\.\d+$/);
+  assert.match(releaseVersion, /^1\.0\.0-beta\.\d+(?:\.\d+)?$/);
   assert.match(readme, /badge\/version-\d+\.\d+\.\d+--beta\.\d+-/);
   assert.ok(buildInfo.includes(`"integrationVersion":"${releaseVersion}"`));
   assert.ok(buildInfo.includes(`"dashboardVersion":"${releaseVersion}"`));

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.20"
+  "version": "1.0.0-beta.20.1"
 }


### PR DESCRIPTION
Hotfix strettamente basata sulla Beta 20.

Cosa cambia:
- usa la chiave di persistenza Home Assistant unificata `dashboardmodern_integration_config`, migrando una sola volta l'eventuale payload `dashboardmodern_v2_config:*`;
- impedisce allo store canonico di sovrascrivere scritture legacy appena salvate dall'editor;
- aggiunge test regressione dedicati per migrazione chiave e salvataggi concorrenti;
- versione `1.0.0-beta.20.1`.

Cosa NON cambia:
- nessun refactor UI delle Beta 21–24;
- nessuna modifica a Temperatura, icone, layout, moduli o renderer rispetto alla Beta 20, salvo la persistenza.

Base: commit Beta 20 `251eb544f7f96f865d4dcba5bf55e12155409d92`.