### PR TITLE
fix: carichi Energia, SOC, Temperatura e costi — beta.23

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,11 +15,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  playwright:
+  playwright-project:
+    name: playwright / ${{ matrix.project }}
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.54.1-noble
-    timeout-minutes: 35
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        project:
+          - desktop
+          - mobile
+          - webkit-ipad
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -34,11 +43,27 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           python scripts/generate_build_info.py --expected-commit "$GITHUB_SHA"
-      - run: npm run test:e2e
+      - name: Run ${{ matrix.project }} E2E
+        run: npx playwright test --project="${{ matrix.project }}"
       - uses: actions/upload-artifact@v6
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.project }}
           path: |
             playwright-report
             test-results
+
+  # Keep the historical required check name `playwright`, but make the three
+  # browser projects run in parallel. This job is only the final gate/aggregator.
+  playwright:
+    name: playwright
+    runs-on: ubuntu-latest
+    needs: playwright-project
+    if: always()
+    steps:
+      - name: Verify all browser projects
+        env:
+          RESULT: ${{ needs.playwright-project.result }}
+        run: |
+          echo "Browser matrix result: $RESULT"
+          test "$RESULT" = "success"

--- a/custom_components/dashboardmodern/frontend/e2e/beta2-persistence-ev-flow.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta2-persistence-ev-flow.spec.js
@@ -198,35 +198,73 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await boot(page, variant, testInfo);
 
     await page.evaluate(async () => {
+      const state = (entity_id, value) => ({
+        entity_id,
+        state: String(value),
+        attributes: { unit_of_measurement: "kWh" },
+      });
+      const seeded = [
+        state("sensor.flow_boiler_day", 1.25),
+        state("sensor.flow_clima_day", 0.16),
+        state("sensor.flow_lav_day", 0),
+        state("sensor.flow_cuc_month", 12.4),
+      ];
+      for (const item of seeded) {
+        _RAW_STATES[item.entity_id] = structuredClone(item);
+        STATES[item.entity_id] = structuredClone(item);
+      }
       await DashboardModernModules.store.replaceSection("loads", [
-        { id: "flow-boiler", name: "Boiler", order: 0, show_in_dashboard: true },
+        {
+          id: "flow-boiler",
+          name: "Boiler",
+          order: 0,
+          show_in_dashboard: true,
+          daily_energy_entity: "sensor.flow_boiler_day",
+        },
         { id: "flow-wallbox", name: "Wallbox", order: 1, show_in_dashboard: true },
-        { id: "flow-clima", name: "Clima", order: 2, show_in_dashboard: true },
-        { id: "flow-lav", name: "Lavanderia", order: 3, show_in_dashboard: true },
-        { id: "flow-cuc", name: "Cucina", order: 4, show_in_dashboard: true },
+        {
+          id: "flow-clima",
+          name: "Clima",
+          order: 2,
+          show_in_dashboard: true,
+          daily_energy_entity: "sensor.flow_clima_day",
+        },
+        {
+          id: "flow-lav",
+          name: "Lavanderia",
+          order: 3,
+          show_in_dashboard: true,
+          daily_energy_entity: "sensor.flow_lav_day",
+        },
+        {
+          id: "flow-cuc",
+          name: "Cucina",
+          order: 4,
+          show_in_dashboard: true,
+          monthly_energy_entity: "sensor.flow_cuc_month",
+        },
       ]);
-      await new Promise((resolve) => setTimeout(resolve, 180));
-      const set = (id, value) => {
-        const node = document.getElementById(id);
-        if (!node) throw new Error(`missing ${id}`);
-        node.textContent = value;
-      };
-      set("v-boiler-day", "1,25 kWh");
-      set("v-clima-day", "0.16 kWh");
-      set("v-lav-day", "0 kWh");
-      set("v-cuc-month", "12.4 kWh");
+      dispatchEvent(new CustomEvent("dashboardmodern:states-ready"));
+      await new Promise((resolve) => setTimeout(resolve, 260));
       window.dmRefreshEnergyFlows?.();
     });
 
+    await expect(page.locator("#v-boiler-day")).toContainText(/1[,.]3|1[,.]25/);
+    await expect(page.locator("#v-clima-day")).toContainText(/0[,.]2|0[,.]16/);
+    await expect(page.locator("#v-cuc-month")).toContainText(/12[,.]4/);
     await expect(page.locator("#line-home-boiler-day")).toHaveClass(/active/);
     await expect(page.locator("#line-home-boiler-day")).toHaveClass(/dm-energy-flow-active/);
     await expect(page.locator("#line-home-clima-day")).toHaveClass(/active/);
     await expect(page.locator("#line-home-lav-day")).not.toHaveClass(/active/);
     await expect(page.locator("#line-home-cuc-month")).toHaveClass(/active/);
 
-    await page.evaluate(() => {
-      document.getElementById("v-boiler-day").textContent = "0 kWh";
-      document.getElementById("v-cuc-month").textContent = "0 kWh";
+    await page.evaluate(async () => {
+      _RAW_STATES["sensor.flow_boiler_day"].state = "0";
+      STATES["sensor.flow_boiler_day"].state = "0";
+      _RAW_STATES["sensor.flow_cuc_month"].state = "0";
+      STATES["sensor.flow_cuc_month"].state = "0";
+      dispatchEvent(new CustomEvent("dashboardmodern:states-ready"));
+      await new Promise((resolve) => setTimeout(resolve, 180));
       window.dmRefreshEnergyFlows?.();
     });
     await expect(page.locator("#line-home-boiler-day")).not.toHaveClass(/active/);

--- a/custom_components/dashboardmodern/frontend/e2e/beta2-persistence-ev-flow.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta2-persistence-ev-flow.spec.js
@@ -191,13 +191,21 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     expect(persisted).toEqual({ brand: "Leapmotor", model: "B10" });
   });
 
