### PR TITLE
fix: recupera energia e carichi cross-device in beta 24

### DIFF
--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -8,4 +8,5 @@ import "../src/sections/beta12-room-color-lock-section.js";
 import "../src/sections/beta14-real-device-hotfix-section.js";
 import "../src/sections/beta16-real-device-layout-section.js";
 import "../src/sections/beta22-load-slots-hotfix-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.23","dashboardVersion":"1.0.0-beta.23","moduleVersion":14,"schemaVersion":4,"date":"2026-08-15T13:24:11+00:00","commit":"fb51bd47267c2dd51fbbe9afb0cb2125f0988c56","assetHash":"873ab4bfc9b01341"});
+import "../src/sections/beta24-energy-recovery-section.js";
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.24","dashboardVersion":"1.0.0-beta.24","moduleVersion":14,"schemaVersion":4,"date":"2026-08-16T03:30:00+00:00","commit":"e6fd0f44f5c4d967a99b4d870aa7c83bf5c93d4f","assetHash":"873ab4bfc9b01341"});

--- a/custom_components/dashboardmodern/frontend/src/sections/beta24-energy-recovery-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta24-energy-recovery-section.js
@@ -1,0 +1,338 @@
+/* Beta 24 recovery for configurations that crossed the Beta 22/23 persistence rewrite.
+ *
+ * The canonical store deliberately keeps legacy projection keys for backwards
+ * compatibility.  A schema-v4 dm_dashboard_state can however be older than its
+ * cd_energy_model/cd_entity_overrides/cd_loads siblings (for example after a
+ * cross-device restore).  DashboardStore.migrate() persists immediately, so
+ * those newer sibling values used to be overwritten before they could be
+ * reconciled.  Capture them before migration, recover only missing canonical
+ * fields, then persist the repaired canonical state once.
+ */
+
+import { DashboardStore } from "../core/dashboard-store.js";
+import { normalizeDevice } from "../core/device-model.js";
+import { ENERGY_SLOT_MAP } from "../core/energy-projection.js";
+
+const root = globalThis;
+const doc = root.document;
+const PATCH_MARKER = "__DASHBOARDMODERN_BETA24_STORE_RECOVERY__";
+const SOC_MARKER = "dmBeta24SocOwner";
+
+const clean = (value) => String(value ?? "").trim();
+const objectValue = (value) =>
+  value && typeof value === "object" && !Array.isArray(value) ? value : {};
+
+const LEGACY_FIXED_LOADS = Object.freeze([
+  {
+    id: "load-boiler",
+    name: "Boiler",
+    icon: "mdi:water-boiler",
+    powerSlot: "dm.boiler_potenza_resistenza_boiler",
+    dailySlot: "dm.energy_boiler_oggi",
+  },
+  {
+    id: "load-wallbox",
+    name: "Wallbox",
+    icon: "mdi:car-electric",
+    powerSlot: "dm.ev_potenza_wallbox",
+    dailySlot: "dm.ev_energia_wallbox_oggi",
+  },
+  {
+    id: "load-clima",
+    name: "Clima",
+    icon: "mdi:snowflake",
+    powerSlot: "dm.energy_potenza_condizionatori",
+    dailySlot: "dm.energy_condizionatori_oggi",
+  },
+  {
+    id: "load-lavanderia",
+    name: "Lavanderia",
+    icon: "mdi:washing-machine",
+    powerSlot: "dm.energy_potenza_lavanderia",
+    dailySlot: "dm.energy_lavanderia_oggi",
+  },
+  {
+    id: "load-cucina",
+    name: "Cucina",
+    icon: "mdi:stove",
+    powerSlot: "dm.energy_potenza_cucina",
+    dailySlot: "dm.energy_cucina_oggi",
+  },
+]);
+
+function parseStorage(storage, key, fallback) {
+  try {
+    return JSON.parse(storage?.getItem?.(key) || "null") ?? fallback;
+  } catch (_error) {
+    return fallback;
+  }
+}
+
+function captureBeforeMigration(storage) {
+  return {
+    energy: parseStorage(storage, "cd_energy_model", {}),
+    overrides: parseStorage(storage, "cd_entity_overrides", {}),
+    loads: parseStorage(storage, "cd_loads", []),
+    retiredEnergyLoads: parseStorage(storage, "cd_energy_loads", []),
+  };
+}
+
+function ensureEnergyShape(state) {
+  state.sections ||= {};
+  const current = objectValue(state.sections.energy);
+  const energy = {
+    ...current,
+    house: { ...objectValue(current.house) },
+    grid: { ...objectValue(current.grid) },
+    solar: { ...objectValue(current.solar) },
+    battery: { ...objectValue(current.battery) },
+    metadata: { ...objectValue(current.metadata) },
+  };
+  state.sections.energy = energy;
+  return energy;
+}
+
+export function recoverEnergyConfiguration(state, captured = {}) {
+  if (!state || typeof state !== "object") return 0;
+  const energy = ensureEnergyShape(state);
+  const legacyEnergy = objectValue(captured.energy);
+  const overrides = {
+    ...objectValue(captured.overrides),
+    ...objectValue(state.sections?.entityOverrides),
+  };
+  let recovered = 0;
+
+  for (const group of ["house", "grid", "solar", "battery"]) {
+    for (const [key, value] of Object.entries(objectValue(legacyEnergy[group]))) {
+      if (key === "metadata" || clean(energy[group]?.[key]) || !clean(value)) continue;
+      energy[group][key] = value;
+      recovered += 1;
+    }
+  }
+
+  for (const [path, slot] of Object.entries(ENERGY_SLOT_MAP)) {
+    const [group, key] = path.split(".");
+    const value = clean(overrides[slot]);
+    if (!value || clean(energy[group]?.[key])) continue;
+    energy[group][key] = value;
+    recovered += 1;
+  }
+
+  if (recovered) {
+    energy.metadata = {
+      ...energy.metadata,
+      beta24_recovered_energy: true,
+    };
+  }
+  return recovered;
+}
+
+function loadEntities(load = {}) {
+  return [
+    load.power_entity,
+    load.daily_energy_entity,
+    load.monthly_energy_entity,
+    load.total_energy_entity,
+    load.history_entity,
+    load.energy_entity,
+  ]
+    .map(clean)
+    .filter(Boolean);
+}
+
+function sameLoad(existing, candidate) {
+  if (clean(existing?.id) && clean(existing.id) === clean(candidate?.id)) return true;
+  const left = new Set(loadEntities(existing));
+  if (loadEntities(candidate).some((entity) => left.has(entity))) return true;
+  const leftName = clean(existing?.name).toLocaleLowerCase();
+  const rightName = clean(candidate?.name).toLocaleLowerCase();
+  return Boolean(leftName && rightName && leftName === rightName);
+}
+
+function normalizeLoad(raw, rooms, index) {
+  return normalizeDevice(
+    {
+      ...raw,
+      category: clean(raw?.category) || "secondary",
+      show_in_dashboard: raw?.show_in_dashboard !== false,
+      show_in_report: raw?.show_in_report !== false,
+      order: Number.isFinite(+raw?.order) ? +raw.order : index,
+    },
+    "loads",
+    { rooms, index },
+  );
+}
+
+function retiredLoadCandidate(item = {}, index = 0) {
+  const cumulative = clean(
+    item.total_energy_entity || item.history_entity || item.energy_entity,
+  );
+  return {
+    id: clean(item.id) || `load-beta22-${index + 1}`,
+    name: clean(item.name) || `Carico ${index + 1}`,
+    icon: clean(item.icon) || "mdi:power-plug",
+    power_entity: clean(item.power_entity),
+    daily_energy_entity: clean(item.daily_energy_entity),
+    monthly_energy_entity: clean(item.monthly_energy_entity),
+    total_energy_entity: cumulative,
+    history_entity: clean(item.history_entity) || cumulative,
+    category: "secondary",
+    show_in_dashboard: true,
+    show_in_report: true,
+    order: Number.isFinite(+item.order) ? +item.order : index,
+    metadata: { ...(item.metadata || {}), migrated_from_beta22_energy_loads: true },
+  };
+}
+
+export function recoverCanonicalLoads(state, captured = {}) {
+  if (!state || typeof state !== "object") return 0;
+  state.sections ||= {};
+  const rooms = Array.isArray(state.sections.rooms) ? state.sections.rooms : [];
+  const current = Array.isArray(state.sections.loads) ? state.sections.loads.slice() : [];
+  const candidates = [];
+
+  if (Array.isArray(captured.loads)) candidates.push(...captured.loads);
+
+  const overrides = {
+    ...objectValue(captured.overrides),
+    ...objectValue(state.sections.entityOverrides),
+  };
+  for (const definition of LEGACY_FIXED_LOADS) {
+    const power = clean(overrides[definition.powerSlot]);
+    const daily = clean(overrides[definition.dailySlot]);
+    if (!power && !daily) continue;
+    candidates.push({
+      id: definition.id,
+      name: definition.name,
+      icon: definition.icon,
+      power_entity: power,
+      daily_energy_entity: daily,
+      category: "secondary",
+      show_in_dashboard: true,
+      show_in_report: true,
+      order: candidates.length,
+      metadata: { migrated_from_fixed_energy_flow: true },
+    });
+  }
+
+  const retired = [
+    ...(Array.isArray(state.sections.energyLoads) ? state.sections.energyLoads : []),
+    ...(Array.isArray(captured.retiredEnergyLoads) ? captured.retiredEnergyLoads : []),
+  ];
+  retired.forEach((item, index) => candidates.push(retiredLoadCandidate(item, index)));
+
+  let added = 0;
+  for (const raw of candidates) {
+    const candidate = normalizeLoad(raw, rooms, current.length);
+    if (!loadEntities(candidate).length && !clean(candidate.name)) continue;
+    if (current.some((item) => sameLoad(item, candidate))) continue;
+    current.push(candidate);
+    added += 1;
+  }
+
+  state.sections.loads = current.map((item, index) => normalizeLoad(item, rooms, index));
+  // Beta 22's parallel Energy Loads model is retired.  Its data has now been
+  // promoted into the canonical Loads collection and must not become a second
+  // editor/renderer owner again.
+  state.sections.energyLoads = [];
+  return added;
+}
+
+export function recoverStoreState(store, captured = {}) {
+  if (!store?.state) return { energy: 0, loads: 0 };
+  const energy = recoverEnergyConfiguration(store.state, captured);
+  const loads = recoverCanonicalLoads(store.state, captured);
+  if (energy || loads) store.persist();
+  return { energy, loads };
+}
+
+export function installBeta24StoreRecovery() {
+  const proto = DashboardStore.prototype;
+  if (proto[PATCH_MARKER]) return false;
+  const original = proto.migrate;
+  if (typeof original !== "function") return false;
+
+  proto.migrate = function dashboardModernBeta24Migrate(...args) {
+    const captured = captureBeforeMigration(this.storage);
+    const result = original.apply(this, args);
+    const repaired = recoverStoreState(this, captured);
+    if (repaired.energy || repaired.loads) {
+      result.changes ||= [];
+      result.changes.push(
+        `beta24 recovery: energy ${repaired.energy}, loads ${repaired.loads}`,
+      );
+      root.console?.info?.("[DashboardStore] beta24 recovery", repaired);
+    }
+    return result;
+  };
+  proto[PATCH_MARKER] = true;
+  return true;
+}
+
+export function normalizeBatterySocText(value) {
+  const text = clean(value);
+  if (!text) return text;
+  if (/^soc\b/i.test(text)) return `SOC ${text.replace(/^soc\s*/i, "")}`.trim();
+  if (/^(?:\d+(?:[.,]\d+)?%|—)$/.test(text)) return `SOC ${text}`;
+  return text;
+}
+
+function normalizeBatterySocNode(node) {
+  if (!node || node.hidden) return false;
+  const normalized = normalizeBatterySocText(node.textContent);
+  if (!normalized || normalized === clean(node.textContent)) return false;
+  node.textContent = normalized;
+  return true;
+}
+
+function bindBatterySocOwner() {
+  const node = doc?.querySelector?.("#view-ist #v-battery-soc,#v-battery-soc");
+  if (!node) return false;
+  normalizeBatterySocNode(node);
+  if (node.dataset?.[SOC_MARKER] === "true") return true;
+  if (node.dataset) node.dataset[SOC_MARKER] = "true";
+  if (typeof root.MutationObserver === "function") {
+    const observer = new root.MutationObserver(() => normalizeBatterySocNode(node));
+    observer.observe(node, { childList: true, characterData: true, subtree: true });
+  }
+  return true;
+}
+
+function scheduleSocOwner() {
+  root.requestAnimationFrame?.(bindBatterySocOwner);
+  root.setTimeout?.(bindBatterySocOwner, 0);
+  root.setTimeout?.(bindBatterySocOwner, 120);
+}
+
+function requestInitialRemoteReconcile() {
+  // config-persistence-section is imported before this module.  Defer one task
+  // so modules-entry can construct/migrate the store first, then perform an
+  // unconditional initial pull.  Previously some WebViews missed both runtime
+  // events and never hydrated until a later focus/pageshow.
+  root.setTimeout?.(() => root.cdSyncPull?.(), 0);
+}
+
+function installRuntimeRecovery() {
+  installBeta24StoreRecovery();
+  requestInitialRemoteReconcile();
+  for (const name of [
+    "dashboardmodern:legacy-ready",
+    "dashboardmodern:runtime-ready",
+    "dashboardmodern:states-ready",
+    "dashboardmodern:energy-stable",
+    "dashboardmodern:period-bundle",
+  ])
+    root.addEventListener?.(name, scheduleSocOwner);
+  if (doc?.readyState === "loading")
+    doc.addEventListener("DOMContentLoaded", scheduleSocOwner, { once: true });
+  else scheduleSocOwner();
+}
+
+installRuntimeRecovery();
+
+export const beta24EnergyRecovery = Object.freeze({
+  recoverEnergyConfiguration,
+  recoverCanonicalLoads,
+  recoverStoreState,
+  normalizeBatterySocText,
+});

