### PR TITLE
Beta 30.4: pannello solo sotto la sua scheda, riga icona propria, nome più chiaro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.0.0-beta.30.4 — 2026-08-17
+
+### Modificato
+
+- La scheda dell'editor Energia si chiama ora **CARICHI E DISPOSITIVI**: dice
+  quello che ci si configura — i cerchi del flusso e i dispositivi dentro
+  ciascuno — invece della parola interna "carichi".
+
+### Corretto
+
+- La sezione dei carichi compariva anche sotto **Flussi ed entità**: la regola
+  di visibilità dell'editor scavalcava l'attributo `hidden` del pannello, che è
+  come l'editor Energia nasconde le schede non attive. Ora il pannello resta
+  nascosto quando è aperta un'altra scheda.
+- L'icona di un carico e il pulsante per sceglierla erano due riquadri vuoti:
+  il campo usava le classi legacy, larghe 72px fisse, e il pulsante veniva
+  ridipinto dal proprietario canonico delle icone con il proprio markup e il
+  font azzerato. Ora la riga è disegnata da questo editor: il campo mostra
+  l'icona e il pulsante ne è l'anteprima, e apre lo stesso catalogo di prima.
+
 ## 1.0.0-beta.30.2 — 2026-08-17
 
 ### Corretto

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.3","dashboardVersion":"1.0.0-beta.30.3","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T10:43:13+00:00","commit":"5178ba61b7da520bddd354b2c0038cef7a9935af","assetHash":"560eb2172b94f6ef"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.4","dashboardVersion":"1.0.0-beta.30.4","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T11:59:48+00:00","commit":"a403227742636f48bd8b13d8dcd3e2c6ad607d66","assetHash":"6e361450fa8ef2cd"});