-  test(`${variant}: beta2 binds daily and monthly load flow animation to displayed energy`, async ({
+  test(`${variant}: beta2 binds daily and monthly load flow animation to configured canonical loads`, async ({
     page,
   }, testInfo) => {
     test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
     await boot(page, variant, testInfo);
 
-    await page.evaluate(() => {
+    await page.evaluate(async () => {
+      await DashboardModernModules.store.replaceSection("loads", [
+        { id: "flow-boiler", name: "Boiler", order: 0, show_in_dashboard: true },
+        { id: "flow-wallbox", name: "Wallbox", order: 1, show_in_dashboard: true },
+        { id: "flow-clima", name: "Clima", order: 2, show_in_dashboard: true },
+        { id: "flow-lav", name: "Lavanderia", order: 3, show_in_dashboard: true },
+        { id: "flow-cuc", name: "Cucina", order: 4, show_in_dashboard: true },
+      ]);
+      await new Promise((resolve) => setTimeout(resolve, 180));
       const set = (id, value) => {
         const node = document.getElementById(id);
         if (!node) throw new Error(`missing ${id}`);

--- a/custom_components/dashboardmodern/frontend/e2e/beta5-root-causes.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta5-root-causes.spec.js
@@ -241,7 +241,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     }
   });
 
-  test(`${variant}: beta5 Energy chart never invents future days and keeps Wallbox in the flow`, async ({
+  test(`${variant}: beta5 Energy chart hides unconfigured load circles and keeps configured Wallbox in the flow`, async ({
     page,
   }, testInfo) => {
     test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
@@ -250,10 +250,31 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await page.evaluate(async () => {
       window.render?.();
       await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      await new Promise((resolve) => setTimeout(resolve, 120));
+    });
+    for (const id of ["n-wb", "n-wb-day", "n-wb-month"]) {
+      await expect(page.locator(`#${id}`)).toHaveCSS("display", "none");
+    }
+    for (const id of ["line-home-wb", "line-home-wb-day", "line-home-wb-month"]) {
+      await expect(page.locator(`#${id}`)).toHaveCSS("display", "none");
+    }
+
+    await page.evaluate(async () => {
+      await DashboardModernModules.store.replaceSection("loads", [
+        { id: "flow-boiler", name: "Boiler", order: 0, show_in_dashboard: true },
+        { id: "flow-wallbox", name: "Wallbox", order: 1, show_in_dashboard: true },
+      ]);
+      window.render?.();
+      await new Promise((resolve) => setTimeout(resolve, 180));
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
     });
     await expect(page.locator("#n-wb-day")).toHaveAttribute("data-dm-beta5-flow-complete", "true");
+    await expect(page.locator("#n-wb")).not.toHaveCSS("display", "none");
     await expect(page.locator("#n-wb-day")).not.toHaveCSS("display", "none");
+    await expect(page.locator("#n-wb-month")).not.toHaveCSS("display", "none");
+    await expect(page.locator("#line-home-wb")).not.toHaveCSS("display", "none");
     await expect(page.locator("#line-home-wb-day")).not.toHaveCSS("display", "none");
+    await expect(page.locator("#line-home-wb-month")).not.toHaveCSS("display", "none");
 
     const result = await page.evaluate(async () => {
       let loading = document.getElementById("ed-chart-loading");

--- a/custom_components/dashboardmodern/frontend/e2e/temperature-labels-real-device.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/temperature-labels-real-device.spec.js
@@ -87,9 +87,24 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       '[data-temperature-room][data-room-id="room-cameretta"]',
     );
     await expect(row).toBeVisible();
-    await expect(
-      row.locator(":scope > .ed-row-main > .ed-row-new"),
-    ).toHaveText("Cameretta");
+    const roomName = row.locator(":scope > .ed-row-main > .ed-row-new");
+    await expect(roomName).toHaveText("Cameretta");
+    const roomNameGeometry = await roomName.evaluate((node) => {
+      const rect = node.getBoundingClientRect();
+      const style = getComputedStyle(node);
+      return {
+        width: rect.width,
+        height: rect.height,
+        display: style.display,
+        visibility: style.visibility,
+        opacity: Number(style.opacity || 1),
+      };
+    });
+    expect(roomNameGeometry.width).toBeGreaterThan(24);
+    expect(roomNameGeometry.height).toBeGreaterThan(12);
+    expect(roomNameGeometry.display).not.toBe("none");
+    expect(roomNameGeometry.visibility).toBe("visible");
+    expect(roomNameGeometry.opacity).toBeGreaterThan(0);
 
     await row.locator("[data-temperature-edit]").click();
     const tempName = page.locator("#dm-temperature-name");

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -7,4 +7,5 @@ import "../src/sections/beta12-real-device-polish-section.js";
 import "../src/sections/beta12-room-color-lock-section.js";
 import "../src/sections/beta14-real-device-hotfix-section.js";
 import "../src/sections/beta16-real-device-layout-section.js";
+import "../src/sections/beta22-load-slots-hotfix-section.js";
 export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.22","dashboardVersion":"1.0.0-beta.22","moduleVersion":14,"schemaVersion":4,"date":"2026-08-15T13:24:11+00:00","commit":"fb51bd47267c2dd51fbbe9afb0cb2125f0988c56","assetHash":"873ab4bfc9b01341"});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -8,4 +8,4 @@ import "../src/sections/beta12-room-color-lock-section.js";
 import "../src/sections/beta14-real-device-hotfix-section.js";
 import "../src/sections/beta16-real-device-layout-section.js";
 import "../src/sections/beta22-load-slots-hotfix-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.22","dashboardVersion":"1.0.0-beta.22","moduleVersion":14,"schemaVersion":4,"date":"2026-08-15T13:24:11+00:00","commit":"fb51bd47267c2dd51fbbe9afb0cb2125f0988c56","assetHash":"873ab4bfc9b01341"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.23","dashboardVersion":"1.0.0-beta.23","moduleVersion":14,"schemaVersion":4,"date":"2026-08-15T13:24:11+00:00","commit":"fb51bd47267c2dd51fbbe9afb0cb2125f0988c56","assetHash":"873ab4bfc9b01341"});

--- a/custom_components/dashboardmodern/frontend/src/legacy/bridge-socket.js
+++ b/custom_components/dashboardmodern/frontend/src/legacy/bridge-socket.js
@@ -47,6 +47,23 @@ export const ALLOWED_MESSAGE_TYPES = Object.freeze([
 
 const OPEN = 1;
 const CLOSED = 3;
+const MODERN_PERSISTENCE_ID_MIN = 700000;
+const DASHBOARD_CONFIG_KEY_PREFIX = "dashboardmodern_integration_config";
+
+/**
+ * The vendored runtime still contains its historical flat user_data sync.
+ * Modern persistence uses request ids >= 700000 and an envelope
+ * `{version, updated_at, values}`. Both used to write the same HA key, so a
+ * phone and a desktop could alternately overwrite it with incompatible shapes.
+ * The hosted bridge is early enough to stop the old writer before modules load.
+ */
+export function isLegacyDashboardPersistenceMessage(message = {}) {
+  const type = String(message?.type || "");
+  if (type !== "frontend/get_user_data" && type !== "frontend/set_user_data") return false;
+  if (!String(message?.key || "").startsWith(DASHBOARD_CONFIG_KEY_PREFIX)) return false;
+  const id = Number(message?.id);
+  return !Number.isFinite(id) || id < MODERN_PERSISTENCE_ID_MIN;
+}
 
 /**
  * Create the shim class.
@@ -119,6 +136,16 @@ export function createBridgeSocket({
           "not_allowed",
           `Message type not permitted through the bridge: ${type}`,
         );
+        return;
+      }
+
+      // The classic runtime executes before deferred ES modules, therefore
+      // merely replacing cdSyncPush later is not enough: its auth_ok handler can
+      // already have issued a flat get/set_user_data request. A harmless success
+      // reply keeps that old code from hanging while guaranteeing only the
+      // canonical modern owner reaches Home Assistant for this config key.
+      if (isLegacyDashboardPersistenceMessage(message)) {
+        this._reply(id, type === "frontend/get_user_data" ? { value: null } : null);
         return;
       }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/beta22-load-slots-hotfix-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta22-load-slots-hotfix-section.js
@@ -1,0 +1,506 @@
+/* DM-FIX-20260815D
+ * Beta 22 corrective owner:
+ * - the existing canonical Loads editor owns the five flow bubbles below Home;
+ * - the temporary energyLoads editor/runtime introduced in beta.22 is suppressed;
+ * - unconfigured load bubbles/connectors are hidden in instant/day/month views;
+ * - battery SOC uses energy.battery.soc in the instant flow;
+ * - Temperature configured rows keep the canonical room name visible;
+ * - Energy settings keep import/export price controls visible and labelled.
+ *
+ * Event driven only: no setInterval and no document-wide MutationObserver.
+ */
+
+const root = globalThis;
+const doc = root.document;
+const SLOT_KEYS = Object.freeze(["boiler", "wb", "clima", "lav", "cuc"]);
+const SECTION_STORAGE = Object.freeze({ loads: "cd_loads", energy: "cd_energy_model" });
+const MARKER = "__DASHBOARDMODERN_BETA22_LOAD_SLOTS_HOTFIX__";
+
+const clean = (value) => String(value ?? "").trim();
+const finite = (value) => {
+  const parsed = Number(String(value ?? "").replace(",", "."));
+  return Number.isFinite(parsed) ? parsed : null;
+};
+const escapeHtml = (value) =>
+  clean(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+
+function store() {
+  return root.DashboardModernModules?.store || null;
+}
+
+function readSection(name, fallback) {
+  try {
+    const value = store()?.getSection?.(name);
+    if (value !== undefined && value !== null) return value;
+  } catch (_error) {}
+  try {
+    return JSON.parse(root.localStorage?.getItem?.(SECTION_STORAGE[name]) || "null") ?? fallback;
+  } catch (_error) {
+    return fallback;
+  }
+}
+
+function states() {
+  return root.STATES || root.hass?.states || root.__HASS__?.states || {};
+}
+
+export function configuredFlowLoads(loads = []) {
+  return (Array.isArray(loads) ? loads : [])
+    .filter(
+      (item) =>
+        item &&
+        item.category !== "manual-report" &&
+        item.show_in_dashboard !== false &&
+        (clean(item.name) ||
+          clean(item.power_entity) ||
+          clean(item.daily_energy_entity) ||
+          clean(item.monthly_energy_entity) ||
+          clean(item.total_energy_entity) ||
+          clean(item.history_entity)),
+    )
+    .slice()
+    .sort((left, right) => (Number(left.order) || 0) - (Number(right.order) || 0))
+    .slice(0, SLOT_KEYS.length);
+}
+
+export function loadPeriodEntity(load = {}, period = "instant") {
+  if (period === "day") return clean(load.daily_energy_entity);
+  if (period === "month")
+    return clean(load.monthly_energy_entity || load.history_entity || load.total_energy_entity);
+  return clean(load.power_entity);
+}
+
+export function socEntity(energy = {}) {
+  return clean(
+    energy?.battery?.soc ||
+      energy?.battery?.battery_soc_entity ||
+      energy?.battery?.battery_soc,
+  );
+}
+
+function stateNumber(entity) {
+  if (!entity) return null;
+  const source = states()?.[entity];
+  return finite(source?.state ?? source);
+}
+
+function formatValue(value, period) {
+  if (value === null || !Number.isFinite(Number(value))) return "—";
+  const locale = doc?.documentElement?.lang === "en" ? "en-GB" : "it-IT";
+  const digits = period === "instant" ? 0 : 1;
+  return `${new Intl.NumberFormat(locale, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  }).format(Number(value))} ${period === "instant" ? "W" : "kWh"}`;
+}
+
+const flowState = (root[MARKER] ||= {
+  installed: false,
+  frame: 0,
+  timer: 0,
+  bundle: null,
+  storeBound: false,
+  wrappersBound: false,
+});
+
+function periodDeviceValue(load, period) {
+  if (period !== "month") return stateNumber(loadPeriodEntity(load, period));
+  const bundle = flowState.bundle;
+  const devices = bundle?.deviceMonth?.devices || [];
+  const values = bundle?.deviceMonth?.values;
+  if (values?.get) {
+    const device = devices.find(
+      (item) =>
+        clean(item.id) === clean(load.id) ||
+        clean(item.key) === clean(load.id) ||
+        clean(item.name) === clean(load.name),
+    );
+    const source = clean(device?.history || device?.entity);
+    if (source) {
+      const value = finite(values.get(source));
+      if (value !== null) return value;
+    }
+  }
+  return stateNumber(loadPeriodEntity(load, period));
+}
+
+function viewConfig(period) {
+  if (period === "day") return { id: "view-day", suffix: "-day" };
+  if (period === "month") return { id: "view-month", suffix: "-month" };
+  return { id: "view-ist", suffix: "" };
+}
+
+function slotNode(scope, slot, suffix, index) {
+  return (
+    scope?.querySelector?.(`#n-${slot}${suffix}`) ||
+    scope?.querySelector?.(`#n-${slot}`) ||
+    [...(scope?.querySelectorAll?.(".node.n-load") || [])][index] ||
+    null
+  );
+}
+
+function valueNode(scope, slot, period, node) {
+  const id =
+    period === "instant" ? `v-${slot}-p` : period === "day" ? `v-${slot}-day` : `v-${slot}-month`;
+  return (
+    scope?.querySelector?.(`#${id}`) ||
+    node?.querySelector?.(".node-value,[data-node-value],.n-value") ||
+    null
+  );
+}
+
+function setVisible(node, visible) {
+  if (!node) return;
+  node.hidden = !visible;
+  if (visible) {
+    node.style.removeProperty("display");
+    node.style.setProperty("visibility", "visible", "important");
+    node.style.setProperty("opacity", "1", "important");
+  } else {
+    node.style.setProperty("display", "none", "important");
+    node.style.setProperty("visibility", "hidden", "important");
+  }
+}
+
+function setConnector(scope, slot, suffix, visible, loadId = "") {
+  for (const id of [`line-home-${slot}${suffix}`, `m-line-home-${slot}${suffix}`]) {
+    const line = scope?.querySelector?.(`#${id}`) || doc?.getElementById?.(id);
+    if (!line) continue;
+    line.hidden = !visible;
+    if (visible) {
+      line.style.setProperty("display", "inline", "important");
+      line.style.setProperty("visibility", "visible", "important");
+      line.dataset.dmCanonicalLoad = loadId;
+    } else {
+      line.style.setProperty("display", "none", "important");
+      line.style.setProperty("visibility", "hidden", "important");
+      delete line.dataset.dmCanonicalLoad;
+    }
+  }
+}
+
+function writeLoadNode(node, load, period, value) {
+  if (!node || !load) return;
+  const name = clean(load.name) || (doc?.documentElement?.lang === "en" ? "Load" : "Carico");
+  const icon = clean(load.emoji_icon || load.icon || "🔌");
+  const label = node.querySelector?.(".node-label,.n-label,[data-node-label]");
+  const iconNode = node.querySelector?.(".node-icon,.n-icon,[data-node-icon]");
+  if (label) label.textContent = name;
+  if (iconNode) {
+    if (/^mdi:/i.test(icon) && typeof root.cdIconMarkup === "function")
+      iconNode.innerHTML = root.cdIconMarkup(icon, 28);
+    else iconNode.textContent = icon;
+  }
+  const valueTarget = valueNode(node.closest?.("#view-ist,#view-day,#view-month") || doc, node.dataset.dmFlowSlot || "", period, node);
+  if (valueTarget) valueTarget.textContent = formatValue(value, period);
+  node.dataset.dmCanonicalLoad = clean(load.id) || name;
+  node.dataset.dmCanonicalLoadPeriod = period;
+}
+
+function removeTemporaryEnergyLoads() {
+  doc
+    ?.querySelectorAll?.(
+      "[data-energy-load-node],[data-energy-load-arc],[data-energy-loads-editor],.dm-energy-loads-editor",
+    )
+    .forEach((node) => node.remove());
+}
+
+function syncCanonicalLoadBubbles() {
+  if (!doc) return false;
+  removeTemporaryEnergyLoads();
+  const loads = configuredFlowLoads(readSection("loads", []));
+  for (const period of ["instant", "day", "month"]) {
+    const { id, suffix } = viewConfig(period);
+    const scope = doc.getElementById(id);
+    if (!scope) continue;
+    const fallbackNodes = [...scope.querySelectorAll(".node.n-load")];
+    SLOT_KEYS.forEach((slot, index) => {
+      const node = slotNode(scope, slot, suffix, index);
+      const load = loads[index] || null;
+      if (!node) return;
+      node.dataset.dmFlowSlot = slot;
+      setVisible(node, Boolean(load));
+      setConnector(scope, slot, suffix, Boolean(load), clean(load?.id));
+      if (!load) return;
+      const value = periodDeviceValue(load, period);
+      const label = node.querySelector?.(".node-label,.n-label,[data-node-label]");
+      const iconNode = node.querySelector?.(".node-icon,.n-icon,[data-node-icon]");
+      if (label) label.textContent = clean(load.name) || "Carico";
+      const icon = clean(load.emoji_icon || load.icon || "🔌");
+      if (iconNode) {
+        if (/^mdi:/i.test(icon) && typeof root.cdIconMarkup === "function")
+          iconNode.innerHTML = root.cdIconMarkup(icon, 28);
+        else iconNode.textContent = icon;
+      }
+      const target = valueNode(scope, slot, period, node);
+      if (target) target.textContent = formatValue(value, period);
+      node.dataset.dmCanonicalLoad = clean(load.id) || clean(load.name);
+      node.dataset.dmCanonicalLoadPeriod = period;
+    });
+    // Any extra legacy/dynamic load nodes must not survive when canonical Loads
+    // contains fewer entries than the fixed five-slot topology.
+    fallbackNodes.slice(SLOT_KEYS.length).forEach((node) => setVisible(node, false));
+    scope.dataset.dmCanonicalLoadCount = String(loads.length);
+  }
+  return true;
+}
+
+function syncBatterySoc() {
+  if (!doc) return false;
+  const energy = readSection("energy", {});
+  const entity = socEntity(energy);
+  const battery = doc.querySelector("#view-ist #n-battery,#n-battery");
+  if (!battery) return false;
+  let node = battery.querySelector("#v-battery-soc,.dm-battery-soc");
+  if (!node) {
+    node = doc.createElement("small");
+    node.id = "v-battery-soc";
+    node.className = "dm-battery-soc";
+    battery.append(node);
+  }
+  if (!entity) {
+    node.hidden = true;
+    node.textContent = "";
+    node.removeAttribute("data-entity");
+    return true;
+  }
+  const value = stateNumber(entity);
+  node.hidden = false;
+  node.dataset.entity = entity;
+  node.textContent = value === null ? "SOC —" : `SOC ${Math.round(value)}%`;
+  return true;
+}
+
+function canonicalRoomName(row) {
+  const id = clean(row?.dataset?.roomId);
+  const rooms = readSection("rooms", []);
+  const room = Array.isArray(rooms)
+    ? rooms.find((item) => clean(item.id) === id || clean(item.room_id) === id)
+    : null;
+  return (
+    clean(room?.name) ||
+    clean(row?.dataset?.roomName) ||
+    clean(row?.querySelector?.(".ed-row-new")?.textContent) ||
+    (doc?.documentElement?.lang === "en" ? "Room" : "Stanza")
+  );
+}
+
+function repairTemperatureRows() {
+  if (!doc) return false;
+  const rows = doc.querySelectorAll(
+    "#editor-modal [data-temperature-room],#ed-body [data-temperature-room]",
+  );
+  rows.forEach((row) => {
+    let main = row.querySelector(".ed-row-main");
+    if (!main) {
+      main = doc.createElement("div");
+      main.className = "ed-row-main";
+      const icon = row.querySelector(".dm-temperature-card-icon,.ed-row-icon");
+      if (icon) icon.after(main);
+      else row.prepend(main);
+    }
+    let name = main.querySelector(".ed-row-new");
+    if (!name) {
+      name = doc.createElement("div");
+      name.className = "ed-row-new";
+      main.prepend(name);
+    }
+    const label = canonicalRoomName(row);
+    name.textContent = label;
+    row.dataset.roomName = label;
+    row.dataset.dmTemperatureNameVisible = "true";
+  });
+  return rows.length > 0;
+}
+
+function configuredRate(key) {
+  const value = root.cdCfg?.(key);
+  if (value !== undefined && value !== null && value !== "") return clean(value);
+  return clean(root.localStorage?.getItem?.(key));
+}
+
+function repairEnergyCostEditor() {
+  if (!doc) return false;
+  const editor = doc.querySelector('#ed-body[data-editor="energy"],#editor-modal [data-editor="energy"]');
+  const settings = editor?.querySelector?.('[data-energy-panel="settings"]');
+  if (!settings) return false;
+  let card = settings.querySelector(".dm-energy-cost-card");
+  if (!card) {
+    card = doc.createElement("div");
+    card.className = "ed-form dm-energy-cost-card";
+    settings.append(card);
+  }
+  if (card.dataset.dmCostOwner === "beta22-hotfix") return true;
+  const english = doc.documentElement?.lang === "en";
+  const buy = configuredRate("cd_costo_kwh");
+  const sell = configuredRate("cd_prezzo_immissione");
+  card.dataset.dmCostOwner = "beta22-hotfix";
+  card.innerHTML = `
+    <div class="ed-sec-title">💶 ${english ? "Energy cost" : "Costo energia"}</div>
+    <div class="ed-hint">${english ? "Rates used by the Energy Report." : "Tariffe usate dal Report Energia."}</div>
+    <div class="dm-energy-cost-grid">
+      <label class="dm-energy-cost-field"><span>${english ? "Purchased energy" : "Energia acquistata"} <small>€/kWh</small></span><input id="ed-costo-kwh" class="ed-input" type="number" inputmode="decimal" step="0.001" min="0" value="${escapeHtml(buy)}" placeholder="0,000"></label>
+      <label class="dm-energy-cost-field"><span>${english ? "Sold energy" : "Energia venduta"} <small>€/kWh</small></span><input id="ed-prezzo-imm" class="ed-input" type="number" inputmode="decimal" step="0.001" min="0" value="${escapeHtml(sell)}" placeholder="0,000"></label>
+    </div>
+    <button type="button" class="ed-save-btn" data-dm-save-energy-costs>💾 ${english ? "Save costs" : "Salva costi"}</button>`;
+  card.querySelector("[data-dm-save-energy-costs]")?.addEventListener("click", () => {
+    if (typeof root.edSaveCosti === "function") {
+      root.edSaveCosti();
+      return;
+    }
+    const importValue = clean(card.querySelector("#ed-costo-kwh")?.value);
+    const exportValue = clean(card.querySelector("#ed-prezzo-imm")?.value);
+    root.localStorage?.setItem?.("cd_costo_kwh", importValue);
+    root.localStorage?.setItem?.("cd_prezzo_immissione", exportValue);
+    root.cdMarkDirty?.();
+    root.cdSyncPush?.();
+  });
+  return true;
+}
+
+function repairEnergyEditor() {
+  removeTemporaryEnergyLoads();
+  repairEnergyCostEditor();
+}
+
+function applyAll() {
+  flowState.frame = 0;
+  syncCanonicalLoadBubbles();
+  syncBatterySoc();
+  repairTemperatureRows();
+  repairEnergyEditor();
+}
+
+function schedule(delay = 0) {
+  if (!doc) return;
+  if (delay > 0) {
+    root.setTimeout?.(() => schedule(), delay);
+    return;
+  }
+  if (flowState.frame) return;
+  flowState.frame = root.requestAnimationFrame?.(applyAll) || root.setTimeout?.(applyAll, 0);
+}
+
+function scheduleSettled() {
+  schedule();
+  schedule(90);
+}
+
+function wrapAfter(name) {
+  const current = root[name];
+  const marker = `__dmBeta22LoadSlots_${name}`;
+  if (typeof current !== "function" || current[marker]) return false;
+  const wrapped = function (...args) {
+    const result = current.apply(this, args);
+    if (result && typeof result.finally === "function") result.finally(scheduleSettled);
+    else scheduleSettled();
+    return result;
+  };
+  wrapped[marker] = true;
+  wrapped.__dmWrappedOriginal = current;
+  root[name] = wrapped;
+  return true;
+}
+
+function installWrappers() {
+  if (flowState.wrappersBound) return;
+  let wrapped = false;
+  for (const name of [
+    "dmRefreshEnergyFlows",
+    "renderEnergyDashboard",
+    "renderEnergyDay",
+    "renderEnergyMonth",
+    "switchEnergyView",
+    "render",
+    "editorSwitch",
+  ])
+    wrapped = wrapAfter(name) || wrapped;
+  if (wrapped) flowState.wrappersBound = true;
+}
+
+function bindStore() {
+  if (flowState.storeBound) return;
+  const currentStore = store();
+  if (!currentStore?.subscribe) return;
+  flowState.storeBound = true;
+  currentStore.subscribe((change) => {
+    if (["loads", "energy", "rooms"].includes(change?.section)) scheduleSettled();
+  });
+}
+
+function installStyle() {
+  if (!doc || doc.getElementById("dm-beta22-load-slots-hotfix-style")) return;
+  const style = doc.createElement("style");
+  style.id = "dm-beta22-load-slots-hotfix-style";
+  style.textContent = `
+    [data-energy-loads-editor],.dm-energy-loads-editor,[data-energy-load-node],[data-energy-load-arc]{display:none!important}
+    #editor-modal [data-temperature-room],#ed-body [data-temperature-room]{display:grid!important;grid-template-columns:auto minmax(0,1fr) auto auto!important;align-items:center!important;column-gap:12px!important}
+    #editor-modal [data-temperature-room] .ed-row-main,#ed-body [data-temperature-room] .ed-row-main{display:flex!important;flex-direction:column!important;justify-content:center!important;min-width:0!important;width:auto!important;max-width:none!important;opacity:1!important;visibility:visible!important;overflow:visible!important}
+    #editor-modal [data-temperature-room] .ed-row-new,#ed-body [data-temperature-room] .ed-row-new{display:block!important;position:static!important;width:auto!important;max-width:100%!important;min-width:0!important;height:auto!important;opacity:1!important;visibility:visible!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important;color:var(--text,#0f172a)!important;font-weight:800!important;font-size:16px!important;line-height:1.25!important}
+    #editor-modal [data-temperature-room] .ed-row-old,#ed-body [data-temperature-room] .ed-row-old{display:block!important;max-width:100%!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important;color:var(--muted,#64748b)!important}
+    .dm-energy-cost-card{display:block!important;visibility:visible!important;opacity:1!important}
+    .dm-energy-cost-grid{display:grid!important;grid-template-columns:minmax(0,1fr) minmax(0,1fr)!important;gap:12px!important;margin:12px 0!important}
+    .dm-energy-cost-field{display:grid!important;gap:7px!important;min-width:0!important;color:var(--text,#0f172a)!important;font-weight:700!important}
+    .dm-energy-cost-field .ed-input{display:block!important;box-sizing:border-box!important;width:100%!important;min-width:0!important;min-height:48px!important;padding:10px 12px!important;color:var(--text,#0f172a)!important;background:var(--card-bg,#fff)!important;border:1px solid var(--border,rgba(15,23,42,.14))!important;border-radius:14px!important;font-size:16px!important}
+    .dm-battery-soc{display:block;margin-top:3px;font-size:12px;font-weight:800;line-height:1.15;color:var(--success-color,#16a34a)}
+    .dm-battery-soc[hidden]{display:none!important}
+    @media(max-width:640px){.dm-energy-cost-grid{grid-template-columns:1fr!important}}
+  `;
+  doc.head?.append(style);
+}
+
+function install() {
+  if (!doc || flowState.installed) return;
+  flowState.installed = true;
+  installStyle();
+  installWrappers();
+  bindStore();
+  for (const eventName of [
+    "dashboardmodern:legacy-ready",
+    "dashboardmodern:runtime-ready",
+    "dashboardmodern:states-ready",
+    "dashboardmodern:energy-stable",
+    "dashboardmodern:energy-bundle",
+    "dashboardmodern:temperature-editor-rendered",
+  ])
+    root.addEventListener?.(eventName, scheduleSettled);
+  root.addEventListener?.("dashboardmodern:period-bundle", (event) => {
+    flowState.bundle = event?.detail || null;
+    scheduleSettled();
+  });
+  doc.addEventListener(
+    "click",
+    (event) => {
+      if (
+        event.target?.closest?.(
+          "[data-energy-tab],.energy-tab,.sub-tab-btn,.ed-inner-tab,[data-temperature-edit],[data-tab='sez1'],[data-tab='sez7']",
+        )
+      )
+        scheduleSettled();
+    },
+    true,
+  );
+  scheduleSettled();
+  root.setTimeout?.(() => {
+    installWrappers();
+    bindStore();
+    scheduleSettled();
+  }, 250);
+}
+
+if (doc?.readyState === "loading") doc.addEventListener("DOMContentLoaded", install, { once: true });
+else install();
+
+export const beta22LoadSlotsHotfix = Object.freeze({
+  configuredFlowLoads,
+  loadPeriodEntity,
+  socEntity,
+  sync: () => {
+    scheduleSettled();
+    return true;
+  },
+});

--- a/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
@@ -1,23 +1,29 @@
-// DM-FIX-20260815A
+// DM-FIX-20260815E
 import { normalizeSection } from "../core/migrations.js";
 import { root } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_CONFIG_PERSISTENCE__";
 const USER_DATA_VERSION = 1;
+const PERSIST_META_KEY = "dm_persistence_meta";
+const REMOTE_REFRESH_MIN_MS = 1200;
 const state = (root[KEY] ||= {
   installed: false,
   dirtyAt: 0,
+  dirtyMarkTimer: 0,
   pushTimer: 0,
   pushPromise: null,
   needsPush: false,
   hydrating: false,
   hydrated: false,
   localWasConfigured: false,
+  lastPullAt: 0,
+  refreshTimer: 0,
   resetOwnerInstalled: false,
   resetting: false,
+  mutationBridgeInstalled: false,
 });
 
-const CONFIG_KEYS = Object.freeze([
+export const CONFIG_KEYS = Object.freeze([
   "dm_dashboard_state",
   "dm_schema_version",
   "cd_sections",
@@ -93,13 +99,17 @@ export async function migrateLegacyUserData(fetchValue, pushValue) {
   return legacy;
 }
 
-function localValues() {
+function valuesFromStorage(storage = root.localStorage) {
   const values = {};
   for (const key of CONFIG_KEYS) {
-    const value = root.localStorage?.getItem(key);
+    const value = storage?.getItem?.(key);
     if (value !== null && value !== undefined) values[key] = value;
   }
   return values;
+}
+
+function localValues() {
+  return valuesFromStorage(root.localStorage);
 }
 
 function meaningfulLocal(values = localValues()) {
@@ -126,6 +136,53 @@ function meaningfulLocal(values = localValues()) {
   );
 }
 
+export function sameConfigValues(left = {}, right = {}) {
+  return CONFIG_KEYS.every((key) => {
+    const a = Object.prototype.hasOwnProperty.call(left || {}, key) ? String(left[key]) : null;
+    const b = Object.prototype.hasOwnProperty.call(right || {}, key) ? String(right[key]) : null;
+    return a === b;
+  });
+}
+
+export function persistenceReconcileAction({
+  remote = null,
+  localConfigured = false,
+  pendingAt = 0,
+  local = {},
+} = {}) {
+  if (!remote) return localConfigured ? "push-local" : "none";
+  if (
+    typeof remote !== "object" ||
+    Array.isArray(remote) ||
+    Number(remote.version) !== USER_DATA_VERSION ||
+    !remote.values ||
+    typeof remote.values !== "object" ||
+    Array.isArray(remote.values)
+  )
+    return "unsupported";
+  if (sameConfigValues(local, remote.values)) return "in-sync";
+  const remoteUpdated = Number(remote.updated_at) || 0;
+  return Number(pendingAt) > remoteUpdated ? "push-local" : "restore-remote";
+}
+
+function readMeta(storage = root.localStorage) {
+  try {
+    const parsed = JSON.parse(storage?.getItem?.(PERSIST_META_KEY) || "null");
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch (_error) {
+    return {};
+  }
+}
+
+function writeMeta(patch = {}, storage = root.localStorage) {
+  const current = readMeta(storage);
+  const next = { ...current, ...patch };
+  try {
+    storage?.setItem?.(PERSIST_META_KEY, JSON.stringify(next));
+  } catch (_error) {}
+  return next;
+}
+
 function snapshot() {
   return {
     version: USER_DATA_VERSION,
@@ -147,13 +204,18 @@ function bridgeRequest(type, payload = {}) {
     const id = 700000 + Math.floor(Math.random() * 200000);
     let sent = false;
     let socket;
+    let finished = false;
     const timer = root.setTimeout?.(() => {
+      if (finished) return;
       try {
         socket?.close?.();
       } catch (_error) {}
+      finished = true;
       reject(new Error(`${type} timed out`));
     }, 8000);
     const finish = (callback, value) => {
+      if (finished) return;
+      finished = true;
       if (timer) root.clearTimeout?.(timer);
       try {
         socket?.close?.();
@@ -161,7 +223,7 @@ function bridgeRequest(type, payload = {}) {
       callback(value);
     };
     const send = () => {
-      if (sent) return;
+      if (sent || finished) return;
       sent = true;
       try {
         socket.send(JSON.stringify({ id, type, ...payload }));
@@ -189,12 +251,39 @@ function bridgeRequest(type, payload = {}) {
       };
       socket.onerror = () => finish(reject, new Error(`${type} bridge error`));
       root.setTimeout?.(() => {
-        if (!sent && socket?.readyState === 1 && root.__DASHBOARDMODERN_BRIDGE_WS__) send();
+        if (!sent && !finished && socket?.readyState === 1 && root.__DASHBOARDMODERN_BRIDGE_WS__)
+          send();
       }, 25);
     } catch (error) {
       finish(reject, error);
     }
   });
+}
+
+function markPending({ schedule = true } = {}) {
+  if (
+    state.resetting ||
+    state.hydrating ||
+    !state.hydrated ||
+    root.__DASHBOARDMODERN_PERSIST_RESTORE__ ||
+    root.__DASHBOARDMODERN_CONFIG_RESETTING__
+  )
+    return state.dirtyAt;
+  const now = Date.now();
+  state.dirtyAt = now;
+  writeMeta({ pending_at: now });
+  if (schedule && hostedBridge()) schedulePush();
+  return now;
+}
+
+function queuePendingFromStorage() {
+  if (state.dirtyMarkTimer) return;
+  state.dirtyMarkTimer =
+    root.setTimeout?.(() => {
+      state.dirtyMarkTimer = 0;
+      markPending();
+    }, 0) || 0;
+  if (!state.dirtyMarkTimer) markPending();
 }
 
 async function pushNow() {
@@ -203,6 +292,8 @@ async function pushNow() {
   try {
     await bridgeRequest("frontend/set_user_data", { key: userDataKey(), value });
     state.dirtyAt = 0;
+    state.localWasConfigured = meaningfulLocal(value.values);
+    writeMeta({ synced_at: value.updated_at, pending_at: 0 });
     root.dispatchEvent?.(new CustomEvent("dashboardmodern:persistence-saved", { detail: value }));
     return true;
   } catch (error) {
@@ -225,7 +316,9 @@ function schedulePush() {
       state.pushPromise = null;
       resolve(result);
     };
-    state.pushTimer = root.setTimeout?.(run, 80) || 0;
+    // Give the canonical store/legacy bridge one turn to finish before taking
+    // the remote snapshot. This also coalesces several fields saved together.
+    state.pushTimer = root.setTimeout?.(run, 140) || 0;
     if (!state.pushTimer) run();
   });
   return state.pushPromise;
@@ -242,65 +335,97 @@ export function normalizeRestoredValues(values) {
   }
   if (typeof restored.dm_dashboard_state === "string") {
     try {
-      const snapshot = JSON.parse(restored.dm_dashboard_state);
-      snapshot.sections ||= {};
-      snapshot.sections.rooms = normalizeSection("rooms", snapshot.sections.rooms || []);
-      restored.dm_dashboard_state = JSON.stringify(snapshot);
+      const restoredSnapshot = JSON.parse(restored.dm_dashboard_state);
+      restoredSnapshot.sections ||= {};
+      restoredSnapshot.sections.rooms = normalizeSection(
+        "rooms",
+        restoredSnapshot.sections.rooms || [],
+      );
+      restored.dm_dashboard_state = JSON.stringify(restoredSnapshot);
     } catch (_error) {}
   }
   return restored;
 }
 
-function restoreValues(values) {
-  if (!values || typeof values !== "object" || Array.isArray(values)) return false;
-  root.__DASHBOARDMODERN_PERSIST_RESTORE__ = true;
-  try {
-    for (const [key, value] of Object.entries(normalizeRestoredValues(values))) {
-      if (!CONFIG_KEYS.includes(key) || typeof value !== "string") continue;
-      root.localStorage?.setItem(key, value);
-    }
-  } finally {
-    delete root.__DASHBOARDMODERN_PERSIST_RESTORE__;
+export function applyRestoredValues(storage, values) {
+  if (!storage || !values || typeof values !== "object" || Array.isArray(values)) return false;
+  const restored = normalizeRestoredValues(values);
+  // Remote is the authoritative full snapshot. Removing keys absent remotely is
+  // essential: otherwise a deletion made on the phone survives forever on a
+  // desktop that still has the old localStorage value.
+  for (const key of CONFIG_KEYS) {
+    const value = restored[key];
+    if (typeof value === "string") storage.setItem(key, value);
+    else storage.removeItem?.(key);
   }
   return true;
 }
 
-async function hydrateRemote() {
-  if (state.hydrating || state.hydrated || state.resetting || !hostedBridge()) return false;
+function restoreValues(values) {
+  root.__DASHBOARDMODERN_PERSIST_RESTORE__ = true;
+  try {
+    return applyRestoredValues(root.localStorage, values);
+  } finally {
+    delete root.__DASHBOARDMODERN_PERSIST_RESTORE__;
+  }
+}
+
+function refreshRuntimeAfterRestore(remote) {
+  try {
+    root.DashboardModernModules?.store?.migrate?.();
+  } catch (error) {
+    console.warn("[DashboardModern] canonical state reload after persistence restore failed", error);
+  }
+  root.cdEvCarsRefresh?.();
+  root.buildQuickActions?.();
+  root.cdApplyNavOrder?.();
+  root.cdApplyNavVis?.();
+  root.buildTempCards?.();
+  root.buildClimaCards?.();
+  root.render?.();
+  root.dispatchEvent?.(new CustomEvent("dashboardmodern:persistence-restored", { detail: remote }));
+}
+
+async function hydrateRemote(options = {}) {
+  const force = options?.force === true;
+  if (
+    state.hydrating ||
+    state.resetting ||
+    (!force && state.hydrated) ||
+    !hostedBridge()
+  )
+    return false;
   state.hydrating = true;
   try {
     const remote = await migrateLegacyUserData(
       async (key) => (await bridgeRequest("frontend/get_user_data", { key }))?.value,
       (key, value) => bridgeRequest("frontend/set_user_data", { key, value }),
     );
-    if (
-      !state.localWasConfigured &&
-      remote &&
-      typeof remote === "object" &&
-      remote.version === USER_DATA_VERSION &&
-      restoreValues(remote.values)
-    ) {
-      try {
-        root.DashboardModernModules?.store?.migrate?.();
-      } catch (error) {
-        console.warn(
-          "[DashboardModern] canonical state reload after persistence restore failed",
-          error,
-        );
-      }
-      root.cdEvCarsRefresh?.();
-      root.buildQuickActions?.();
-      root.cdApplyNavOrder?.();
-      root.cdApplyNavVis?.();
-      root.buildTempCards?.();
-      root.buildClimaCards?.();
-      root.render?.();
-      root.dispatchEvent?.(
-        new CustomEvent("dashboardmodern:persistence-restored", { detail: remote }),
-      );
+    state.lastPullAt = Date.now();
+    const local = localValues();
+    const meta = readMeta();
+    const pendingAt = Math.max(Number(state.dirtyAt) || 0, Number(meta.pending_at) || 0);
+    const localConfigured = meaningfulLocal(local);
+    const action = persistenceReconcileAction({ remote, localConfigured, pendingAt, local });
+
+    if (action === "push-local") return await pushNow();
+    if (action === "restore-remote") {
+      if (!restoreValues(remote.values)) return false;
+      state.dirtyAt = 0;
+      state.localWasConfigured = meaningfulLocal(localValues());
+      writeMeta({ synced_at: Number(remote.updated_at) || Date.now(), pending_at: 0 });
+      refreshRuntimeAfterRestore(remote);
       return true;
     }
-    if (!remote && state.localWasConfigured) await pushNow();
+    if (action === "in-sync") {
+      state.dirtyAt = 0;
+      state.localWasConfigured = localConfigured;
+      writeMeta({ synced_at: Number(remote.updated_at) || Date.now(), pending_at: 0 });
+      return false;
+    }
+    if (action === "unsupported") {
+      console.warn("[DashboardModern] unsupported remote config snapshot retained without overwrite");
+    }
     return false;
   } catch (error) {
     console.warn("[DashboardModern] config restore skipped", error);
@@ -309,6 +434,66 @@ async function hydrateRemote() {
     state.hydrating = false;
     state.hydrated = true;
   }
+}
+
+function scheduleRemoteRefresh(delay = 0) {
+  if (state.resetting || !hostedBridge()) return;
+  if (root.document?.visibilityState === "hidden") return;
+  if (state.refreshTimer) return;
+  const elapsed = Date.now() - (Number(state.lastPullAt) || 0);
+  const wait = Math.max(Number(delay) || 0, REMOTE_REFRESH_MIN_MS - elapsed, 0);
+  state.refreshTimer =
+    root.setTimeout?.(() => {
+      state.refreshTimer = 0;
+      hydrateRemote({ force: true }).catch((error) =>
+        root.console?.warn?.("[DashboardModern] cross-device refresh failed", error),
+      );
+    }, wait) || 0;
+  if (!state.refreshTimer) hydrateRemote({ force: true });
+}
+
+function installStorageMutationBridge() {
+  const storage = root.localStorage;
+  if (!storage || storage.__dmPersistenceMutationBridge) return false;
+  const originalSetItem = storage.setItem?.bind(storage);
+  const originalRemoveItem = storage.removeItem?.bind(storage);
+  if (!originalSetItem || !originalRemoveItem) return false;
+
+  storage.setItem = function dashboardModernPersistentSetItem(key, value) {
+    const managed = CONFIG_KEYS.includes(String(key));
+    const before = managed ? storage.getItem(key) : null;
+    const result = originalSetItem(key, value);
+    if (
+      managed &&
+      before !== String(value) &&
+      state.hydrated &&
+      !state.hydrating &&
+      !state.resetting &&
+      !root.__DASHBOARDMODERN_PERSIST_RESTORE__ &&
+      !root.__DASHBOARDMODERN_CONFIG_RESETTING__
+    )
+      queuePendingFromStorage();
+    return result;
+  };
+  storage.removeItem = function dashboardModernPersistentRemoveItem(key) {
+    const managed = CONFIG_KEYS.includes(String(key));
+    const before = managed ? storage.getItem(key) : null;
+    const result = originalRemoveItem(key);
+    if (
+      managed &&
+      before !== null &&
+      state.hydrated &&
+      !state.hydrating &&
+      !state.resetting &&
+      !root.__DASHBOARDMODERN_PERSIST_RESTORE__ &&
+      !root.__DASHBOARDMODERN_CONFIG_RESETTING__
+    )
+      queuePendingFromStorage();
+    return result;
+  };
+  storage.__dmPersistenceMutationBridge = true;
+  state.mutationBridgeInstalled = true;
+  return true;
 }
 
 function resetConfirmation() {
@@ -326,16 +511,11 @@ export async function resetAllConfig({ skipConfirm = false, reload = true } = {}
   state.localWasConfigured = false;
   root.__DASHBOARDMODERN_CONFIG_RESETTING__ = true;
 
-  // Let a push or legacy-store reconciliation already queued before the click
-  // finish first. The reset is then the final writer both locally and remotely.
   try {
     if (state.pushPromise) await state.pushPromise;
     await Promise.resolve();
   } catch (_error) {}
 
-  // storage-namespace.js makes clear() instance-scoped: this removes every
-  // cd_/dm_ key for this dashboard, including alert keys unknown to older
-  // snapshots, without touching another DashboardModern instance or HA data.
   try {
     root.localStorage?.clear?.();
   } catch (error) {
@@ -349,23 +529,21 @@ export async function resetAllConfig({ skipConfirm = false, reload = true } = {}
   try {
     if (hostedBridge())
       await bridgeRequest("frontend/set_user_data", { key: userDataKey(), value: empty });
+    writeMeta({ synced_at: empty.updated_at, pending_at: 0 });
   } catch (error) {
-    // Local reset remains valid; a later sync still carries the empty snapshot.
     root.console?.warn?.("[DashboardModern] remote reset deferred", error);
+    state.dirtyAt = Date.now();
+    writeMeta({ pending_at: state.dirtyAt });
     state.needsPush = true;
     schedulePush();
   }
 
-  // Rendering/store bridges may have completed work while the remote reset was
-  // in flight. Clear once more so Reset totale always wins that race too.
   try {
     root.localStorage?.clear?.();
   } catch (_error) {}
 
   root.dispatchEvent?.(new CustomEvent("dashboardmodern:config-reset", { detail: empty }));
   if (reload) {
-    // Reload the exact versioned iframe URL. Rebuilding pathname/search with
-    // location.replace() caused 404s inside the Home Assistant panel mount.
     root.setTimeout?.(() => root.location?.reload?.(), 40);
   } else {
     state.resetting = false;
@@ -389,18 +567,20 @@ function installResetOwner() {
 export function installConfigPersistenceSection() {
   if (state.installed) {
     installResetOwner();
+    installStorageMutationBridge();
     return;
   }
   state.installed = true;
   state.localWasConfigured = meaningfulLocal();
+  const initialMeta = readMeta();
+  state.dirtyAt = Number(initialMeta.pending_at) || 0;
 
   const previousMarkDirty = typeof root.cdMarkDirty === "function" ? root.cdMarkDirty : null;
   root.cdMarkDirty = function dashboardModernMarkDirty(...args) {
     try {
       previousMarkDirty?.apply(this, args);
     } catch (_error) {}
-    state.dirtyAt = Date.now();
-    return state.dirtyAt;
+    return markPending();
   };
 
   const previousSyncPush = typeof root.cdSyncPush === "function" ? root.cdSyncPush : null;
@@ -408,19 +588,34 @@ export function installConfigPersistenceSection() {
     try {
       previousSyncPush?.apply(this, args);
     } catch (_error) {}
+    if (state.hydrated && !state.hydrating && !state.resetting) markPending({ schedule: false });
     return schedulePush();
   };
 
-  root.cdSyncPull = hydrateRemote;
+  root.cdSyncPull = () => hydrateRemote({ force: true });
   root.dmResetAllConfig = resetAllConfig;
   installResetOwner();
+  installStorageMutationBridge();
+
   root.addEventListener?.("dashboardmodern:legacy-ready", () => {
     installResetOwner();
-    root.setTimeout?.(hydrateRemote, 0);
+    installStorageMutationBridge();
+    root.setTimeout?.(() => hydrateRemote(), 0);
   });
   root.addEventListener?.("dashboardmodern:runtime-ready", () => {
     installResetOwner();
-    root.setTimeout?.(hydrateRemote, 0);
+    installStorageMutationBridge();
+    root.setTimeout?.(() => hydrateRemote(), 0);
+  });
+
+  // A dashboard that remains open on desktop must not freeze on yesterday's
+  // local copy after edits made from the phone. Reconcile when the user returns
+  // to the page; no polling, interval or document-wide observer is used.
+  root.addEventListener?.("focus", () => scheduleRemoteRefresh(40));
+  root.addEventListener?.("pageshow", () => scheduleRemoteRefresh(40));
+  root.addEventListener?.("storage", () => scheduleRemoteRefresh(40));
+  root.document?.addEventListener?.("visibilitychange", () => {
+    if (root.document?.visibilityState === "visible") scheduleRemoteRefresh(40);
   });
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
@@ -1,4 +1,4 @@
-// DM-FIX-20260815G
+// DM-FIX-20260815H
 import { normalizeSection } from "../core/migrations.js";
 import { root } from "./shared.js";
 
@@ -24,10 +24,9 @@ const state = (root[KEY] ||= {
   mutationBridgeInstalled: false,
 });
 
-// Complete dashboard configuration snapshot. Runtime counters/timers such as
-// cd_pool_run and cd_irr_lastrun are intentionally excluded, while every
-// user-editable legacy/canonical key is included so phone and desktop cannot
-// silently diverge just because one editor still writes a legacy key.
+// Complete shared dashboard configuration snapshot. Runtime counters/timers and
+// true per-device preferences (connection credentials, theme/navbar mode) stay
+// local. Everything edited as dashboard content is shared across devices.
 export const CONFIG_KEYS = Object.freeze([
   "dm_dashboard_state",
   "dm_schema_version",
@@ -36,6 +35,7 @@ export const CONFIG_KEYS = Object.freeze([
   "cd_section_names",
   "cd_stanze",
   "cd_floors",
+  "cd_floor_icons",
   "cd_cameras",
   "cd_appliances",
   "cd_loads",
@@ -63,6 +63,7 @@ export const CONFIG_KEYS = Object.freeze([
   "cd_gruppi_removed",
   "cd_avvisi_names_extra",
   "cd_avvisi_custom",
+  "cd_subload_groups",
   "cd_subloads_extra",
   "cd_report_devices",
   "cd_lavatrice_visual",
@@ -70,8 +71,6 @@ export const CONFIG_KEYS = Object.freeze([
   "cd_hidden_elements",
   "cd_costo_kwh",
   "cd_prezzo_immissione",
-  "cd_theme",
-  "cd_nav_mode",
 ]);
 
 const LEGACY_SYNC_CONTROL_KEYS = Object.freeze(["cd_sync_ts", "cd_sync_dirty"]);
@@ -188,10 +187,8 @@ export function normalizeRemoteSnapshot(remote) {
     };
   }
 
-  // beta20/beta21 and the vendored legacy runtime wrote a flat payload to the
-  // very same frontend user_data key. Accept it once, then upgrade it to the
-  // single modern envelope after reconciliation. Without this compatibility
-  // path whichever device wrote last could make the other format unreadable.
+  // Older releases and the vendored legacy runtime wrote a flat payload to the
+  // same user_data key. Accept it once and upgrade it to the canonical envelope.
   const legacyValues = Object.fromEntries(
     CONFIG_KEYS.flatMap((key) => (typeof remote[key] === "string" ? [[key, remote[key]]] : [])),
   );
@@ -213,11 +210,9 @@ export function normalizeRemoteSnapshot(remote) {
 
 /**
  * Before revision 2 several real editor keys were not part of the modern cloud
- * snapshot at all. Absence in those old payloads therefore cannot mean
- * "deleted". Fill only the missing old fields from this device once, while
- * remote values still win wherever the old snapshot actually contains a key.
- * The upgraded revision-2 snapshot is then complete and future absence again
- * has normal deletion semantics.
+ * snapshot. Absence in those payloads cannot mean "deleted". Fill only missing
+ * old fields from the current device once; values actually present remotely
+ * still win. Revision 2 is complete, so future absence means deletion again.
  */
 export function mergeLegacyMissingConfig(remote, local = {}) {
   if (!remote || Number(remote.keys_revision) >= CONFIG_KEYS_REVISION) return remote;

--- a/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
@@ -1,4 +1,4 @@
-// DM-FIX-20260815E
+// DM-FIX-20260815F
 import { normalizeSection } from "../core/migrations.js";
 import { root } from "./shared.js";
 
@@ -23,15 +23,22 @@ const state = (root[KEY] ||= {
   mutationBridgeInstalled: false,
 });
 
+// Complete dashboard configuration snapshot. Runtime counters/timers such as
+// cd_pool_run and cd_irr_lastrun are intentionally excluded, while every
+// user-editable legacy/canonical key is included so phone and desktop cannot
+// silently diverge just because one editor still writes a legacy key.
 export const CONFIG_KEYS = Object.freeze([
   "dm_dashboard_state",
   "dm_schema_version",
+  "cd_branding",
   "cd_sections",
+  "cd_section_names",
   "cd_stanze",
   "cd_floors",
   "cd_cameras",
   "cd_appliances",
   "cd_loads",
+  "cd_devices",
   "cd_luci",
   "cd_luci_rooms",
   "cd_luci_order",
@@ -47,21 +54,28 @@ export const CONFIG_KEYS = Object.freeze([
   "cd_energy_model",
   "cd_entity_overrides",
   "cd_quick_actions",
-  "cd_section_names",
   "cd_navbar_order",
   "cd_energy_views",
   "cd_slot_labels",
+  "cd_flow_nodes",
   "cd_gruppi_extra",
   "cd_gruppi_removed",
   "cd_avvisi_names_extra",
+  "cd_avvisi_custom",
   "cd_subloads_extra",
   "cd_report_devices",
   "cd_lavatrice_visual",
+  "cd_text_overrides",
+  "cd_hidden_elements",
   "cd_costo_kwh",
   "cd_prezzo_immissione",
+  // Kept for compatibility with the modern editor. Legacy deliberately treated
+  // appearance as device-local; these keys do not affect entity configuration.
   "cd_theme",
   "cd_nav_mode",
 ]);
+
+const LEGACY_SYNC_CONTROL_KEYS = Object.freeze(["cd_sync_ts", "cd_sync_dirty"]);
 
 function instanceId() {
   return String(
@@ -112,6 +126,22 @@ function localValues() {
   return valuesFromStorage(root.localStorage);
 }
 
+function meaningfulScalar(value) {
+  if (typeof value === "string") return value.trim().length > 0;
+  if (typeof value === "number") return Number.isFinite(value) && value !== 0;
+  if (typeof value === "boolean") return value;
+  return false;
+}
+
+function meaningfulNested(value, { ignoreMetadata = false } = {}) {
+  if (Array.isArray(value)) return value.some((item) => meaningfulNested(item));
+  if (value && typeof value === "object")
+    return Object.entries(value).some(
+      ([key, child]) => !(ignoreMetadata && key === "metadata") && meaningfulNested(child),
+    );
+  return meaningfulScalar(value);
+}
+
 function meaningfulLocal(values = localValues()) {
   const stateValue = values.dm_dashboard_state;
   if (stateValue) {
@@ -119,21 +149,65 @@ function meaningfulLocal(values = localValues()) {
       const parsed = JSON.parse(stateValue);
       const sections = parsed?.sections || {};
       if (
-        Object.values(sections).some((value) =>
-          Array.isArray(value)
-            ? value.length > 0
-            : value && typeof value === "object"
-              ? Object.keys(value).length > 0
-              : Boolean(value),
+        Object.entries(sections).some(([name, value]) =>
+          name === "energy"
+            ? meaningfulNested(value, { ignoreMetadata: true })
+            : meaningfulNested(value),
         )
       )
         return true;
     } catch (_error) {}
   }
-  return Object.entries(values).some(
-    ([key, value]) =>
-      !["dm_schema_version", "cd_sections"].includes(key) && String(value || "").length > 2,
+  return Object.entries(values).some(([key, value]) => {
+    if (["dm_dashboard_state", "dm_schema_version", "cd_sections"].includes(key)) return false;
+    try {
+      return meaningfulNested(JSON.parse(value));
+    } catch (_error) {
+      return String(value || "").trim().length > 0;
+    }
+  });
+}
+
+export function normalizeRemoteSnapshot(remote) {
+  if (!remote || typeof remote !== "object" || Array.isArray(remote)) return null;
+  if (
+    Number(remote.version) === USER_DATA_VERSION &&
+    remote.values &&
+    typeof remote.values === "object" &&
+    !Array.isArray(remote.values)
+  ) {
+    return {
+      version: USER_DATA_VERSION,
+      updated_at: Number(remote.updated_at) || 0,
+      values: Object.fromEntries(
+        CONFIG_KEYS.flatMap((key) =>
+          typeof remote.values[key] === "string" ? [[key, remote.values[key]]] : [],
+        ),
+      ),
+      migrated_from: remote.migrated_from || "",
+    };
+  }
+
+  // beta20/beta21 and the vendored legacy runtime wrote a flat payload to the
+  // very same frontend user_data key. Accept it once, then upgrade it to the
+  // single modern envelope after reconciliation. Without this compatibility
+  // path whichever device wrote last could make the other format unreadable.
+  const legacyValues = Object.fromEntries(
+    CONFIG_KEYS.flatMap((key) => (typeof remote[key] === "string" ? [[key, remote[key]]] : [])),
   );
+  if (
+    Object.keys(legacyValues).length ||
+    Object.prototype.hasOwnProperty.call(remote, "__ts") ||
+    Object.prototype.hasOwnProperty.call(remote, "_savedAt")
+  ) {
+    return {
+      version: USER_DATA_VERSION,
+      updated_at: Number(remote.__ts || remote._savedAt) || 0,
+      values: legacyValues,
+      migrated_from: "legacy-flat",
+    };
+  }
+  return null;
 }
 
 export function sameConfigValues(left = {}, right = {}) {
@@ -151,18 +225,12 @@ export function persistenceReconcileAction({
   local = {},
 } = {}) {
   if (!remote) return localConfigured ? "push-local" : "none";
-  if (
-    typeof remote !== "object" ||
-    Array.isArray(remote) ||
-    Number(remote.version) !== USER_DATA_VERSION ||
-    !remote.values ||
-    typeof remote.values !== "object" ||
-    Array.isArray(remote.values)
-  )
-    return "unsupported";
-  if (sameConfigValues(local, remote.values)) return "in-sync";
-  const remoteUpdated = Number(remote.updated_at) || 0;
-  return Number(pendingAt) > remoteUpdated ? "push-local" : "restore-remote";
+  const normalized = normalizeRemoteSnapshot(remote);
+  if (!normalized) return "unsupported";
+  if (sameConfigValues(local, normalized.values)) return "in-sync";
+  return Number(pendingAt) > Number(normalized.updated_at || 0)
+    ? "push-local"
+    : "restore-remote";
 }
 
 function readMeta(storage = root.localStorage) {
@@ -316,8 +384,6 @@ function schedulePush() {
       state.pushPromise = null;
       resolve(result);
     };
-    // Give the canonical store/legacy bridge one turn to finish before taking
-    // the remote snapshot. This also coalesces several fields saved together.
     state.pushTimer = root.setTimeout?.(run, 140) || 0;
     if (!state.pushTimer) run();
   });
@@ -350,9 +416,6 @@ export function normalizeRestoredValues(values) {
 export function applyRestoredValues(storage, values) {
   if (!storage || !values || typeof values !== "object" || Array.isArray(values)) return false;
   const restored = normalizeRestoredValues(values);
-  // Remote is the authoritative full snapshot. Removing keys absent remotely is
-  // essential: otherwise a deletion made on the phone survives forever on a
-  // desktop that still has the old localStorage value.
   for (const key of CONFIG_KEYS) {
     const value = restored[key];
     if (typeof value === "string") storage.setItem(key, value);
@@ -388,44 +451,53 @@ function refreshRuntimeAfterRestore(remote) {
 
 async function hydrateRemote(options = {}) {
   const force = options?.force === true;
-  if (
-    state.hydrating ||
-    state.resetting ||
-    (!force && state.hydrated) ||
-    !hostedBridge()
-  )
+  if (state.hydrating || state.resetting || (!force && state.hydrated) || !hostedBridge())
     return false;
   state.hydrating = true;
   try {
-    const remote = await migrateLegacyUserData(
+    const rawRemote = await migrateLegacyUserData(
       async (key) => (await bridgeRequest("frontend/get_user_data", { key }))?.value,
       (key, value) => bridgeRequest("frontend/set_user_data", { key, value }),
     );
     state.lastPullAt = Date.now();
+    const remote = normalizeRemoteSnapshot(rawRemote);
     const local = localValues();
     const meta = readMeta();
     const pendingAt = Math.max(Number(state.dirtyAt) || 0, Number(meta.pending_at) || 0);
-    const localConfigured = meaningfulLocal(local);
-    const action = persistenceReconcileAction({ remote, localConfigured, pendingAt, local });
+    // On the very first pull use the pre-module value captured before
+    // DashboardStore.migrate() writes empty canonical defaults. Otherwise a
+    // pristine desktop could incorrectly seed an empty cloud snapshot.
+    const localConfigured = state.hydrated ? meaningfulLocal(local) : state.localWasConfigured;
+    const action = persistenceReconcileAction({
+      remote: rawRemote,
+      localConfigured,
+      pendingAt,
+      local,
+    });
 
     if (action === "push-local") return await pushNow();
-    if (action === "restore-remote") {
+    if (action === "restore-remote" && remote) {
       if (!restoreValues(remote.values)) return false;
       state.dirtyAt = 0;
       state.localWasConfigured = meaningfulLocal(localValues());
       writeMeta({ synced_at: Number(remote.updated_at) || Date.now(), pending_at: 0 });
       refreshRuntimeAfterRestore(remote);
+      // Migration/normalization can legitimately add canonical empty keys or
+      // convert legacy room shapes. Upgrade the remote envelope once so later
+      // focus pulls compare against the exact canonical local snapshot.
+      if (remote.migrated_from === "legacy-flat" || !sameConfigValues(localValues(), remote.values))
+        await pushNow();
       return true;
     }
-    if (action === "in-sync") {
+    if (action === "in-sync" && remote) {
       state.dirtyAt = 0;
       state.localWasConfigured = localConfigured;
       writeMeta({ synced_at: Number(remote.updated_at) || Date.now(), pending_at: 0 });
+      if (remote.migrated_from === "legacy-flat") await pushNow();
       return false;
     }
-    if (action === "unsupported") {
+    if (action === "unsupported")
       console.warn("[DashboardModern] unsupported remote config snapshot retained without overwrite");
-    }
     return false;
   } catch (error) {
     console.warn("[DashboardModern] config restore skipped", error);
@@ -529,7 +601,6 @@ export async function resetAllConfig({ skipConfirm = false, reload = true } = {}
   try {
     if (hostedBridge())
       await bridgeRequest("frontend/set_user_data", { key: userDataKey(), value: empty });
-    writeMeta({ synced_at: empty.updated_at, pending_at: 0 });
   } catch (error) {
     root.console?.warn?.("[DashboardModern] remote reset deferred", error);
     state.dirtyAt = Date.now();
@@ -543,9 +614,8 @@ export async function resetAllConfig({ skipConfirm = false, reload = true } = {}
   } catch (_error) {}
 
   root.dispatchEvent?.(new CustomEvent("dashboardmodern:config-reset", { detail: empty }));
-  if (reload) {
-    root.setTimeout?.(() => root.location?.reload?.(), 40);
-  } else {
+  if (reload) root.setTimeout?.(() => root.location?.reload?.(), 40);
+  else {
     state.resetting = false;
     delete root.__DASHBOARDMODERN_CONFIG_RESETTING__;
   }
@@ -564,8 +634,23 @@ function installResetOwner() {
   return true;
 }
 
+function disableLegacySyncState() {
+  // The vendored runtime and this module used to write incompatible payloads to
+  // the same frontend user_data key. The modern module is now the only owner.
+  root.__DASHBOARDMODERN_PERSISTENCE_OWNER__ = "modern-v1";
+  for (const key of LEGACY_SYNC_CONTROL_KEYS) {
+    try {
+      root.localStorage?.removeItem?.(key);
+    } catch (_error) {}
+  }
+  try {
+    root._cdSyncReqId = -1;
+  } catch (_error) {}
+}
+
 export function installConfigPersistenceSection() {
   if (state.installed) {
+    disableLegacySyncState();
     installResetOwner();
     installStorageMutationBridge();
     return;
@@ -574,21 +659,22 @@ export function installConfigPersistenceSection() {
   state.localWasConfigured = meaningfulLocal();
   const initialMeta = readMeta();
   state.dirtyAt = Number(initialMeta.pending_at) || 0;
+  disableLegacySyncState();
 
-  const previousMarkDirty = typeof root.cdMarkDirty === "function" ? root.cdMarkDirty : null;
-  root.cdMarkDirty = function dashboardModernMarkDirty(...args) {
-    try {
-      previousMarkDirty?.apply(this, args);
-    } catch (_error) {}
+  // Intentionally do NOT invoke the legacy cdMarkDirty/cdSyncPush functions.
+  // They used a flat payload while this owner uses {version, updated_at, values}
+  // and the two writers racing on the same HA key is the root cause of devices
+  // showing different configurations.
+  root.cdMarkDirty = function dashboardModernMarkDirty() {
     return markPending();
   };
 
-  const previousSyncPush = typeof root.cdSyncPush === "function" ? root.cdSyncPush : null;
-  root.cdSyncPush = function dashboardModernSyncPush(...args) {
-    try {
-      previousSyncPush?.apply(this, args);
-    } catch (_error) {}
-    if (state.hydrated && !state.hydrating && !state.resetting) markPending({ schedule: false });
+  root.cdSyncPush = function dashboardModernSyncPush() {
+    if (!state.hydrated || state.hydrating) {
+      // Remote must be read before a local snapshot is allowed to overwrite it.
+      return hydrateRemote().then(() => true);
+    }
+    markPending({ schedule: false });
     return schedulePush();
   };
 
@@ -598,19 +684,18 @@ export function installConfigPersistenceSection() {
   installStorageMutationBridge();
 
   root.addEventListener?.("dashboardmodern:legacy-ready", () => {
+    disableLegacySyncState();
     installResetOwner();
     installStorageMutationBridge();
     root.setTimeout?.(() => hydrateRemote(), 0);
   });
   root.addEventListener?.("dashboardmodern:runtime-ready", () => {
+    disableLegacySyncState();
     installResetOwner();
     installStorageMutationBridge();
     root.setTimeout?.(() => hydrateRemote(), 0);
   });
 
-  // A dashboard that remains open on desktop must not freeze on yesterday's
-  // local copy after edits made from the phone. Reconcile when the user returns
-  // to the page; no polling, interval or document-wide observer is used.
   root.addEventListener?.("focus", () => scheduleRemoteRefresh(40));
   root.addEventListener?.("pageshow", () => scheduleRemoteRefresh(40));
   root.addEventListener?.("storage", () => scheduleRemoteRefresh(40));

--- a/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
@@ -1,9 +1,10 @@
-// DM-FIX-20260815F
+// DM-FIX-20260815G
 import { normalizeSection } from "../core/migrations.js";
 import { root } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_CONFIG_PERSISTENCE__";
 const USER_DATA_VERSION = 1;
+const CONFIG_KEYS_REVISION = 2;
 const PERSIST_META_KEY = "dm_persistence_meta";
 const REMOTE_REFRESH_MIN_MS = 1200;
 const state = (root[KEY] ||= {
@@ -69,8 +70,6 @@ export const CONFIG_KEYS = Object.freeze([
   "cd_hidden_elements",
   "cd_costo_kwh",
   "cd_prezzo_immissione",
-  // Kept for compatibility with the modern editor. Legacy deliberately treated
-  // appearance as device-local; these keys do not affect entity configuration.
   "cd_theme",
   "cd_nav_mode",
 ]);
@@ -178,6 +177,7 @@ export function normalizeRemoteSnapshot(remote) {
   ) {
     return {
       version: USER_DATA_VERSION,
+      keys_revision: Number(remote.keys_revision) || 0,
       updated_at: Number(remote.updated_at) || 0,
       values: Object.fromEntries(
         CONFIG_KEYS.flatMap((key) =>
@@ -202,12 +202,29 @@ export function normalizeRemoteSnapshot(remote) {
   ) {
     return {
       version: USER_DATA_VERSION,
+      keys_revision: 0,
       updated_at: Number(remote.__ts || remote._savedAt) || 0,
       values: legacyValues,
       migrated_from: "legacy-flat",
     };
   }
   return null;
+}
+
+/**
+ * Before revision 2 several real editor keys were not part of the modern cloud
+ * snapshot at all. Absence in those old payloads therefore cannot mean
+ * "deleted". Fill only the missing old fields from this device once, while
+ * remote values still win wherever the old snapshot actually contains a key.
+ * The upgraded revision-2 snapshot is then complete and future absence again
+ * has normal deletion semantics.
+ */
+export function mergeLegacyMissingConfig(remote, local = {}) {
+  if (!remote || Number(remote.keys_revision) >= CONFIG_KEYS_REVISION) return remote;
+  return {
+    ...remote,
+    values: { ...local, ...(remote.values || {}) },
+  };
 }
 
 export function sameConfigValues(left = {}, right = {}) {
@@ -251,9 +268,20 @@ function writeMeta(patch = {}, storage = root.localStorage) {
   return next;
 }
 
+function legacyPendingTimestamp(storage = root.localStorage) {
+  try {
+    if (!storage?.getItem?.("cd_sync_dirty")) return 0;
+    const value = Number(storage.getItem("cd_sync_ts"));
+    return Number.isFinite(value) ? value : 0;
+  } catch (_error) {
+    return 0;
+  }
+}
+
 function snapshot() {
   return {
     version: USER_DATA_VERSION,
+    keys_revision: CONFIG_KEYS_REVISION,
     updated_at: Date.now(),
     values: localValues(),
   };
@@ -460,20 +488,13 @@ async function hydrateRemote(options = {}) {
       (key, value) => bridgeRequest("frontend/set_user_data", { key, value }),
     );
     state.lastPullAt = Date.now();
-    const remote = normalizeRemoteSnapshot(rawRemote);
     const local = localValues();
+    const normalizedRemote = normalizeRemoteSnapshot(rawRemote);
+    const remote = mergeLegacyMissingConfig(normalizedRemote, local);
     const meta = readMeta();
     const pendingAt = Math.max(Number(state.dirtyAt) || 0, Number(meta.pending_at) || 0);
-    // On the very first pull use the pre-module value captured before
-    // DashboardStore.migrate() writes empty canonical defaults. Otherwise a
-    // pristine desktop could incorrectly seed an empty cloud snapshot.
     const localConfigured = state.hydrated ? meaningfulLocal(local) : state.localWasConfigured;
-    const action = persistenceReconcileAction({
-      remote: rawRemote,
-      localConfigured,
-      pendingAt,
-      local,
-    });
+    const action = persistenceReconcileAction({ remote, localConfigured, pendingAt, local });
 
     if (action === "push-local") return await pushNow();
     if (action === "restore-remote" && remote) {
@@ -482,10 +503,11 @@ async function hydrateRemote(options = {}) {
       state.localWasConfigured = meaningfulLocal(localValues());
       writeMeta({ synced_at: Number(remote.updated_at) || Date.now(), pending_at: 0 });
       refreshRuntimeAfterRestore(remote);
-      // Migration/normalization can legitimately add canonical empty keys or
-      // convert legacy room shapes. Upgrade the remote envelope once so later
-      // focus pulls compare against the exact canonical local snapshot.
-      if (remote.migrated_from === "legacy-flat" || !sameConfigValues(localValues(), remote.values))
+      if (
+        Number(remote.keys_revision) < CONFIG_KEYS_REVISION ||
+        remote.migrated_from === "legacy-flat" ||
+        !sameConfigValues(localValues(), remote.values)
+      )
         await pushNow();
       return true;
     }
@@ -493,7 +515,8 @@ async function hydrateRemote(options = {}) {
       state.dirtyAt = 0;
       state.localWasConfigured = localConfigured;
       writeMeta({ synced_at: Number(remote.updated_at) || Date.now(), pending_at: 0 });
-      if (remote.migrated_from === "legacy-flat") await pushNow();
+      if (Number(remote.keys_revision) < CONFIG_KEYS_REVISION || remote.migrated_from === "legacy-flat")
+        await pushNow();
       return false;
     }
     if (action === "unsupported")
@@ -635,8 +658,6 @@ function installResetOwner() {
 }
 
 function disableLegacySyncState() {
-  // The vendored runtime and this module used to write incompatible payloads to
-  // the same frontend user_data key. The modern module is now the only owner.
   root.__DASHBOARDMODERN_PERSISTENCE_OWNER__ = "modern-v1";
   for (const key of LEGACY_SYNC_CONTROL_KEYS) {
     try {
@@ -658,7 +679,9 @@ export function installConfigPersistenceSection() {
   state.installed = true;
   state.localWasConfigured = meaningfulLocal();
   const initialMeta = readMeta();
-  state.dirtyAt = Number(initialMeta.pending_at) || 0;
+  const legacyPending = legacyPendingTimestamp();
+  state.dirtyAt = Math.max(Number(initialMeta.pending_at) || 0, legacyPending);
+  if (legacyPending) writeMeta({ pending_at: state.dirtyAt });
   disableLegacySyncState();
 
   // Intentionally do NOT invoke the legacy cdMarkDirty/cdSyncPush functions.
@@ -671,7 +694,6 @@ export function installConfigPersistenceSection() {
 
   root.cdSyncPush = function dashboardModernSyncPush() {
     if (!state.hydrated || state.hydrating) {
-      // Remote must be read before a local snapshot is allowed to overwrite it.
       return hydrateRemote().then(() => true);
     }
     markPending({ schedule: false });

--- a/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
@@ -1,4 +1,4 @@
-// DM-FIX-20260815H
+// DM-FIX-20260815I
 import { normalizeSection } from "../core/migrations.js";
 import { root } from "./shared.js";
 
@@ -49,6 +49,7 @@ export const CONFIG_KEYS = Object.freeze([
   "cd_ev_car_active",
   "cd_ev_visual",
   "cd_ev_image",
+  "cd_visual_prefer_image",
   "cd_tapparelle",
   "cd_piscina",
   "cd_irrigazione",

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-flow-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-flow-section.js
@@ -1,15 +1,6 @@
-import {
-  allStates,
-  clean,
-  doc,
-  formatNumber,
-  installStyle,
-  root,
-  section,
-  wrapFunction,
-} from "./shared.js";
+import { allStates, clean, doc, installStyle, root, section, wrapFunction } from "./shared.js";
 
-root.__DM_20260815C__ = true;
+root.__DM_20260815E__ = true;
 const KEY = "__DASHBOARDMODERN_ENERGY_FLOW_SECTION__";
 const state = (root[KEY] ||= { installed: false, frame: 0 });
 
@@ -33,74 +24,20 @@ const LOADS = Object.freeze([
   { key: "cuc", instant: "v-cuc-p" },
 ]);
 
-const LEGACY_LOAD_SELECTOR = ".node.n-load,[id^='line-home-'],[id^='m-line-home-']";
-
 function stateNumber(states, entity) {
   const value = states?.[entity]?.state ?? states?.[entity];
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-export function renderDynamicEnergyLoads(
-  targetDocument,
-  loads = [],
-  states = {},
-  periodValues = null,
-) {
-  if (!targetDocument) return 0;
-  const normalized = (Array.isArray(loads) ? loads : []).slice(0, 8);
-  for (const view of ["view-ist", "view-day"]) {
-    const stage = targetDocument.getElementById(view)?.querySelector?.(".flow-stage");
-    if (!stage) continue;
-    stage.querySelectorAll(LEGACY_LOAD_SELECTOR).forEach((node) => {
-      node.hidden = true;
-      node.dataset.dmLegacyEnergyLoad = "hidden";
-    });
-    stage
-      .querySelectorAll("[data-energy-load-node],[data-energy-load-arc]")
-      .forEach((node) => node.remove());
-    if (!normalized.length) {
-      stage.dataset.energyLoads = "0";
-      continue;
-    }
-    const svg = stage.querySelector("svg.desktop-svg") || stage.querySelector("svg");
-    normalized.forEach((load, index) => {
-      const x = ((index + 1) * 100) / (normalized.length + 1);
-      if (svg) {
-        const path = targetDocument.createElementNS("http://www.w3.org/2000/svg", "path");
-        path.dataset.energyLoadArc = load.id;
-        path.classList.add("flow-line", "dm-energy-load-arc");
-        path.setAttribute("d", `M 500 365 Q ${x * 10} 420 ${x * 10} 445`);
-        path.style.setProperty("--line-color", load.color || "#0ea5e9");
-        svg.append(path);
-      }
-      const node = targetDocument.createElement("div");
-      node.className = "node n-load dm-energy-load-node";
-      node.dataset.energyLoadNode = load.id;
-      node.style.left = `${x}%`;
-      node.style.top = "83%";
-      node.style.setProperty("--n-color", load.color || "#0ea5e9");
-      const isDaily = view === "view-day";
-      const value = isDaily
-        ? periodValues instanceof Map
-          ? periodValues.get(load.id)
-          : periodValues?.[load.id]
-        : stateNumber(states, load.power_entity);
-      const formatted = Number.isFinite(Number(value))
-        ? `${formatNumber(Number(value), isDaily ? 2 : 0)} ${isDaily ? "kWh" : "W"}`
-        : "—";
-      node.innerHTML = `<div class="node-label">${clean(load.name)}</div><div class="node-icon">${clean(load.icon || "⚡")}</div><span>${formatted}</span>`;
-      stage.append(node);
-    });
-    stage.dataset.energyLoads = String(normalized.length);
-  }
-  return normalized.length;
-}
-
 export function renderBatterySoc(targetDocument, energy = {}, states = {}) {
   const node = targetDocument?.getElementById?.("v-battery-soc");
   if (!node) return "—";
-  const entity = clean(energy?.battery?.battery_soc_entity || energy?.battery?.battery_soc);
+  const entity = clean(
+    energy?.battery?.soc ||
+      energy?.battery?.battery_soc_entity ||
+      energy?.battery?.battery_soc,
+  );
   const value = stateNumber(states, entity);
   const text = entity && value !== null ? `${Math.round(value)}%` : "—";
   node.textContent = text;
@@ -292,9 +229,6 @@ function directionalEndpointValue(kind, node, period) {
 
 function directionalMainFlowValue(node, period) {
   const id = String(node?.id || "").toLowerCase();
-  // A connector is driven by its directional source. Requiring both endpoints
-  // to be >0 made every main flow stop whenever the aggregate Home node was
-  // temporarily blank/zero even though PV/grid/battery had a valid live value.
   if (id.includes("solar-grid")) return directionalEndpointValue("grid", node, period);
   if (id.includes("solar-battery")) return directionalEndpointValue("battery", node, period);
   if (id.includes("grid-home")) return directionalEndpointValue("grid", node, period);
@@ -347,7 +281,8 @@ export function refreshEnergyFlows() {
     touched = syncLoadFlows(period) || touched;
     scope.dataset.dmEnergyFlows = "directional-value-bound";
   }
-  renderDynamicEnergyLoads(doc, section("energyLoads", []), allStates(), state.periodValues);
+  // Beta22's second dynamic `energyLoads` topology is deliberately gone.
+  // The canonical Loads editor owns the five existing circles below Home.
   renderBatterySoc(doc, section("energy", {}), allStates());
   return touched;
 }
@@ -393,10 +328,7 @@ export function installEnergyFlowSection() {
     "render",
   ])
     wrapFunction(name, `__dmEnergyFlow_${name}`, scheduleSettled);
-  root.addEventListener?.("dashboardmodern:period-bundle", (event) => {
-    state.periodValues = event?.detail?.energyLoadsDay || null;
-    scheduleSettled();
-  });
+  root.addEventListener?.("dashboardmodern:period-bundle", scheduleSettled);
   root.addEventListener?.("dashboardmodern:energy-bundle", scheduleSettled);
   root.addEventListener?.("dashboardmodern:energy-stable", scheduleSettled);
   root.addEventListener?.("dashboardmodern:states-ready", scheduleSettled);

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-flow-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-flow-section.js
@@ -75,6 +75,63 @@ function nodeVisible(node) {
   return true;
 }
 
+function canonicalFlowLoads() {
+  const configured = section("loads", []);
+  return (Array.isArray(configured) ? configured : [])
+    .filter(
+      (item) =>
+        item &&
+        item.category !== "manual-report" &&
+        item.show_in_dashboard !== false &&
+        (clean(item.name) ||
+          clean(item.power_entity) ||
+          clean(item.daily_energy_entity) ||
+          clean(item.monthly_energy_entity) ||
+          clean(item.total_energy_entity) ||
+          clean(item.history_entity)),
+    )
+    .slice()
+    .sort((left, right) => (Number(left.order) || 0) - (Number(right.order) || 0))
+    .slice(0, LOADS.length);
+}
+
+function periodEntity(load, period) {
+  if (period === "day") return clean(load?.daily_energy_entity);
+  if (period === "month") return clean(load?.monthly_energy_entity);
+  return clean(load?.power_entity);
+}
+
+function formatPeriodValue(value) {
+  const locale = doc?.documentElement?.lang === "en" ? "en-GB" : "it-IT";
+  return `${new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(value)} kWh`;
+}
+
+function syncCanonicalPeriodValues() {
+  if (!doc) return false;
+  const configured = canonicalFlowLoads();
+  const states = allStates();
+  let touched = false;
+  for (const period of ["day", "month"]) {
+    LOADS.forEach((slot, index) => {
+      const load = configured[index];
+      const entity = periodEntity(load, period);
+      if (!load || !entity) return;
+      const value = stateNumber(states, entity);
+      if (value === null) return;
+      const node = doc.getElementById(loadValueId(slot, period));
+      if (!node) return;
+      node.textContent = formatPeriodValue(value);
+      node.dataset.dmCanonicalLoad = clean(load.id) || clean(load.name);
+      node.dataset.dmCanonicalEntity = entity;
+      touched = true;
+    });
+  }
+  return touched;
+}
+
 function rememberConnectorVisibility(node) {
   if (!node || node.dataset.dmFlowVisibilityCaptured === "true") return;
   node.dataset.dmFlowVisibilityCaptured = "true";
@@ -273,7 +330,7 @@ function mirrorLegacyMainFlows(scope, period) {
 
 export function refreshEnergyFlows() {
   if (!doc) return false;
-  let touched = false;
+  let touched = syncCanonicalPeriodValues();
   for (const period of ["", "day", "month"]) {
     const scope = scopeFor(period);
     if (!scope) continue;

--- a/custom_components/dashboardmodern/frontend/tests/beta22-load-slots-hotfix.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta22-load-slots-hotfix.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  configuredFlowLoads,
+  loadPeriodEntity,
+  socEntity,
+} from "../src/sections/beta22-load-slots-hotfix-section.js";
+
+test("canonical Loads own the five flow slots", () => {
+  const loads = configuredFlowLoads([
+    { id: "hidden", name: "Hidden", show_in_dashboard: false, order: 0 },
+    { id: "manual", name: "Manual", category: "manual-report", order: 1 },
+    { id: "three", name: "Three", power_entity: "sensor.three", order: 3 },
+    { id: "one", name: "One", power_entity: "sensor.one", order: 1 },
+    { id: "two", name: "Two", power_entity: "sensor.two", order: 2 },
+    { id: "four", name: "Four", power_entity: "sensor.four", order: 4 },
+    { id: "five", name: "Five", power_entity: "sensor.five", order: 5 },
+    { id: "six", name: "Six", power_entity: "sensor.six", order: 6 },
+  ]);
+
+  assert.deepEqual(
+    loads.map(({ id }) => id),
+    ["one", "two", "three", "four", "five"],
+  );
+});
+
+test("flow periods use the canonical load entities", () => {
+  const load = {
+    power_entity: "sensor.power",
+    daily_energy_entity: "sensor.day",
+    monthly_energy_entity: "sensor.month",
+    history_entity: "sensor.total",
+  };
+  assert.equal(loadPeriodEntity(load, "instant"), "sensor.power");
+  assert.equal(loadPeriodEntity(load, "day"), "sensor.day");
+  assert.equal(loadPeriodEntity(load, "month"), "sensor.month");
+  assert.equal(loadPeriodEntity({ history_entity: "sensor.total" }, "month"), "sensor.total");
+});
+
+test("battery SOC reads the existing Energy battery.soc field", () => {
+  assert.equal(socEntity({ battery: { soc: "sensor.battery_soc" } }), "sensor.battery_soc");
+  assert.equal(
+    socEntity({ battery: { battery_soc_entity: "sensor.legacy_soc" } }),
+    "sensor.legacy_soc",
+  );
+});

--- a/custom_components/dashboardmodern/frontend/tests/legacy-host.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/legacy-host.test.js
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { HOST_KEY, legacyVariantForLocale, mountLegacyHost } from "../src/legacy/host.js";
-import { ALLOWED_MESSAGE_TYPES, createBridgeSocket } from "../src/legacy/bridge-socket.js";
+import {
+  ALLOWED_MESSAGE_TYPES,
+  createBridgeSocket,
+  isLegacyDashboardPersistenceMessage,
+} from "../src/legacy/bridge-socket.js";
 
 function fakeElement(tag) {
   return {
@@ -40,14 +44,19 @@ function connectionWith(handler = async () => ({}), subscribe = async () => () =
 
 function mount(overrides = {}) {
   const container = fakeElement("div");
-  const hostWindow = { location: { href: "http://ha.local:8123/dashboardmodern", host: "ha.local:8123" } };
+  const hostWindow = {
+    location: { href: "http://ha.local:8123/dashboardmodern", host: "ha.local:8123" },
+  };
   const host = mountLegacyHost(container, {
     hass: { locale: { language: "it" } },
     connection: connectionWith(),
     staticBase: "/dashboardmodern_static/abc",
     documentRef,
     hostWindow,
-    fetchRef: async () => ({ ok: true, text: async () => "<!doctype html><html><head></head><body></body></html>" }),
+    fetchRef: async () => ({
+      ok: true,
+      text: async () => "<!doctype html><html><head></head><body></body></html>",
+    }),
     ...overrides,
   });
   return { host, container, hostWindow };
@@ -99,7 +108,10 @@ test("the frame records the versioned source and keeps playback permissions", as
     "/dashboardmodern_static/abc/legacy/dashboard.html?dmi=integration&dmp=1",
   );
   assert.equal(host.frame.getAttribute("src"), undefined);
-  assert.match(host.frame.srcdoc, /<base href="http:\/\/ha\.local:8123\/dashboardmodern_static\/abc\/legacy\/">/);
+  assert.match(
+    host.frame.srcdoc,
+    /<base href="http:\/\/ha\.local:8123\/dashboardmodern_static\/abc\/legacy\/">/,
+  );
   assert.match(host.frame.srcdoc, /__DASHBOARDMODERN_BRIDGE_WS__/);
   for (const permission of ["autoplay", "fullscreen", "picture-in-picture"]) {
     assert.equal(host.frame.getAttribute("allow").includes(permission), true);
@@ -117,8 +129,13 @@ test("a container with no height falls back to viewport units", () => {
     connection: connectionWith(),
     staticBase: "/dashboardmodern_static/abc",
     documentRef: { createElement: () => frame },
-    hostWindow: { location: { href: "http://ha.local:8123/dashboardmodern", host: "ha.local:8123" } },
-    fetchRef: async () => ({ ok: true, text: async () => "<!doctype html><html><head></head><body></body></html>" }),
+    hostWindow: {
+      location: { href: "http://ha.local:8123/dashboardmodern", host: "ha.local:8123" },
+    },
+    fetchRef: async () => ({
+      ok: true,
+      text: async () => "<!doctype html><html><head></head><body></body></html>",
+    }),
   });
   assert.equal(host.frame.style.height, "100dvh");
 });
@@ -161,6 +178,76 @@ test("permitted messages are forwarded and their replies returned", async () => 
   const result = received.find((item) => item.id === 7);
   assert.equal(result.success, true);
   assert.deepEqual(result.result, [{ entity_id: "light.x" }]);
+});
+
+test("legacy hosted config reads and writes are recognized by request id", () => {
+  assert.equal(
+    isLegacyDashboardPersistenceMessage({
+      id: 17,
+      type: "frontend/get_user_data",
+      key: "dashboardmodern_integration_config",
+    }),
+    true,
+  );
+  assert.equal(
+    isLegacyDashboardPersistenceMessage({
+      id: 22,
+      type: "frontend/set_user_data",
+      key: "dashboardmodern_integration_config__secondary",
+    }),
+    true,
+  );
+  assert.equal(
+    isLegacyDashboardPersistenceMessage({
+      id: 700001,
+      type: "frontend/get_user_data",
+      key: "dashboardmodern_integration_config",
+    }),
+    false,
+  );
+});
+
+test("legacy hosted config writer is acknowledged but never reaches Home Assistant", async () => {
+  const sent = [];
+  const Socket = createBridgeSocket({
+    connection: connectionWith(async (message) => {
+      sent.push(message);
+      return { value: "remote" };
+    }),
+  });
+  const read = await exchange(new Socket(), {
+    id: 18,
+    type: "frontend/get_user_data",
+    key: "dashboardmodern_integration_config",
+  });
+  assert.deepEqual(read.find((item) => item.id === 18)?.result, { value: null });
+  const write = await exchange(new Socket(), {
+    id: 19,
+    type: "frontend/set_user_data",
+    key: "dashboardmodern_integration_config",
+    value: { __ts: Date.now(), cd_sections: "{}" },
+  });
+  assert.equal(write.find((item) => item.id === 19)?.success, true);
+  assert.deepEqual(sent, []);
+});
+
+test("modern persistence requests still reach Home Assistant", async () => {
+  const sent = [];
+  const Socket = createBridgeSocket({
+    connection: connectionWith(async (message) => {
+      sent.push(message);
+      return message.type === "frontend/get_user_data" ? { value: { version: 1 } } : null;
+    }),
+  });
+  const received = await exchange(new Socket(), {
+    id: 700123,
+    type: "frontend/get_user_data",
+    key: "dashboardmodern_integration_config",
+  });
+  assert.equal(received.find((item) => item.id === 700123)?.success, true);
+  assert.deepEqual(sent, [
+    { type: "frontend/get_user_data", key: "dashboardmodern_integration_config" },
+  ]);
 });
 
 test("a message type outside the allowed set is refused and reported", async () => {

--- a/custom_components/dashboardmodern/frontend/tests/persistence-hotfix.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/persistence-hotfix.test.js
@@ -7,6 +7,7 @@ const {
   applyRestoredValues,
   CONFIG_KEYS,
   integrationUserDataKey,
+  mergeLegacyMissingConfig,
   migrateLegacyUserData,
   normalizeRemoteSnapshot,
   normalizeRestoredValues,
@@ -14,7 +15,7 @@ const {
   sameConfigValues,
 } = await import("../src/sections/config-persistence-section.js");
 
-// DM-FIX-20260815F
+// DM-FIX-20260815G
 
 class MemoryStorage {
   values = new Map();
@@ -85,6 +86,7 @@ test("flat legacy cloud payload is accepted and upgraded to the modern envelope"
   });
   assert.deepEqual(remote, {
     version: 1,
+    keys_revision: 0,
     updated_at: 12345,
     migrated_from: "legacy-flat",
     values: {
@@ -92,6 +94,36 @@ test("flat legacy cloud payload is accepted and upgraded to the modern envelope"
       cd_devices: '[{"name":"Pompa"}]',
     },
   });
+});
+
+test("old incomplete cloud snapshot keeps local fields that were never synchronized", () => {
+  const local = {
+    cd_sections: '{"energy":true}',
+    cd_devices: '[{"name":"Pompa smartphone"}]',
+    cd_avvisi_custom: '[{"name":"Allarme"}]',
+  };
+  const oldRemote = normalizeRemoteSnapshot({
+    version: 1,
+    updated_at: 5000,
+    values: { cd_sections: '{"energy":false}' },
+  });
+  const merged = mergeLegacyMissingConfig(oldRemote, local);
+  assert.equal(merged.values.cd_sections, '{"energy":false}');
+  assert.equal(merged.values.cd_devices, local.cd_devices);
+  assert.equal(merged.values.cd_avvisi_custom, local.cd_avvisi_custom);
+});
+
+test("revision-2 cloud absence is authoritative and is not filled from stale local data", () => {
+  const remote = normalizeRemoteSnapshot({
+    version: 1,
+    keys_revision: 2,
+    updated_at: 5000,
+    values: { cd_sections: '{"energy":false}' },
+  });
+  const merged = mergeLegacyMissingConfig(remote, {
+    cd_devices: '[{"name":"Stale"}]',
+  });
+  assert.equal(Object.hasOwn(merged.values, "cd_devices"), false);
 });
 
 test("store preserves a fresh legacy visibility write instead of overwriting it", () => {
@@ -142,6 +174,7 @@ test("configured desktop restores the newer remote phone snapshot", () => {
   };
   const remote = {
     version: 1,
+    keys_revision: 2,
     updated_at: 5000,
     values: {
       cd_stanze: JSON.stringify([{ id: "room-new", name: "Nuova" }]),
@@ -167,6 +200,7 @@ test("newer unsynced local edit wins over an older remote snapshot", () => {
   const local = { cd_sections: JSON.stringify({ energy: true }) };
   const remote = {
     version: 1,
+    keys_revision: 2,
     updated_at: 4000,
     values: { cd_sections: JSON.stringify({ energy: false }) },
   };
@@ -195,7 +229,7 @@ test("identical local and remote snapshots do not rewrite either side", () => {
   assert.equal(sameConfigValues(values, { ...values }), true);
   assert.equal(
     persistenceReconcileAction({
-      remote: { version: 1, updated_at: 100, values: { ...values } },
+      remote: { version: 1, keys_revision: 2, updated_at: 100, values: { ...values } },
       localConfigured: true,
       pendingAt: 200,
       local: values,

--- a/custom_components/dashboardmodern/frontend/tests/persistence-hotfix.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/persistence-hotfix.test.js
@@ -3,10 +3,16 @@ import test from "node:test";
 import { DashboardStore } from "../src/core/dashboard-store.js";
 
 globalThis.addEventListener = () => {};
-const { integrationUserDataKey, migrateLegacyUserData, normalizeRestoredValues } =
-  await import("../src/sections/config-persistence-section.js");
+const {
+  applyRestoredValues,
+  integrationUserDataKey,
+  migrateLegacyUserData,
+  normalizeRestoredValues,
+  persistenceReconcileAction,
+  sameConfigValues,
+} = await import("../src/sections/config-persistence-section.js");
 
-// DM-FIX-20260815A
+// DM-FIX-20260815E
 
 class MemoryStorage {
   values = new Map();
@@ -95,4 +101,82 @@ test("restore normalizes room names in canonical and legacy snapshots", () => {
   });
   assert.equal(JSON.parse(restored.cd_stanze)[0].name, "Room 1");
   assert.equal(JSON.parse(restored.dm_dashboard_state).sections.rooms[0].name, "Room 1");
+});
+
+test("configured desktop restores the newer remote phone snapshot", () => {
+  const local = {
+    cd_stanze: JSON.stringify([{ id: "room-old", name: "Vecchia" }]),
+    cd_sections: JSON.stringify({ temp: true }),
+  };
+  const remote = {
+    version: 1,
+    updated_at: 5000,
+    values: {
+      cd_stanze: JSON.stringify([{ id: "room-new", name: "Nuova" }]),
+      cd_sections: JSON.stringify({ temp: true, energy: true }),
+    },
+  };
+  assert.equal(
+    persistenceReconcileAction({ remote, localConfigured: true, pendingAt: 0, local }),
+    "restore-remote",
+  );
+});
+
+test("newer unsynced local edit wins over an older remote snapshot", () => {
+  const local = { cd_sections: JSON.stringify({ energy: true }) };
+  const remote = {
+    version: 1,
+    updated_at: 4000,
+    values: { cd_sections: JSON.stringify({ energy: false }) },
+  };
+  assert.equal(
+    persistenceReconcileAction({ remote, localConfigured: true, pendingAt: 5000, local }),
+    "push-local",
+  );
+});
+
+test("first configured device seeds remote storage when no remote exists", () => {
+  assert.equal(
+    persistenceReconcileAction({
+      remote: null,
+      localConfigured: true,
+      local: { cd_stanze: "[]" },
+    }),
+    "push-local",
+  );
+});
+
+test("identical local and remote snapshots do not rewrite either side", () => {
+  const values = {
+    cd_sections: JSON.stringify({ energy: true }),
+    cd_costo_kwh: "0.28",
+  };
+  assert.equal(sameConfigValues(values, { ...values }), true);
+  assert.equal(
+    persistenceReconcileAction({
+      remote: { version: 1, updated_at: 100, values: { ...values } },
+      localConfigured: true,
+      pendingAt: 200,
+      local: values,
+    }),
+    "in-sync",
+  );
+});
+
+test("remote restore propagates deletions instead of leaving stale desktop keys", () => {
+  const storage = new MemoryStorage();
+  storage.setItem("cd_sections", JSON.stringify({ energy: true }));
+  storage.setItem("cd_stanze", JSON.stringify([{ id: "stale", name: "Stale" }]));
+  storage.setItem("cd_costo_kwh", "0.31");
+
+  assert.equal(
+    applyRestoredValues(storage, {
+      cd_sections: JSON.stringify({ energy: false }),
+      cd_costo_kwh: "0.27",
+    }),
+    true,
+  );
+  assert.equal(storage.getItem("cd_stanze"), null);
+  assert.equal(storage.getItem("cd_costo_kwh"), "0.27");
+  assert.deepEqual(JSON.parse(storage.getItem("cd_sections")), { energy: false });
 });

--- a/custom_components/dashboardmodern/frontend/tests/persistence-hotfix.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/persistence-hotfix.test.js
@@ -5,14 +5,16 @@ import { DashboardStore } from "../src/core/dashboard-store.js";
 globalThis.addEventListener = () => {};
 const {
   applyRestoredValues,
+  CONFIG_KEYS,
   integrationUserDataKey,
   migrateLegacyUserData,
+  normalizeRemoteSnapshot,
   normalizeRestoredValues,
   persistenceReconcileAction,
   sameConfigValues,
 } = await import("../src/sections/config-persistence-section.js");
 
-// DM-FIX-20260815E
+// DM-FIX-20260815F
 
 class MemoryStorage {
   values = new Map();
@@ -60,6 +62,36 @@ test("legacy remote payload migrates once to the unified key", async () => {
   assert.equal(await migrateLegacyUserData(fetchValue, pushValue), legacy);
   assert.equal(await migrateLegacyUserData(fetchValue, pushValue), legacy);
   assert.deepEqual(pushes, [["dashboardmodern_integration_config", legacy]]);
+});
+
+test("modern persistence covers legacy user-editable keys that used to stay device-local", () => {
+  for (const key of [
+    "cd_branding",
+    "cd_devices",
+    "cd_flow_nodes",
+    "cd_avvisi_custom",
+    "cd_text_overrides",
+    "cd_hidden_elements",
+  ])
+    assert.ok(CONFIG_KEYS.includes(key), `${key} must be synchronized`);
+});
+
+test("flat legacy cloud payload is accepted and upgraded to the modern envelope", () => {
+  const remote = normalizeRemoteSnapshot({
+    __ts: 12345,
+    _savedAt: 12000,
+    cd_sections: '{"energy":true}',
+    cd_devices: '[{"name":"Pompa"}]',
+  });
+  assert.deepEqual(remote, {
+    version: 1,
+    updated_at: 12345,
+    migrated_from: "legacy-flat",
+    values: {
+      cd_sections: '{"energy":true}',
+      cd_devices: '[{"name":"Pompa"}]',
+    },
+  });
 });
 
 test("store preserves a fresh legacy visibility write instead of overwriting it", () => {
@@ -122,6 +154,15 @@ test("configured desktop restores the newer remote phone snapshot", () => {
   );
 });
 
+test("configured desktop also restores a newer flat legacy phone snapshot", () => {
+  const local = { cd_devices: '[{"name":"Vecchio"}]' };
+  const remote = { __ts: 5000, cd_devices: '[{"name":"Nuovo"}]' };
+  assert.equal(
+    persistenceReconcileAction({ remote, localConfigured: true, pendingAt: 0, local }),
+    "restore-remote",
+  );
+});
+
 test("newer unsynced local edit wins over an older remote snapshot", () => {
   const local = { cd_sections: JSON.stringify({ energy: true }) };
   const remote = {
@@ -167,6 +208,7 @@ test("remote restore propagates deletions instead of leaving stale desktop keys"
   const storage = new MemoryStorage();
   storage.setItem("cd_sections", JSON.stringify({ energy: true }));
   storage.setItem("cd_stanze", JSON.stringify([{ id: "stale", name: "Stale" }]));
+  storage.setItem("cd_devices", JSON.stringify([{ name: "Stale device" }]));
   storage.setItem("cd_costo_kwh", "0.31");
 
   assert.equal(
@@ -177,6 +219,7 @@ test("remote restore propagates deletions instead of leaving stale desktop keys"
     true,
   );
   assert.equal(storage.getItem("cd_stanze"), null);
+  assert.equal(storage.getItem("cd_devices"), null);
   assert.equal(storage.getItem("cd_costo_kwh"), "0.27");
   assert.deepEqual(JSON.parse(storage.getItem("cd_sections")), { energy: false });
 });

--- a/custom_components/dashboardmodern/frontend/tests/persistence-hotfix.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/persistence-hotfix.test.js
@@ -15,7 +15,7 @@ const {
   sameConfigValues,
 } = await import("../src/sections/config-persistence-section.js");
 
-// DM-FIX-20260815G
+// DM-FIX-20260815H
 
 class MemoryStorage {
   values = new Map();
@@ -65,16 +65,20 @@ test("legacy remote payload migrates once to the unified key", async () => {
   assert.deepEqual(pushes, [["dashboardmodern_integration_config", legacy]]);
 });
 
-test("modern persistence covers legacy user-editable keys that used to stay device-local", () => {
+test("modern persistence covers every shared legacy editor key that used to stay device-local", () => {
   for (const key of [
     "cd_branding",
     "cd_devices",
+    "cd_floor_icons",
     "cd_flow_nodes",
+    "cd_subload_groups",
     "cd_avvisi_custom",
     "cd_text_overrides",
     "cd_hidden_elements",
   ])
     assert.ok(CONFIG_KEYS.includes(key), `${key} must be synchronized`);
+  for (const key of ["cd_connection", "cd_theme", "cd_navbar_mode", "cd_nav_mode"])
+    assert.equal(CONFIG_KEYS.includes(key), false, `${key} must remain device-local`);
 });
 
 test("flat legacy cloud payload is accepted and upgraded to the modern envelope", () => {

--- a/custom_components/dashboardmodern/frontend/tests/persistence-key-audit.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/persistence-key-audit.test.js
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { CONFIG_KEYS } from "../src/sections/config-persistence-section.js";
+
+const frontendRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// These are intentionally not shared dashboard configuration:
+// - connection can contain credentials/endpoint data;
+// - navbar mode/theme are per-device presentation preferences;
+// - sync bookkeeping and irrigation/pool run markers are runtime state.
+const DEVICE_LOCAL_OR_RUNTIME = new Set([
+  "cd_connection",
+  "cd_theme",
+  "cd_navbar_mode",
+  "cd_nav_mode",
+  "cd_sync_ts",
+  "cd_sync_dirty",
+  "cd_irr_lastrun",
+  "cd_pool_run",
+  "cd_pool_lastrun",
+]);
+
+function literalStorageWrites(source) {
+  return new Set(
+    [...source.matchAll(/localStorage\.setItem\(\s*["']((?:cd|dm)_[a-z0-9_]+)["']/gi)].map(
+      (match) => match[1],
+    ),
+  );
+}
+
+test("every literal legacy dashboard config write is either synced or explicitly device-local", async () => {
+  for (const variant of ["it", "en"]) {
+    const source = await readFile(
+      path.join(frontendRoot, "legacy", `dashboard-runtime-${variant}.js`),
+      "utf8",
+    );
+    const unknown = [...literalStorageWrites(source)]
+      .filter((key) => !CONFIG_KEYS.includes(key) && !DEVICE_LOCAL_OR_RUNTIME.has(key))
+      .sort();
+    assert.deepEqual(
+      unknown,
+      [],
+      `${variant} runtime has unclassified localStorage writes that can diverge across devices:\n${unknown.join("\n")}`,
+    );
+  }
+});
+
+test("the cross-device snapshot includes the legacy editor fields previously omitted", () => {
+  for (const key of [
+    "cd_floor_icons",
+    "cd_subload_groups",
+    "cd_flow_nodes",
+    "cd_report_devices",
+    "cd_avvisi_custom",
+    "cd_text_overrides",
+    "cd_hidden_elements",
+  ]) {
+    assert.equal(CONFIG_KEYS.includes(key), true, `${key} must be shared across devices`);
+  }
+});

--- a/custom_components/dashboardmodern/frontend/tests/persistence-key-audit.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/persistence-key-audit.test.js
@@ -11,7 +11,7 @@ const frontendRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 
 // These are intentionally not shared dashboard configuration:
 // - connection can contain credentials/endpoint data;
 // - navbar mode/theme are per-device presentation preferences;
-// - sync bookkeeping and irrigation/pool run markers are runtime state.
+// - sync bookkeeping, reset/fresh-start state and irrigation/pool run markers are runtime state.
 const DEVICE_LOCAL_OR_RUNTIME = new Set([
   "cd_connection",
   "cd_theme",
@@ -22,6 +22,7 @@ const DEVICE_LOCAL_OR_RUNTIME = new Set([
   "cd_irr_lastrun",
   "cd_pool_run",
   "cd_pool_lastrun",
+  "dm_fresh_start",
 ]);
 
 function literalStorageWrites(source) {

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -126,8 +126,11 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // canonical icon-engine owner while historical beta modules delegate instead
   // of repainting the same icon DOM. Beta20.2 adds exactly one canonical save
   // owner to close the legacy editor -> store -> visibility -> HA persistence
-  // transaction. All facade/cycle/orphan/polling/observer checks stay active.
-  assert.ok(relative.length <= 73, `production graph unexpectedly grew to ${relative.length} modules`);
+  // transaction. Beta22 adds one final scoped, event-driven corrective owner
+  // that binds canonical Loads to the existing Energy flow slots, restores SOC,
+  // Temperature room labels and Energy cost fields, without polling or a global
+  // observer. All facade/cycle/orphan/polling/observer checks stay active.
+  assert.ok(relative.length <= 74, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.22"
+  "version": "1.0.0-beta.23"
 }

--- a/scripts/generate_build_info.py
+++ b/scripts/generate_build_info.py
@@ -127,6 +127,7 @@ def main() -> None:
         'import "../src/sections/beta12-room-color-lock-section.js";\n'
         'import "../src/sections/beta14-real-device-hotfix-section.js";\n'
         'import "../src/sections/beta16-real-device-layout-section.js";\n'
+        'import "../src/sections/beta22-load-slots-hotfix-section.js";\n'
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(


### PR DESCRIPTION
Correzione mirata costruita direttamente sulla release `v1.0.0-beta.22`, candidata a `v1.0.0-beta.23`.

### Correzioni richieste
- **Eliminato dalla UI/runtime il secondo blocco `energyLoads` introdotto in beta.22**: non compare più il blocco Carichi aggiunto in fondo a Flussi ed Entità e non vengono più lasciati cerchi dinamici separati.
- **La sezione canonica `CARICHI` è l’unico owner dei cerchi sotto CASA**: i carichi abilitati alla dashboard popolano nome, icona e valore dei cinque slot esistenti.
- **Niente cerchi vuoti**: se i carichi non sono configurati, cerchi e relativi collegamenti vengono nascosti in **Istantanea, Giornaliera e Mensile**; con meno di cinque carichi vengono mostrati solo gli slot effettivamente configurati.
- **SOC Batteria in Istantanea**: usa il campo già presente `energy.battery.soc` e mostra `SOC xx%` nel nodo Batteria, con fallback compatibile per vecchie chiavi.
- **Temperatura**: il nome canonico della stanza viene ricostruito e forzato realmente visibile accanto all’icona nelle righe già configurate, incluso layout mobile reale.
- **Impostazioni Energia / costi**: ripristinati con etichette esplicite i campi `Energia acquistata (€/kWh)` e `Energia venduta (€/kWh)`, mantenendo il salvataggio esistente `edSaveCosti()`.
- Nessun `setInterval` e nessun `MutationObserver` globale: la riconciliazione resta event-driven.

### Test
- Aggiunti test unitari su ownership dei cinque slot Carichi, mapping delle entità per periodo e SOC batteria.
- Il guard del grafo runtime mantiene attivi i controlli su cicli, facade, polling, observer e moduli orfani, registrando il solo owner correttivo aggiunto per beta.23.

### Release
- Manifest e build metadata allineati a `1.0.0-beta.23`.
- Dopo merge con tutti i gate verdi, il workflow `Release` pubblicherà automaticamente `v1.0.0-beta.23` con `dashboardmodern.zip`.