--- a/custom_components/dashboardmodern/frontend/src/sections/beta24-energy-recovery-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta24-energy-recovery-section.js
@@ -17,6 +17,7 @@ const root = globalThis;
 const doc = root.document;
 const PATCH_MARKER = "__DASHBOARDMODERN_BETA24_STORE_RECOVERY__";
 const SOC_MARKER = "dmBeta24SocOwner";
+const PERSIST_META_KEY = "dm_persistence_meta";
 
 const clean = (value) => String(value ?? "").trim();
 const objectValue = (value) =>
@@ -238,11 +239,30 @@ export function recoverCanonicalLoads(state, captured = {}) {
   return added;
 }
 
+export function markRecoveredConfigPending(storage, now = Date.now()) {
+  if (!storage?.setItem) return false;
+  let current = {};
+  try {
+    const parsed = JSON.parse(storage.getItem?.(PERSIST_META_KEY) || "null");
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) current = parsed;
+  } catch (_error) {}
+  const timestamp = Math.max(Number(current.pending_at) || 0, Number(now) || Date.now());
+  storage.setItem(PERSIST_META_KEY, JSON.stringify({ ...current, pending_at: timestamp }));
+  return true;
+}
+
 export function recoverStoreState(store, captured = {}) {
   if (!store?.state) return { energy: 0, loads: 0 };
   const energy = recoverEnergyConfiguration(store.state, captured);
   const loads = recoverCanonicalLoads(store.state, captured);
-  if (energy || loads) store.persist();
+  if (energy || loads) {
+    store.persist();
+    // The persistence owner is already installed but intentionally ignores
+    // pre-hydration writes. Mark this repair explicitly as pending so the first
+    // cloud reconciliation pushes the recovered configuration instead of
+    // restoring a newer-but-damaged Beta23 remote snapshot over it.
+    markRecoveredConfigPending(store.storage);
+  }
   return { energy, loads };
 }
 