--- a/custom_components/dashboardmodern/frontend/src/core/renderers.js
+++ b/custom_components/dashboardmodern/frontend/src/core/renderers.js
@@ -331,7 +331,9 @@ export function renderEnergyEditor(
   const loadsButton = document.createElement("button");
   loadsButton.className = "ed-inner-tab";
   loadsButton.type = "button";
-  loadsButton.textContent = locale === "it" ? "CARICHI" : "LOADS";
+  // The panel configures the circles under Home and the devices inside each
+  // one, so it is named after both rather than after the internal word "loads".
+  loadsButton.textContent = locale === "it" ? "CARICHI E DISPOSITIVI" : "LOADS & DEVICES";
   const reportButton = document.createElement("button");
   reportButton.className = "ed-inner-tab";
   reportButton.type = "button";

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-loads-editor-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-loads-editor-section.js
@@ -14,6 +14,7 @@
  * Every write goes through the canonical `loads` section; the legacy popup keys
  * are re-derived from it on save. Event driven: no polling, no observer.
  */
+import { openIconPicker } from "./icon-engine-section.js";
 import { createEntityPickerField } from "../core/renderers.js";
 import {
   MAX_FLOW_LOADS,
@@ -319,25 +320,34 @@ function loadCard(panel, load, index, total) {
 
   const iconField = element("label", "ed-slot dm-loads-field");
   iconField.append(element("span", "ed-slot-lbl", t("Icona", "Icon")));
-  const iconRow = element("span", "ed-form-row dm-loads-icon-row");
+  const iconRow = element("span", "dm-loads-icon-row");
   const icon = doc.createElement("input");
-  icon.className = "ed-input ed-icon-input";
+  icon.className = "ed-input dm-loads-icon-input";
   icon.id = `dm-loads-${load.id}-icon`;
   icon.dataset.dmLoadIcon = "true";
   icon.value = load.icon;
   icon.placeholder = "🍳 / mdi:stove";
+  icon.addEventListener("input", () => iconInto(pick, clean(icon.value)));
   icon.addEventListener("change", () => {
     load.icon = clean(icon.value);
     markDirty(panel);
   });
-  // The canonical icon picker: it writes the chosen glyph into the input it is
-  // pointed at and fires `change`, so the same handler persists either way.
-  const pick = element("button", "dm-icon-picker", "🎨");
+  /* The canonical picker is opened directly instead of through the legacy
+   * `.dm-icon-picker` hook: that class is decorated by another owner, which
+   * repaints the button with its own preview markup and zeroes the font size,
+   * so the button came out blank. Opening the picker by hand keeps the same
+   * catalogue — it writes the glyph into this input and fires `change` — while
+   * the button stays ours to draw. */
+  const pick = element("button", "dm-loads-icon-btn");
   pick.type = "button";
-  pick.dataset.iconTarget = icon.id;
-  pick.dataset.iconCategory = "action";
+  pick.dataset.dmLoadIconPick = "true";
   pick.title = t("Scegli icona", "Choose icon");
   pick.setAttribute("aria-label", t("Scegli icona", "Choose icon"));
+  iconInto(pick, load.icon);
+  pick.addEventListener("click", (event) => {
+    event.preventDefault();
+    openIconPicker(icon, "action");
+  });
   iconRow.append(icon, pick);
   iconField.append(iconRow);
   iconField.append(
@@ -513,8 +523,8 @@ export function renderEnergyLoadsEditor(panel = doc?.querySelector?.(PANEL)) {
         "div",
         "ed-intro",
         t(
-          "Ogni carico è un cerchio sotto Casa, nell'ordine di questa lista. Quello che scrivi qui è quello che vedi nel flusso.",
-          "Every load is a circle under Home, in the order of this list. What you write here is what the flow shows.",
+          "Ogni carico qui sotto è un cerchio del flusso Energia, sotto Casa, nell'ordine di questa lista. Quello che scrivi qui è quello che vedi nel flusso, e i dispositivi che gli assegni sono quelli che compaiono toccando il cerchio.",
+          "Every load below is a circle of the Energy flow, under Home, in the order of this list. What you write here is what the flow shows, and the devices you file under it are the ones that appear when you tap the circle.",
         ),
       ),
     );
@@ -592,7 +602,9 @@ function installStyles() {
   installStyle(
     "dm-energy-loads-editor-style",
     `
-    [data-energy-panel="loads"][data-dm-loads-editor="true"]{display:block!important}
+    /* The display rule must not defeat the panel's own hidden attribute: the
+       editor set it once and the section then showed under Flows too. */
+    [data-energy-panel="loads"][data-dm-loads-editor="true"]:not([hidden]){display:block!important}
     .dm-loads-list{display:grid;gap:10px}
     .dm-loads-card>.ed-acc-head{display:flex;align-items:center;gap:10px;justify-content:space-between}
     .dm-loads-preview{display:flex;align-items:center;gap:10px;min-width:0}
@@ -608,8 +620,10 @@ function installStyles() {
     .dm-loads-field{display:grid;gap:6px;min-width:0}
     .dm-loads-field .ed-slot-lbl{color:var(--text,#0f172a);font-size:13px;font-weight:800;letter-spacing:.2px}
     .dm-loads-field .ed-input{width:100%;min-width:0;min-height:46px;box-sizing:border-box}
-    .dm-loads-icon-row{display:grid!important;grid-template-columns:minmax(0,1fr) 54px;gap:10px;align-items:center}
-    .dm-loads-icon-row .dm-icon-picker{display:grid;place-items:center;width:54px;height:46px;padding:0;border:1px solid var(--border,rgba(15,23,42,.14));border-radius:14px;background:var(--card-bg,#fff);font-size:20px;cursor:pointer}
+    .dm-loads-icon-row{display:grid!important;grid-template-columns:minmax(0,1fr) 56px!important;gap:10px!important;align-items:center!important}
+    .dm-loads-icon-input{width:100%!important;min-width:0!important;flex:none!important;text-align:left!important;font-size:18px!important;color:var(--text,#0f172a)!important}
+    .dm-loads-icon-btn{display:grid!important;place-items:center!important;width:56px!important;height:46px!important;padding:0!important;border:1px solid var(--border,rgba(15,23,42,.14))!important;border-radius:14px!important;background:var(--card-bg,#fff)!important;font-size:22px!important;line-height:1!important;color:var(--text,#0f172a)!important;cursor:pointer}
+    .dm-loads-icon-btn svg,.dm-loads-icon-btn img{width:26px!important;height:26px!important}
     .dm-loads-color-field{grid-template-columns:minmax(0,1fr) 64px;align-items:center}
     .dm-loads-color{width:64px;height:46px;padding:2px;border:1px solid var(--border,rgba(15,23,42,.14));border-radius:12px;background:var(--card-bg,#fff)}
     .dm-loads-switch{display:flex;align-items:center;gap:9px;margin:10px 0;color:var(--text,#0f172a);font-weight:700}
@@ -620,7 +634,7 @@ function installStyles() {
     .dm-loads-subload-form{margin:0 0 10px;padding:12px;border-radius:14px;background:color-mix(in srgb,var(--card-bg,#fff) 92%,var(--divider-color,#e2e8f0))}
     /* The phone is exactly where the three squeezed fields were unreadable, so
        there is no narrow variant that puts them back side by side. */
-    @media(max-width:640px){.dm-loads-color-field{grid-template-columns:minmax(0,1fr) 56px}.dm-loads-icon-row{grid-template-columns:minmax(0,1fr) 48px}.dm-loads-icon-row .dm-icon-picker{width:48px}}
+    @media(max-width:640px){.dm-loads-color-field{grid-template-columns:minmax(0,1fr) 56px}.dm-loads-icon-row{grid-template-columns:minmax(0,1fr) 50px!important}.dm-loads-icon-btn{width:50px!important}}
   `,
   );
 }

--- a/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
@@ -7,5 +7,5 @@ const manifest = JSON.parse(
 );
 
 test("beta30 release manifest is versioned correctly", () => {
-  assert.equal(manifest.version, "1.0.0-beta.30.3");
+  assert.equal(manifest.version, "1.0.0-beta.30.4");
 });

--- a/custom_components/dashboardmodern/frontend/tests/energy-loads-editor-panel.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energy-loads-editor-panel.test.js
@@ -308,12 +308,13 @@ test("name, icon and colour are labelled fields, with the canonical icon picker"
   assert.equal(name.value, previewName(first), "the field shows the name it is editing");
   assert.ok(name.value, "and that name is not blank");
 
-  // The picker button points at the icon input, which is how the canonical
-  // icon engine finds what to write into.
+  // The picker button is drawn by this editor, not decorated by the legacy
+  // `.dm-icon-picker` owner, which repainted it into an empty box.
   const icon = first.querySelector("[data-dm-load-icon]");
-  const picker = first.querySelector(".dm-icon-picker");
-  assert.equal(picker.dataset.iconTarget, icon.id);
-  assert.ok(icon.id);
+  const picker = first.querySelector("[data-dm-load-icon-pick]");
+  assert.ok(icon.id, "the input is addressable, so the picker can write into it");
+  assert.equal(picker.classList.contains("dm-icon-picker"), false);
+  assert.equal(picker.textContent, icon.value, "the button previews the current icon");
 
   // The engine writes the glyph and fires change; the card must persist it.
   icon.value = "🔥";
@@ -343,4 +344,17 @@ test("the labelled fields stay stacked on a phone, where they were unreadable", 
   // put name, icon and colour back on one row.
   assert.doesNotMatch(narrow, /\.dm-loads-identity\s*\{[^}]*grid-template-columns/);
   assert.match(css, /\.dm-loads-identity\{display:grid;gap:12px/);
+});
+
+test("the panel stays hidden when another Energy tab is open", () => {
+  render();
+  const css = globalThis.document.head.descendants().map((node) => node.textContent).join("\n");
+  // The editor set `display:block` unconditionally, which defeats the panel's
+  // own `hidden` attribute: the section then showed under Flows & entities too.
+  assert.match(css, /\[data-energy-panel="loads"\]\[data-dm-loads-editor="true"\]:not\(\[hidden\]\)/);
+  assert.doesNotMatch(
+    css,
+    /\[data-dm-loads-editor="true"\]\{display:block/,
+    "no unconditional display rule survives",
+  );
 });

--- a/custom_components/dashboardmodern/frontend/tests/energy-loads-editor.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energy-loads-editor.test.js
@@ -91,7 +91,7 @@ test("Energy real DOM opens Flussi by default, switches settings and reuses the 
   const tabs = root.queryAll((node) => node.classList.contains("ed-inner-tab"));
   assert.deepEqual(
     tabs.map((tab) => tab.textContent),
-    ["FLUSSI ED ENTITÀ", "CARICHI", "REPORT", "IMPOSTAZIONI"],
+    ["FLUSSI ED ENTITÀ", "CARICHI E DISPOSITIVI", "REPORT", "IMPOSTAZIONI"],
   );
   tabs[3].click();
   assert.equal(panels.find((node) => node.dataset.energyPanel === "flows").hidden, true);

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.30.3"
+  "version": "1.0.0-beta.30.4"
 }


### PR DESCRIPTION
Tre cose viste sul dispositivo dopo la 30.2.

## La sezione compariva anche sotto "Flussi ed entità"

La regola con cui l'editor si rendeva visibile era incondizionata:

```css
[data-energy-panel="loads"][data-dm-loads-editor="true"]{display:block!important}
```

Quel `display` scavalca l'attributo `hidden` del pannello, che è **il modo in cui l'editor Energia nasconde le schede non attive**. Quindi appena la sezione veniva renderizzata una volta, restava visibile sotto qualunque scheda. Ora la regola vale solo sul pannello non nascosto (`:not([hidden])`).

## L'icona e il pulsante per sceglierla erano riquadri vuoti

Due cause sovrapposte, entrambe dovute al riuso delle classi legacy:

- il campo aveva `ed-icon-input`, che nella CSS legacy è `width: 72px` fisso — da qui il riquadro stretto;
- il pulsante aveva `dm-icon-picker`, che **un altro proprietario decora**: `decorateLegacyIconPickers` gli riscrive l'`innerHTML` con la propria anteprima e gli applica `font-size: 0`. Se quell'anteprima non risolve il valore — ed è il caso di un'emoji — il pulsante resta vuoto.

La riga è ora disegnata da questo editor con classi proprie: il campo mostra l'icona a piena larghezza, e il pulsante **è** l'anteprima dell'icona corrente. Apre lo stesso catalogo di prima, ma chiamando `openIconPicker` direttamente invece di passare per l'aggancio legacy, così nessun altro owner lo ridipinge. Il picker continua a scrivere nell'input e a lanciare `change`, quindi il salvataggio resta uno solo.

## Nome della scheda

Da `CARICHI` a **`CARICHI E DISPOSITIVI`** (EN: `LOADS & DEVICES`): dice cosa ci si configura — i cerchi del flusso e i dispositivi dentro ciascuno — invece della parola interna. L'intro della sezione spiega ora anche che i dispositivi assegnati a un carico sono quelli che compaiono toccando il cerchio.

## Verifica

- `npm run test:frontend` — **559 test verdi**, inclusi i 5 aggiunti dalla #147. Due nuovi qui: uno impedisce il ritorno della regola `display` incondizionata, l'altro fissa che il pulsante icona non porta la classe decorata e mostra l'icona corrente.
- `npx playwright test` desktop e mobile — 186 verdi (un test è caduto sotto carico e passa isolato e in suite).
- `format:check` e `check:inline-syntax` puliti.

Base: `a403227`, cioè dopo la tua #147 e la rigenerazione degli artefatti patches; il manifest su `main` era già `1.0.0-beta.30.3`, quindi questa è la **30.4**. Il mio diff non tocca nessuno dei file della #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HGTLZW14Y4Dsc9haG8mWr

---
_Generated by [Claude Code](https://claude.ai/code/session_012HGTLZW14Y4Dsc9haG8mWr)_