### PR TITLE
Add workflow to regenerate vendor patch artifacts

### DIFF
--- a/.github/workflows/regenerate-vendor-artifacts.yml
+++ b/.github/workflows/regenerate-vendor-artifacts.yml
@@ -1,0 +1,69 @@
+name: Regenerate vendor artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: Branch on which to regenerate the vendor artifacts
+        required: true
+        default: codex/ricostruire-step-di-split-per-vendor
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  regenerate-vendor-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_branch }}
+          persist-credentials: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Regenerate patch artifacts
+        shell: bash
+        run: |
+          REF=$(python -c "import json;print(json.load(open('custom_components/dashboardmodern/frontend/legacy/VENDOR.json'))['commit'])")
+          python scripts/vendor_legacy.py --ref "$REF" && python scripts/split_legacy.py
+
+      - name: Guard generated changes
+        shell: bash
+        run: |
+          PATCH_DIR="custom_components/dashboardmodern/frontend/legacy/patches"
+          git status --porcelain
+          if [[ -n "$(git status --porcelain -- . ":(exclude)$PATCH_DIR" ":(exclude)$PATCH_DIR/**")" ]]; then
+            echo "vendor non riproducibile" >&2
+            exit 1
+          fi
+
+      - name: Commit and push changed patches
+        shell: bash
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+        run: |
+          PATCH_DIR="custom_components/dashboardmodern/frontend/legacy/patches"
+          if [[ -n "$(git status --porcelain -- "$PATCH_DIR")" ]]; then
+            git add -- "$PATCH_DIR"
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -m "Rigenera artefatti patches dalla pipeline"
+            git push origin "HEAD:$TARGET_BRANCH"
+          fi
+
+      - name: Verify reproducibility
+        shell: bash
+        run: |
+          REF=$(python -c "import json;print(json.load(open('custom_components/dashboardmodern/frontend/legacy/VENDOR.json'))['commit'])")
+          python scripts/vendor_legacy.py --ref "$REF" && python scripts/split_legacy.py
+          STATUS=$(git status --porcelain)
+          printf '%s\n' "$STATUS"
+          if [[ -n "$STATUS" ]]; then
+            exit 1
+          fi


### PR DESCRIPTION
### Motivation

- Automate regeneration of legacy vendor patch artifacts in a controlled, reproducible way targeting a user-supplied branch.
- Ensure changes produced by the regeneration are limited to the `patches` directory and fail fast if other files are changed.

### Description

- Added `.github/workflows/regenerate-vendor-artifacts.yml` providing a `workflow_dispatch` input `target_branch` with default `codex/ricostruire-step-di-split-per-vendor` and `contents: write` permission.
- The workflow checks out the requested branch with persistent credentials and sets up Python 3.12 using `actions/setup-python@v5`.
- It extracts `REF` from `custom_components/dashboardmodern/frontend/legacy/VENDOR.json`, runs `python scripts/vendor_legacy.py --ref "$REF"` and `python scripts/split_legacy.py`, and aborts with `vendor non riproducibile` if any changes occur outside `custom_components/dashboardmodern/frontend/legacy/patches`.
- If `patches/` changed the workflow stages add only that folder, record the change under the `github-actions[bot]` identity and push the update to the requested branch, then re-run the generation and fail if the repository is not clean.

### Testing

- Ran `git diff --check` and it completed without issues.
- Parsed the new workflow with Ruby YAML (`YAML.load_file`) and validation succeeded.
- Checked repository status with `git status --short --branch` and the working tree was clean after adding the file.
- Attempted `actionlint` but it was not available in the environment so workflow linting was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a803e4a7314832eb964a9607d03f73c)