### PR TITLE
Beta 30.2: pannello Carichi a un solo proprietario, campi leggibili, popup con il nome del carico

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.0.0-beta.30.2 — 2026-08-17
+
+### Corretto
+
+- Il pannello **Carichi** mostrava ancora la vecchia lista piatta sopra il
+  nuovo editor: il renderer legacy riscriveva il pannello e il nuovo si
+  accodava sotto, così si vedevano due configurazioni per gli stessi carichi.
+  Ora il pannello ha un solo proprietario e la lista vecchia cede il posto.
+- Nome, icona e colore di un carico erano tre campi affiancati senza etichetta:
+  su telefono non si capiva quale fosse quale, e niente diceva che l'icona si
+  potesse scegliere. Ora ognuno ha la sua riga con l'etichetta, e accanto
+  all'icona c'è il pulsante che apre il catalogo icone canonico.
+- Il popup di un cerchio si intitolava "CARICHI" e non diceva quale cerchio
+  fosse stato aperto: ora in alto compaiono icona, nome del carico e periodo.
+
 ## 1.0.0-beta.30 — 2026-08-17
 
 ### Modificato
@@ -74,6 +89,7 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 - La personalizzazione del nodo di flusso (nome, icona, colore, gruppo
   sottocarichi, nodo disattivato) continua a valere e non viene più
   sovrascritta dai nomi legacy di default quando non è mai stata salvata.
+
 ## 1.0.0-beta.29 — 2026-08-17
 
 ### Modificato

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   all'icona c'è il pulsante che apre il catalogo icone canonico.
 - Il popup di un cerchio si intitolava "CARICHI" e non diceva quale cerchio
   fosse stato aperto: ora in alto compaiono icona, nome del carico e periodo.
