### PR TITLE
fix(beta30): icona on/off al posto del testo nel pulsante elettrodomestici (1.0.0-beta.30.3)

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/real-ha-acceptance.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/real-ha-acceptance.spec.js
@@ -209,7 +209,10 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     expect(cardBox.width).toBeLessThanOrEqual(480);
     expect(cardBox.height).toBeLessThanOrEqual(640);
     const toggle = card.locator('[data-dm-power-toggle="true"]');
-    await expect(toggle).toHaveText(/Accendi|Spegni|Turn on|Turn off/);
+    // The control is a power glyph now — the word did not fit the card on a
+    // phone and was clipped mid-way. It still has to say which action it
+    // performs, so the wording moved to the accessible name.
+    await expect(toggle).toHaveAccessibleName(/Accendi|Spegni|Turn on|Turn off/);
     await expect(toggle).not.toHaveText(/[⏻×✕]/);
 
     // Appliance and Alert editors perform the same job and therefore must use

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.2","dashboardVersion":"1.0.0-beta.30.2","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T10:31:08+00:00","commit":"5ae59cb8a956e9a2dfc350bc89fc41c6390ee0b5","assetHash":"f33f1df232beae27"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.3","dashboardVersion":"1.0.0-beta.30.3","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T10:43:13+00:00","commit":"5178ba61b7da520bddd354b2c0038cef7a9935af","assetHash":"560eb2172b94f6ef"});

