### PR TITLE
Release 1.0.0-beta.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.0.0-beta.22 — 2026-08-15
+
+### Corretto
+
+- Testo invisibile con tema Home Assistant scuro: tutte le superfici di proprietà
+  della dashboard (editor, card, barra di navigazione) ora usano i token propri
+  invece di --primary-text-color del tema host; i nomi stanza nell'editor
+  Temperatura tornano visibili (DM-20260815C).
+
+### Aggiunto
+
+- Carichi energia sotto Casa dinamici: configurabili dall'editor (nome, icona,
+  entità potenza/energia, colore, max 8) con migrazione automatica dei vecchi slot
+  fissi; con zero carichi le bolle e gli archi non vengono più mostrati.
+- Campo SOC batteria nella configurazione energia, mostrato nella bolla Batteria
+  del flusso istantaneo (DM-20260815C).
+
 ## 1.0.0-beta.21 — 2026-08-15
 
 ### Modificato

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -7,4 +7,4 @@ import "../src/sections/beta12-real-device-polish-section.js";
 import "../src/sections/beta12-room-color-lock-section.js";
 import "../src/sections/beta14-real-device-hotfix-section.js";
 import "../src/sections/beta16-real-device-layout-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.21","dashboardVersion":"1.0.0-beta.21","moduleVersion":14,"schemaVersion":4,"date":"2026-08-15T11:22:25+00:00","commit":"50b0b05e7e6f347c23e740a36977cc3ab757b662","assetHash":"8fa27df5d839e6c7"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.22","dashboardVersion":"1.0.0-beta.22","moduleVersion":14,"schemaVersion":4,"date":"2026-08-15T13:24:11+00:00","commit":"fb51bd47267c2dd51fbbe9afb0cb2125f0988c56","assetHash":"873ab4bfc9b01341"});

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.21"
+  "version": "1.0.0-beta.22"
 }


### PR DESCRIPTION
### Motivation

- Preparare la release `1.0.0-beta.22` aggiornando la versione dell'integrazione e allineando il metadata di build;
- Documentare la release con la sezione di changelog richiesta contenente correzioni e nuove funzionalità;
- Rigenerare le informazioni di build frontend per garantire che `BUILD_INFO` rifletta la nuova versione e la provenienza del build.

### Description

- Aggiornata la versione in `custom_components/dashboardmodern/manifest.json` a `"1.0.0-beta.22"`.
- Aggiunta in testa a `CHANGELOG.md` la sezione `## 1.0.0-beta.22 — 2026-08-15` con le sezioni `### Corretto` e `### Aggiunto` come richiesto.
- Rigenerato `custom_components/dashboardmodern/frontend/legacy/build-info.js` eseguendo `scripts/generate_build_info.py` in modo che `integrationVersion` e `dashboardVersion` coincidano con il manifest.
- I cambiamenti sono limitati esclusivamente ai file `CHANGELOG.md`, `custom_components/dashboardmodern/manifest.json` e `custom_components/dashboardmodern/frontend/legacy/build-info.js` e sono stati committati con il messaggio `Release 1.0.0-beta.22`.

### Testing

- Eseguito `python3 scripts/generate_build_info.py` con esito positivo.
- Validato il JSON del manifest con `python3 -m json.tool custom_components/dashboardmodern/manifest.json` con esito positivo.
- Eseguito uno script Python che controlla la coerenza tra `manifest.json`, il payload `BUILD_INFO` e la presenza dell'intestazione nel `CHANGELOG.md`, e l'asserzione è passata.
- Eseguiti `git diff --check` e controlli sui file modificati per confermare che solo i tre file richiesti sono stati toccati e il commit è stato creato con successo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80685815b8832eb94d93e568a2959f)