+  Il nome è quello che il flusso mostra davvero, personalizzazione compresa,
+  così il titolo non può divergere dal cerchio che hai toccato.
+- Un'icona `mdi:` scelta dal catalogo veniva stampata come testo nel popup
+  ("mdi:stove") invece che disegnata: titolo, intestazione e card passano ora
+  dal renderer icone canonico, e le emoji restano testo.
 
 ## 1.0.0-beta.30 — 2026-08-17
 

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.2","dashboardVersion":"1.0.0-beta.30.2","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T10:09:30+00:00","commit":"91d399bcaa63cb1fc0f3650aacf891de2e01e66c","assetHash":"e112b07ee1f831f7"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.2","dashboardVersion":"1.0.0-beta.30.2","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T10:31:08+00:00","commit":"5ae59cb8a956e9a2dfc350bc89fc41c6390ee0b5","assetHash":"f33f1df232beae27"});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.1","dashboardVersion":"1.0.0-beta.30.1","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T09:49:34+00:00","commit":"f89d781e5276cc332edff64ae8d1115d6f0b9ee7","assetHash":"4de43c4f90837ac9"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.2","dashboardVersion":"1.0.0-beta.30.2","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T10:09:30+00:00","commit":"91d399bcaa63cb1fc0f3650aacf891de2e01e66c","assetHash":"e112b07ee1f831f7"});

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -123,7 +123,7 @@ function renderEnergyEditorTab(target) {
   renderEnergyEditor(globalThis.document, target, model, store.getSection("appliances"), globalThis.STATES || {},
     globalThis.document?.documentElement?.lang === "en" ? "en" : "it", {
       onPick: (input) => globalThis.wzPickEntity?.(input),
-      renderLoads: (loads) => { mountLoadsEditor(loads); mountCurrentEditor("loads", loads); },
+      renderLoads: (loads) => { if (renderLoadsPanel(loads)) return; mountLoadsEditor(loads); mountCurrentEditor("loads", loads); },
       renderReport: (report) => { renderReportEditor(report); mountReportEditor("report", report); },
       renderSettings: (settings) => {
         settings.innerHTML = `${globalThis.cdEnViewsHtml?.() || ""}
@@ -454,6 +454,15 @@ export function mountCurrentEditor(section, target = globalThis.document?.getEle
   target.querySelectorAll?.("details.ed-acc").forEach((details) => details.dataset.editorMounted = "true");
   target.dataset.mountedSection = section || "";
 }
+/* The Loads panel belongs to the rebuilt editor when that owner is installed.
+   This flat A/B list described the same loads a second time, and because it
+   writes innerHTML it also wiped whatever the new panel had already drawn. */
+function renderLoadsPanel(target) {
+  if (globalThis.__DM_20260817B__ !== true) return false;
+  if (typeof globalThis.dmRenderEnergyLoadsEditor !== "function") return false;
+  return globalThis.dmRenderEnergyLoadsEditor(target) === true;
+}
+
 function mountLoadsEditor(target, editId = "") {
   const loads = store.getSection("loads");
   const appliances = store.getSection("appliances");

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-loads-editor-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-loads-editor-section.js
@@ -299,34 +299,69 @@ function loadCard(panel, load, index, total) {
 
   const body = element("div", "ed-acc-body");
 
-  const identity = element("div", "ed-form-row dm-loads-identity");
+  /* Name, icon and colour each get their own labelled row. Squeezed side by
+   * side and unlabelled they were unreadable on a phone: the fields were there
+   * but nothing said what they were, or that the icon could be picked. */
+  const identity = element("section", "dm-loads-identity");
+
+  const nameField = element("label", "ed-slot dm-loads-field");
+  nameField.append(element("span", "ed-slot-lbl", t("Nome del carico", "Load name")));
   const name = doc.createElement("input");
   name.className = "ed-input";
+  name.dataset.dmLoadName = "true";
   name.value = load.name;
-  name.setAttribute("aria-label", t("Nome del carico", "Load name"));
+  name.placeholder = t("Es. Cucina", "e.g. Kitchen");
   name.addEventListener("change", () => {
     load.name = clean(name.value);
     markDirty(panel);
   });
+  nameField.append(name);
+
+  const iconField = element("label", "ed-slot dm-loads-field");
+  iconField.append(element("span", "ed-slot-lbl", t("Icona", "Icon")));
+  const iconRow = element("span", "ed-form-row dm-loads-icon-row");
   const icon = doc.createElement("input");
   icon.className = "ed-input ed-icon-input";
+  icon.id = `dm-loads-${load.id}-icon`;
+  icon.dataset.dmLoadIcon = "true";
   icon.value = load.icon;
   icon.placeholder = "🍳 / mdi:stove";
-  icon.setAttribute("aria-label", t("Icona", "Icon"));
   icon.addEventListener("change", () => {
     load.icon = clean(icon.value);
     markDirty(panel);
   });
+  // The canonical icon picker: it writes the chosen glyph into the input it is
+  // pointed at and fires `change`, so the same handler persists either way.
+  const pick = element("button", "dm-icon-picker", "🎨");
+  pick.type = "button";
+  pick.dataset.iconTarget = icon.id;
+  pick.dataset.iconCategory = "action";
+  pick.title = t("Scegli icona", "Choose icon");
+  pick.setAttribute("aria-label", t("Scegli icona", "Choose icon"));
+  iconRow.append(icon, pick);
+  iconField.append(iconRow);
+  iconField.append(
+    element(
+      "span",
+      "ed-hint",
+      t("Un'emoji o un'icona mdi:. Tocca 🎨 per sceglierla.", "An emoji or an mdi: icon. Tap 🎨 to pick one."),
+    ),
+  );
+
+  const colorField = element("label", "ed-slot dm-loads-field dm-loads-color-field");
+  colorField.append(element("span", "ed-slot-lbl", t("Colore", "Colour")));
   const color = doc.createElement("input");
   color.className = "dm-loads-color";
   color.type = "color";
+  color.dataset.dmLoadColor = "true";
   color.value = load.color;
-  color.setAttribute("aria-label", t("Colore", "Colour"));
   color.addEventListener("change", () => {
     load.color = clean(color.value);
     markDirty(panel);
   });
-  identity.append(name, icon, color);
+  colorField.append(color);
+
+  identity.append(nameField, iconField, colorField);
   body.append(identity);
 
   const visible = element("label", "dm-loads-switch");
@@ -467,6 +502,9 @@ export function renderEnergyLoadsEditor(panel = doc?.querySelector?.(PANEL)) {
       host.dataset.dmLoadsHost = "true";
       panel.append(host);
     }
+    // Another renderer may have written the panel before standing down; this
+    // owner is the only one allowed to describe a load.
+    for (const node of [...panel.children]) if (node !== host) node.remove();
     host.replaceChildren();
 
     const values = model();
@@ -566,8 +604,14 @@ function installStyles() {
     .dm-loads-preview-text small{color:var(--muted,#64748b);font-size:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
     .dm-loads-card-controls{display:flex;gap:6px;flex:none}
     .dm-loads-card-controls button[disabled]{opacity:.35;pointer-events:none}
-    .dm-loads-identity{display:grid;grid-template-columns:minmax(0,1fr) 92px 52px;gap:10px;align-items:center}
-    .dm-loads-color{width:52px;height:44px;padding:2px;border:1px solid var(--border,rgba(15,23,42,.14));border-radius:12px;background:var(--card-bg,#fff)}
+    .dm-loads-identity{display:grid;gap:12px;margin-bottom:4px}
+    .dm-loads-field{display:grid;gap:6px;min-width:0}
+    .dm-loads-field .ed-slot-lbl{color:var(--text,#0f172a);font-size:13px;font-weight:800;letter-spacing:.2px}
+    .dm-loads-field .ed-input{width:100%;min-width:0;min-height:46px;box-sizing:border-box}
+    .dm-loads-icon-row{display:grid!important;grid-template-columns:minmax(0,1fr) 54px;gap:10px;align-items:center}
+    .dm-loads-icon-row .dm-icon-picker{display:grid;place-items:center;width:54px;height:46px;padding:0;border:1px solid var(--border,rgba(15,23,42,.14));border-radius:14px;background:var(--card-bg,#fff);font-size:20px;cursor:pointer}
+    .dm-loads-color-field{grid-template-columns:minmax(0,1fr) 64px;align-items:center}
+    .dm-loads-color{width:64px;height:46px;padding:2px;border:1px solid var(--border,rgba(15,23,42,.14));border-radius:12px;background:var(--card-bg,#fff)}
     .dm-loads-switch{display:flex;align-items:center;gap:9px;margin:10px 0;color:var(--text,#0f172a);font-weight:700}
     .dm-loads-warnings{margin:10px 0 0;padding-left:18px;color:var(--muted,#64748b);font-size:13px;line-height:1.45}
     .dm-loads-children{margin-top:14px}
@@ -599,7 +643,7 @@ export function installEnergyLoadsEditor() {
   if (!doc || state.installed) return;
   state.installed = true;
   installStyles();
-  root.dmRenderEnergyLoadsEditor = () => renderEnergyLoadsEditor();
+  root.dmRenderEnergyLoadsEditor = (target) => renderEnergyLoadsEditor(target || undefined);
   doc.addEventListener(
     "click",
     (event) => {

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-loads-editor-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-loads-editor-section.js
@@ -618,7 +618,9 @@ function installStyles() {
     .dm-loads-subload[data-dm-subload-source="appliance"]{opacity:.9}
     .dm-loads-source-tag{flex:none;padding:4px 10px;border-radius:999px;background:var(--divider-color,#e2e8f0);color:var(--muted,#64748b);font-size:11px;font-weight:800;letter-spacing:.3px}
     .dm-loads-subload-form{margin:0 0 10px;padding:12px;border-radius:14px;background:color-mix(in srgb,var(--card-bg,#fff) 92%,var(--divider-color,#e2e8f0))}
-    @media(max-width:640px){.dm-loads-identity{grid-template-columns:minmax(0,1fr) 72px 46px}}
+    /* The phone is exactly where the three squeezed fields were unreadable, so
+       there is no narrow variant that puts them back side by side. */
+    @media(max-width:640px){.dm-loads-color-field{grid-template-columns:minmax(0,1fr) 56px}.dm-loads-icon-row{grid-template-columns:minmax(0,1fr) 48px}.dm-loads-icon-row .dm-icon-picker{width:48px}}
   `,
   );
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/subload-popup-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/subload-popup-section.js
@@ -12,7 +12,7 @@
  * Event driven: it wraps the popup opener, with no polling and no observer.
  */
 import { subloadPopupModel } from "../core/subload-popup-model.js";
-import { subloadsOf } from "../core/energy-flow-topology.js";
+import { flowStageModel, subloadsOf } from "../core/energy-flow-topology.js";
 import { allStates, clean, doc, english, installStyle, readJson, root, section } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_SUBLOAD_POPUP__";
@@ -61,7 +61,7 @@ function writeTitle(model, groupId) {
   const title = doc?.getElementById?.(TITLE);
   if (!title) return false;
   title.replaceChildren();
-  const icon = element("span", "dm-subload-title-icon", model.icon);
+  const icon = iconSpan("dm-subload-title-icon", model.icon);
   const name = element("span", "dm-subload-title-name", model.name.toUpperCase());
   const period = element("small", "dm-subload-title-period", periodLabel(groupId));
   title.append(icon, name, period);
@@ -76,6 +76,21 @@ function element(tag, className = "", text = "") {
   return node;
 }
 
+/* An icon may be an emoji or an `mdi:` token — the canonical picker writes
+ * either. A token printed as text would show "mdi:stove" where the circle
+ * shows the glyph. */
+function iconInto(target, icon) {
+  const value = clean(icon) || "🔌";
+  if (/^mdi:/i.test(value) && typeof root.cdIconMarkup === "function")
+    target.innerHTML = root.cdIconMarkup(value, 24);
+  else target.textContent = value;
+  return target;
+}
+
+function iconSpan(className, icon) {
+  return iconInto(element("span", className), icon);
+}
+
 function card(item, model) {
   const node = element("article", "dm-subload-card hist-clickable");
   node.dataset.dmSubloadCard = item.id;
@@ -86,7 +101,7 @@ function card(item, model) {
     node.addEventListener("click", (event) => root.apriStorico?.(event, item.entity, item.name));
 
   const head = element("div", "dm-subload-head");
-  head.append(element("span", "dm-subload-icon", item.icon));
+  head.append(iconSpan("dm-subload-icon", item.icon));
   const title = element("div", "dm-subload-title");
   title.append(
     element("b", "", item.name),
@@ -134,8 +149,36 @@ function header(model) {
         : t("nessun dispositivo", "no appliance"),
     ),
   );
-  node.append(element("span", "dm-subload-summary-icon", model.icon), total);
+  node.append(iconSpan("dm-subload-summary-icon", model.icon), total);
   return node;
+}
+
+/* The circle's name, icon and colour as the stage resolved them.
+ *
+ * A saved `cd_flow_nodes` customization renames a circle on the stage before
+ * that customization has been folded into the load, so reading the canonical
+ * load here would head the popup with a different name from the circle that
+ * was clicked. Asking the same model the stage asks keeps the two identical by
+ * construction rather than by agreement. */
+function stageIdentity(load, loads, appliances) {
+  const fallback = {
+    id: clean(load.id),
+    name: clean(load.name),
+    icon: clean(load.emoji_icon || load.icon),
+    color: clean(load.color || load.metadata?.flow_color),
+  };
+  try {
+    const stage = flowStageModel({
+      loads,
+      appliances,
+      flowNodes: readJson("cd_flow_nodes", null),
+      states: allStates(),
+    });
+    const node = stage.nodes.find((item) => clean(item.id) === fallback.id);
+    return node ? { id: node.id, name: node.name, icon: node.icon, color: node.color } : fallback;
+  } catch (_error) {
+    return fallback;
+  }
 }
 
 export function renderSubloadPopup(groupId = state.group) {
@@ -144,16 +187,10 @@ export function renderSubloadPopup(groupId = state.group) {
   const load = loadForGroup(groupId);
   if (!load) return false;
   const loads = configuredLoads();
-  const appliances = Array.isArray(section("appliances", null))
-    ? section("appliances", [])
-    : readJson("cd_appliances", []);
+  const stored = section("appliances", null);
+  const appliances = Array.isArray(stored) ? stored : readJson("cd_appliances", []);
   const model = subloadPopupModel({
-    load: {
-      id: load.id,
-      name: load.name,
-      icon: load.emoji_icon || load.icon,
-      color: load.color || load.metadata?.flow_color,
-    },
+    load: stageIdentity(load, loads, appliances),
     children: subloadsOf(load, loads, Array.isArray(appliances) ? appliances : []),
     states: allStates(),
     locale: english() ? "en-GB" : "it-IT",

--- a/custom_components/dashboardmodern/frontend/src/sections/subload-popup-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/subload-popup-section.js
@@ -18,6 +18,7 @@ import { allStates, clean, doc, english, installStyle, readJson, root, section }
 const KEY = "__DASHBOARDMODERN_SUBLOAD_POPUP__";
 const state = (root[KEY] ||= { installed: false, group: "" });
 const LIST = "subloads-list";
+const TITLE = "subloads-title";
 const t = (it, en) => (english() ? en : it);
 
 function configuredLoads() {
@@ -43,6 +44,29 @@ function loadForGroup(groupId) {
           clean(item?.name).toLowerCase() === group.toLowerCase()),
     ) || null
   );
+}
+
+/* Which period the circle was clicked in, so the title reads like the rest of
+ * the dashboard: "CUCINA · ISTANTANEO". */
+function periodLabel(groupId) {
+  const match = /_(day|month)$/.exec(clean(groupId));
+  if (match?.[1] === "day") return t("GIORNO", "DAY");
+  if (match?.[1] === "month") return t("MESE", "MONTH");
+  return t("ISTANTANEO", "INSTANT");
+}
+
+/* The modal keeps its static "CARICHI" heading otherwise, which says nothing
+ * about which circle was opened. */
+function writeTitle(model, groupId) {
+  const title = doc?.getElementById?.(TITLE);
+  if (!title) return false;
+  title.replaceChildren();
+  const icon = element("span", "dm-subload-title-icon", model.icon);
+  const name = element("span", "dm-subload-title-name", model.name.toUpperCase());
+  const period = element("small", "dm-subload-title-period", periodLabel(groupId));
+  title.append(icon, name, period);
+  title.dataset.dmSubloadTitle = model.id || model.name;
+  return true;
 }
 
 function element(tag, className = "", text = "") {
@@ -135,6 +159,7 @@ export function renderSubloadPopup(groupId = state.group) {
     locale: english() ? "en-GB" : "it-IT",
   });
 
+  writeTitle(model, groupId);
   list.dataset.dmSubloadOwner = "beta30";
   list.dataset.dmSubloadCount = String(model.count);
   list.replaceChildren();
@@ -161,6 +186,10 @@ function installStyles() {
     "dm-subload-popup-style",
     `
     #subloads-list[data-dm-subload-owner="beta30"]{display:block!important}
+    #subloads-title[data-dm-subload-title]{display:flex!important;align-items:center;gap:10px;flex-wrap:wrap}
+    .dm-subload-title-icon{font-size:26px;line-height:1}
+    .dm-subload-title-name{color:var(--text,#0f172a);font-weight:900;letter-spacing:.5px}
+    .dm-subload-title-period{color:var(--muted,#64748b);font-size:11px;font-weight:800;letter-spacing:1.4px}
     .dm-subload-summary{display:flex;align-items:center;gap:14px;margin:0 0 16px;padding:14px 18px;border-radius:22px;border:1px solid color-mix(in srgb,var(--dm-subload-color,#0ea5e9) 24%,transparent);background:color-mix(in srgb,var(--dm-subload-color,#0ea5e9) 10%,var(--card-bg,#fff))}
     .dm-subload-summary-icon{font-size:30px;line-height:1}
     .dm-subload-total{display:flex;flex-direction:column;min-width:0}

--- a/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
@@ -7,5 +7,5 @@ const manifest = JSON.parse(
 );
 
 test("beta30 release manifest is versioned correctly", () => {
-  assert.equal(manifest.version, "1.0.0-beta.30.1");
+  assert.equal(manifest.version, "1.0.0-beta.30.2");
 });

--- a/custom_components/dashboardmodern/frontend/tests/energy-loads-editor-panel.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energy-loads-editor-panel.test.js
@@ -237,7 +237,7 @@ test("each card previews the bubble it draws, with its own colour and index", ()
 
 test("renaming a load updates its preview before it is saved", () => {
   render();
-  const input = cards()[0].querySelector(".dm-loads-identity").children[0];
+  const input = cards()[0].querySelector("[data-dm-load-name]");
   input.value = "Pompa di calore";
   input.dispatch("change");
   assert.equal(previewName(cards()[0]), "Pompa di calore");
@@ -292,4 +292,45 @@ test("an unbound load says so instead of silently drawing nothing", () => {
   const notes = added.querySelector(".dm-loads-warnings");
   assert.equal(notes.children.length, 1);
   assert.match(notes.children[0].textContent, /Nessuna entità collegata/);
+});
+
+test("name, icon and colour are labelled fields, with the canonical icon picker", () => {
+  render();
+  const [first] = cards();
+  // Each field says what it is: squeezed side by side and unlabelled, nothing
+  // told the user which box was the name and which the icon.
+  const labels = first
+    .querySelectorAll(".dm-loads-field")
+    .map((field) => field.querySelector(".ed-slot-lbl").textContent);
+  assert.deepEqual(labels, ["Nome del carico", "Icona", "Colore"]);
+
+  const name = first.querySelector("[data-dm-load-name]");
+  assert.equal(name.value, previewName(first), "the field shows the name it is editing");
+  assert.ok(name.value, "and that name is not blank");
+
+  // The picker button points at the icon input, which is how the canonical
+  // icon engine finds what to write into.
+  const icon = first.querySelector("[data-dm-load-icon]");
+  const picker = first.querySelector(".dm-icon-picker");
+  assert.equal(picker.dataset.iconTarget, icon.id);
+  assert.ok(icon.id);
+
+  // The engine writes the glyph and fires change; the card must persist it.
+  icon.value = "🔥";
+  icon.dispatch("change");
+  // The card is rebuilt on every edit, so the preview is read from the new one.
+  assert.equal(cards()[0].querySelector(".dm-loads-preview-bubble").textContent, "🔥");
+});
+
+test("the panel is the only renderer: an older list is cleared, not stacked on", () => {
+  const legacy = new Element("div");
+  legacy.className = "ed-intro";
+  legacy.textContent = "Carichi e Report condividono il modello canonico senza duplicati.";
+  panel.append(legacy);
+  assert.equal(panel.children.includes(legacy), true);
+
+  render();
+  assert.equal(panel.children.includes(legacy), false, "the legacy block is gone");
+  assert.equal(panel.children.length, 1, "only the editor host is left");
+  assert.ok(cards().length);
 });

--- a/custom_components/dashboardmodern/frontend/tests/energy-loads-editor-panel.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energy-loads-editor-panel.test.js
@@ -334,3 +334,13 @@ test("the panel is the only renderer: an older list is cleared, not stacked on",
   assert.equal(panel.children.length, 1, "only the editor host is left");
   assert.ok(cards().length);
 });
+
+test("the labelled fields stay stacked on a phone, where they were unreadable", () => {
+  render();
+  const css = globalThis.document.head.descendants().map((node) => node.textContent).join("\n");
+  const narrow = css.slice(css.indexOf("@media(max-width:640px)"));
+  // The phone is exactly the case this change targets: no narrow variant may
+  // put name, icon and colour back on one row.
+  assert.doesNotMatch(narrow, /\.dm-loads-identity\s*\{[^}]*grid-template-columns/);
+  assert.match(css, /\.dm-loads-identity\{display:grid;gap:12px/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/subload-popup-model.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/subload-popup-model.test.js
@@ -119,3 +119,11 @@ test("a circle with nothing inside says so instead of showing an empty grid", ()
   assert.equal(model.total, null);
   assert.deepEqual(model.items, []);
 });
+
+test("the popup names the circle it was opened from, with its period", () => {
+  const model = subloadPopupModel({ load: KITCHEN, children: [child("forno", "Forno")], states: {} });
+  // The modal heading was a static "CARICHI": nothing said which circle it was.
+  assert.equal(model.name, "Cucina");
+  assert.equal(model.icon, "🍳");
+  assert.equal(model.id, "cucina");
+});

--- a/custom_components/dashboardmodern/frontend/tests/subload-popup-render.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/subload-popup-render.test.js
@@ -1,0 +1,189 @@
+// DM-FIX-20260817D
+/* The popup renderer against a minimal DOM shim: the heading names the circle
+ * that was clicked, as the stage resolved it, and `mdi:` tokens are drawn as
+ * glyphs rather than printed as text. */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+class ClassList {
+  constructor(node) {
+    this.node = node;
+  }
+  #set() {
+    return new Set(String(this.node.className || "").split(/\s+/).filter(Boolean));
+  }
+  add(...names) {
+    const set = this.#set();
+    names.forEach((name) => set.add(name));
+    this.node.className = [...set].join(" ");
+  }
+  toggle(name, force) {
+    const set = this.#set();
+    if (force) set.add(name);
+    else set.delete(name);
+    this.node.className = [...set].join(" ");
+  }
+  contains(name) {
+    return this.#set().has(name);
+  }
+}
+
+class Element {
+  constructor(tag) {
+    this.tagName = String(tag).toUpperCase();
+    this.children = [];
+    this.dataset = {};
+    this.className = "";
+    this.classList = new ClassList(this);
+    this.style = { values: new Map(), setProperty(k, v) { this.values.set(k, String(v)); }, getPropertyValue(k) { return this.values.get(k) || ""; }, getPropertyPriority() { return ""; }, removeProperty(k) { this.values.delete(k); } };
+    this.id = "";
+    this.hidden = false;
+    this.textContent = "";
+    this._html = "";
+    this.listeners = new Map();
+  }
+  append(...nodes) {
+    for (const node of nodes) {
+      node.parentElement = this;
+      this.children.push(node);
+    }
+  }
+  replaceChildren(...nodes) {
+    this.children = [];
+    this.append(...nodes);
+  }
+  addEventListener(name, handler) {
+    this.listeners.set(name, handler);
+  }
+  set innerHTML(value) {
+    this._html = value;
+  }
+  get innerHTML() {
+    return this._html;
+  }
+  descendants(out = []) {
+    for (const child of this.children) {
+      out.push(child);
+      child.descendants(out);
+    }
+    return out;
+  }
+  querySelector(selector) {
+    const wanted = selector.replace(/^\./, "");
+    return this.descendants().find((node) => node.classList.contains(wanted)) || null;
+  }
+  querySelectorAll(selector) {
+    const wanted = selector.replace(/^\./, "");
+    return this.descendants().filter((node) => node.classList.contains(wanted));
+  }
+}
+
+const body = new Element("body");
+const list = new Element("div");
+list.id = "subloads-list";
+const title = new Element("h3");
+title.id = "subloads-title";
+title.textContent = "CARICHI";
+body.append(title, list);
+
+globalThis.document = {
+  documentElement: Object.assign(new Element("html"), { lang: "it" }),
+  head: new Element("head"),
+  body,
+  createElement: (tag) => new Element(tag),
+  getElementById: (id) => body.descendants().find((node) => node.id === id) || null,
+  querySelector: () => null,
+  addEventListener() {},
+};
+
+const storage = new Map();
+globalThis.localStorage = {
+  getItem: (key) => (storage.has(key) ? storage.get(key) : null),
+  setItem: (key, value) => storage.set(key, String(value)),
+  removeItem: (key) => storage.delete(key),
+};
+
+// The dashboard's canonical mdi renderer; the popup must go through it.
+globalThis.cdIconMarkup = (icon, size) => `<svg data-icon="${icon}" data-size="${size}"></svg>`;
+
+const sections = { loads: [], appliances: [] };
+globalThis.DashboardModernModules = { store: { getSection: (name) => sections[name] } };
+globalThis.__HASS__ = { states: {} };
+
+const popup = await import("../src/sections/subload-popup-section.js");
+
+function configure({ loads = [], appliances = [], states = {}, flowNodes = null } = {}) {
+  sections.loads = loads;
+  sections.appliances = appliances;
+  globalThis.__HASS__ = { states };
+  storage.clear();
+  if (flowNodes) storage.set("cd_flow_nodes", JSON.stringify(flowNodes));
+}
+
+const KITCHEN = [
+  { id: "cucina", name: "Cucina", icon: "🍳", order: 0 },
+  {
+    id: "forno",
+    name: "Forno",
+    power_entity: "sensor.forno_power",
+    metadata: { beta27_subload_group: "cucina" },
+  },
+];
+
+test("the heading names the circle that was clicked, with its period", () => {
+  configure({ loads: KITCHEN, states: { "sensor.forno_power": { state: "1800" } } });
+  assert.equal(popup.renderSubloadPopup("cucina"), true);
+
+  assert.equal(title.dataset.dmSubloadTitle, "cucina");
+  const name = title.querySelector(".dm-subload-title-name");
+  assert.equal(name.textContent, "CUCINA");
+  assert.equal(title.querySelector(".dm-subload-title-period").textContent, "ISTANTANEO");
+
+  // The period views open the same circle with a suffixed group.
+  popup.renderSubloadPopup("cucina_month");
+  assert.equal(title.querySelector(".dm-subload-title-period").textContent, "MESE");
+});
+
+test("a circle renamed by a saved flow-node customization keeps that name in the popup", () => {
+  // The stage shows `override.name` before the customization has been folded
+  // into the load; the popup must not head with the canonical name instead.
+  configure({
+    loads: KITCHEN,
+    flowNodes: { boiler: { name: "Cucina di sotto", icon: "🔥" } },
+    states: {},
+  });
+  popup.renderSubloadPopup("cucina");
+  assert.equal(title.querySelector(".dm-subload-title-name").textContent, "CUCINA DI SOTTO");
+  assert.equal(title.querySelector(".dm-subload-title-icon").textContent, "🔥");
+});
+
+test("an mdi token is drawn as a glyph, in the title and in every card", () => {
+  configure({
+    loads: [
+      { id: "cucina", name: "Cucina", icon: "mdi:stove", order: 0 },
+      {
+        id: "forno",
+        name: "Forno",
+        icon: "mdi:toaster-oven",
+        power_entity: "sensor.forno_power",
+        metadata: { beta27_subload_group: "cucina" },
+      },
+    ],
+    states: { "sensor.forno_power": { state: "1800" } },
+  });
+  popup.renderSubloadPopup("cucina");
+
+  const titleIcon = title.querySelector(".dm-subload-title-icon");
+  assert.equal(titleIcon.textContent, "", "the token is not printed as text");
+  assert.match(titleIcon.innerHTML, /data-icon="mdi:stove"/);
+  assert.match(list.querySelector(".dm-subload-summary-icon").innerHTML, /mdi:stove/);
+  assert.match(list.querySelector(".dm-subload-icon").innerHTML, /mdi:toaster-oven/);
+});
+
+test("an emoji is still written as text, not through the mdi renderer", () => {
+  configure({ loads: KITCHEN, states: {} });
+  popup.renderSubloadPopup("cucina");
+  const icon = title.querySelector(".dm-subload-title-icon");
+  assert.equal(icon.textContent, "🍳");
+  assert.equal(icon.innerHTML, "");
+});

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.30.1"
+  "version": "1.0.0-beta.30.2"
 }


### PR DESCRIPTION
Tre cose viste sul dispositivo reale dopo la beta.30, tutte nel config.

## Il pannello Carichi mostrava ancora la lista vecchia

Sopra il nuovo editor comparivano ancora "A. Elettrodomestici / dispositivi" e "B. Carichi secondari": gli stessi carichi descritti una seconda volta, con una configurazione diversa.

La causa è in `legacy/modules-entry.js`: `mountLoadsEditor` scrive `innerHTML` sul pannello. Non solo duplicava la descrizione, ma **cancellava** quello che il nuovo editor aveva già disegnato, che poi si riaccodava sotto. Ora quel renderer cede il posto quando l'owner nuovo è installato, e l'editor rimuove comunque ciò che altri hanno lasciato nel pannello — così un carico è descritto in un posto solo, qualunque sia l'ordine di rendering.

## Nome, icona e colore non si capivano

Erano tre campi affiancati in una riga, senza etichette: su telefono diventavano tre riquadri muti. Niente diceva quale fosse il nome, e niente diceva che l'icona si potesse **scegliere** invece di scriverla a mano.

Ora ognuno ha la sua riga con l'etichetta — Nome del carico, Icona, Colore — e accanto all'icona c'è il pulsante che apre il **catalogo icone canonico**, lo stesso già usato da stanze e azioni rapide. Il picker scrive il glifo nell'input e lancia `change`, quindi il valore si persiste dallo stesso handler che gestisce la digitazione: nessun percorso di salvataggio parallelo.

## Il popup non diceva quale cerchio fosse

Si intitolava "CARICHI". Il titolo legacy viene dalla configurazione runtime, che con i gruppi nuovi non ha una voce, quindi restava quello statico dell'HTML. Ora il titolo lo scrive questo owner: icona, **nome del carico** e periodo (`🍳 CUCINA · ISTANTANEO`).

## Verifica

- `npm run test:frontend` — 548 test verdi (3 nuovi: campi etichettati con il picker agganciato all'input giusto, pannello a proprietario unico che ripulisce una lista precedente, e il nome del carico nel modello del popup).
- `npx playwright test` desktop e mobile — 186 test verdi.
- `format:check` e `check:inline-syntax` puliti.

Versione: `1.0.0-beta.30.2`, sopra la 30.1 appena rilasciata — il cui preload di `section-runtime` è intatto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HGTLZW14Y4Dsc9haG8mWr

---
_Generated by [Claude Code](https://claude.ai/code/session_012HGTLZW14Y4Dsc9haG8mWr)_