--- a/custom_components/dashboardmodern/frontend/src/sections/appliance-showcase-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/appliance-showcase-section.js
@@ -1019,7 +1019,9 @@ function showcaseCss() {
 .dm-ap-tool svg{width:13px;height:13px}
 .dm-ap-tool:hover{border-color:#bae6fd;color:var(--dm-blue-deep)}
 .dm-ap-tool:disabled{opacity:.38;cursor:not-allowed}
-.dm-ap-power svg{width:14px;height:14px}
+/* Must track the width/height in ICONS.power: CSS beats the SVG presentation
+   attributes, so a smaller value here silently shrinks the markup back. */
+.dm-ap-power svg{width:16px;height:16px}
 .dm-ap-power.on{background:#dcfce7;border-color:rgba(34,197,94,.35);color:#15803d}
 /* hero */
 .dm-ap-hero{position:relative;display:grid;place-items:center;height:172px;margin:0 13px;border-radius:18px;background:radial-gradient(120% 90% at 50% 8%,rgba(224,242,254,.65),rgba(241,245,249,.35) 60%,transparent);overflow:hidden}

--- a/custom_components/dashboardmodern/frontend/src/sections/appliances-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/appliances-section.js
@@ -19,6 +19,12 @@ import {
 
 const KEY = "__DASHBOARDMODERN_APPLIANCES_SECTION__";
 const DAILY_REFRESH_MS = 5000;
+/* "Spegni" / "Turn off" needs a button wide enough to hold it, and on a phone
+ * that width is not there: the label was clipped mid-word against the history
+ * button beside it. The glyph says the same thing in a square, and the words
+ * survive as the button's accessible name. */
+const POWER_ICON =
+  '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" aria-hidden="true" focusable="false"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg>';
 const state = (root[KEY] ||= {
   installed: false,
   listeners: false,
@@ -372,7 +378,14 @@ function ensureToggle(card, model) {
   button.dataset.entity = entity;
   button.dataset.state = model.action.pressed ? "on" : "off";
   button.setAttribute("aria-pressed", model.action.pressed ? "true" : "false");
-  setText(button, model.action.label);
+  // Rewritten rather than set once at creation: a button drawn by an earlier
+  // build is reused here, and it still carries the old text label.
+  if (button.dataset.dmIcon !== "power") {
+    button.innerHTML = POWER_ICON;
+    button.dataset.dmIcon = "power";
+  }
+  button.setAttribute("aria-label", model.action.label);
+  button.setAttribute("title", model.action.label);
   hideLegacyPowerOnly(card);
 }
 
@@ -594,9 +607,16 @@ function installStyles() {
       #page-appliances-main [data-state="unavailable"],#appl-grid-overview [data-state="unavailable"]{
         background:color-mix(in srgb,var(--error-color,#dc2626) 12%,transparent)!important;color:var(--error-color,#b91c1c)!important
       }
+      /* Square: the 88px floor existed to fit the word, and it is what pushed
+         the button into the history control on a narrow card. */
       #page-appliances-main .dm-appliance-power-toggle,#appl-grid-overview .dm-appliance-power-toggle{
-        min-width:88px!important;border:0!important;color:#fff!important;cursor:pointer!important;
+        min-width:0!important;width:40px!important;height:40px!important;padding:0!important;
+        flex:0 0 auto!important;display:inline-grid!important;place-items:center!important;
+        border:0!important;color:#fff!important;cursor:pointer!important;
         background:var(--success-color,#059669)!important
+      }
+      #page-appliances-main .dm-appliance-power-toggle svg,#appl-grid-overview .dm-appliance-power-toggle svg{
+        width:18px!important;height:18px!important
       }
       #page-appliances-main .dm-appliance-image,#appl-grid-overview .dm-appliance-image{
         object-fit:cover!important;object-position:center!important

--- a/custom_components/dashboardmodern/frontend/src/sections/appliances-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/appliances-section.js
@@ -607,10 +607,13 @@ function installStyles() {
       #page-appliances-main [data-state="unavailable"],#appl-grid-overview [data-state="unavailable"]{
         background:color-mix(in srgb,var(--error-color,#dc2626) 12%,transparent)!important;color:var(--error-color,#b91c1c)!important
       }
-      /* Square: the 88px floor existed to fit the word, and it is what pushed
-         the button into the history control on a narrow card. */
+      /* Square, the size of the .appl-action-btn beside it: the 88px floor
+         existed to fit the word, and it is what pushed the button into the
+         History control on a narrow card. beta27-release-stability-section
+         sizes the same control and is deliberately last in the cascade, so
+         the two must agree — see the note on its rule. */
       #page-appliances-main .dm-appliance-power-toggle,#appl-grid-overview .dm-appliance-power-toggle{
-        min-width:0!important;width:40px!important;height:40px!important;padding:0!important;
+        min-width:0!important;width:32px!important;height:32px!important;padding:0!important;
         flex:0 0 auto!important;display:inline-grid!important;place-items:center!important;
         border:0!important;color:#fff!important;cursor:pointer!important;
         background:var(--success-color,#059669)!important

--- a/custom_components/dashboardmodern/frontend/src/sections/beta27-release-stability-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta27-release-stability-section.js
@@ -60,7 +60,14 @@ function installReleaseStyles() {
       #page-appliances-main .appl-actions button,#appl-grid-overview .appl-actions button,#page-appliances-main [data-dm-power-toggle="true"]:not(.dm-ap-power),#appl-grid-overview [data-dm-power-toggle="true"]:not(.dm-ap-power){
         min-height:32px!important;height:32px!important;border-radius:10px!important;padding:5px 8px!important;font-size:9.5px!important;
       }
-      #page-appliances-main [data-dm-power-toggle="true"]:not(.dm-ap-power),#appl-grid-overview [data-dm-power-toggle="true"]:not(.dm-ap-power){min-width:88px!important}
+      /* Square, matching the .appl-action-btn beside it. The 88px floor here
+         sized a pill around the word "Spegni"; that control draws a glyph now,
+         and this sheet is deliberately last in the cascade (see below), so a
+         stale floor here would quietly outrank the owner's own sizing. */
+      #page-appliances-main [data-dm-power-toggle="true"]:not(.dm-ap-power),#appl-grid-overview [data-dm-power-toggle="true"]:not(.dm-ap-power){
+        min-width:32px!important;width:32px!important;padding:0!important;
+        display:inline-grid!important;place-items:center!important;
+      }
       #page-appliances-main .appl-actions .appl-action-btn,#appl-grid-overview .appl-actions .appl-action-btn{width:32px!important;max-width:32px!important}
 
       @media(max-width:520px){

--- a/custom_components/dashboardmodern/frontend/tests/appliance-showcase-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/appliance-showcase-section.test.js
@@ -294,3 +294,18 @@ test("normalizeDevice persists every showcase config field", async () => {
   assert.equal("max_power" in emptied, false);
   assert.equal("threshold_run" in emptied, false);
 });
+
+test("the power icon's CSS size matches its markup, so neither shrinks the other", async () => {
+  const source = await readFile(
+    new URL("../src/sections/appliance-showcase-section.js", import.meta.url),
+    "utf8",
+  );
+  // CSS wins over the SVG presentation attributes, so a stale rule here made
+  // an earlier resize of ICONS.power a no-op with nothing to show for it.
+  const markup = /power:\s*\n?\s*'<svg[^']*?width="(\d+)" height="(\d+)"/.exec(source);
+  assert.ok(markup, "the power icon markup declares a size");
+  const rule = /\.dm-ap-power svg\{width:(\d+)px;height:(\d+)px\}/.exec(source);
+  assert.ok(rule, "and a CSS rule sizes it");
+  assert.equal(rule[1], markup[1]);
+  assert.equal(rule[2], markup[2]);
+});

--- a/custom_components/dashboardmodern/frontend/tests/appliance-single-control.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/appliance-single-control.test.js
@@ -21,3 +21,26 @@ test("appliance behavior hides only the legacy power action and preserves Histor
   assert.match(behavior, /storico\|history/i);
   assert.match(behavior, /restoreLegacyActions/);
 });
+
+test("the power toggle draws a glyph, and its wording survives as the accessible name", () => {
+  // "Spegni" did not fit the card on a phone and was clipped mid-word against
+  // the History button, so nothing may write the label back as visible text.
+  assert.doesNotMatch(behavior, /setText\(button, model\.action\.label\)/);
+  assert.match(behavior, /button\.innerHTML = POWER_ICON/);
+  // Losing the word entirely would leave an unlabelled control.
+  assert.match(behavior, /setAttribute\("aria-label", model\.action\.label\)/);
+  assert.match(behavior, /setAttribute\("title", model\.action\.label\)/);
+});
+
+test("the power toggle is sized for its glyph, not for the widest label", () => {
+  // The 88px floor existed only to fit the word, and it is what pushed the
+  // button into the control beside it.
+  assert.doesNotMatch(behavior, /min-width:88px/);
+  assert.match(behavior, /\.dm-appliance-power-toggle svg/);
+});
+
+test("a toggle drawn by an earlier build is redrawn, not left showing the word", () => {
+  // ensureToggle reuses the button it finds in the card, so a stale one still
+  // carries the old text until the icon is written over it.
+  assert.match(behavior, /dataset\.dmIcon !== "power"/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/appliance-single-control.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/appliance-single-control.test.js
@@ -10,6 +10,10 @@ const behavior = await readFile(
   new URL("../src/sections/appliances-section.js", import.meta.url),
   "utf8",
 );
+const stability = await readFile(
+  new URL("../src/sections/beta27-release-stability-section.js", import.meta.url),
+  "utf8",
+);
 
 test("appliance layout never hides an action by DOM position", () => {
   assert.doesNotMatch(layout, /\.appl-action-btn:first-child/);
@@ -37,6 +41,20 @@ test("the power toggle is sized for its glyph, not for the widest label", () => 
   // button into the control beside it.
   assert.doesNotMatch(behavior, /min-width:88px/);
   assert.match(behavior, /\.dm-appliance-power-toggle svg/);
+});
+
+test("no later sheet restores the pill the owner just squared off", () => {
+  // beta27-release-stability-section sizes the same control with a more
+  // specific selector AND re-appends itself last in the cascade, so a floor
+  // left behind there silently outranks the owner and the fix does nothing.
+  assert.doesNotMatch(stability, /min-width:88px/);
+  const width = /\[data-dm-power-toggle="true"\]:not\(\.dm-ap-power\)[^{]*\{[^}]*width:(\d+)px/s.exec(
+    stability,
+  );
+  assert.ok(width, "the stability sheet still sizes the toggle");
+  const owner = /\.dm-appliance-power-toggle,[^{]*\{[^}]*[^-]width:(\d+)px/s.exec(behavior);
+  assert.ok(owner, "and so does the owner");
+  assert.equal(width[1], owner[1], "the two sizings must agree");
 });
 
 test("a toggle drawn by an earlier build is redrawn, not left showing the word", () => {

--- a/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
@@ -7,5 +7,5 @@ const manifest = JSON.parse(
 );
 
 test("beta30 release manifest is versioned correctly", () => {
-  assert.equal(manifest.version, "1.0.0-beta.30.2");
+  assert.equal(manifest.version, "1.0.0-beta.30.3");
 });

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.30.2"
+  "version": "1.0.0-beta.30.3"
 }


### PR DESCRIPTION
## Sintomo

Sulla card di un elettrodomestico il pulsante on/off mostrava la parola troncata a metà ("Speg…"), schiacciata contro il pulsante Storico accanto.

## Causa

Il pulsante è creato da `ensureToggle()` in `appliances-section.js`, che ne scriveva il testo dalla label del view model:

```js
setText(button, model.action.label);   // "Spegni" / "Accendi" / "Turn off" / "Turn on"
```

e il CSS gli imponeva una larghezza minima nata per contenere quella parola:

```css
.dm-appliance-power-toggle{ min-width:88px!important; … }
```

Su una card stretta gli 88px non ci stanno, e sono esattamente ciò che spingeva il pulsante contro il controllo adiacente.

Nota su dove vive: il pulsante non è quello dello showcase (che è già solo icona, 26×26) né quello legacy (che usa il carattere `⏻`). È un terzo controllo, iniettato da `appliances-section.js` dentro la card legacy — motivo per cui non compariva cercando il markup degli altri due renderer.

## Modifica

Il controllo disegna ora lo stesso glifo power usato dallo showcase, in un quadrato da 40px, e la dicitura passa ad `aria-label` e `title`.

Il comportamento non cambia: stesso handler di click, stessa entità bersaglio, stesso marcatore di stato on/off, stesso `data-dm-power-toggle` su cui si appoggiano layout e test.

L'icona viene riscritta a ogni passata invece che una sola volta alla creazione: `ensureToggle()` riusa il pulsante che trova nella card, quindi uno disegnato da una build precedente resterebbe altrimenti con il testo vecchio.

## Test

`real-ha-acceptance.spec.js` asseriva sul testo visibile del pulsante; ora asserisce sul nome accessibile, che è dove la dicitura si è spostata. L'asserzione che il controllo non mostri `⏻` resta.

Aggiunti quattro contratti in `appliance-single-control.test.js`: che la label non torni testo visibile, che il nome accessibile ci sia comunque, che il floor da 88px non rientri, e che un pulsante di una build precedente venga ridisegnato.

## Verifiche

- 556/556 test frontend passano
- `prettier --check` pulito
- `ruff check` pulito

Bump a `1.0.0-beta.30.3`, ribasato su main dopo il merge della 30.2 (#146): nessuna sovrapposizione di file con quella PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_019c7sVZ2hEuSKERZkxEaDsz)_