@@ -307,8 +327,9 @@ function scheduleSocOwner() {
 function requestInitialRemoteReconcile() {
   // config-persistence-section is imported before this module.  Defer one task
   // so modules-entry can construct/migrate the store first, then perform an
-  // unconditional initial pull.  Previously some WebViews missed both runtime
-  // events and never hydrated until a later focus/pageshow.
+  // unconditional initial pull. If migration recovered damaged Beta23 data,
+  // dm_persistence_meta.pending_at makes that first reconciliation push the
+  // repaired local snapshot to Home Assistant instead of restoring stale data.
   root.setTimeout?.(() => root.cdSyncPull?.(), 0);
 }
 
@@ -333,6 +354,7 @@ installRuntimeRecovery();
 export const beta24EnergyRecovery = Object.freeze({
   recoverEnergyConfiguration,
   recoverCanonicalLoads,
+  markRecoveredConfigPending,
   recoverStoreState,
   normalizeBatterySocText,
 });

--- a/custom_components/dashboardmodern/frontend/src/sections/shared.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shared.js
@@ -189,7 +189,14 @@ export function section(name, fallback) {
 }
 
 export function allStates() {
-  const values = {};
+  // Hosted Home Assistant surfaces do not all expose the live registry through
+  // the same object at the same moment. Merge every supported source instead of
+  // making the period engine and the compatibility layer observe different
+  // universes on Chrome vs the HA mobile WebView.
+  const values = {
+    ...(root.__HASS__?.states || {}),
+    ...(root.hass?.states || {}),
+  };
   for (const name of ["_RAW_STATES", "STATES"]) {
     let lexical = null;
     try {

--- a/custom_components/dashboardmodern/frontend/tests/beta24-energy-recovery.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta24-energy-recovery.test.js
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DashboardStore } from "../src/core/dashboard-store.js";
+import { allStates } from "../src/sections/shared.js";
+import {
+  normalizeBatterySocText,
+  recoverCanonicalLoads,
+  recoverEnergyConfiguration,
+} from "../src/sections/beta24-energy-recovery-section.js";
+
+class MemoryStorage {
+  constructor(seed = {}) {
+    this.values = new Map(Object.entries(seed));
+  }
+  getItem(key) {
+    return this.values.get(key) ?? null;
+  }
+  setItem(key, value) {
+    this.values.set(key, String(value));
+  }
+  removeItem(key) {
+    this.values.delete(key);
+  }
+}
+
+const json = (value) => JSON.stringify(value);
+
+function emptySchema4() {
+  return {
+    schema_version: 4,
+    sections: {
+      rooms: [],
+      cameras: [],
+      appliances: [],
+      loads: [],
+      lights: [],
+      climate: [],
+      ev: [],
+      covers: [],
+      pool: {},
+      irrigation: {},
+      energy: { house: {}, grid: {}, solar: {}, battery: {}, metadata: { semantics_version: 4 } },
+      energyLoads: [],
+      entityOverrides: {},
+    },
+    visibility: { energy: true },
+  };
+}
+
+test("schema-v4 migration recovers newer energy/load sibling keys before they are overwritten", () => {
+  const storage = new MemoryStorage({
+    dm_dashboard_state: json(emptySchema4()),
+    cd_energy_model: json({
+      house: {
+        power: "sensor.house_power",
+        daily_energy: "sensor.house_today",
+        monthly_energy: "sensor.house_month",
+      },
+      solar: { daily_energy: "sensor.solar_today" },
+      grid: {},
+      battery: { soc: "sensor.battery_soc" },
+      metadata: { semantics_version: 4 },
+    }),
+    cd_entity_overrides: json({
+      "dm.energy_energia_prelevata_oggi": "sensor.grid_import_today",
+      "dm.energy_energia_immessa_oggi": "sensor.grid_export_today",
+      "dm.boiler_potenza_resistenza_boiler": "sensor.boiler_power",
+      "dm.energy_boiler_oggi": "sensor.boiler_today",
+    }),
+    cd_loads: json([
+      {
+        id: "load-boiler-user",
+        name: "Boiler",
+        icon: "mdi:water-boiler",
+        power_entity: "sensor.boiler_power",
+        daily_energy_entity: "sensor.boiler_today",
+        show_in_dashboard: true,
+      },
+    ]),
+  });
+
+  const store = new DashboardStore({ storage, sync: async () => {} });
+  const result = store.migrate();
+  const energy = store.getSection("energy");
+  const loads = store.getSection("loads");
+
+  assert.equal(energy.house.power, "sensor.house_power");
+  assert.equal(energy.house.daily_energy, "sensor.house_today");
+  assert.equal(energy.house.monthly_energy, "sensor.house_month");
+  assert.equal(energy.solar.daily_energy, "sensor.solar_today");
+  assert.equal(energy.grid.daily_import_energy, "sensor.grid_import_today");
+  assert.equal(energy.grid.daily_export_energy, "sensor.grid_export_today");
+  assert.equal(energy.battery.soc, "sensor.battery_soc");
+  assert.equal(loads.length, 1);
+  assert.equal(loads[0].power_entity, "sensor.boiler_power");
+  assert.equal(loads[0].daily_energy_entity, "sensor.boiler_today");
+  assert.match(result.changes.join("\n"), /beta24 recovery/);
+
+  const persistedEnergy = JSON.parse(storage.getItem("cd_energy_model"));
+  const persistedLoads = JSON.parse(storage.getItem("cd_loads"));
+  assert.equal(persistedEnergy.house.daily_energy, "sensor.house_today");
+  assert.equal(persistedLoads[0].daily_energy_entity, "sensor.boiler_today");
+});
+
+test("energy recovery fills only missing canonical fields and never overwrites configured ones", () => {
+  const state = emptySchema4();
+  state.sections.energy.house.daily_energy = "sensor.keep_today";
+  const recovered = recoverEnergyConfiguration(state, {
+    energy: {
+      house: {
+        daily_energy: "sensor.old_today",
+        monthly_energy: "sensor.house_month",
+      },
+    },
+    overrides: {
+      "dm.energy_produzione_solare_oggi": "sensor.solar_today",
+    },
+  });
+  assert.equal(state.sections.energy.house.daily_energy, "sensor.keep_today");
+  assert.equal(state.sections.energy.house.monthly_energy, "sensor.house_month");
+  assert.equal(state.sections.energy.solar.daily_energy, "sensor.solar_today");
+  assert.equal(recovered, 2);
+});
+
+test("retired Beta22 energy loads are promoted once into canonical Loads", () => {
+  const state = emptySchema4();
+  state.sections.energyLoads = [
+    {
+      id: "energy-load-pompa",
+      name: "Pompa",
+      icon: "mdi:pump",
+      power_entity: "sensor.pump_power",
+      energy_entity: "sensor.pump_total",
+    },
+  ];
+  const added = recoverCanonicalLoads(state, {
+    loads: [],
+    overrides: {
+      "dm.boiler_potenza_resistenza_boiler": "sensor.boiler_power",
+      "dm.energy_boiler_oggi": "sensor.boiler_today",
+    },
+    retiredEnergyLoads: state.sections.energyLoads,
+  });
+
+  assert.equal(added, 2);
+  assert.equal(state.sections.energyLoads.length, 0);
+  assert.equal(state.sections.loads.length, 2);
+  const boiler = state.sections.loads.find((item) => item.name === "Boiler");
+  const pump = state.sections.loads.find((item) => item.name === "Pompa");
+  assert.equal(boiler.daily_energy_entity, "sensor.boiler_today");
+  assert.equal(pump.total_energy_entity, "sensor.pump_total");
+  assert.equal(pump.history_entity, "sensor.pump_total");
+
+  const second = recoverCanonicalLoads(state, {
+    loads: state.sections.loads,
+    overrides: {
+      "dm.boiler_potenza_resistenza_boiler": "sensor.boiler_power",
+      "dm.energy_boiler_oggi": "sensor.boiler_today",
+    },
+  });
+  assert.equal(second, 0);
+  assert.equal(state.sections.loads.length, 2);
+});
+
+test("SOC text has one stable visible contract", () => {
+  assert.equal(normalizeBatterySocText("62%"), "SOC 62%");
+  assert.equal(normalizeBatterySocText("SOC 62%"), "SOC 62%");
+  assert.equal(normalizeBatterySocText("—"), "SOC —");
+});
+
+test("allStates merges Home Assistant, WebView and canonical state registries", () => {
+  const previousHass = globalThis.__HASS__;
+  const previousPublicHass = globalThis.hass;
+  const previousStates = globalThis.STATES;
+  const previousRaw = globalThis._RAW_STATES;
+  try {
+    globalThis.__HASS__ = { states: { "sensor.from_hass": { state: "1" } } };
+    globalThis.hass = { states: { "sensor.from_webview": { state: "2" } } };
+    globalThis.STATES = { "sensor.from_states": { state: "3" } };
+    globalThis._RAW_STATES = { "sensor.from_raw": { state: "4" } };
+    const states = allStates();
+    assert.equal(states["sensor.from_hass"].state, "1");
+    assert.equal(states["sensor.from_webview"].state, "2");
+    assert.equal(states["sensor.from_states"].state, "3");
+    assert.equal(states["sensor.from_raw"].state, "4");
+  } finally {
+    globalThis.__HASS__ = previousHass;
+    globalThis.hass = previousPublicHass;
+    globalThis.STATES = previousStates;
+    globalThis._RAW_STATES = previousRaw;
+  }
+});

--- a/custom_components/dashboardmodern/frontend/tests/beta24-energy-recovery.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta24-energy-recovery.test.js
@@ -3,6 +3,7 @@ import test from "node:test";
 import { DashboardStore } from "../src/core/dashboard-store.js";
 import { allStates } from "../src/sections/shared.js";
 import {
+  markRecoveredConfigPending,
   normalizeBatterySocText,
   recoverCanonicalLoads,
   recoverEnergyConfiguration,
@@ -98,8 +99,26 @@ test("schema-v4 migration recovers newer energy/load sibling keys before they ar
 
   const persistedEnergy = JSON.parse(storage.getItem("cd_energy_model"));
   const persistedLoads = JSON.parse(storage.getItem("cd_loads"));
+  const persistenceMeta = JSON.parse(storage.getItem("dm_persistence_meta"));
   assert.equal(persistedEnergy.house.daily_energy, "sensor.house_today");
   assert.equal(persistedLoads[0].daily_energy_entity, "sensor.boiler_today");
+  assert.ok(Number(persistenceMeta.pending_at) > 0);
+});
+
+test("recovered config keeps the newest pending timestamp so stale cloud data cannot win", () => {
+  const storage = new MemoryStorage({
+    dm_persistence_meta: json({ synced_at: 100, pending_at: 250 }),
+  });
+  assert.equal(markRecoveredConfigPending(storage, 200), true);
+  assert.deepEqual(JSON.parse(storage.getItem("dm_persistence_meta")), {
+    synced_at: 100,
+    pending_at: 250,
+  });
+  assert.equal(markRecoveredConfigPending(storage, 500), true);
+  assert.deepEqual(JSON.parse(storage.getItem("dm_persistence_meta")), {
+    synced_at: 100,
+    pending_at: 500,
+  });
 });
 
 test("energy recovery fills only missing canonical fields and never overwrites configured ones", () => {

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -129,16 +129,20 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // transaction. Beta22 adds one final scoped, event-driven corrective owner
   // that binds canonical Loads to the existing Energy flow slots, restores SOC,
   // Temperature room labels and Energy cost fields, without polling or a global
-  // observer. All facade/cycle/orphan/polling/observer checks stay active.
-  assert.ok(relative.length <= 74, `production graph unexpectedly grew to ${relative.length} modules`);
+  // observer. Beta24 adds one boot-time recovery module for schema-v4 snapshots
+  // that crossed the persistence rewrite; its only observer is scoped to the
+  // single Battery SOC text node so competing legacy writes cannot visibly win.
+  // All facade/cycle/orphan/polling/global-observer checks stay active.
+  assert.ok(relative.length <= 75, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 
   const observers = [...graph.entries()].filter(([, source]) => /new\s+(?:root\.)?MutationObserver\s*\(/.test(source));
   // Beta17 contributes one page-scoped observer so delayed legacy writes on
-  // #page-temp cannot resurrect the progress placeholder. The loop below still
-  // rejects any observer rooted at document/body/documentElement.
-  assert.ok(observers.length <= 3, `too many production observers: ${observers.length}`);
+  // #page-temp cannot resurrect the progress placeholder. Beta24 may add one
+  // node-scoped SOC observer. The loop below still rejects observers rooted at
+  // document/body/documentElement.
+  assert.ok(observers.length <= 4, `too many production observers: ${observers.length}`);
   for (const [file, source] of observers) {
     assert.doesNotMatch(
       source,

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.23"
+  "version": "1.0.0-beta.24"
 }

--- a/scripts/generate_build_info.py
+++ b/scripts/generate_build_info.py
@@ -128,6 +128,7 @@ def main() -> None:
         'import "../src/sections/beta14-real-device-hotfix-section.js";\n'
         'import "../src/sections/beta16-real-device-layout-section.js";\n'
         'import "../src/sections/beta22-load-slots-hotfix-section.js";\n'
+        'import "../src/sections/beta24-energy-recovery-section.js";\n'
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(


### PR DESCRIPTION
## Beta 24 — regressioni real-device dopo Beta 23

Corregge i problemi riprodotti su due dispositivi diversi:

- preserva `cd_energy_model`, `cd_entity_overrides`, `cd_loads` e il vecchio `cd_energy_loads` **prima** che uno snapshot schema-v4 stale possa sovrascriverli durante `DashboardStore.migrate()`;
- ricostruisce solo i campi Energia mancanti dagli slot legacy, inclusi i sensori giornalieri, senza sovrascrivere configurazioni canoniche valide;
- promuove una sola volta i carichi del modello parallelo Beta22 nella sezione canonica **Carichi** e recupera anche i 5 vecchi slot fissi;
- forza un primo pull della configurazione condivisa dopo la costruzione dello store, evitando WebView/browser che potevano perdere gli eventi iniziali di hydrate;
- rende `allStates()` coerente tra browser e HA WebView (`__HASS__.states`, `hass.states`, `_RAW_STATES`, `STATES`);
- stabilizza il testo SOC con contratto unico `SOC xx%` tramite observer limitato al solo nodo SOC, così i renderer legacy/canonico non producono più il cambio visibile `SOC 62%` → `62%`;
- bump a `1.0.0-beta.24` e build runtime aggiornato.

### Test aggiunti
- recovery schema-v4 da sibling keys ancora validi;
- recupero energia non distruttivo;
- promozione idempotente Beta22 Energy Loads → Loads;
- contratto SOC stabile;
- merge dei registri stati HA su runtime diversi.
