### PR TITLE
fix(beta30): elimina il flash della vecchia sezione elettrodomestici al primo click (1.0.0-beta.30.1)

### DIFF
--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30","dashboardVersion":"1.0.0-beta.30","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T08:35:12+00:00","commit":"046d72f6a9a7ea80cfdaa8463e88040c15afd6f7","assetHash":"a0c69f218c687bd9"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.1","dashboardVersion":"1.0.0-beta.30.1","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T09:49:34+00:00","commit":"f89d781e5276cc332edff64ae8d1115d6f0b9ee7","assetHash":"4de43c4f90837ac9"});

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head><link rel="stylesheet" href="./dashboard-runtime-en.css">
+<!-- config.js imports section-runtime.js dynamically, but only once the legacy
+     runtime has booted. Without this hint the module graph starts downloading
+     after that boot finishes, so a tab clicked in the meantime paints the
+     legacy render before the modular sections can take it over. -->
+<link rel="modulepreload" href="../src/sections/section-runtime.js">
 <script src="./storage-namespace.js"></script>
 <script src="./bridge-prelude.js"></script>
 <script type="module" src="./modules-entry.js"></script>

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html lang="it">
 <head><link rel="stylesheet" href="./dashboard-runtime-it.css">
+<!-- config.js imports section-runtime.js dynamically, but only once the legacy
+     runtime has booted. Without this hint the module graph starts downloading
+     after that boot finishes, so a tab clicked in the meantime paints the
+     legacy render before the modular sections can take it over. -->
+<link rel="modulepreload" href="../src/sections/section-runtime.js">
 <script src="./storage-namespace.js"></script>
 <script src="./bridge-prelude.js"></script>
 <script type="module" src="./modules-entry.js"></script>

--- a/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
@@ -7,5 +7,5 @@ const manifest = JSON.parse(
 );
 
 test("beta30 release manifest is versioned correctly", () => {
-  assert.equal(manifest.version, "1.0.0-beta.30");
+  assert.equal(manifest.version, "1.0.0-beta.30.1");
 });

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.30"
+  "version": "1.0.0-beta.30.1"
 }


### PR DESCRIPTION
## Sintomo

Al primo click sulla tab Elettrodomestici viene dipinta la **vecchia** sezione, che solo dopo viene sostituita da quella nuova.

## Causa

`config.js` importa `section-runtime.js` con un `import()` dinamico, e l'import parte solo quando `__DASHBOARDMODERN_LEGACY_READY__` è impostato e il bridge dei moduli esiste:

```js
state.promise = import("../src/sections/section-runtime.js").catch(…)
```

Nessun hint segnalava il grafo dei moduli in anticipo (verificato: zero occorrenze di `modulepreload` in entrambe le dashboard), quindi **il browser iniziava a scaricarlo solo dopo che il runtime legacy aveva finito il boot**. Una tab cliccata dentro quella finestra veniva renderizzata dal `renderApplianceSection` legacy, e lo showcase sostituiva il markup solo a grafo arrivato.

## Perché è un flash e non un render bloccato

`ensureSkeleton()` fa `host.innerHTML = skeletonMarkup(labels)` (preservando solo il pulsante "← Home" iniettato dal legacy), quindi il markup legacy viene comunque rimpiazzato per intero. Il render vecchio era sempre transitorio: la finestra era solo abbastanza larga da renderlo visibile.

## Modifica

Aggiunto un hint `modulepreload` a entrambe le dashboard vendored, così il grafo si scarica **in parallelo** al boot legacy invece che dopo:

```html
<link rel="modulepreload" href="../src/sections/section-runtime.js">
```

Quando `start()` esegue l'import dinamico, questo risolve dalla cache: tra il click e il paint dello showcase resta solo la valutazione dei moduli.

È un hint di caricamento e nulla più — sequenza di boot, garanzie di ordinamento e fallback in caso di errore di bootstrap restano invariati. Non elimina la race in senso stretto, la riduce a una finestra non percepibile; chiuderla del tutto richiederebbe impedire al legacy di renderizzare la sezione, cambiamento ben più invasivo del boot.

## Verifiche

- 545/545 test frontend passano
- `prettier --check` pulito
- `ruff check` pulito
- `npm run check:inline-syntax` ok su entrambe le dashboard
- `pytest` non eseguito in locale (modulo non installato nell'ambiente); nessun codice Python toccato, lo esegue la CI

Bump a `1.0.0-beta.30.1` con aggiornamento del version contract e rigenerazione di `build-info.js`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019c7sVZ2hEuSKERZkxEaDsz)_