### PR TITLE
Beta 30.7: l'etichetta sopra la temperatura non cambia più da sola, Solare Termico in vista isometrica, Sicurezza, EV, Tapparelle e Clima ridisegnate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,27 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   i titoli di piano e stanza hanno la loro riga con la linea che sfuma.
 - Tutta la pagina segue il tema chiaro e scuro, si adatta al telefono e chi ha
   attivato "riduci animazioni" vede la scena ferma.
+- **La ricerca delle entità nella configurazione è diventata istantanea.** Il
+  selettore (la lente 🔍 accanto a ogni campo entità) rileggeva tutte le entità
+  della casa a ogni lettera digitata e ridisegnava trecento righe ogni volta: su
+  un impianto con qualche migliaio di entità la lista arrancava dietro alla
+  tastiera. Ora l'elenco viene preparato una volta sola, mentre la
+  configurazione è aperta, e ogni lettera successiva ricerca soltanto dentro i
+  risultati della lettera precedente. Si vede una pagina di risultati per volta,
+  che si allunga scorrendo, quindi la fluidità non dipende più da quante entità
+  ci sono.
+- **Il selettore ora propone da solo le entità giuste per il campo.** Ogni campo
+  dice già cosa gli serve — "Entità temperatura", `sensor.` nel segnaposto,
+  "(kWh)" nell'etichetta — e il selettore lo legge: aprendo la lente sul campo
+  della temperatura di una stanza, in cima ci sono i sensori di temperatura
+  della casa, contrassegnati con ✨, senza digitare nulla. Il filtro
+  **✨ Suggerite** mostra solo quelli, e le pastiglie accanto (`sensor`,
+  `light`, `switch`…) restringono per dominio.
+- La ricerca ignora accenti e maiuscole (cercando `citta` si trova "Città"),
+  richiede tutte le parole digitate in qualsiasi ordine, e mette in fondo le
+  entità che Home Assistant riporta come non disponibili. Ogni riga mostra ora
+  anche il valore attuale e la stanza dell'entità, e la lista si comanda da
+  tastiera con ↑ ↓ e Invio.
 
 ### Corretto
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,21 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
 ### Modificato
 
+- **Tapparelle** ha ora una testata con il riepilogo — quante sono aperte,
+  chiuse e in movimento in questo momento — e i comandi "Apri tutte / Chiudi
+  tutte" dentro la testata invece che come due bottoni nudi in cima alla
+  pagina. Le tapparelle sono raggruppate per piano e stanza, ogni gruppo ha il
+  suo titolo con il numero di tapparelle, e sotto il nome di ogni scheda si
+  legge la stanza a cui appartiene.
+- **Accanto a ogni finestra c'è il cursore della posizione.** Si trascina in
+  verticale come la tapparella vera: la parte grigia in alto è la tapparella,
+  quella azzurra sotto è il cielo, e la tapparella nella finestra segue il dito
+  mentre trascini. Al rilascio la tapparella va esattamente a quella posizione.
+  La posizione scelta resta ferma mentre il motore si muove, invece di tornare
+  indietro al primo aggiornamento. Le tapparelle che non accettano una
+  posizione mostrano lo stesso indicatore, in sola lettura.
+- Quando la tapparella è alzata, sotto la finestra si vede la luce che entra
+  nella stanza, tanta quanta ne lascia passare.
 - **Tapparelle** è stata ridisegnata. Ogni scheda non mostra più un rettangolo
   azzurro con delle righe grigie: adesso c'è una finestra vera, con il telaio,
   il montante centrale, le guide laterali, il cassonetto in alto e, dietro il

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   posizione mostrano lo stesso indicatore, in sola lettura.
 - Quando la tapparella è alzata, sotto la finestra si vede la luce che entra
   nella stanza, tanta quanta ne lascia passare.
+- La freccia **← Home** è sempre in alto, come nelle altre sezioni, e ora è
+  allineata con la testata e con le schede invece di stare attaccata al bordo
+  sinistro dello schermo.
 - **Tapparelle** è stata ridisegnata. Ogni scheda non mostra più un rettangolo
   azzurro con delle righe grigie: adesso c'è una finestra vera, con il telaio,
   il montante centrale, le guide laterali, il cassonetto in alto e, dietro il

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
 ## 1.0.0-beta.30.7 — 2026-08-17
 
+### Aggiunto
+
+- Il selettore delle icone di un carico ha ora un catalogo suo, diviso in **Aree
+  della casa** e **Apparecchi e impianti**. Prima offriva quello delle azioni
+  rapide, che è costruito attorno a quello che un pulsante *fa* — una scena, uno
+  script, un avviso, l'antifurto, una telecamera — e che quindi si intitolava
+  "Scegli icona azione" e non conteneva nessuna stanza. Ora ci sono tutte le
+  aree della casa (cucina, salone, garage, bagno, cantina, giardino…) e una
+  quarantina di apparecchi che consumano davvero: forno, piano cottura, cappa,
+  frigorifero, congelatore, lavastoviglie, lavatrice, asciugatrice, boiler,
+  pompa di calore, condizionatore, stufa a pellet, auto elettrica e colonnina,
+  fotovoltaico, batteria, pompe, irrigazione, tapparelle, cancello, ascensore e
+  altro. Antifurto, telecamere, scene, script e avvisi non compaiono più: non
+  sono carichi. Nessuna icona è offerta due volte e la ricerca nasconde le
+  intestazioni dei gruppi rimasti vuoti.
+
 ### Corretto
 
 - In **Temperature** l'etichetta sopra il numero cambiava da sola: la stessa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,26 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
 ### Modificato
 
+- **Tapparelle** è stata ridisegnata. Ogni scheda non mostra più un rettangolo
+  azzurro con delle righe grigie: adesso c'è una finestra vera, con il telaio,
+  il montante centrale, le guide laterali, il cassonetto in alto e, dietro il
+  vetro, il cielo con il sole, le nuvole, il prato e le siepi. Di notte la
+  stessa finestra passa al cielo scuro con la luna e le stelle.
+- La tapparella è disegnata come una tapparella: stecche con la loro curvatura,
+  la stecca finale più scura con la maniglia e l'ombra che cade sul vetro
+  sotto. **Mentre sale o scende le stecche scorrono davvero**, nel verso
+  giusto, e la scheda in movimento si illumina di azzurro sul bordo.
+- Risolto un difetto della vecchia grafica: a tapparella completamente chiusa
+  la parte alta restava trasparente e si vedeva il cielo attraverso le fessure.
+  Ora la tapparella chiusa copre tutta la finestra.
+- Lo stato ("Aperta", "Chiusa", "In apertura", "In chiusura") è una pastiglia
+  con il pallino colorato che pulsa quando la tapparella si muove, la
+  percentuale è una pastiglia con l'icona della tapparella e i tre comandi
+  hanno colori diversi tra loro: salire, fermare e scendere non si confondono
+  più. La barra "Apri tutte / Chiudi tutte" è centrata e più alta da toccare, e
+  i titoli di piano e stanza hanno la loro riga con la linea che sfuma.
+- Tutta la pagina segue il tema chiaro e scuro, si adatta al telefono e chi ha
+  attivato "riduci animazioni" vede la scena ferma.
 - **Piscina** e **Irrigazione** sono state ridisegnate: ognuna ha ora una scena
   vera al posto del pannello azzurro piatto e della lista di riquadri grigi.
 - La Piscina disegna il giardino, il bordo in pietra, la vasca in prospettiva

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,22 +22,6 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   sono carichi. Nessuna icona è offerta due volte e la ricerca nasconde le
   intestazioni dei gruppi rimasti vuoti.
 
-### Corretto
-
-- In **Temperature** l'etichetta sopra il numero cambiava da sola: la stessa
-  scheda mostrava "TEMPERATURA" e un istante dopo il nome dato al sensore. Quel
-  testo aveva tre proprietari che non erano d'accordo — i renderer scrivevano la
-  parola generica alla creazione, la passata di rifinitura beta17 scriveva il
-  nome della stanza su **tutte** le schede di quella stanza (seconda sonda
-  compresa) a ogni frame, e il livello beta27 lo scriveva per associazione. Su un
-  impianto vero i sensori aggiornano di continuo, quindi l'etichetta ballava a
-  ogni ridisegno. Ora la regola sta in un punto solo: la prima associazione porta
-  il nome dato in configurazione, una sonda aggiuntiva porta il proprio, e senza
-  nome resta la parola "Temperatura". La passata beta17 continua a occuparsi
-  dell'editor e non tocca più le schede.
-
-## 1.0.0-beta.30.6 — 2026-08-17
-
 ### Modificato
 
 - **Tapparelle** ha ora una testata con il riepilogo — quante sono aperte,
@@ -78,6 +62,25 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   i titoli di piano e stanza hanno la loro riga con la linea che sfuma.
 - Tutta la pagina segue il tema chiaro e scuro, si adatta al telefono e chi ha
   attivato "riduci animazioni" vede la scena ferma.
+
+### Corretto
+
+- In **Temperature** l'etichetta sopra il numero cambiava da sola: la stessa
+  scheda mostrava "TEMPERATURA" e un istante dopo il nome dato al sensore. Quel
+  testo aveva tre proprietari che non erano d'accordo — i renderer scrivevano la
+  parola generica alla creazione, la passata di rifinitura beta17 scriveva il
+  nome della stanza su **tutte** le schede di quella stanza (seconda sonda
+  compresa) a ogni frame, e il livello beta27 lo scriveva per associazione. Su un
+  impianto vero i sensori aggiornano di continuo, quindi l'etichetta ballava a
+  ogni ridisegno. Ora la regola sta in un punto solo: la prima associazione porta
+  il nome dato in configurazione, una sonda aggiuntiva porta il proprio, e senza
+  nome resta la parola "Temperatura". La passata beta17 continua a occuparsi
+  dell'editor e non tocca più le schede.
+
+## 1.0.0-beta.30.6 — 2026-08-17
+
+### Modificato
+
 - **Piscina** e **Irrigazione** sono state ridisegnate: ognuna ha ora una scena
   vera al posto del pannello azzurro piatto e della lista di riquadri grigi.
 - La Piscina disegna il giardino, il bordo in pietra, la vasca in prospettiva

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.0.0-beta.30.7 — 2026-08-17
+
+### Corretto
+
+- In **Temperature** l'etichetta sopra il numero cambiava da sola: la stessa
+  scheda mostrava "TEMPERATURA" e un istante dopo il nome dato al sensore. Quel
+  testo aveva tre proprietari che non erano d'accordo — i renderer scrivevano la
+  parola generica alla creazione, la passata di rifinitura beta17 scriveva il
+  nome della stanza su **tutte** le schede di quella stanza (seconda sonda
+  compresa) a ogni frame, e il livello beta27 lo scriveva per associazione. Su un
+  impianto vero i sensori aggiornano di continuo, quindi l'etichetta ballava a
+  ogni ridisegno. Ora la regola sta in un punto solo: la prima associazione porta
+  il nome dato in configurazione, una sonda aggiuntiva porta il proprio, e senza
+  nome resta la parola "Temperatura". La passata beta17 continua a occuparsi
+  dell'editor e non tocca più le schede.
+
 ## 1.0.0-beta.30.6 — 2026-08-17
 
 ### Modificato

--- a/custom_components/dashboardmodern/frontend/e2e/beta16-real-device-layout.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta16-real-device-layout.spec.js
@@ -141,7 +141,7 @@ async function openEditor(page, tab) {
   await expect(page.locator(`.ed-tab[data-tab="${tab}"]`)).toHaveClass(/active/);
 }
 
-test("beta16: Climate resolves canonical room labels and stays two cards per row on phone", async ({
+test("beta16: Climate resolves canonical room labels and lays the cards out per screen", async ({
   page,
 }, testInfo) => {
   test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
@@ -165,29 +165,30 @@ test("beta16: Climate resolves canonical room labels and stays two cards per row
     setClimaPageMode("freddo", true);
   });
 
-  await expect(page.locator("#page-clima .clima-section-title").first()).toContainText("Cameretta");
-  await expect(page.locator("#page-clima .clima-section-title").first()).not.toContainText(
-    "room_msqjk307",
-  );
-  await expect(page.locator("#page-clima .cp-card")).toHaveCount(2);
-  await expect(page.locator("#page-clima .cp-card .dm-beta16-climate-room").first()).toContainText(
+  // The climate redesign prints the room inside the card instead of a heading
+  // above it, and it must still be the name the user typed, never the raw id.
+  await expect(page.locator("#page-clima .dm-cl-card .dm-cl-meta").first()).toContainText(
     "Cameretta",
   );
+  await expect(page.locator("#page-clima .dm-cl-card .dm-cl-meta").first()).not.toContainText(
+    "room_msqjk307",
+  );
+  await expect(page.locator("#page-clima .dm-cl-card")).toHaveCount(2);
 
-  const layout = await page.evaluate(() => {
-    const grid = document.querySelector("#page-clima .clima-premium-grid");
+  const measure = () => {
+    const grid = document.querySelector("#page-clima .dm-cl-grid");
     const switchNode = document.querySelector(
       '#page-clima .clima-page-mode-switch[data-dm-beta12-climate="true"]',
     );
     const buttons = [...(switchNode?.querySelectorAll(".clima-page-mode-btn") || [])];
-    const cards = [...document.querySelectorAll("#page-clima .cp-card")].map((card) =>
+    const cards = [...document.querySelectorAll("#page-clima .dm-cl-card")].map((card) =>
       card.getBoundingClientRect(),
     );
     const gridBox = grid?.getBoundingClientRect();
     const columns = grid
       ? getComputedStyle(grid).gridTemplateColumns.split(/\s+/).filter(Boolean)
       : [];
-    const headings = [...document.querySelectorAll("#page-clima .dm-beta16-climate-group-heading")];
+    const headings = [...document.querySelectorAll("#page-clima .dm-cl-floor")];
     return {
       columns: columns.length,
       switchHeight: switchNode?.getBoundingClientRect().height || 0,
@@ -197,19 +198,32 @@ test("beta16: Climate resolves canonical room labels and stays two cards per row
       cardWidth: cards[0]?.width || 0,
       gridWidth: gridBox?.width || 0,
       sameRow: cards.length >= 2 && Math.abs(cards[0].top - cards[1].top) <= 3,
-      hiddenHeadings:
-        headings.length > 0 &&
-        headings.every((heading) => getComputedStyle(heading).display === "none"),
+      headingCount: headings.length,
       overflow: grid ? grid.scrollWidth - grid.clientWidth : 999,
     };
-  });
-  expect(layout.columns).toBe(2);
+  };
+
+  // boot() puts every project on a phone-sized viewport, so this is the phone
+  // layout: the thermal card carries a rail, a legend and four controls, so it
+  // takes the full width instead of squeezing two per row.
+  const layout = await page.evaluate(measure);
+  expect(layout.columns).toBe(1);
   expect(layout.switchHeight).toBeLessThan(75);
   expect(layout.maxButtonHeight).toBeLessThanOrEqual(60);
-  expect(layout.cardWidth).toBeLessThan(layout.gridWidth * 0.55);
-  expect(layout.sameRow).toBe(true);
-  expect(layout.hiddenHeadings).toBe(true);
+  expect(layout.sameRow).toBe(false);
+  expect(layout.cardWidth).toBeGreaterThan(layout.gridWidth * 0.9);
+  // No floor is configured here, so the grid prints no group heading at all:
+  // the room belongs to the card, not to a band above it.
+  expect(layout.headingCount).toBe(0);
   expect(layout.overflow).toBeLessThanOrEqual(2);
+
+  // From the tablet up the same grid pairs the cards two per row.
+  await page.setViewportSize({ width: 1200, height: 915 });
+  const wide = await page.evaluate(measure);
+  expect(wide.columns).toBe(2);
+  expect(wide.sameRow).toBe(true);
+  expect(wide.cardWidth).toBeLessThan(wide.gridWidth * 0.55);
+  expect(wide.overflow).toBeLessThanOrEqual(2);
 });
 
 test("beta16: editor rows show saved Action, Climate and Temperature names", async ({

--- a/custom_components/dashboardmodern/frontend/e2e/beta5-root-causes.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta5-root-causes.spec.js
@@ -227,14 +227,17 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     // physical viewport. DOM click exercises the same application handler
     // without turning navbar scrolling into a prerequisite for this layout test.
     await page.locator('.tab[data-tab="clima"]').evaluate((button) => button.click());
-    await expect(page.locator("#page-clima.active .cp-card").first()).toBeVisible();
+    // The climate redesign owns this page: cards are .dm-cl-card inside
+    // .dm-cl-grid, which is what keeps the legacy .cp-card corrections from
+    // fighting over the layout.
+    await expect(page.locator("#page-clima.active .dm-cl-card").first()).toBeVisible();
     if (testInfo.project.name === "mobile") {
       const climateHeight = await page
-        .locator("#page-clima.active .cp-card")
+        .locator("#page-clima.active .dm-cl-card")
         .first()
         .evaluate((card) => card.getBoundingClientRect().height);
       expect(climateHeight).toBeLessThan(260);
-      await expect(page.locator("#page-clima.active .clima-premium-grid").first()).toHaveCSS(
+      await expect(page.locator("#page-clima.active .dm-cl-grid").first()).toHaveCSS(
         "grid-template-columns",
         /.+/,
       );

--- a/custom_components/dashboardmodern/frontend/e2e/entity-search-picker.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/entity-search-picker.spec.js
@@ -1,0 +1,165 @@
+/* The entity picker on an instance that is big enough to hurt.
+ *
+ * Three hundred entities is a modest real house and was already enough for the
+ * old picker to rebuild three hundred rows on every keystroke. These tests hold
+ * the two properties that replaced it: the list paints one page and grows on
+ * demand, and the field's own label decides what is proposed first.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const ROOMS = ["kitchen", "living", "bathroom", "garage", "garden"];
+
+function buildStates() {
+  const states = [];
+  const push = (entity_id, state, attributes) => states.push({ entity_id, state, attributes });
+  for (const room of ROOMS) {
+    push(`sensor.${room}_temperature`, "21.5", {
+      friendly_name: `${room} temperature`,
+      unit_of_measurement: "°C",
+      device_class: "temperature",
+    });
+    push(`sensor.${room}_humidity`, "48", {
+      friendly_name: `${room} humidity`,
+      unit_of_measurement: "%",
+      device_class: "humidity",
+    });
+  }
+  for (let index = 0; index < 120; index += 1) {
+    push(`light.lamp_${index}`, index % 2 ? "on" : "off", { friendly_name: `Lamp ${index}` });
+  }
+  for (let index = 0; index < 120; index += 1) {
+    push(`switch.socket_${index}`, "off", { friendly_name: `Socket ${index}` });
+  }
+  for (let index = 0; index < 60; index += 1) {
+    push(`automation.routine_${index}`, "on", { friendly_name: `Routine ${index}` });
+  }
+  return states;
+}
+
+const STATES = buildStates();
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [
+      { id: "room-kitchen", name: "Kitchen", icon: "mdi:sofa", floor: "Ground", temp: "", hum: "" },
+    ],
+  },
+  visibility: {},
+};
+
+async function openTemperaturePicker(page) {
+  await page.locator('.dm-entity-picker[data-entity-target="ed-pl-temp"]').click();
+  await expect(page.locator("#cd-entpick")).toBeVisible();
+  await expect(page.locator("#cd-ep-list .dm-ep-row").first()).toBeVisible();
+}
+
+const rowIds = (page) =>
+  page
+    .locator("#cd-ep-list .dm-ep-row")
+    .evaluateAll((rows) => rows.map((row) => row.dataset.entity));
+
+test.describe("entity picker search", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await page.addInitScript((haStates) => {
+      window.WebSocket = class extends EventTarget {
+        static OPEN = 1;
+        readyState = 1;
+        constructor() {
+          super();
+          queueMicrotask(() =>
+            this.onmessage?.({ data: JSON.stringify({ type: "auth_required" }) }),
+          );
+        }
+        send(raw) {
+          const message = JSON.parse(raw);
+          if (message.type === "auth")
+            this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+          else
+            this.onmessage?.({
+              data: JSON.stringify({
+                id: message.id,
+                type: "result",
+                success: true,
+                result: message.type === "get_states" ? haStates : [],
+              }),
+            });
+        }
+        close() {}
+      };
+    }, STATES);
+  });
+
+  for (const variant of ["dashboard.html", "dashboard-en.html"]) {
+    test(`${variant}: one page of rows, field-aware ranking, chips and keyboard`, async ({
+      page,
+    }, testInfo) => {
+      await bootNamespacedDashboard(page, variant, testInfo, seed);
+      await page
+        .locator("#setup-wizard")
+        .evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+      await page.evaluate((haStates) => {
+        haStates.forEach((state) => {
+          _RAW_STATES[state.entity_id] = state;
+          STATES[state.entity_id] = state;
+        });
+        apriConfigEntita();
+        editorSwitch("sez7");
+      }, STATES);
+      await expect(page.locator("#ed-pl-temp")).toBeVisible();
+
+      await openTemperaturePicker(page);
+
+      // One page in the DOM, the whole inventory in the counter.
+      const first = await rowIds(page);
+      expect(first.length).toBeGreaterThan(10);
+      expect(first.length).toBeLessThanOrEqual(60);
+      await expect(page.locator("#dm-ep-status")).toContainText(String(STATES.length));
+
+      // The field says "temperature", so temperature sensors are proposed and
+      // marked before anything else — with no query typed at all.
+      expect(first[0]).toMatch(/^sensor\.\w+_temperature$/);
+      await expect(page.locator("#cd-ep-list .dm-ep-row").first()).toHaveAttribute(
+        "data-hinted",
+        "true",
+      );
+
+      // Scrolling extends the same result set instead of re-rendering it.
+      await page.locator("#cd-ep-list").evaluate((list) => {
+        list.scrollTop = list.scrollHeight;
+      });
+      await expect.poll(async () => (await rowIds(page)).length).toBeGreaterThan(first.length);
+
+      // Typing narrows to the two matches, temperature first because that is
+      // what this field is for.
+      await page.locator("#cd-ep-search").fill("kitchen");
+      await expect
+        .poll(async () => await rowIds(page))
+        .toEqual(["sensor.kitchen_temperature", "sensor.kitchen_humidity"]);
+
+      // A domain chip filters the same match set.
+      await page.locator("#cd-ep-search").fill("");
+      await page.locator('#dm-ep-chips [data-dm-domain="light"]').click();
+      const lights = await rowIds(page);
+      expect(lights.length).toBeGreaterThan(0);
+      expect(lights.every((id) => id.startsWith("light."))).toBe(true);
+      await page.locator('#dm-ep-chips [data-dm-domain="*"]').click();
+
+      // Keyboard: first row without touching the list.
+      await page.locator("#cd-ep-search").fill("kitchen temperature");
+      await page.locator("#cd-ep-search").press("ArrowDown");
+      await page.locator("#cd-ep-search").press("Enter");
+      await expect(page.locator("#cd-entpick")).toHaveCount(0);
+      await expect(page.locator("#ed-pl-temp")).toHaveValue("sensor.kitchen_temperature");
+
+      // Clicking a row still writes the field, which is the contract the
+      // vendored `cdEpChoose` has always had.
+      await page.locator('.dm-entity-picker[data-entity-target="dm-humidity-new"]').click();
+      await page.locator("#cd-ep-search").fill("kitchen humidity");
+      await page.locator("#cd-ep-list .dm-ep-row").first().click();
+      await expect(page.locator("#dm-humidity-new")).toHaveValue("sensor.kitchen_humidity");
+    });
+  }
+});

--- a/custom_components/dashboardmodern/frontend/e2e/ev-showcase.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/ev-showcase.spec.js
@@ -1,0 +1,125 @@
+// DM-FIX-20260817D
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [
+      { id: "ev-b10", name: "B10", brand: "Leapmotor", model: "B10", icon: "mdi:car-electric" },
+      { id: "ev-t03", name: "T03", brand: "Leapmotor", model: "T03", icon: "mdi:car-electric" },
+    ],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  visibility: { home: true, energy: true, ev: true },
+};
+
+/** Put the EV page on screen with the values the render loop would have written. */
+async function openEvPage(page, { mode = "off", charging = false } = {}) {
+  await page.evaluate(
+    ({ mode: activeMode, charging: isCharging }) => {
+      document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
+      document.getElementById("page-ev")?.classList.add("active");
+      const fill = document.getElementById("ev-mod-batt-fill");
+      if (fill) {
+        fill.style.width = "68%";
+        fill.style.setProperty("--batt-col", "#16a34a");
+      }
+      document.querySelectorAll(".v-ev-pow").forEach((el) => (el.textContent = "7.4 kW"));
+      document.querySelectorAll(".v-ev-remain").forEach((el) => (el.textContent = "1h 25m"));
+      document.querySelectorAll(".v-auto-limite").forEach((el) => (el.textContent = "368 km"));
+      document.querySelectorAll(".evcc-mode-btn").forEach((btn) => btn.classList.remove("active"));
+      document.getElementById(`m-btn-${activeMode}`)?.classList.add("active");
+      document.getElementById("lm-hero-card")?.classList.toggle("lm-charging", isCharging);
+      window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: {} }));
+    },
+    { mode, charging },
+  );
+}
+
+test.describe("EV page redesign", () => {
+  test("the skin mounts without losing a single legacy hook", async ({ page }, testInfo) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+    await openEvPage(page, { mode: "off" });
+
+    // The photo, the battery bar and the badge ids keep existing: the legacy
+    // render loop writes into them on every state event.
+    await expect(page.locator("#page-ev")).toHaveClass(/dm-evv/);
+    await expect(page.locator("#ev-mod-car-img")).toHaveCount(1);
+    await expect(page.locator("#ev-mod-batt-fill")).toHaveCount(1);
+    await expect(page.locator("#lm-charge-badge #lm-stato-txt")).toHaveCount(1);
+
+    // The battery block is moved into the ring, not copied.
+    await expect(page.locator(".dm-evv-gauge .lm-batt-section")).toHaveCount(1);
+    await expect(page.locator(".lm-batt-section")).toHaveCount(1);
+
+    // The ring draws the value the bar carries: 68% of the circumference.
+    const arc = page.locator(".dm-evv-arc");
+    const [drawn, gap] = ((await arc.getAttribute("stroke-dasharray")) || "")
+      .split(" ")
+      .map(Number);
+    expect(Math.round((drawn / (drawn + gap)) * 100)).toBe(68);
+
+    // The rows next to the ring are filled by the legacy value classes.
+    await expect(page.locator(".dm-evv-row-val.v-ev-pow")).toHaveText("7.4 kW");
+    await expect(page.locator(".dm-evv-row-val.v-ev-remain")).toHaveText("1h 25m");
+  });
+
+  test("the page follows the colour of the active EVCC mode", async ({ page }, testInfo) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+
+    for (const mode of ["off", "pv", "minpv", "now"]) {
+      await openEvPage(page, { mode });
+      await expect(page.locator("#page-ev")).toHaveAttribute("data-dm-ev-mode", mode);
+    }
+
+    // With no mode marked the page falls back to the neutral colour instead of
+    // keeping the last one.
+    await page.evaluate(() => {
+      document.querySelectorAll(".evcc-mode-btn").forEach((btn) => btn.classList.remove("active"));
+      window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: {} }));
+    });
+    await expect(page.locator("#page-ev")).toHaveAttribute("data-dm-ev-mode", "");
+  });
+
+  test("the vehicle picker keeps switching profiles", async ({ page }, testInfo) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+    await openEvPage(page, { mode: "pv" });
+
+    const cards = page.locator(".dm-vehicle-profile-card");
+    await expect(cards).toHaveCount(2);
+    await expect(cards.first()).toHaveClass(/active/);
+    await cards.nth(1).click();
+    await expect(cards.nth(1)).toHaveClass(/active/);
+    await expect(cards.first()).not.toHaveClass(/active/);
+  });
+
+  test("re-rendering never duplicates the cards it mounts", async ({ page }, testInfo) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+    await openEvPage(page, { mode: "pv" });
+    for (let pass = 0; pass < 4; pass += 1) await openEvPage(page, { mode: "pv" });
+
+    await expect(page.locator(".dm-evv-power")).toHaveCount(1);
+    await expect(page.locator(".dm-evv-row")).toHaveCount(3);
+    await expect(page.locator("#m-btn-pv .dm-evv-fx")).toHaveCount(1);
+    // The page must never scroll sideways on a phone.
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth + 1,
+    );
+    expect(overflow).toBe(true);
+  });
+});

--- a/custom_components/dashboardmodern/frontend/e2e/temperature-card-labels.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/temperature-card-labels.spec.js
@@ -1,0 +1,138 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+/* The small label above the reading used to have three writers: the renderers
+ * wrote the generic word at creation, the Beta 17 repair pass wrote the room's
+ * custom name on every card of that room, and the Beta 27 sync wrote it per
+ * association. They disagreed, so the label flipped between "Temperatura" and
+ * the custom name on every repaint — and a real install repaints on every
+ * sensor update. This pins one value per association, across repaints. */
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [
+      {
+        id: "room-cameretta",
+        name: "Cameretta",
+        icon: "🛏️",
+        temp: "sensor.cameretta_temperature",
+        hum: "sensor.cameretta_humidity",
+        temp_name: "Cameretta",
+        metadata: {
+          temperature_entries: [
+            {
+              id: "temperature-extra-1",
+              name: "Seconda sonda",
+              temp: "sensor.cameretta_seconda_temperature",
+            },
+          ],
+        },
+      },
+      {
+        id: "room-matrimoniale",
+        name: "Matrimoniale",
+        icon: "🛏️",
+        temp: "sensor.matrimoniale_temperature",
+        temp_name: "Pippo",
+      },
+    ],
+  },
+  visibility: { temp: true },
+};
+
+const states = [
+  {
+    entity_id: "sensor.cameretta_temperature",
+    state: "31.4",
+    attributes: { unit_of_measurement: "°C", device_class: "temperature" },
+  },
+  {
+    entity_id: "sensor.cameretta_humidity",
+    state: "54",
+    attributes: { unit_of_measurement: "%", device_class: "humidity" },
+  },
+  {
+    entity_id: "sensor.matrimoniale_temperature",
+    state: "30.8",
+    attributes: { unit_of_measurement: "°C", device_class: "temperature" },
+  },
+];
+
+test("the label above each reading never changes on its own", async ({ page }, testInfo) => {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript((haStates) => {
+    window.WebSocket = class extends EventTarget {
+      static OPEN = 1;
+      readyState = 1;
+      constructor() {
+        super();
+        queueMicrotask(() => this.onmessage?.({ data: JSON.stringify({ type: "auth_required" }) }));
+      }
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") {
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+        } else {
+          this.onmessage?.({
+            data: JSON.stringify({
+              id: message.id,
+              type: "result",
+              success: true,
+              result: message.type === "get_states" ? haStates : [],
+            }),
+          });
+        }
+      }
+      close() {}
+    };
+  }, states);
+
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+  await page
+    .locator("#setup-wizard")
+    .evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await page.evaluate((haStates) => {
+    haStates.forEach((state) => {
+      _RAW_STATES[state.entity_id] = state;
+      STATES[state.entity_id] = state;
+    });
+    document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
+    document.getElementById("page-temp")?.classList.add("active");
+    window.render?.();
+    window.buildTempCards?.();
+  }, states);
+  await expect(page.locator("#temp-grid .temp-card").first()).toBeVisible();
+
+  // Sample every association while forcing the repaints a live install produces.
+  const seen = await page.evaluate(async () => {
+    const values = {};
+    for (let round = 0; round < 100; round += 1) {
+      for (const card of document.querySelectorAll("#temp-grid .temp-card[data-room-id]")) {
+        const key = `${card.dataset.roomId}::${card.dataset.temperatureId || "primary"}`;
+        const label = card.querySelector(".cp-temp-current-lbl")?.textContent || "";
+        values[key] = values[key] || [];
+        if (!values[key].includes(label)) values[key].push(label);
+      }
+      if (round % 8 === 0) {
+        window.dispatchEvent(
+          new CustomEvent("dashboardmodern:state-changed", {
+            detail: { entity_ids: ["sensor.cameretta_temperature"] },
+          }),
+        );
+        window.buildTempCards?.();
+        window.renderTemperature?.();
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    return values;
+  });
+
+  // The first association carries the room's custom name, an extra probe its
+  // own, and each one keeps exactly that value for the whole session.
+  expect(seen).toEqual({
+    "room-cameretta::primary": ["Cameretta"],
+    "room-cameretta::temperature-extra-1": ["Seconda sonda"],
+    "room-matrimoniale::primary": ["Pippo"],
+  });
+});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.7","dashboardVersion":"1.0.0-beta.30.7","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T18:41:56+00:00","commit":"58bfd478336c32d8e8dfc0efd802fc4e346674f7","assetHash":"a2b8872878d55fdb"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.7","dashboardVersion":"1.0.0-beta.30.7","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T21:53:28+00:00","commit":"869d9875795375940a5ebcf52f79c0bfc1aa80ab","assetHash":"d2d5f1c3c66bac16"});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.6","dashboardVersion":"1.0.0-beta.30.6","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T15:02:56+00:00","commit":"3cc618cd97897f5fef23fa2ac7fd039218bdb6f7","assetHash":"759214facdac4007"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.7","dashboardVersion":"1.0.0-beta.30.7","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T18:41:56+00:00","commit":"58bfd478336c32d8e8dfc0efd802fc4e346674f7","assetHash":"a2b8872878d55fdb"});

--- a/custom_components/dashboardmodern/frontend/src/core/entity-search-index.js
+++ b/custom_components/dashboardmodern/frontend/src/core/entity-search-index.js
@@ -1,0 +1,791 @@
+/* Entity search that stays instant on a real Home Assistant instance.
+ *
+ * The picker used to rescan the whole entity list on every keystroke, and every
+ * scan rebuilt the same throwaway strings: two `toLowerCase()` calls and one
+ * concatenation per entity, per character typed. On an installation with a few
+ * thousand entities that is tens of thousands of allocations for a single
+ * letter, and it showed on a phone as the keyboard running ahead of the list.
+ *
+ * The fix is to pay that cost once. `buildEntityIndex` folds every id, name and
+ * area to a comparable form, tokenizes it, and keeps the result until the
+ * entity list itself changes. A search then does one `indexOf` per term over
+ * strings that already exist, keeps only the best `limit` rows through a bounded
+ * insertion instead of sorting every match, and — because extending a query can
+ * only ever shrink its result set — rescans just the previous matches when the
+ * user adds a character. Typing therefore gets cheaper the longer the query.
+ *
+ * The second half is the auto-detection. The field that opened the picker knows
+ * a lot about what belongs in it: its slot reference carries a domain, its
+ * placeholder and label carry words like "temperatura" or "kWh". `fieldHints`
+ * turns that into expected domains, device classes and units, and the scorer
+ * pushes the entities that satisfy them to the top — with an empty query too,
+ * so opening the picker already proposes the right entity instead of the
+ * alphabetically first one.
+ *
+ * Pure: no DOM, no storage, no globals. The section around it owns rendering.
+ */
+
+export const DEFAULT_LIMIT = 60;
+
+const NON_ASCII = /[^\u0000-\u007f]/;
+const COMBINING = /[\u0300-\u036f]/g;
+const SPLIT = /[^a-z0-9]+/;
+const UNAVAILABLE = new Set(["unavailable", "unknown", "none", ""]);
+
+/** Lowercase and strip accents, so "città" and "citta" are the same needle. */
+export function foldText(value) {
+  const text = String(value ?? "").toLowerCase();
+  if (!NON_ASCII.test(text)) return text;
+  return text.normalize("NFD").replace(COMBINING, "");
+}
+
+export function tokenize(folded) {
+  return String(folded ?? "")
+    .split(SPLIT)
+    .filter((token) => token.length > 0);
+}
+
+function initialsOf(tokens) {
+  let initials = "";
+  for (const token of tokens) initials += token[0];
+  return initials;
+}
+
+/* Accepts both shapes the runtime has: the wizard metadata
+ * ({id, name, dc, unit, sc, area, state}) and a raw Home Assistant state
+ * object, so the index can be built from whichever list is warm first. */
+export function normalizeEntry(raw) {
+  if (!raw) return null;
+  const id = String(raw.id || raw.entity_id || "").trim();
+  if (!id || !id.includes(".")) return null;
+  const attributes = raw.attributes || {};
+  const dot = id.indexOf(".");
+  const domain = id.slice(0, dot);
+  const object = id.slice(dot + 1);
+  const name = String(raw.name || attributes.friendly_name || id).trim() || id;
+  const area = String(raw.area || attributes.area || "").trim();
+  const idFold = foldText(id);
+  const nameFold = foldText(name);
+  const areaFold = area ? foldText(area) : "";
+  const hay = `${idFold} ${nameFold} ${areaFold}`;
+  const tokens = tokenize(hay);
+  const state = String(raw.state ?? "");
+  /* Both parts of the constant penalty are query-independent: an entity that is
+   * currently unavailable is rarely the one being configured, and between two
+   * equally good matches the shorter id is the more specific one. */
+  const penalty = (UNAVAILABLE.has(state.toLowerCase()) ? -80 : 0) - Math.min(id.length, 80) * 0.25;
+  return {
+    id,
+    name,
+    domain,
+    object,
+    dc: String(raw.dc || attributes.device_class || "").toLowerCase(),
+    unit: String(raw.unit || attributes.unit_of_measurement || ""),
+    sc: String(raw.sc || attributes.state_class || "").toLowerCase(),
+    area,
+    state,
+    penalty,
+    idFold,
+    objectFold: foldText(object),
+    nameFold,
+    areaFold,
+    unitFold: foldText(raw.unit || attributes.unit_of_measurement || ""),
+    hay,
+    tokens,
+    initials: initialsOf(tokenize(nameFold)),
+  };
+}
+
+const INDEX_CACHE = new WeakMap();
+
+function signatureOf(entries) {
+  const first = entries[0];
+  const last = entries[entries.length - 1];
+  const firstId = first ? first.id || first.entity_id : "";
+  const lastId = last ? last.id || last.entity_id : "";
+  return `${entries.length}|${firstId}|${lastId}`;
+}
+
+/**
+ * Build (or reuse) the searchable index for an entity list.
+ *
+ * `enrich` may return extra metadata for an id — device class, unit, area —
+ * when the warm list only carries ids and names. It is consulted once per
+ * entity at build time, never during a search.
+ */
+export function buildEntityIndex(entries, { enrich = null, version = "" } = {}) {
+  const list = Array.isArray(entries) ? entries : [];
+  const signature = `${signatureOf(list)}|${version}`;
+  const cached = INDEX_CACHE.get(list);
+  if (cached && cached.signature === signature) return cached;
+
+  const records = [];
+  const domains = new Map();
+  const domainList = [];
+  for (const entry of list) {
+    const extra = enrich ? enrich(entry?.id || entry?.entity_id, entry) : null;
+    const record = normalizeEntry(extra ? { ...entry, ...extra } : entry);
+    if (!record) continue;
+    let slot = domains.get(record.domain);
+    if (slot === undefined) {
+      slot = domainList.length;
+      domainList.push({ domain: record.domain, count: 0 });
+      domains.set(record.domain, slot);
+    }
+    domainList[slot].count += 1;
+    /* Counting the domains of a match set is a per-keystroke pass, so a record
+     * carries the slot its domain occupies and the count becomes an integer
+     * increment instead of a hash lookup. */
+    record.domainSlot = slot;
+    records.push(record);
+  }
+  const index = {
+    records,
+    size: records.length,
+    domainList,
+    domainSlots: domains,
+    signature,
+    buffer: new Int32Array(records.length),
+    counts: new Int32Array(domainList.length),
+  };
+  INDEX_CACHE.set(list, index);
+  return index;
+}
+
+/* ── Query planning ───────────────────────────────────────────────────────── */
+
+export function parseQuery(query) {
+  const folded = foldText(query).trim().replace(/\s+/g, " ");
+  const terms = folded ? folded.split(" ").filter(Boolean) : [];
+  return { folded, terms, empty: terms.length === 0 };
+}
+
+export function createSearchSession() {
+  return { signature: "", query: "", matches: null, count: 0, poolA: null, poolB: null };
+}
+
+/* Two buffers, used alternately: a pass reads the previous match list while it
+ * writes the next one, and neither is reallocated between keystrokes. */
+function nextBuffer(session, size) {
+  if (!session.poolA || session.poolA.length < size) {
+    session.poolA = new Int32Array(size);
+    session.poolB = new Int32Array(size);
+  }
+  return session.matches === session.poolA ? session.poolB : session.poolA;
+}
+
+/* ── Field auto-detection ─────────────────────────────────────────────────── */
+
+/* Words a configuration field uses, mapped to what an entity must look like to
+ * belong in it. Kept deliberately small: every entry here has to earn its place
+ * by describing a field that actually exists in the editor. */
+const HINT_RULES = Object.freeze([
+  {
+    words: ["temperatura", "temperature", "temp", "termometro", "sonda"],
+    dc: ["temperature"],
+    units: ["°C", "°F"],
+    domains: ["sensor"],
+  },
+  { words: ["umidita", "humidity", "hum"], dc: ["humidity"], units: ["%"], domains: ["sensor"] },
+  {
+    words: ["potenza", "power", "watt", "istantanea", "istantaneo", "assorbimento"],
+    dc: ["power"],
+    units: ["W", "kW"],
+    domains: ["sensor"],
+  },
+  {
+    words: [
+      "energia",
+      "energy",
+      "kwh",
+      "consumo",
+      "consumi",
+      "produzione",
+      "prelievo",
+      "immissione",
+      "prelevata",
+      "immessa",
+      "acquistata",
+      "venduta",
+      "giornaliera",
+      "mensile",
+      "annuale",
+    ],
+    dc: ["energy"],
+    units: ["kWh", "Wh", "MWh"],
+    domains: ["sensor"],
+  },
+  {
+    words: ["batteria", "battery", "soc", "carica", "accumulo"],
+    dc: ["battery"],
+    units: ["%"],
+    domains: ["sensor"],
+  },
+  { words: ["tensione", "voltage", "volt"], dc: ["voltage"], units: ["V"], domains: ["sensor"] },
+  { words: ["corrente", "current", "ampere"], dc: ["current"], units: ["A"], domains: ["sensor"] },
+  {
+    words: ["pressione", "pressure"],
+    dc: ["pressure", "atmospheric_pressure"],
+    units: ["bar", "hPa", "psi"],
+    domains: ["sensor"],
+  },
+  {
+    words: ["illuminamento", "illuminance", "lux", "luminosita"],
+    dc: ["illuminance"],
+    units: ["lx"],
+    domains: ["sensor"],
+  },
+  {
+    words: ["pioggia", "rain", "precipitazioni"],
+    dc: ["precipitation", "precipitation_intensity"],
+    units: ["mm"],
+    domains: ["sensor"],
+  },
+  { words: ["vento", "wind"], dc: ["wind_speed"], units: ["km/h", "m/s"], domains: ["sensor"] },
+  { words: ["acqua", "water", "portata"], dc: ["water"], units: ["L", "m³"], domains: ["sensor"] },
+  { words: ["gas", "metano"], dc: ["gas"], units: ["m³"], domains: ["sensor"] },
+  {
+    words: ["prezzo", "price", "costo", "tariffa"],
+    dc: ["monetary"],
+    units: ["€", "EUR", "€/kWh"],
+    domains: ["sensor"],
+  },
+  {
+    words: ["luce", "luci", "light", "lampada", "lampadario", "faretti", "led"],
+    dc: [],
+    units: [],
+    domains: ["light"],
+  },
+  {
+    words: [
+      "clima",
+      "climate",
+      "condizionatore",
+      "termostato",
+      "termosifone",
+      "riscaldamento",
+      "hvac",
+      "split",
+    ],
+    dc: [],
+    units: [],
+    domains: ["climate"],
+  },
+  { words: ["telecamera", "camera", "videocamera", "cam"], dc: [], units: [], domains: ["camera"] },
+  {
+    words: [
+      "tapparella",
+      "tapparelle",
+      "serranda",
+      "serrande",
+      "cover",
+      "shutter",
+      "blind",
+      "tenda",
+    ],
+    dc: [],
+    units: [],
+    domains: ["cover"],
+  },
+  {
+    words: ["presa", "plug", "socket", "interruttore", "switch", "relay", "rele"],
+    dc: [],
+    units: [],
+    domains: ["switch", "input_boolean"],
+  },
+  {
+    words: ["porta", "door", "finestra", "window", "contatto", "apertura"],
+    dc: ["door", "window", "opening", "garage_door"],
+    units: [],
+    domains: ["binary_sensor"],
+  },
+  {
+    words: ["movimento", "motion", "presenza", "presence", "occupancy", "pir"],
+    dc: ["motion", "occupancy", "presence"],
+    units: [],
+    domains: ["binary_sensor"],
+  },
+  {
+    words: ["allagamento", "leak", "perdita"],
+    dc: ["moisture"],
+    units: [],
+    domains: ["binary_sensor"],
+  },
+  { words: ["fumo", "smoke"], dc: ["smoke"], units: [], domains: ["binary_sensor"] },
+  { words: ["meteo", "weather", "previsioni"], dc: [], units: [], domains: ["weather"] },
+  { words: ["scena", "scene"], dc: [], units: [], domains: ["scene"] },
+  { words: ["script", "azione"], dc: [], units: [], domains: ["script"] },
+  { words: ["automazione", "automation"], dc: [], units: [], domains: ["automation"] },
+  { words: ["allarme", "alarm", "antifurto"], dc: [], units: [], domains: ["alarm_control_panel"] },
+  {
+    words: ["pompa", "pump", "irrigazione", "irrigation", "valvola", "valve", "elettrovalvola"],
+    dc: [],
+    units: [],
+    domains: ["switch", "valve"],
+  },
+  { words: ["ventilatore", "fan", "ventola", "aspiratore"], dc: [], units: [], domains: ["fan"] },
+  {
+    words: ["serratura", "lock", "cancello", "gate", "garage"],
+    dc: ["garage", "door"],
+    units: [],
+    domains: ["lock", "cover"],
+  },
+]);
+
+const HINT_STOP = new Set([
+  "entita",
+  "entity",
+  "id",
+  "sensore",
+  "sensor",
+  "seleziona",
+  "scegli",
+  "campo",
+  "opzionale",
+  "oppure",
+  "esempio",
+  "the",
+  "and",
+  "for",
+  "del",
+  "della",
+  "delle",
+  "dei",
+  "con",
+  "per",
+  "nel",
+  "una",
+  "uno",
+  "che",
+  "lo",
+  "la",
+  "il",
+  "di",
+  "da",
+]);
+
+const KNOWN_DOMAINS = new Set([
+  "sensor",
+  "binary_sensor",
+  "switch",
+  "light",
+  "cover",
+  "climate",
+  "camera",
+  "weather",
+  "automation",
+  "script",
+  "scene",
+  "select",
+  "number",
+  "fan",
+  "lock",
+  "vacuum",
+  "media_player",
+  "water_heater",
+  "valve",
+  "button",
+  "person",
+  "device_tracker",
+  "alarm_control_panel",
+  "sun",
+  "input_boolean",
+  "input_number",
+  "input_select",
+  "input_text",
+  "input_datetime",
+  "counter",
+  "humidifier",
+]);
+
+function collectDomains(text, into) {
+  const matcher = /\b([a-z_]+)\./g;
+  let match;
+  while ((match = matcher.exec(text))) {
+    if (KNOWN_DOMAINS.has(match[1])) into.add(match[1]);
+  }
+}
+
+/**
+ * Read what a configuration field expects from the way it is described.
+ *
+ * `descriptor` collects everything the DOM already knows about the field: its
+ * slot reference, id, placeholder, visible label, current value and any
+ * `data-domain`. Nothing here touches the DOM — the caller gathers the strings.
+ */
+export function fieldHints(descriptor = {}) {
+  const ref = String(descriptor.ref || "").trim();
+  const value = String(descriptor.value || "").trim();
+  const domains = new Set();
+  const deviceClasses = new Set();
+  const units = new Set();
+  const keywords = [];
+
+  for (const domain of String(descriptor.domain || "").split(/[,\s]+/)) {
+    if (KNOWN_DOMAINS.has(domain)) domains.add(domain);
+  }
+  const text = foldText(
+    [ref, descriptor.id, descriptor.placeholder, descriptor.label, value].filter(Boolean).join(" "),
+  );
+  collectDomains(text, domains);
+
+  const unitMatch = /\((w|kw|wh|kwh|mwh|v|a|%|°c|°f|bar|lx|mm|m3|km\/h|m\/s)\)/i.exec(text);
+  if (unitMatch) {
+    const unit = unitMatch[1].toLowerCase();
+    const canonical = {
+      w: "W",
+      kw: "kW",
+      wh: "Wh",
+      kwh: "kWh",
+      mwh: "MWh",
+      v: "V",
+      a: "A",
+      "%": "%",
+      "°c": "°C",
+      "°f": "°F",
+      bar: "bar",
+      lx: "lx",
+      mm: "mm",
+      m3: "m³",
+      "km/h": "km/h",
+      "m/s": "m/s",
+    }[unit];
+    if (canonical) units.add(canonical);
+  }
+
+  const words = tokenize(text).filter(
+    (word) => word.length >= 3 && !HINT_STOP.has(word) && !KNOWN_DOMAINS.has(word),
+  );
+  for (const rule of HINT_RULES) {
+    if (
+      !rule.words.some((word) =>
+        words.some(
+          (candidate) => candidate === word || (word.length >= 4 && candidate.startsWith(word)),
+        ),
+      )
+    )
+      continue;
+    for (const domain of rule.domains) domains.add(domain);
+    for (const dc of rule.dc) deviceClasses.add(dc);
+    for (const unit of rule.units) units.add(unit);
+  }
+  for (const word of words) {
+    if (keywords.length >= 6) break;
+    if (!keywords.includes(word)) keywords.push(word);
+  }
+
+  const area = foldText(descriptor.area || "");
+  return {
+    domains,
+    deviceClasses,
+    units,
+    keywords,
+    area,
+    current: value.includes(".") ? value : "",
+    empty:
+      domains.size === 0 && deviceClasses.size === 0 && units.size === 0 && keywords.length === 0,
+  };
+}
+
+/* ── Scoring ──────────────────────────────────────────────────────────────── */
+
+/* `strong` is what earns the suggested badge: belonging to the expected domain
+ * is a weak signal on its own — most of an instance is `sensor.` — while the
+ * device class, the unit, the area or one of the field's own words is evidence
+ * that this entity is the one the field is asking for. */
+function hintDetail(record, hints) {
+  if (!hints || hints.empty) return { score: 0, strong: false };
+  let score = 0;
+  let strong = false;
+  if (hints.domains.size) score += hints.domains.has(record.domain) ? 150 : -35;
+  if (hints.deviceClasses.size && record.dc && hints.deviceClasses.has(record.dc)) {
+    score += 110;
+    strong = true;
+  }
+  if (hints.units.size && record.unit) {
+    if (hints.units.has(record.unit)) {
+      score += 70;
+      strong = true;
+    } else score -= 20;
+  }
+  if (hints.area && record.areaFold && record.areaFold === hints.area) {
+    score += 45;
+    strong = true;
+  }
+  let matched = 0;
+  for (const keyword of hints.keywords) {
+    if (matched >= 3) break;
+    for (const token of record.tokens) {
+      if (token === keyword || (keyword.length >= 4 && token.startsWith(keyword))) {
+        score += 28;
+        matched += 1;
+        strong = true;
+        break;
+      }
+    }
+  }
+  /* A field that knows its domain cannot be satisfied by another one: a light
+   * whose name happens to contain the room word is not a temperature sensor,
+   * and badging it as suggested would make the badge mean nothing. */
+  if (strong && hints.domains.size && !hints.domains.has(record.domain)) strong = false;
+  return { score, strong };
+}
+
+function hintScore(record, hints) {
+  return hintDetail(record, hints).score;
+}
+
+/* The first thing a term does is reject, thousands of times per keystroke, so
+ * rejection has to cost exactly one `indexOf` over a string that already
+ * exists. Only a record that survives it pays for the ranking detail below. */
+function termScore(record, term) {
+  if (record.hay.indexOf(term) < 0) {
+    return term.length >= 2 && record.initials.indexOf(term) >= 0 ? 18 : -1;
+  }
+  if (record.idFold.startsWith(term)) return 100;
+  if (record.objectFold.startsWith(term)) return 92;
+  if (record.nameFold.startsWith(term)) return 88;
+  for (const token of record.tokens) {
+    if (token.startsWith(term)) return 70;
+  }
+  const inId = record.idFold.indexOf(term) >= 0;
+  if (inId) return 40;
+  if (record.nameFold.indexOf(term) >= 0) return 34;
+  if (record.areaFold && record.areaFold.indexOf(term) >= 0) return 26;
+  if (term.length >= 2 && record.initials.indexOf(term) >= 0) return 18;
+  return -1;
+}
+
+/**
+ * Score one record against a parsed query, ignoring the field hints. Returns
+ * `-Infinity` when a term does not match at all: matching and ranking are the
+ * same single pass over the record's precomputed strings.
+ */
+export function queryScore(record, plan) {
+  let score = record.penalty;
+  for (const term of plan.terms) {
+    const value = termScore(record, term);
+    if (value < 0) return -Infinity;
+    score += value;
+  }
+  if (plan.terms.length > 1 && record.idFold.indexOf(plan.folded) >= 0) score += 30;
+  if (plan.folded && record.idFold === plan.folded) score += 400;
+  return score;
+}
+
+/** Full score, hints included. The hot loop uses the precomputed hint table. */
+export function scoreRecord(record, plan, hints = null) {
+  const base = queryScore(record, plan);
+  if (base === -Infinity) return base;
+  return (
+    base +
+    hintDetail(record, hints).score +
+    (hints?.current && record.id === hints.current ? 220 : 0)
+  );
+}
+
+/* The hint part of a score does not depend on the query, so it is computed once
+ * per (index, field) pair when the picker opens and read back as an array
+ * lookup while the user types. Without this, every keystroke would re-walk the
+ * field's keywords against every entity's tokens. */
+const HINT_TABLES = new WeakMap();
+
+export function prepareHints(index, hints) {
+  if (!index || !hints || hints.empty) return null;
+  let perIndex = HINT_TABLES.get(hints);
+  if (!perIndex) {
+    perIndex = new WeakMap();
+    HINT_TABLES.set(hints, perIndex);
+  }
+  const cached = perIndex.get(index);
+  if (cached && cached.signature === index.signature) return cached;
+  const scores = new Float32Array(index.size);
+  const strong = new Uint8Array(index.size);
+  for (let position = 0; position < index.size; position += 1) {
+    const record = index.records[position];
+    const detail = hintDetail(record, hints);
+    scores[position] = detail.score + (hints.current && record.id === hints.current ? 220 : 0);
+    strong[position] = detail.strong ? 1 : 0;
+  }
+  const table = { scores, strong, signature: index.signature };
+  perIndex.set(index, table);
+  return table;
+}
+
+/* Bounded top-K: keeping only `limit` rows costs one comparison per match in
+ * the common case, where sorting every match costs an allocation per match and
+ * an O(n log n) pass. With 4000 matching entities and 60 visible rows that is
+ * the difference between a visible hitch and nothing at all. */
+function pushTop(top, limit, entry) {
+  const full = top.length >= limit;
+  /* The comparison is the full ranking, not the score alone: a page boundary
+   * that fell inside a group of equal scores would otherwise be resolved by
+   * scan order, and the next page — ranked over a different cut — would repeat
+   * some rows and lose others. */
+  if (full && byRank(entry, top[limit - 1]) >= 0) return;
+  let position = full ? limit - 1 : top.length;
+  if (!full) top.push(entry);
+  while (position > 0 && byRank(entry, top[position - 1]) < 0) {
+    top[position] = top[position - 1];
+    position -= 1;
+  }
+  top[position] = entry;
+}
+
+/* Ties are broken by shorter id then alphabetically, so the same query always
+ * produces the same order — a picker that reshuffles under the finger is worse
+ * than a slow one. */
+function byRank(left, right) {
+  return (
+    right.score - left.score ||
+    left.record.id.length - right.record.id.length ||
+    (left.record.id < right.record.id ? -1 : left.record.id > right.record.id ? 1 : 0)
+  );
+}
+
+/* The badge itself is only needed on the rows that are actually drawn, so this
+ * runs on the page; the match set's own count comes from the hint table. */
+function annotateHints(rows, hints, table = null) {
+  let hinted = 0;
+  const active = Boolean(hints && !hints.empty);
+  for (const row of rows) {
+    row.hinted =
+      active &&
+      (table && row.position !== undefined
+        ? table.strong[row.position] === 1
+        : hintDetail(row.record, hints).strong);
+    if (row.hinted) hinted += 1;
+  }
+  return hinted;
+}
+
+/**
+ * Search the index.
+ *
+ * `session` (from `createSearchSession`) makes consecutive keystrokes cheap:
+ * extending a query can only shrink its match set, so the next pass rescans the
+ * previous matches instead of the whole instance. `scanned` reports how many
+ * records the pass actually looked at.
+ */
+export function searchEntityIndex(index, query, options = {}) {
+  const {
+    limit = DEFAULT_LIMIT,
+    domain = "",
+    hints = null,
+    session = null,
+    withDomains = false,
+    hintedOnly = false,
+  } = options;
+  const records = index?.records || [];
+  const plan = parseQuery(query);
+  const total = records.length;
+
+  const reusable =
+    session &&
+    session.matches &&
+    session.signature === index.signature &&
+    session.query &&
+    plan.folded.startsWith(session.query);
+  const source = reusable ? session.matches : null;
+  const sourceCount = reusable ? session.count : total;
+
+  if (!index.buffer || index.buffer.length < total) index.buffer = new Int32Array(total);
+  const nextMatches = session ? nextBuffer(session, total) : index.buffer;
+  const hintTable = prepareHints(index, hints);
+  const hintScores = hintTable?.scores || null;
+  const top = [];
+  let matched = 0;
+  let visible = 0;
+  let hinted = 0;
+
+  for (let cursor = 0; cursor < sourceCount; cursor += 1) {
+    const position = source ? source[cursor] : cursor;
+    const record = records[position];
+    const base = queryScore(record, plan);
+    if (base === -Infinity) continue;
+    nextMatches[matched] = position;
+    matched += 1;
+    const strong = hintTable ? hintTable.strong[position] === 1 : false;
+    if (strong) hinted += 1;
+    if (domain && record.domain !== domain) continue;
+    /* `matched` stays the full text match set even when a filter is on: it is
+     * what the next keystroke narrows from, and dropping rows here would make
+     * the filter permanent. */
+    if (hintedOnly && !strong) continue;
+    visible += 1;
+    pushTop(top, limit, {
+      record,
+      score: hintScores ? base + hintScores[position] : base,
+      position,
+    });
+  }
+
+  if (session) {
+    session.matches = nextMatches;
+    session.count = matched;
+    session.query = plan.folded;
+    session.signature = index.signature;
+  }
+
+  top.sort(byRank);
+  annotateHints(top, hints, hintTable);
+
+  let domainCounts = null;
+  if (withDomains) {
+    const counts = index.counts;
+    counts.fill(0);
+    for (let cursor = 0; cursor < matched; cursor += 1)
+      counts[records[nextMatches[cursor]].domainSlot] += 1;
+    domainCounts = new Map();
+    for (let slot = 0; slot < index.domainList.length; slot += 1) {
+      if (counts[slot] > 0) domainCounts.set(index.domainList[slot].domain, counts[slot]);
+    }
+  }
+
+  return {
+    rows: top,
+    matched,
+    filtered: visible,
+    hinted,
+    scanned: sourceCount,
+    total,
+    truncated: matched > top.length,
+    domains: domainCounts,
+    plan,
+  };
+}
+
+/**
+ * Rows for a match set beyond the first page, used by the picker when the user
+ * scrolls. The ordering matches `searchEntityIndex`, so paging never repeats or
+ * skips a row.
+ */
+export function rankMatches(
+  index,
+  session,
+  {
+    offset = 0,
+    limit = DEFAULT_LIMIT,
+    domain = "",
+    hints = null,
+    query = "",
+    hintedOnly = false,
+  } = {},
+) {
+  const plan = parseQuery(query);
+  const wanted = offset + limit;
+  const table = prepareHints(index, hints);
+  const top = [];
+  for (let cursor = 0; cursor < session.count; cursor += 1) {
+    const position = session.matches[cursor];
+    const record = index.records[position];
+    if (domain && record.domain !== domain) continue;
+    if (hintedOnly && table?.strong[position] !== 1) continue;
+    const base = queryScore(record, plan);
+    pushTop(top, wanted, { record, position, score: table ? base + table.scores[position] : base });
+  }
+  top.sort(byRank);
+  const page = top.slice(offset, wanted);
+  annotateHints(page, hints, table);
+  return page;
+}

--- a/custom_components/dashboardmodern/frontend/src/core/personalization-catalog.js
+++ b/custom_components/dashboardmodern/frontend/src/core/personalization-catalog.js
@@ -555,6 +555,190 @@ export function actionVisual(value, size = 48) {
   return `<span class="dm-action-glyph" data-visual="${item.id}" style="font-size:${safeSize}px"><span aria-hidden="true">${item.glyph || "⭐"}</span></span>`;
 }
 
+/* What can actually draw power in a home. The action catalogue was the wrong
+ * list to offer here: it is built around what a button on the dashboard *does*
+ * — a scene, a script, an alert, the alarm, a camera — and none of those is a
+ * load. This one is built around what consumes: the appliances and plants
+ * themselves, and the areas a load is measured in, because a circle is just as
+ * often "the kitchen" as it is "the oven".
+ *
+ * Every entry keeps a distinct `mdi`, so the same icon is never offered twice;
+ * `LOAD_ROOM_SKIP` drops the areas whose icon is already an appliance here. */
+const LOAD_APPLIANCE_DEFINITIONS = [
+  ["power", "Energia", "Power", "mdi:flash", "⚡", "consumo generale casa totale"],
+  ["socket", "Presa", "Socket", "mdi:power-socket-eu", "🔌", "presa spina generica"],
+  ["light", "Illuminazione", "Lighting", "mdi:lightbulb", "💡", "luce luci lampada"],
+  ["lights-group", "Gruppo luci", "Light group", "mdi:lightbulb-group", "🪔", "luci gruppo"],
+  ["boiler", "Boiler", "Boiler", "mdi:water-boiler", "♨️", "scaldabagno acqua calda resistenza"],
+  ["heat-pump", "Pompa di calore", "Heat pump", "mdi:heat-pump", "🌡️", "pompa calore termica"],
+  [
+    "air-conditioner",
+    "Condizionatore",
+    "Air conditioner",
+    "mdi:air-conditioner",
+    "❄️",
+    "clima split freddo",
+  ],
+  ["radiator", "Riscaldamento", "Heating", "mdi:radiator", "🔥", "termosifone calorifero caldo"],
+  [
+    "floor-heating",
+    "Riscaldamento a pavimento",
+    "Underfloor heating",
+    "mdi:heating-coil",
+    "🌡️",
+    "pavimento radiante",
+  ],
+  [
+    "fireplace",
+    "Stufa a pellet",
+    "Pellet stove",
+    "mdi:fireplace",
+    "🪵",
+    "stufa camino pellet legna",
+  ],
+  ["oven", "Forno", "Oven", "mdi:toaster-oven", "🍕", "forno cottura"],
+  ["hob", "Piano cottura", "Hob", "mdi:countertop", "🍳", "fornelli induzione piastra"],
+  ["hood", "Cappa", "Cooker hood", "mdi:air-filter", "💨", "cappa aspirazione cucina"],
+  ["microwave", "Microonde", "Microwave", "mdi:microwave", "🍲", "microonde forno"],
+  ["fridge", "Frigorifero", "Fridge", "mdi:fridge", "🧊", "frigo frigorifero"],
+  [
+    "freezer",
+    "Congelatore",
+    "Freezer",
+    "mdi:snowflake-variant",
+    "🥶",
+    "freezer congelatore surgelati",
+  ],
+  ["dishwasher", "Lavastoviglie", "Dishwasher", "mdi:dishwasher", "🍽️", "lavastoviglie piatti"],
+  [
+    "washer",
+    "Lavatrice",
+    "Washing machine",
+    "mdi:washing-machine",
+    "🧺",
+    "lavatrice bucato lavaggio",
+  ],
+  [
+    "dryer",
+    "Asciugatrice",
+    "Tumble dryer",
+    "mdi:tumble-dryer",
+    "👕",
+    "asciugatrice asciugabiancheria",
+  ],
+  ["iron", "Ferro da stiro", "Iron", "mdi:iron", "👔", "ferro stiro stireria"],
+  ["coffee", "Macchina caffè", "Coffee machine", "mdi:coffee-maker", "☕", "caffe espresso"],
+  ["kettle", "Bollitore", "Kettle", "mdi:kettle", "🫖", "bollitore te acqua"],
+  ["grill", "Barbecue", "Grill", "mdi:grill", "🍖", "barbecue griglia bbq"],
+  ["vacuum", "Aspirapolvere", "Vacuum", "mdi:robot-vacuum", "🤖", "aspirapolvere robot pulizia"],
+  ["fan", "Ventilatore", "Fan", "mdi:fan", "🌀", "ventilatore ventola aria"],
+  [
+    "dehumidifier",
+    "Deumidificatore",
+    "Dehumidifier",
+    "mdi:air-humidifier",
+    "🌫️",
+    "deumidificatore umidita umidificatore",
+  ],
+  ["hairdryer", "Asciugacapelli", "Hair dryer", "mdi:hair-dryer", "💇", "phon asciugacapelli"],
+  ["tv", "TV", "TV", "mdi:television", "📺", "televisore tv salotto"],
+  ["computer", "Computer", "Computer", "mdi:desktop-tower-monitor", "💻", "pc computer postazione"],
+  ["server", "Server / NAS", "Server / NAS", "mdi:server", "🖥️", "server nas rack homelab"],
+  ["router", "Rete e router", "Network", "mdi:router-wireless", "📶", "router modem rete wifi"],
+  ["printer", "Stampante", "Printer", "mdi:printer", "🖨️", "stampante stampa"],
+  [
+    "ev",
+    "Auto elettrica",
+    "Electric car",
+    "mdi:car-electric",
+    "🚗",
+    "auto macchina veicolo elettrica",
+  ],
+  [
+    "wallbox",
+    "Colonnina di ricarica",
+    "Charging station",
+    "mdi:ev-station",
+    "⛽",
+    "wallbox colonnina ricarica",
+  ],
+  ["solar", "Fotovoltaico", "Solar", "mdi:solar-power", "☀️", "solare fotovoltaico pannelli"],
+  ["battery", "Batteria", "Battery", "mdi:battery-charging", "🔋", "batteria accumulo"],
+  ["pump", "Pompa", "Pump", "mdi:pump", "💧", "pompa autoclave rilancio"],
+  ["water", "Acqua", "Water", "mdi:water", "🚰", "acqua idrico"],
+  [
+    "irrigation",
+    "Irrigazione",
+    "Irrigation",
+    "mdi:sprinkler-variant",
+    "🌱",
+    "irrigazione giardino annaffiare",
+  ],
+  [
+    "sauna",
+    "Sauna e idromassaggio",
+    "Sauna and hot tub",
+    "mdi:hot-tub",
+    "🧖",
+    "sauna idromassaggio jacuzzi",
+  ],
+  ["gate", "Cancello", "Gate", "mdi:gate", "🚪", "cancello portone motore"],
+  [
+    "shutters",
+    "Tapparelle",
+    "Shutters",
+    "mdi:window-shutter",
+    "🪟",
+    "tapparelle serrande persiane",
+  ],
+  ["lift", "Ascensore", "Lift", "mdi:elevator", "🛗", "ascensore montacarichi"],
+];
+
+// Areas whose icon is an appliance offered above: the appliance wins, so the
+// same tile is never drawn twice.
+const LOAD_ROOM_SKIP = Object.freeze(new Set(["laundry"]));
+
+export const LOAD_ICON_CATALOG = Object.freeze([
+  ...ROOM_CATALOG.filter((item) => !LOAD_ROOM_SKIP.has(item.id)).map((item) =>
+    Object.freeze({
+      id: `room-${item.id}`,
+      it: item.it,
+      en: item.en,
+      mdi: item.mdi,
+      glyph: ROOM_GLYPHS[item.id] || "🏠",
+      group: "room",
+      keywords: item.keywords,
+    }),
+  ),
+  ...LOAD_APPLIANCE_DEFINITIONS.map(([id, it, en, mdi, glyph, keywords]) =>
+    Object.freeze({ id, it, en, mdi, glyph, group: "appliance", keywords }),
+  ),
+]);
+
+export function loadCatalogMatch(value) {
+  const token = normalized(value).replace(/^mdi:/, "").replace(/[-_]+/g, " ");
+  if (!token) return null;
+  return (
+    LOAD_ICON_CATALOG.find(
+      (item) =>
+        normalized(item.id) === token ||
+        normalized(item.mdi).replace(/^mdi:/, "").replace(/[-_]+/g, " ") === token ||
+        normalized(item.it) === token ||
+        normalized(item.en) === token,
+    ) || null
+  );
+}
+
+export function loadGlyph(value) {
+  const token = clean(value);
+  // An unset icon is a plug, like every other default in the loads model — not
+  // the first entry of the action catalogue, which is a house.
+  if (!token) return "🔌";
+  const direct = directEmoji(token);
+  if (direct) return direct;
+  return loadCatalogMatch(token)?.glyph || actionCatalogMatch(token)?.glyph || "🔌";
+}
+
 export function roomOptionsMarkup({ selected = "", english = false } = {}) {
   return ROOM_CATALOG.map(
     (item) =>

--- a/custom_components/dashboardmodern/frontend/src/sections/beta17-final-icon-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta17-final-icon-polish-section.js
@@ -264,32 +264,13 @@ function repairTemperatureEditor() {
   return ensureTemperatureNameFields(form);
 }
 
-function repairTemperatureDashboardLabels() {
-  const grid = doc?.getElementById("temp-grid");
-  if (!grid) return false;
-  let repaired = false;
-  grid.querySelectorAll(".temp-card[data-room-id]").forEach((card) => {
-    const room = temperatureRoom(card.dataset.roomId);
-    if (!room) return;
-    const temp = card.querySelector(".cp-temp-current-lbl");
-    const hum = card.querySelector(".cp-temp-target .lbl");
-    if (temp) {
-      temp.textContent = temperatureLabel(room);
-      temp.title = temperatureLabel(room);
-    }
-    if (hum) {
-      hum.textContent = `💧 ${humidityLabel(room)}`;
-      hum.title = humidityLabel(room);
-    }
-    card.dataset.dmBeta20TemperatureEntityLabels = "true";
-    repaired = true;
-  });
-  return repaired;
-}
+/* The dashboard labels are written by the layer that renders the cards, from
+ * temperatureCardLabels() in shared.js. This pass used to rewrite them every
+ * frame with the room's name — on every card of the room, extra probes
+ * included — so the label flipped on each repaint. Editor repairs stay here. */
 
 function runTemperatureRepair() {
   repairTemperatureEditor();
-  repairTemperatureDashboardLabels();
 }
 
 function scheduleTemperatureRepair() {
@@ -458,7 +439,6 @@ function install() {
   }
   root.addEventListener?.("dashboardmodern:state-changed", () => {
     hideTemperatureProgressCopy();
-    repairTemperatureDashboardLabels();
   });
   root.addEventListener?.("click", scheduleCanonicalModalClaim, true);
   doc.addEventListener("click", scheduleTemperatureRepairFromEvent, true);

--- a/custom_components/dashboardmodern/frontend/src/sections/beta25-real-device-fixes-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta25-real-device-fixes-section.js
@@ -11,6 +11,7 @@ import {
   esc,
   root,
   section,
+  temperatureCardLabels,
 } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_BETA25_REAL_DEVICE_FIXES__";
@@ -188,14 +189,15 @@ function createTemperatureCard(record) {
   body.className = "cp-body temp-card-body";
   const current = doc.createElement("div");
   current.className = "cp-temp-current-wrap";
+  const labels = temperatureCardLabels(room, entry);
   current.append(
-    makeText("cp-temp-current-lbl", english() ? "Temperature" : "Temperatura"),
+    makeText("cp-temp-current-lbl", labels.temperature),
     makeText("cp-temp-current temp-value", "—"),
   );
   const humidity = doc.createElement("div");
   humidity.className = "cp-temp-target";
   humidity.append(
-    makeText("lbl", `💧 ${english() ? "Humidity" : "Umidità"}`),
+    makeText("lbl", `💧 ${labels.humidity}`),
     makeText("val temp-hum-val", "—%"),
   );
   humidity.addEventListener("click", (event) => {

--- a/custom_components/dashboardmodern/frontend/src/sections/beta26-real-device-stability-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta26-real-device-stability-section.js
@@ -19,6 +19,7 @@ import {
   readJson,
   root,
   section,
+  temperatureCardLabels,
   writeIconGlyph,
   writeJsonIfChanged,
 } from "./shared.js";
@@ -105,14 +106,6 @@ function rooms() {
   return Array.isArray(values) ? values : [];
 }
 
-function defaultTemperatureLabel() {
-  return english() ? "Temperature" : "Temperatura";
-}
-
-function defaultHumidityLabel() {
-  return english() ? "Humidity" : "Umidità";
-}
-
 function humidityEntity(entry = {}) {
   const explicit = clean(entry.hum);
   if (explicit) return explicit;
@@ -181,18 +174,10 @@ export function temperatureRoomTabsModel(roomValues = rooms()) {
 
 function cardLabels(card, room) {
   const associationId = clean(card?.dataset?.temperatureId);
-  const primary = !associationId || associationId === "primary";
-  if (!primary) {
-    return {
-      temperature: defaultTemperatureLabel(),
-      humidity: defaultHumidityLabel(),
-    };
-  }
-  return {
-    temperature:
-      clean(room?.temp_name || room?.temperature_name) || defaultTemperatureLabel(),
-    humidity: clean(room?.hum_name || room?.humidity_name) || defaultHumidityLabel(),
-  };
+  const entry =
+    temperatureEntries(room).find((item) => clean(item.id) === associationId) ||
+    (associationId && associationId !== "primary" ? { id: associationId } : {});
+  return temperatureCardLabels(room, entry);
 }
 
 export function installCanonicalApplianceArtworkBridge() {

--- a/custom_components/dashboardmodern/frontend/src/sections/beta9-real-device-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta9-real-device-polish-section.js
@@ -404,12 +404,9 @@ function polishShutters() {
     slat.style.setProperty("filter", "none", "important");
     slat.style.setProperty("transform", "none", "important");
   });
-  page.querySelectorAll(".tapp-btn").forEach((button) => {
-    button.style.setProperty("height", "40px", "important");
-    button.style.setProperty("min-height", "40px", "important");
-    button.style.setProperty("font-size", "12px", "important");
-    button.style.setProperty("border-radius", "12px", "important");
-  });
+  // Buttons are deliberately absent here: the shutter section skins the card
+  // controls and the "open/close everything" bar at two different sizes, and an
+  // inline rule would flatten both back to one.
   return true;
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/climate-thermal-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/climate-thermal-section.js
@@ -1,0 +1,902 @@
+// DM-FIX-20260817D
+/* Climate section redesign — the "Termica" card.
+ *
+ * Rebuilds #page-clima as one owner: a masthead with the zone readout, the
+ * Freddo/Caldo segmented control and two card grids that put target and room
+ * temperature on the same scale instead of printing two unrelated numbers.
+ *
+ * Contracts preserved on purpose — behaviour stays in the legacy runtime:
+ * - the page keeps `.clima-zone-freddo` / `.clima-zone-caldo` and the `.show`
+ *   class, plus `#clima-page-mode-freddo` / `#clima-page-mode-caldo` inside
+ *   `.clima-page-mode-switch`, so `setClimaPageMode()` and the Beta 12 switch
+ *   repair keep working untouched;
+ * - the grids keep the ids `#clima-grid-freddo` / `#clima-grid-caldo` and the
+ *   cards keep `id="card-<entity with dashes>"`, which is what every legacy
+ *   caller looks up;
+ * - the buttons call `setTemp()`, `toggleClima()` and `apriClimaPopup()`, so
+ *   the service calls, the haptics and the HVAC/fan popup are unchanged. The
+ *   card keeps its own `onclick="apriClimaPopup(...)"` so `cdAutoHide()` still
+ *   finds the entity reference and hides unmapped units;
+ * - the back arrow already in the page is moved back to the top of the section
+ *   after every skeleton rebuild.
+ *
+ * The card no longer carries the legacy `.cp-card` / `.cp-header` / `.cp-body`
+ * / `.cp-controls` / `.clima-premium-grid` class names. That is deliberate: the
+ * Beta 4 / Beta 7 / Beta 16 / personalization layers all shipped `!important`
+ * corrections for those names, so five stylesheets used to fight over one card.
+ * With the new names none of those rules match any more and the page has a
+ * single renderer and a single stylesheet, the same clean-up the Pool and
+ * Irrigation redesign did.
+ */
+import { canonicalClimateType } from "../core/device-model.js";
+import {
+  allStates,
+  clean,
+  doc,
+  english,
+  esc,
+  finiteOrNull,
+  installStyle,
+  readClimateUnits,
+  root,
+  t,
+  wrapFunction,
+} from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_CLIMATE_THERMAL__";
+const STYLE_ID = "dm-climate-thermal-style";
+const state = (root[KEY] ||= { installed: false, listeners: false, history: new Map() });
+
+/* Scale of the rail. Cooling units are set between 16° and 30°, radiators
+ * between 10° and 28°, which is the range the legacy popup already clamps to. */
+const RANGE = Object.freeze({ freddo: [16, 30], caldo: [10, 28] });
+const SPARK = Object.freeze({ width: 132, height: 42, pad: 6, samples: 24 });
+const OFF_STATES = new Set(["off", "unavailable", "unknown", "none", ""]);
+
+const ICONS = Object.freeze({
+  snow: '<svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M12 2v20M4.2 7l15.6 10M19.8 7 4.2 17"/><path d="M12 6.2 9.6 4M12 6.2 14.4 4M12 17.8 9.6 20M12 17.8l2.4 2.2"/></svg>',
+  flame:
+    '<svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" aria-hidden="true"><path d="M12 2.5c3.2 3 4.8 5.6 4.8 8a4.8 4.8 0 0 1-9.6 0c0-1.3.5-2.5 1.4-3.6.3 1.4 1 2.2 2 2.4-.4-2.4.1-4.7 1.4-6.8Z"/><path d="M6.4 13.5A6.6 6.6 0 0 0 12 21.5a6.6 6.6 0 0 0 5.6-8"/></svg>',
+  thermo:
+    '<svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><path d="M14 13.6V5a2 2 0 1 0-4 0v8.6a4.4 4.4 0 1 0 4 0Z"/><path d="M12 9.5v6.2"/></svg>',
+  power:
+    '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><path d="M12 2v10"/></svg>',
+  minus:
+    '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true"><path d="M5 12h14"/></svg>',
+  plus: '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true"><path d="M5 12h14M12 5v14"/></svg>',
+  sliders:
+    '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M4 8h16M4 16h16"/><circle cx="9.5" cy="8" r="2.6"/><circle cx="15" cy="16" r="2.6"/></svg>',
+});
+
+const FAN_LABELS = Object.freeze({
+  auto: () => t("Auto", "Auto"),
+  low: () => t("Min", "Low"),
+  medium: () => t("Med", "Med"),
+  medium_low: () => t("Med-", "Med-"),
+  medium_high: () => t("Med+", "Med+"),
+  high: () => t("Max", "High"),
+  turbo: () => t("Turbo", "Turbo"),
+  quiet: () => t("Silenzioso", "Quiet"),
+});
+
+const MODE_LABELS = Object.freeze({
+  cool: () => t("Freddo", "Cooling"),
+  heat: () => t("Caldo", "Heating"),
+  auto: () => t("Auto", "Auto"),
+  heat_cool: () => t("Auto", "Auto"),
+  dry: () => t("Deumidifica", "Dry"),
+  fan_only: () => t("Ventola", "Fan"),
+});
+
+const copy = () => ({
+  title: t("Sistema climatico", "Climate system"),
+  cold: t("Freddo", "Cooling"),
+  warm: t("Caldo", "Heating"),
+  onLabel: t("Accesi", "Running"),
+  ambient: t("Ambiente medio", "Average room"),
+  allOn: t("Accendi tutto", "Turn all on"),
+  allOff: t("Spegni tutto", "Turn all off"),
+  target: t("Target", "Target"),
+  room: t("Ambiente", "Room"),
+  off: t("Spento", "Off"),
+  modes: t("Modalità", "Mode"),
+  modesAria: t("Modalità e ventola", "Mode and fan speed"),
+  warmer: t("Alza il target", "Raise the target"),
+  cooler: t("Abbassa il target", "Lower the target"),
+  power: t("Accendi o spegni", "Turn on or off"),
+  coolers: t("Condizionatori", "Air conditioners"),
+  radiators: t("Termosifoni", "Radiators"),
+  emptyCold: t("Nessun condizionatore configurato", "No air conditioner configured"),
+  emptyWarm: t("Nessun termosifone configurato", "No radiator configured"),
+  emptyHint: t(
+    "Aggiungi le unità dalla Configurazione della plancia.",
+    "Add the units from the dashboard configuration.",
+  ),
+  unitsOne: t("1 unità", "1 unit"),
+  units: (value) => t(`${value} unità`, `${value} units`),
+  floorsOne: t("1 piano", "1 floor"),
+  floors: (value) => t(`${value} piani`, `${value} floors`),
+});
+
+/* ── model ────────────────────────────────────────────────────────────── */
+
+export function climateZone(unit) {
+  return canonicalClimateType(unit?.type) === "termo" ? "caldo" : "freddo";
+}
+
+export function climateUnits() {
+  let values = null;
+  if (typeof root.getClimaUnits === "function") {
+    try {
+      const legacy = root.getClimaUnits();
+      if (Array.isArray(legacy) && legacy.length) values = legacy;
+    } catch (_error) {}
+  }
+  if (!values) values = readClimateUnits();
+  if (!Array.isArray(values)) return [];
+  let rooms = [];
+  try {
+    rooms = root.cdRoomList?.() || [];
+  } catch (_error) {}
+  return values
+    .map((unit, index) => {
+      const entity = clean(unit?.entity || unit?.entity_id || unit?.entities?.[0]);
+      if (!entity) return null;
+      return {
+        entity,
+        name: clean(unit?.name) || entity,
+        room: unitRoom(unit, rooms),
+        zone: climateZone(unit),
+        cardId: `card-${entity.replaceAll(".", "-")}`,
+        index,
+      };
+    })
+    .filter(Boolean);
+}
+
+/* The store normalizes a unit to `room_id`, the legacy editor still writes
+ * `room` — and since the canonical registry landed, `room` itself often holds
+ * an id like `room_msqjk307`. Whatever the field, the card has to print the
+ * name the user typed, which is also what the floor grouping asks about. */
+export function unitRoom(unit, rooms = null) {
+  const reference = clean(unit?.room) || clean(unit?.room_id);
+  if (!reference) return "";
+  let list = rooms;
+  if (!Array.isArray(list)) {
+    try {
+      list = root.cdRoomList?.() || [];
+    } catch (_error) {
+      list = [];
+    }
+  }
+  const match = list.find(
+    (room) => clean(room?.id) === reference || clean(room?.name) === reference,
+  );
+  return clean(match?.name) || reference;
+}
+
+function resolvedState(entity, states) {
+  const reference = clean(entity);
+  if (!reference) return null;
+  const resolved = clean(root.resolveEntity?.(reference) || reference);
+  return states?.[reference] || states?.[resolved] || null;
+}
+
+/**
+ * One reading of a unit. `on` follows the legacy rule — anything that is not
+ * off/unavailable counts as running — so the card agrees with the popup.
+ */
+export function climateReading(entity, states = allStates()) {
+  const entry = resolvedState(entity, states);
+  const raw = clean(entry?.state).toLowerCase();
+  const attributes = entry?.attributes || {};
+  return {
+    known: Boolean(entry),
+    on: Boolean(entry) && !OFF_STATES.has(raw),
+    mode: raw,
+    action: clean(attributes.hvac_action).toLowerCase(),
+    target: finiteOrNull(attributes.temperature),
+    ambient: finiteOrNull(attributes.current_temperature),
+    fan: clean(attributes.fan_mode).toLowerCase(),
+  };
+}
+
+function stateLabel(reading, zone, labels) {
+  if (!reading.on) return labels.off;
+  if (reading.mode === "fan_only") return t("Ventilazione", "Fan only");
+  if (reading.mode === "dry") return t("Deumidifica", "Drying");
+  if (reading.action === "idle") return t("In pausa", "Idle");
+  if (reading.mode === "heat" || zone === "caldo") return t("Riscalda", "Heating");
+  return t("Raffresca", "Cooling");
+}
+
+function modeCaption(reading, labels) {
+  if (!reading.on) return labels.modes;
+  const mode = MODE_LABELS[reading.mode]?.() || labels.modes;
+  const fan = reading.fan ? FAN_LABELS[reading.fan]?.() || reading.fan : "";
+  return fan ? `${mode} · ${fan}` : mode;
+}
+
+function ratio(value, zone) {
+  const [low, high] = RANGE[zone];
+  if (value === null) return null;
+  return Math.min(1, Math.max(0, (value - low) / (high - low)));
+}
+
+/* ── ambient history (kept in memory, no polling and no history API) ──── */
+
+function pushSample(entity, ambient) {
+  if (ambient === null) return false;
+  const series = state.history.get(entity) || [];
+  const last = series[series.length - 1];
+  if (last !== undefined && Math.abs(last - ambient) < 0.05) return false;
+  series.push(ambient);
+  while (series.length > SPARK.samples) series.shift();
+  state.history.set(entity, series);
+  return true;
+}
+
+export function sparklinePath(series, { width, height, pad } = SPARK) {
+  if (!Array.isArray(series) || series.length < 3) return null;
+  const low = Math.min(...series);
+  const high = Math.max(...series);
+  const span = high - low || 1;
+  const points = series.map((value, index) => [
+    (index / (series.length - 1)) * (width - pad) + pad / 2,
+    pad + (1 - (value - low) / span) * (height - pad * 2),
+  ]);
+  const line = points
+    .map(([x, y], index) => `${index ? "L" : "M"}${x.toFixed(1)} ${y.toFixed(1)}`)
+    .join(" ");
+  const last = points[points.length - 1];
+  return {
+    line,
+    area: `${line} L${last[0].toFixed(1)} ${height} L${points[0][0].toFixed(1)} ${height} Z`,
+    end: last,
+  };
+}
+
+/* ── markup ───────────────────────────────────────────────────────────── */
+
+function zoneButton(zone, labels) {
+  const cold = zone === "freddo";
+  return `<button type="button" class="clima-page-mode-btn dm-cl-tab${cold ? " active-freddo" : ""}"
+      id="clima-page-mode-${cold ? "freddo" : "caldo"}" data-dm-cl-zone="${zone}"
+      aria-pressed="${cold ? "true" : "false"}" onclick="setClimaPageMode('${zone}')">
+      <span class="icon dm-cl-tab-ic">${cold ? ICONS.snow : ICONS.flame}</span>
+      <span class="dm-cl-tab-tx">${esc(cold ? labels.cold : labels.warm)}</span>
+      <span class="dm-cl-tab-count" data-dm-cl-count="${zone}">0</span>
+    </button>`;
+}
+
+function skeletonMarkup(labels) {
+  return `<div class="dm-cl-shell" data-dm-lang="${english() ? "en" : "it"}">
+  <div class="dm-cl-mast">
+    <span class="dm-cl-mast-ic" aria-hidden="true">${ICONS.thermo}</span>
+    <div class="dm-cl-mast-copy">
+      <h2>${esc(labels.title)}</h2>
+      <p data-dm-cl-sub></p>
+    </div>
+    <div class="dm-cl-summary">
+      <div class="dm-cl-kpi">
+        <span>${esc(labels.onLabel)}</span>
+        <b data-dm-cl-running>0<small> / 0</small></b>
+      </div>
+      <div class="dm-cl-kpi">
+        <span>${esc(labels.ambient)}</span>
+        <b data-dm-cl-average>--°</b>
+      </div>
+      <div class="dm-cl-bulk">
+        <button type="button" data-dm-cl-bulk="on">${ICONS.power}${esc(labels.allOn)}</button>
+        <span class="dm-cl-bulk-div" aria-hidden="true"></span>
+        <button type="button" data-dm-cl-bulk="off">${ICONS.power}${esc(labels.allOff)}</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="clima-page-mode-switch dm-cl-switch">
+    ${zoneButton("freddo", labels)}
+    ${zoneButton("caldo", labels)}
+  </div>
+
+  <div class="clima-zone clima-zone-freddo show">
+    <div class="dm-cl-grid" id="clima-grid-freddo"></div>
+  </div>
+  <div class="clima-zone clima-zone-caldo">
+    <div class="dm-cl-grid" id="clima-grid-caldo"></div>
+  </div>
+</div>`;
+}
+
+function emptyMarkup(zone, labels) {
+  return `<div class="dm-cl-empty">
+      <span class="dm-cl-empty-ic" aria-hidden="true">${zone === "caldo" ? ICONS.flame : ICONS.snow}</span>
+      <strong>${esc(zone === "caldo" ? labels.emptyWarm : labels.emptyCold)}</strong>
+      <p>${esc(labels.emptyHint)}</p>
+    </div>`;
+}
+
+function cardMarkup(unit, labels) {
+  const [low, high] = RANGE[unit.zone];
+  const entity = esc(unit.entity).replaceAll("'", "&#39;");
+  // The family is already in the masthead, so an unassigned unit shows nothing
+  // here rather than repeating "Condizionatori" on every card.
+  const meta = unit.room;
+  return `<article class="dm-cl-card" id="${esc(unit.cardId)}" data-dm-cl="${esc(unit.entity)}"
+      data-dm-cl-zone="${unit.zone}" onclick="apriClimaPopup('${entity}', event)">
+      <div class="dm-cl-head">
+        <span class="dm-cl-ic" aria-hidden="true">${unit.zone === "caldo" ? ICONS.flame : ICONS.snow}</span>
+        <div class="dm-cl-txt">
+          <div class="dm-cl-name">${esc(unit.name)}</div>
+          ${meta ? `<div class="dm-cl-meta">${esc(meta)}</div>` : ""}
+        </div>
+        <span class="dm-cl-state"><i aria-hidden="true"></i><span data-dm-cl-state>${esc(labels.off)}</span></span>
+      </div>
+      <div class="dm-cl-main">
+        <div class="dm-cl-target">
+          <b data-dm-cl-target>--<span class="dm-cl-deg">°</span></b>
+          <span class="dm-cl-cap">${esc(labels.target)}</span>
+        </div>
+        <svg class="dm-cl-spark" viewBox="0 0 ${SPARK.width} ${SPARK.height}" data-dm-cl-spark hidden aria-hidden="true">
+          <path class="dm-cl-spark-area" d=""></path>
+          <path class="dm-cl-spark-line" d=""></path>
+          <circle class="dm-cl-spark-end" cx="0" cy="0" r="3"></circle>
+        </svg>
+      </div>
+      <div class="dm-cl-rail" aria-hidden="true">
+        <span class="dm-cl-bed"></span>
+        <span class="dm-cl-fill" data-dm-cl-fill></span>
+        <span class="dm-cl-mark" data-dm-cl-mark hidden></span>
+        <span class="dm-cl-knob" data-dm-cl-knob hidden></span>
+      </div>
+      <div class="dm-cl-legend">
+        <span>${low}°</span>
+        <span>${esc(labels.room)} <b data-dm-cl-ambient>--°</b></span>
+        <span>${high}°</span>
+      </div>
+      <div class="dm-cl-foot">
+        <button type="button" class="dm-cl-modes" data-dm-cl-modes aria-label="${esc(labels.modesAria)}"
+          onclick="event.stopPropagation(); apriClimaPopup('${entity}')">
+          ${ICONS.sliders}<span data-dm-cl-mode-cap>${esc(labels.modes)}</span>
+        </button>
+        <div class="dm-cl-actions">
+          <button type="button" class="dm-cl-step" aria-label="${esc(labels.cooler)}"
+            onclick="event.stopPropagation(); setTemp('${entity}', 'down')">${ICONS.minus}</button>
+          <button type="button" class="dm-cl-step" aria-label="${esc(labels.warmer)}"
+            onclick="event.stopPropagation(); setTemp('${entity}', 'up')">${ICONS.plus}</button>
+          <button type="button" class="dm-cl-pwr" data-dm-cl-pwr aria-label="${esc(labels.power)}"
+            onclick="event.stopPropagation(); toggleClima('${entity}')">${ICONS.power}</button>
+        </div>
+      </div>
+    </article>`;
+}
+
+/* Group by floor only. The legacy grouping printed one heading per room, which
+ * on this layout means a heading above every single card; the room already has
+ * its own line inside the card. */
+function floorOf(unit) {
+  try {
+    return clean(root.cdRoomFloorOf?.(unit.room));
+  } catch (_error) {
+    return "";
+  }
+}
+
+function groupedMarkup(units, labels) {
+  const groups = new Map();
+  for (const unit of units) {
+    const floor = floorOf(unit);
+    if (!groups.has(floor)) groups.set(floor, []);
+    groups.get(floor).push(unit);
+  }
+  const order = [];
+  try {
+    const names = root.cdFloorNames?.();
+    if (Array.isArray(names)) order.push(...names.map(clean));
+  } catch (_error) {}
+  const keys = [...groups.keys()].sort((a, b) => {
+    const ia = order.indexOf(a);
+    const ib = order.indexOf(b);
+    return (ia < 0 ? 9999 : ia) - (ib < 0 ? 9999 : ib);
+  });
+  return keys
+    .map((floor) => {
+      const cards = groups.get(floor).map((unit) => cardMarkup(unit, labels)).join("");
+      const heading = floor && keys.length > 1 ? `<div class="dm-cl-floor">🏢 ${esc(floor)}</div>` : "";
+      return `${heading}${cards}`;
+    })
+    .join("");
+}
+
+/* ── rendering ────────────────────────────────────────────────────────── */
+
+function ensureSkeleton(host, labels) {
+  if (host.querySelector(":scope > .dm-cl-shell")) return false;
+  const backButton = host.querySelector(":scope > .back-home-btn");
+  host.innerHTML = skeletonMarkup(labels);
+  // The back arrow belongs to the page, not to the shell: put it back on top.
+  if (backButton) host.insertBefore(backButton, host.firstChild);
+  return true;
+}
+
+function signature(units) {
+  return JSON.stringify(units.map((unit) => [unit.entity, unit.name, unit.room, unit.zone]));
+}
+
+function syncGrid(grid, units, labels) {
+  const current = signature(units);
+  if (grid._dmClimaSig === current) return false;
+  grid.innerHTML = units.length ? groupedMarkup(units, labels) : emptyMarkup(grid.dataset.dmClZone, labels);
+  grid._dmClimaSig = current;
+  return true;
+}
+
+function visibleZone() {
+  return doc?.querySelector(".clima-zone-caldo.show") ? "caldo" : "freddo";
+}
+
+function paintCard(card, unit, reading, labels) {
+  const zone = unit.zone;
+  card.classList.toggle("is-on", reading.on);
+  card.dataset.dmClMode = reading.on ? reading.mode : "off";
+
+  const stateChip = card.querySelector("[data-dm-cl-state]");
+  if (stateChip) stateChip.textContent = stateLabel(reading, zone, labels);
+
+  const target = card.querySelector("[data-dm-cl-target]");
+  if (target) {
+    const value = reading.target;
+    target.innerHTML =
+      value === null
+        ? `--<span class="dm-cl-deg">°</span>`
+        : `${Math.round(value * 10) / 10}<span class="dm-cl-deg">°</span>`;
+  }
+
+  const ambient = card.querySelector("[data-dm-cl-ambient]");
+  if (ambient) ambient.textContent = reading.ambient === null ? "--°" : `${reading.ambient.toFixed(1)}°`;
+
+  const caption = card.querySelector("[data-dm-cl-mode-cap]");
+  if (caption) caption.textContent = modeCaption(reading, labels);
+
+  const targetRatio = ratio(reading.target, zone);
+  const fill = card.querySelector("[data-dm-cl-fill]");
+  const knob = card.querySelector("[data-dm-cl-knob]");
+  if (fill) fill.style.width = targetRatio === null ? "0%" : `${(targetRatio * 100).toFixed(1)}%`;
+  if (knob) {
+    knob.hidden = targetRatio === null;
+    if (targetRatio !== null) knob.style.left = `${(targetRatio * 100).toFixed(1)}%`;
+  }
+  const ambientRatio = ratio(reading.ambient, zone);
+  const mark = card.querySelector("[data-dm-cl-mark]");
+  if (mark) {
+    mark.hidden = ambientRatio === null;
+    if (ambientRatio !== null) mark.style.left = `${(ambientRatio * 100).toFixed(1)}%`;
+  }
+
+  paintSpark(card, unit, reading);
+}
+
+function paintSpark(card, unit, reading) {
+  const svg = card.querySelector("[data-dm-cl-spark]");
+  if (!svg) return;
+  const changed = pushSample(unit.entity, reading.ambient);
+  const series = state.history.get(unit.entity) || [];
+  const path = sparklinePath(series);
+  if (!path) {
+    svg.hidden = true;
+    return;
+  }
+  svg.hidden = false;
+  if (!changed && svg.dataset.dmClDrawn === String(series.length)) return;
+  svg.dataset.dmClDrawn = String(series.length);
+  svg.querySelector(".dm-cl-spark-area")?.setAttribute("d", path.area);
+  svg.querySelector(".dm-cl-spark-line")?.setAttribute("d", path.line);
+  const end = svg.querySelector(".dm-cl-spark-end");
+  if (end) {
+    end.setAttribute("cx", path.end[0].toFixed(1));
+    end.setAttribute("cy", path.end[1].toFixed(1));
+  }
+}
+
+function paintSummary(shell, units, states, labels) {
+  const zone = visibleZone();
+  const inZone = units.filter((unit) => unit.zone === zone);
+  const readings = inZone.map((unit) => climateReading(unit.entity, states));
+  const running = readings.filter((reading) => reading.on).length;
+  const ambient = readings.map((reading) => reading.ambient).filter((value) => value !== null);
+
+  const runningEl = shell.querySelector("[data-dm-cl-running]");
+  if (runningEl) runningEl.innerHTML = `${running}<small> / ${inZone.length}</small>`;
+  const averageEl = shell.querySelector("[data-dm-cl-average]");
+  if (averageEl) {
+    averageEl.textContent = ambient.length
+      ? `${(ambient.reduce((sum, value) => sum + value, 0) / ambient.length).toFixed(1)}°`
+      : "--°";
+  }
+  const subtitle = shell.querySelector("[data-dm-cl-sub]");
+  if (subtitle) {
+    const family = zone === "caldo" ? labels.radiators : labels.coolers;
+    const count = inZone.length === 1 ? labels.unitsOne : labels.units(inZone.length);
+    subtitle.textContent = inZone.length ? `${family} · ${count}` : family;
+  }
+  for (const button of shell.querySelectorAll("[data-dm-cl-bulk]")) {
+    const wantsOn = button.dataset.dmClBulk === "on";
+    button.disabled = wantsOn ? running === inZone.length : running === 0;
+  }
+  for (const badge of shell.querySelectorAll("[data-dm-cl-count]")) {
+    badge.textContent = String(units.filter((unit) => unit.zone === badge.dataset.dmClCount).length);
+  }
+  shell.dataset.dmClZone = zone;
+}
+
+export function renderClimate({ rebuild = false } = {}) {
+  const host = doc?.getElementById?.("page-clima");
+  if (!host) return false;
+  const labels = copy();
+  ensureSkeleton(host, labels);
+  const shell = host.querySelector(":scope > .dm-cl-shell");
+  if (!shell) return false;
+
+  const units = climateUnits();
+  for (const zone of ["freddo", "caldo"]) {
+    const grid = doc.getElementById(`clima-grid-${zone}`);
+    if (!grid) continue;
+    grid.dataset.dmClZone = zone;
+    if (rebuild) grid._dmClimaSig = "";
+    syncGrid(
+      grid,
+      units.filter((unit) => unit.zone === zone),
+      labels,
+    );
+  }
+
+  const states = allStates();
+  for (const unit of units) {
+    const card = doc.getElementById(unit.cardId);
+    if (card) paintCard(card, unit, climateReading(unit.entity, states), labels);
+  }
+  paintSummary(shell, units, states, labels);
+  return true;
+}
+
+/* ── wiring ───────────────────────────────────────────────────────────── */
+
+function bulkSwitch(wantsOn) {
+  if (typeof root.toggleClima !== "function") return;
+  const zone = visibleZone();
+  const states = allStates();
+  for (const unit of climateUnits()) {
+    if (unit.zone !== zone) continue;
+    const reading = climateReading(unit.entity, states);
+    if (!reading.known || reading.on === wantsOn) continue;
+    root.toggleClima(unit.entity);
+  }
+  root.queueMicrotask?.(() => renderClimate());
+}
+
+function onClick(event) {
+  const button = event.target?.closest?.("[data-dm-cl-bulk]");
+  if (!button || button.disabled) return;
+  event.preventDefault();
+  bulkSwitch(button.dataset.dmClBulk === "on");
+}
+
+/**
+ * One step, one degree — everywhere.
+ *
+ * The card's ± call `setTemp()`, which has moved by a whole degree since v253.
+ * The HVAC popup still ships `onclick="cpSetTemp(±0.5)"` in the legacy markup,
+ * so the same unit answered with half a degree there and a full one here. This
+ * keeps the legacy service call and only corrects the delta it is handed: aim
+ * at the whole degree above or below the value the popup is showing.
+ */
+export function wholeDegreeDelta(shown, delta) {
+  const down = Number(delta) < 0;
+  const current = Number(shown);
+  if (!Number.isFinite(current)) return down ? -1 : 1;
+  // A unit parked on a half degree walks to the next whole one, not past it.
+  const next = down ? Math.ceil(current) - 1 : Math.floor(current) + 1;
+  return next - current;
+}
+
+function installTemperatureStep() {
+  const current = root.cpSetTemp;
+  if (typeof current !== "function" || current.__dmClimateThermal) return;
+  function cpSetTempThermal(delta) {
+    const shown = parseFloat(clean(doc?.getElementById("cp-temp-val")?.textContent));
+    return current.call(this, wholeDegreeDelta(shown, delta));
+  }
+  cpSetTempThermal.__dmClimateThermal = true;
+  cpSetTempThermal.__dmPrevious = current;
+  root.cpSetTemp = cpSetTempThermal;
+}
+
+/**
+ * The legacy `buildClimaCards` / `updateClimaCards` are called by the editor,
+ * by the store render coordinator and by the main render loop. Route all of
+ * them here so nothing repaints the legacy markup underneath this page.
+ */
+function installOverrides() {
+  const build = root.buildClimaCards;
+  if (typeof build !== "function" || !build.__dmClimateThermal) {
+    function buildClimaCardsThermal() {
+      return renderClimate({ rebuild: true });
+    }
+    buildClimaCardsThermal.__dmClimateThermal = true;
+    buildClimaCardsThermal.__dmPrevious = build;
+    root.buildClimaCards = buildClimaCardsThermal;
+  }
+  const update = root.updateClimaCards;
+  if (typeof update !== "function" || !update.__dmClimateThermal) {
+    function updateClimaCardsThermal() {
+      return renderClimate();
+    }
+    updateClimaCardsThermal.__dmClimateThermal = true;
+    updateClimaCardsThermal.__dmPrevious = update;
+    root.updateClimaCards = updateClimaCardsThermal;
+  }
+  installTemperatureStep();
+  // Switching zone changes what the readout summarises.
+  wrapFunction("setClimaPageMode", "__dmClimateThermalMode", () => renderClimate());
+}
+
+export function installClimateThermalSection() {
+  if (!doc) return;
+  installStyle(STYLE_ID, climateCss());
+  installOverrides();
+  if (!state.listeners) {
+    state.listeners = true;
+    doc.addEventListener("click", onClick);
+    for (const eventName of [
+      "dashboardmodern:legacy-ready",
+      "dashboardmodern:runtime-ready",
+      "pageshow",
+    ]) {
+      root.addEventListener?.(eventName, () => {
+        installOverrides();
+        renderClimate({ rebuild: true });
+      });
+    }
+    // The legacy runtime builds its own cards on DOMContentLoaded through a
+    // direct reference, so that one call cannot be intercepted: repaint after it.
+    if (doc.readyState === "loading") {
+      doc.addEventListener("DOMContentLoaded", () => renderClimate({ rebuild: true }), {
+        once: true,
+      });
+    }
+    root.addEventListener?.("dashboardmodern:state-changed", () => renderClimate());
+  }
+  state.installed = true;
+  renderClimate({ rebuild: true });
+}
+
+/* ── styles ───────────────────────────────────────────────────────────── */
+
+function climateCss() {
+  return `
+.dm-cl-shell,.dm-cl-shell *,.dm-cl-shell *::before,.dm-cl-shell *::after{box-sizing:border-box}
+.dm-cl-shell{
+  --dm-cl-cold:14,165,233;--dm-cl-warm:234,88,12;--dm-cl-off:148,163,184;
+  --dm-cl-card:var(--card-bg,#fff);--dm-cl-line:var(--card-border,#e6ecf3);
+  --dm-cl-text:var(--text,#0f172a);--dm-cl-dim:var(--text-dim,#64748b);
+  --dm-cl-soft:var(--surface-2,#f7f9fc);--dm-cl-sunk:var(--surface-3,#eef2f8);
+  --dm-cl-shadow:0 4px 20px rgba(15,23,42,.06),0 1px 4px rgba(15,23,42,.04);
+  --dm-cl-zone:var(--dm-cl-cold);
+  display:flex;flex-direction:column;gap:18px;width:100%;max-width:1250px;margin:0 auto;
+  color:var(--dm-cl-text)
+}
+.dm-cl-shell[data-dm-cl-zone="caldo"]{--dm-cl-zone:var(--dm-cl-warm)}
+.dm-cl-shell button{font:inherit;color:inherit}
+
+/* ── masthead ─────────────────────────────────────────────────────────── */
+.dm-cl-mast{display:flex;align-items:center;gap:14px;flex-wrap:wrap;padding:2px 2px 0}
+.dm-cl-mast-ic{
+  width:48px;height:48px;flex:0 0 48px;display:grid;place-items:center;border-radius:16px;
+  background:rgba(var(--dm-cl-zone),.12);color:rgb(var(--dm-cl-zone));transition:background .4s ease,color .4s ease
+}
+.dm-cl-mast-copy{flex:1 1 220px;min-width:0}
+.dm-cl-mast-copy h2{
+  margin:0;font-family:"Oswald",system-ui,sans-serif;font-size:clamp(20px,2.6vw,26px);font-weight:700;
+  letter-spacing:1.6px;text-transform:uppercase;color:var(--dm-cl-text)
+}
+.dm-cl-mast-copy p{margin:2px 0 0;font-size:12.5px;font-weight:600;color:var(--dm-cl-dim)}
+.dm-cl-summary{display:flex;align-items:stretch;gap:10px;flex-wrap:wrap}
+.dm-cl-kpi{
+  display:flex;flex-direction:column;justify-content:center;gap:1px;min-width:96px;padding:9px 15px;
+  border:1px solid var(--dm-cl-line);border-radius:16px;background:var(--dm-cl-card);box-shadow:var(--dm-cl-shadow)
+}
+.dm-cl-kpi span{font-size:9px;font-weight:800;letter-spacing:1.2px;text-transform:uppercase;color:var(--dm-cl-dim)}
+.dm-cl-kpi b{font-size:19px;font-weight:800;letter-spacing:-.4px;font-variant-numeric:tabular-nums}
+.dm-cl-kpi b small{font-size:12px;font-weight:700;color:var(--dm-cl-dim);letter-spacing:0}
+.dm-cl-bulk{
+  display:flex;align-items:stretch;border:1px solid var(--dm-cl-line);border-radius:16px;
+  background:var(--dm-cl-card);box-shadow:var(--dm-cl-shadow);overflow:hidden
+}
+.dm-cl-bulk button{
+  display:inline-flex;align-items:center;gap:8px;padding:11px 16px;border:0;background:transparent;cursor:pointer;
+  font-size:12px;font-weight:800;letter-spacing:.4px;color:var(--dm-cl-dim);
+  transition:color .25s ease,background .25s ease
+}
+.dm-cl-bulk button[data-dm-cl-bulk="on"]:hover:not(:disabled){color:rgb(var(--dm-cl-zone));background:rgba(var(--dm-cl-zone),.09)}
+.dm-cl-bulk button[data-dm-cl-bulk="off"]:hover:not(:disabled){color:var(--dm-cl-text);background:var(--dm-cl-sunk)}
+.dm-cl-bulk button:disabled{opacity:.4;cursor:default}
+.dm-cl-bulk-div{width:1px;margin:8px 0;background:var(--dm-cl-line)}
+
+/* ── Freddo / Caldo switch (ids and classes kept for setClimaPageMode) ── */
+#page-clima .dm-cl-shell .clima-page-mode-switch.dm-cl-switch{
+  display:grid!important;grid-template-columns:repeat(2,minmax(0,1fr))!important;gap:4px!important;
+  width:100%!important;max-width:none!important;margin:0!important;padding:5px!important;
+  border:1px solid var(--dm-cl-line)!important;border-radius:20px!important;
+  background:var(--dm-cl-card)!important;box-shadow:var(--dm-cl-shadow)!important;overflow:hidden!important
+}
+#page-clima .dm-cl-shell .clima-page-mode-switch.dm-cl-switch .clima-page-mode-btn{
+  display:flex!important;align-items:center!important;justify-content:center!important;gap:9px!important;
+  min-height:0!important;padding:13px 10px!important;margin:0!important;border:0!important;border-radius:15px!important;
+  background:transparent!important;color:var(--dm-cl-dim)!important;cursor:pointer!important;
+  font-family:inherit!important;font-size:13px!important;font-weight:800!important;letter-spacing:1.2px!important;
+  text-transform:uppercase!important;box-shadow:none!important;transition:background .3s ease,color .3s ease!important
+}
+#page-clima .dm-cl-shell .clima-page-mode-switch.dm-cl-switch .clima-page-mode-btn .icon{
+  display:inline-flex!important;align-items:center!important;font-size:0!important;line-height:0!important
+}
+.dm-cl-tab-count{
+  padding:2px 8px;border-radius:999px;background:var(--dm-cl-sunk);color:var(--dm-cl-dim);
+  font-size:10px;font-weight:800;letter-spacing:.4px;font-variant-numeric:tabular-nums
+}
+#page-clima .dm-cl-shell #clima-page-mode-freddo.active-freddo{
+  background:linear-gradient(135deg,rgb(var(--dm-cl-cold)),rgba(var(--dm-cl-cold),.78))!important;color:#fff!important;
+  box-shadow:0 8px 20px rgba(var(--dm-cl-cold),.34)!important
+}
+#page-clima .dm-cl-shell #clima-page-mode-caldo.active-caldo{
+  background:linear-gradient(135deg,rgb(var(--dm-cl-warm)),rgba(var(--dm-cl-warm),.78))!important;color:#fff!important;
+  box-shadow:0 8px 20px rgba(var(--dm-cl-warm),.34)!important
+}
+#page-clima .dm-cl-shell .clima-page-mode-btn.active-freddo .dm-cl-tab-count,
+#page-clima .dm-cl-shell .clima-page-mode-btn.active-caldo .dm-cl-tab-count{background:rgba(255,255,255,.24);color:#fff}
+
+/* ── grids ────────────────────────────────────────────────────────────── */
+.dm-cl-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:16px;align-items:start}
+.dm-cl-floor{
+  grid-column:1/-1;display:flex;align-items:center;gap:12px;padding:6px 2px 0;
+  font-size:10px;font-weight:800;letter-spacing:1.6px;text-transform:uppercase;color:var(--dm-cl-dim)
+}
+.dm-cl-floor::after{content:"";flex:1;height:1px;background:var(--dm-cl-line)}
+.dm-cl-empty{
+  grid-column:1/-1;display:flex;flex-direction:column;align-items:center;gap:6px;padding:34px 18px;
+  border:1px dashed var(--dm-cl-line);border-radius:22px;background:var(--dm-cl-soft);text-align:center
+}
+.dm-cl-empty-ic{display:grid;place-items:center;width:44px;height:44px;border-radius:14px;background:var(--dm-cl-sunk);color:var(--dm-cl-dim)}
+.dm-cl-empty strong{font-size:14px;font-weight:800}
+.dm-cl-empty p{margin:0;font-size:12.5px;color:var(--dm-cl-dim)}
+
+/* ── card ─────────────────────────────────────────────────────────────── */
+.dm-cl-card{
+  --dm-cl-u:var(--dm-cl-off);
+  position:relative;overflow:hidden;display:flex;flex-direction:column;gap:13px;padding:16px 18px 18px;
+  border:1px solid var(--dm-cl-line);border-radius:22px;background:var(--dm-cl-card);
+  box-shadow:var(--dm-cl-shadow);cursor:pointer;
+  transition:border-color .4s ease,box-shadow .4s ease,transform .4s ease
+}
+.dm-cl-card[data-dm-cl-zone="freddo"].is-on{--dm-cl-u:var(--dm-cl-cold)}
+.dm-cl-card[data-dm-cl-zone="caldo"].is-on{--dm-cl-u:var(--dm-cl-warm)}
+.dm-cl-card::before{
+  content:"";position:absolute;inset:0;pointer-events:none;opacity:0;transition:opacity .5s ease;
+  background:radial-gradient(125% 95% at 86% -20%,rgba(var(--dm-cl-u),.22),transparent 60%)
+}
+.dm-cl-card.is-on{border-color:rgba(var(--dm-cl-u),.34)}
+.dm-cl-card.is-on::before{opacity:1}
+.dm-cl-card:hover{transform:translateY(-3px);box-shadow:0 16px 38px rgba(15,23,42,.11)}
+.dm-cl-card>*{position:relative}
+
+.dm-cl-head{display:flex;align-items:center;gap:11px}
+.dm-cl-ic{
+  width:34px;height:34px;flex:0 0 34px;display:grid;place-items:center;border-radius:12px;
+  background:var(--dm-cl-sunk);color:var(--dm-cl-dim);transition:background .4s ease,color .4s ease
+}
+.dm-cl-card.is-on .dm-cl-ic{background:rgba(var(--dm-cl-u),.14);color:rgb(var(--dm-cl-u))}
+.dm-cl-txt{flex:1;min-width:0}
+.dm-cl-name{font-size:14.5px;font-weight:800;letter-spacing:.1px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.dm-cl-meta{margin-top:1px;font-size:11px;font-weight:600;color:var(--dm-cl-dim);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.dm-cl-state{
+  display:inline-flex;align-items:center;gap:5px;flex:0 0 auto;padding:4px 9px;border-radius:8px;
+  background:var(--dm-cl-sunk);color:var(--dm-cl-dim);
+  font-size:9.5px;font-weight:800;letter-spacing:1px;text-transform:uppercase;
+  transition:background .35s ease,color .35s ease
+}
+.dm-cl-state i{display:none;width:5px;height:5px;border-radius:50%;background:currentColor}
+.dm-cl-card.is-on .dm-cl-state{background:rgba(var(--dm-cl-u),.14);color:rgb(var(--dm-cl-u))}
+.dm-cl-card.is-on .dm-cl-state i{display:block}
+
+.dm-cl-main{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.dm-cl-target{display:flex;align-items:baseline;gap:9px;min-width:0}
+.dm-cl-target b{
+  font-size:44px;font-weight:800;line-height:.92;letter-spacing:-1.6px;font-variant-numeric:tabular-nums;
+  color:var(--dm-cl-dim);transition:color .4s ease
+}
+.dm-cl-card.is-on .dm-cl-target b{color:rgb(var(--dm-cl-u))}
+.dm-cl-deg{font-size:.62em;font-weight:700;letter-spacing:0}
+.dm-cl-cap{font-size:9px;font-weight:800;letter-spacing:1.3px;text-transform:uppercase;color:var(--dm-cl-dim)}
+.dm-cl-spark{width:132px;height:42px;flex:0 0 auto;overflow:visible}
+.dm-cl-spark[hidden]{display:none}
+.dm-cl-spark-area{fill:rgba(var(--dm-cl-u),.14)}
+.dm-cl-spark-line{fill:none;stroke:rgb(var(--dm-cl-u));stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
+.dm-cl-spark-end{fill:rgb(var(--dm-cl-u));stroke:var(--dm-cl-card);stroke-width:2}
+
+.dm-cl-rail{position:relative;height:22px;display:flex;align-items:center}
+.dm-cl-bed{position:absolute;left:0;right:0;height:8px;border-radius:999px;background:var(--dm-cl-sunk)}
+.dm-cl-fill{
+  position:absolute;left:0;height:8px;border-radius:999px;width:0;
+  background:linear-gradient(90deg,rgba(var(--dm-cl-u),.32),rgb(var(--dm-cl-u)));
+  transition:width .5s ease,background .4s ease
+}
+.dm-cl-mark{
+  position:absolute;width:3px;height:20px;border-radius:2px;background:var(--dm-cl-text);
+  transform:translateX(-50%);box-shadow:0 0 0 3px var(--dm-cl-card);transition:left .5s ease
+}
+.dm-cl-knob{
+  position:absolute;width:18px;height:18px;border-radius:50%;background:var(--dm-cl-card);
+  border:3.5px solid rgba(var(--dm-cl-off),.9);transform:translateX(-50%);
+  box-shadow:0 3px 8px rgba(15,23,42,.18);transition:left .5s ease,border-color .4s ease
+}
+.dm-cl-card.is-on .dm-cl-knob{border-color:rgb(var(--dm-cl-u))}
+.dm-cl-mark[hidden],.dm-cl-knob[hidden]{display:none}
+.dm-cl-legend{
+  display:flex;align-items:center;justify-content:space-between;gap:8px;margin-top:-4px;
+  font-size:10px;font-weight:700;color:var(--dm-cl-dim);font-variant-numeric:tabular-nums
+}
+.dm-cl-legend b{color:var(--dm-cl-text);font-weight:800}
+
+.dm-cl-foot{display:flex;align-items:center;justify-content:space-between;gap:10px}
+.dm-cl-modes{
+  display:inline-flex;align-items:center;gap:7px;min-width:0;flex:0 1 auto;padding:8px 13px 8px 10px;cursor:pointer;
+  border:1px solid var(--dm-cl-line);border-radius:999px;background:var(--dm-cl-soft);color:var(--dm-cl-dim);
+  font-size:10.5px;font-weight:800;letter-spacing:.9px;text-transform:uppercase;
+  transition:color .25s ease,border-color .25s ease,background .25s ease
+}
+.dm-cl-modes span{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.dm-cl-modes:hover{color:var(--dm-cl-text);background:var(--dm-cl-sunk)}
+.dm-cl-card.is-on .dm-cl-modes{border-color:rgba(var(--dm-cl-u),.34);color:rgb(var(--dm-cl-u));background:rgba(var(--dm-cl-u),.1)}
+.dm-cl-actions{display:flex;align-items:center;gap:7px;flex:0 0 auto}
+.dm-cl-step{
+  width:38px;height:38px;display:grid;place-items:center;cursor:pointer;border-radius:50%;
+  border:1px solid var(--dm-cl-line);background:var(--dm-cl-soft);color:var(--dm-cl-dim);
+  transition:background .2s ease,color .2s ease,transform .12s ease
+}
+.dm-cl-step:hover{background:var(--dm-cl-sunk);color:var(--dm-cl-text)}
+.dm-cl-step:active{transform:scale(.9)}
+.dm-cl-pwr{
+  width:38px;height:38px;display:grid;place-items:center;cursor:pointer;border:0;border-radius:50%;
+  background:var(--dm-cl-sunk);color:var(--dm-cl-dim);
+  transition:background .3s ease,color .3s ease,box-shadow .3s ease,transform .12s ease
+}
+.dm-cl-pwr:active{transform:scale(.95)}
+.dm-cl-card.is-on .dm-cl-pwr{background:rgb(var(--dm-cl-u));color:#fff;box-shadow:0 6px 16px rgba(var(--dm-cl-u),.34)}
+
+/* ── dark theme ───────────────────────────────────────────────────────── */
+html[data-theme="dark"] .dm-cl-shell{
+  --dm-cl-cold:56,189,248;--dm-cl-warm:251,146,60;--dm-cl-off:100,116,139;
+  --dm-cl-shadow:0 4px 20px rgba(0,0,0,.38),0 1px 4px rgba(0,0,0,.26)
+}
+html[data-theme="dark"] .dm-cl-card:hover{box-shadow:0 16px 38px rgba(0,0,0,.5)}
+html[data-theme="dark"] .dm-cl-knob{box-shadow:0 3px 8px rgba(0,0,0,.45)}
+
+/* ── phone: one card per row, compact enough to stay under the beta.5
+      layout guard (a climate card must not grow past 260px) ───────────── */
+@media(max-width:760px){
+  #page-clima .dm-cl-shell .dm-cl-grid{grid-template-columns:1fr!important;gap:12px!important}
+  #page-clima .dm-cl-shell .dm-cl-card{padding:13px 14px 14px!important;gap:9px!important;border-radius:20px!important}
+  #page-clima .dm-cl-shell .dm-cl-target b{font-size:34px!important}
+  #page-clima .dm-cl-shell .dm-cl-spark{display:none!important}
+  #page-clima .dm-cl-shell .dm-cl-rail{height:18px!important}
+  #page-clima .dm-cl-shell .dm-cl-step,#page-clima .dm-cl-shell .dm-cl-pwr{width:34px!important;height:34px!important}
+  #page-clima .dm-cl-shell .clima-page-mode-switch.dm-cl-switch .clima-page-mode-btn{padding:11px 8px!important;font-size:12px!important;letter-spacing:1px!important}
+  .dm-cl-summary{width:100%}
+  .dm-cl-bulk{flex:1 1 auto}
+  .dm-cl-bulk button{flex:1 1 auto;justify-content:center;padding:11px 10px}
+}
+
+@media(prefers-reduced-motion:reduce){
+  .dm-cl-shell *{transition:none!important;animation:none!important}
+}
+`;
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-flow-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-flow-section.js
@@ -237,7 +237,7 @@ function hideLegacyLoadTopology(stage) {
 function writeIcon(target, icon) {
   if (!target || target.dataset.dmFlowIcon === icon) return;
   target.dataset.dmFlowIcon = icon;
-  writeIconGlyph(target, icon, { size: 28 });
+  writeIconGlyph(target, icon, { size: 28, kind: "load" });
 }
 
 function bindNodeClick(element, node, period) {

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-loads-editor-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-loads-editor-section.js
@@ -104,7 +104,7 @@ function element(tag, className = "", text = "") {
 }
 
 function iconInto(target, icon) {
-  writeIconGlyph(target, icon, { size: 24 });
+  writeIconGlyph(target, icon, { size: 24, kind: "load" });
 }
 
 /* The bubble this card will draw. Same icon, name and colour as the stage, so
@@ -324,6 +324,7 @@ function loadCard(panel, load, index, total) {
   icon.className = "ed-input dm-loads-icon-input";
   icon.id = `dm-loads-${load.id}-icon`;
   icon.dataset.dmLoadIcon = "true";
+  icon.dataset.iconCategory = "load";
   icon.value = load.icon;
   icon.placeholder = "🍳 / mdi:stove";
   icon.addEventListener("input", () => iconInto(pick, clean(icon.value)));
@@ -345,7 +346,7 @@ function loadCard(panel, load, index, total) {
   iconInto(pick, load.icon);
   pick.addEventListener("click", (event) => {
     event.preventDefault();
-    openIconPicker(icon, "action");
+    openIconPicker(icon, "load");
   });
   iconRow.append(icon, pick);
   iconField.append(iconRow);
@@ -353,7 +354,10 @@ function loadCard(panel, load, index, total) {
     element(
       "span",
       "ed-hint",
-      t("Un'emoji o un'icona mdi:. Tocca 🎨 per sceglierla.", "An emoji or an mdi: icon. Tap 🎨 to pick one."),
+      t(
+        "Un'emoji o un'icona mdi:. Tocca il riquadro accanto per sceglierla dal catalogo dei carichi.",
+        "An emoji or an mdi: icon. Tap the box beside it to pick one from the load catalogue.",
+      ),
     ),
   );
 

--- a/custom_components/dashboardmodern/frontend/src/sections/entity-search-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/entity-search-section.js
@@ -1,0 +1,534 @@
+/* The entity picker, made fast and made to guess.
+ *
+ * The canonical dialog (`wzPickEntity` in the vendored runtime) stays exactly
+ * where it is: same `#cd-entpick` overlay, same `#cd-ep-search` field, same
+ * `cdEpChoose` on a row. What this section replaces is the part that got slow
+ * and the part that was blind.
+ *
+ * Slow: `cdEpFilter` rescanned every entity on every keystroke, lowercasing and
+ * concatenating two strings per entity as it went, then rebuilt up to 300 rows
+ * as one HTML string and handed it to `innerHTML`. On a house with a few
+ * thousand entities that is the list visibly trailing the keyboard. Now the
+ * scan runs over a prebuilt index (`core/entity-search-index.js`), it only
+ * rescans the previous matches while a query grows, and the list paints one
+ * page of recycled rows and extends on scroll — so what it costs no longer
+ * depends on how many entities the instance has.
+ *
+ * Blind: every field opened the same alphabetical list, so configuring the room
+ * temperature slot meant scrolling past every `automation.` in the house. The
+ * field already says what it wants — its slot reference carries a domain, its
+ * label and placeholder carry the words "temperatura", "kWh", "tapparella" —
+ * and the index turns that into expected domains, device classes and units. The
+ * entities that satisfy them are ranked first and marked, with an empty query
+ * too, which is the auto-detection the wizard does for a whole configuration
+ * brought down to the single field being edited.
+ *
+ * Anything this section cannot do falls back to the runtime's own filter, so a
+ * picker opened before the index is warm still works.
+ */
+import {
+  buildEntityIndex,
+  createSearchSession,
+  fieldHints,
+  rankMatches,
+  searchEntityIndex,
+} from "../core/entity-search-index.js";
+import { allStates, clean, doc, installStyle, root, t } from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_ENTITY_SEARCH__";
+const PAGE = 60;
+const SCROLL_MARGIN = 240;
+
+const state = (root[KEY] ||= {
+  installed: false,
+  index: null,
+  signature: "",
+  session: null,
+  hints: null,
+  hintsRef: null,
+  sourceRef: null,
+  domain: "",
+  hintedOnly: false,
+  query: "",
+  rendered: 0,
+  matched: 0,
+  filtered: 0,
+  active: -1,
+  nodes: [],
+  list: null,
+  rendering: false,
+  warmed: false,
+});
+
+const entryId = (entry) => clean(entry?.id || entry?.entity_id);
+
+/* ── Entity sources ───────────────────────────────────────────────────────── */
+
+function areaOf(id) {
+  const wiz = root.WIZ;
+  const registry = wiz?.entReg?.[id];
+  if (!registry) return "";
+  const areaId = registry.a || (registry.d && wiz.devArea?.[registry.d]) || "";
+  return clean(areaId && wiz.areaNames?.[areaId]);
+}
+
+/* The picker list and the live state map each know something the other does
+ * not: the list is the complete inventory fetched from Home Assistant, the
+ * state map carries device classes, units and current values. The index is
+ * built from the union so a search can rank on all of it. */
+function composeEntries() {
+  const provided = Array.isArray(root._cdEpAll) ? root._cdEpAll : [];
+  const states = allStates();
+  const entries = [];
+  const seen = new Set();
+  for (const entry of provided) {
+    const id = entryId(entry);
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    entries.push(entry);
+  }
+  for (const id of Object.keys(states)) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    entries.push({ id, name: clean(states[id]?.attributes?.friendly_name) || id });
+  }
+  return { entries, states };
+}
+
+/* Composing the entity universe means walking the live state map, which is not
+ * something a keystroke should do. The composition is refreshed when the picker
+ * opens, when the runtime hands over a different inventory, and when the warm-up
+ * runs — never in between. */
+function ensureIndex({ refresh = false } = {}) {
+  if (!refresh && state.index && state.sourceRef === root._cdEpAll) return state.index;
+  const { entries, states } = composeEntries();
+  const signature = `${entries.length}|${entryId(entries[0])}|${entryId(entries[entries.length - 1])}`;
+  state.sourceRef = root._cdEpAll;
+  if (state.index && state.signature === signature) return state.index;
+  const enrich = (id) => {
+    const live = states[id];
+    const area = areaOf(id);
+    if (!live) return area ? { area } : null;
+    return {
+      dc: live.attributes?.device_class || "",
+      unit: live.attributes?.unit_of_measurement || "",
+      sc: live.attributes?.state_class || "",
+      state: live.state,
+      area,
+    };
+  };
+  state.index = buildEntityIndex(entries, { enrich, version: signature });
+  state.signature = signature;
+  state.session = createSearchSession();
+  /* The full inventory can land from Home Assistant while the dialog is
+   * already open. The rows on screen then belong to an index that no longer
+   * exists, and paging them would page nothing, so the open picker is repainted
+   * against the new one. */
+  if (!state.rendering && doc?.getElementById("cd-ep-list")?.dataset.dmFastPicker === "true") {
+    root.queueMicrotask?.(() => render(state.query));
+  }
+  return state.index;
+}
+
+/* ── Field auto-detection ─────────────────────────────────────────────────── */
+
+function fieldElement(ref) {
+  if (ref?.nodeType === 1) return ref;
+  const value = clean(ref);
+  if (!value) return null;
+  if (value.startsWith("#")) return doc?.getElementById(value.slice(1)) || null;
+  if (value === "__qa__") return doc?.getElementById("wz-qa-ent") || null;
+  if (value === "__ed_qa__") return doc?.getElementById("ed-qa-ent") || null;
+  try {
+    return doc?.querySelector(`input[data-ref="${CSS.escape(value)}"]`) || null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function fieldLabel(element) {
+  if (!element) return "";
+  const slot = element.closest?.(".ed-slot,.wz-slot,label,[data-entity-field]");
+  if (!slot) return "";
+  const editable = slot.querySelector?.(".ed-slot-lbl input,.wz-lbl-edit");
+  if (editable) return clean(editable.value);
+  const label = slot.querySelector?.(".ed-slot-lbl,.wz-lbl,.ed-lbl");
+  return clean(label?.textContent || "");
+}
+
+/* Rebuilt only when the picker points at a different field: the hint table it
+ * feeds is precomputed over the whole index, and recomputing it per keystroke
+ * would give back everything the index saves. */
+function currentHints() {
+  const ref = root._cdEpRef;
+  if (state.hints && state.hintsRef === ref) return state.hints;
+  const element = fieldElement(ref);
+  const descriptor = {
+    ref: clean(element?.dataset?.ref || (typeof ref === "string" ? ref : "")),
+    id: clean(element?.id),
+    placeholder: clean(element?.placeholder),
+    domain: clean(element?.dataset?.domain),
+    label: fieldLabel(element),
+    value: clean(element?.value),
+  };
+  state.hints = fieldHints(descriptor);
+  state.hintsRef = ref;
+  return state.hints;
+}
+
+/* ── Rendering ────────────────────────────────────────────────────────────── */
+
+function dialogParts(list) {
+  const dialog = list.parentElement;
+  if (!dialog) return null;
+  if (list.dataset.dmFastPicker === "true") {
+    return {
+      dialog,
+      status: dialog.querySelector("#dm-ep-status"),
+      chips: dialog.querySelector("#dm-ep-chips"),
+    };
+  }
+  const status = doc.createElement("div");
+  status.id = "dm-ep-status";
+  status.className = "dm-ep-status";
+  const chips = doc.createElement("div");
+  chips.id = "dm-ep-chips";
+  chips.className = "dm-ep-chips";
+  dialog.insertBefore(status, list);
+  dialog.insertBefore(chips, list);
+  list.dataset.dmFastPicker = "true";
+  list.setAttribute("role", "listbox");
+  list.addEventListener("scroll", () => {
+    if (list.scrollTop + list.clientHeight < list.scrollHeight - SCROLL_MARGIN) return;
+    appendPage();
+  });
+  chips.addEventListener("click", (event) => {
+    const chip = event.target?.closest?.("[data-dm-domain],[data-dm-suggested]");
+    if (!chip) return;
+    if (chip.dataset.dmSuggested) state.hintedOnly = !state.hintedOnly;
+    else {
+      state.domain = chip.dataset.dmDomain === "*" ? "" : chip.dataset.dmDomain;
+      state.hintedOnly = false;
+    }
+    render(state.query);
+  });
+  const search = dialog.querySelector("#cd-ep-search");
+  search?.addEventListener("keydown", onSearchKeydown);
+  return { dialog, status, chips };
+}
+
+function rowNode(position) {
+  const existing = state.nodes[position];
+  if (existing) return existing;
+  const row = doc.createElement("div");
+  row.className = "dm-ep-row";
+  row.setAttribute("role", "option");
+  /* A constant handler string: the row is recycled, so the attribute is set
+   * once and only the dataset changes. The picker's own `cdEpChoose` still does
+   * the writing back into the field. */
+  row.setAttribute("onclick", "cdEpChoose(this.dataset.entity)");
+  row.innerHTML =
+    '<span class="dm-ep-main"><b class="dm-ep-name"></b><span class="dm-ep-id mono"></span></span>' +
+    '<span class="dm-ep-meta"><span class="dm-ep-badge"></span><span class="dm-ep-value"></span><span class="dm-ep-area"></span></span>';
+  row.__parts = {
+    name: row.querySelector(".dm-ep-name"),
+    id: row.querySelector(".dm-ep-id"),
+    badge: row.querySelector(".dm-ep-badge"),
+    value: row.querySelector(".dm-ep-value"),
+    area: row.querySelector(".dm-ep-area"),
+  };
+  state.nodes[position] = row;
+  return row;
+}
+
+function paintRow(row, entry) {
+  const record = entry.record;
+  const parts = row.__parts;
+  row.dataset.entity = record.id;
+  row.dataset.hinted = entry.hinted ? "true" : "false";
+  parts.name.textContent = record.name;
+  parts.id.textContent = record.id;
+  parts.badge.textContent = entry.hinted ? "✨" : "";
+  const value = clean(record.state);
+  parts.value.textContent = value && value !== "unknown" && value !== "unavailable"
+    ? `${value}${record.unit ? ` ${record.unit}` : ""}`
+    : "";
+  parts.area.textContent = record.area ? `🏠 ${record.area}` : "";
+  row.classList.remove("is-active");
+}
+
+function paintRows(list, rows, { append = false } = {}) {
+  const offset = append ? state.rendered : 0;
+  if (!append) {
+    state.active = -1;
+    list.textContent = "";
+  }
+  const fragment = doc.createDocumentFragment();
+  rows.forEach((entry, position) => {
+    const row = rowNode(offset + position);
+    paintRow(row, entry);
+    fragment.append(row);
+  });
+  list.append(fragment);
+  state.rendered = offset + rows.length;
+  if (!state.rendered) {
+    const empty = doc.createElement("div");
+    empty.className = "dm-ep-empty";
+    empty.textContent = t("Nessun risultato", "No results");
+    list.append(empty);
+  }
+}
+
+function paintStatus(status, result) {
+  if (!status) return;
+  const parts = [t(`${result.total} entità`, `${result.total} entities`)];
+  if (result.plan.folded || state.domain || state.hintedOnly) {
+    parts.push(t(`${result.filtered} risultati`, `${result.filtered} results`));
+  }
+  if (result.hinted && !result.plan.folded && !state.hintedOnly) {
+    parts.push(t(`${result.hinted} suggerite per questo campo`, `${result.hinted} suggested for this field`));
+  }
+  status.textContent = parts.join(" · ");
+}
+
+function chipNode(label, on) {
+  const chip = doc.createElement("button");
+  chip.type = "button";
+  chip.className = on ? "dm-ep-chip is-on" : "dm-ep-chip";
+  chip.textContent = label;
+  return chip;
+}
+
+function paintChips(chips, counts, suggested) {
+  if (!chips) return;
+  const entries = counts ? [...counts.entries()].sort((left, right) => right[1] - left[1]) : [];
+  if (entries.length < 2 && !suggested) {
+    chips.textContent = "";
+    chips.hidden = true;
+    return;
+  }
+  chips.hidden = false;
+  chips.textContent = "";
+  const total = entries.reduce((sum, [, count]) => sum + count, 0);
+  const all = chipNode(t("Tutte", "All") + ` ${total}`, !state.domain && !state.hintedOnly);
+  all.dataset.dmDomain = "*";
+  chips.append(all);
+  /* The auto-detection as a filter: one tap to see only what fits this field,
+   * which is the fastest path on an instance where the right entity is one of
+   * three thousand. */
+  if (suggested) {
+    const chip = chipNode(`✨ ${t("Suggerite", "Suggested")} ${suggested}`, state.hintedOnly);
+    chip.dataset.dmSuggested = "true";
+    chips.append(chip);
+  }
+  const domains = entries.slice(0, 6);
+  if (state.domain && !domains.some(([domain]) => domain === state.domain)) {
+    domains.push([state.domain, counts.get(state.domain) || 0]);
+  }
+  for (const [domain, count] of domains) {
+    const chip = chipNode(`${domain} ${count}`, domain === state.domain);
+    chip.dataset.dmDomain = domain;
+    chips.append(chip);
+  }
+}
+
+function appendPage() {
+  const list = state.list;
+  if (!list?.isConnected || state.rendered >= state.filtered) return;
+  if (state.session?.signature !== state.index?.signature) {
+    render(state.query);
+    return;
+  }
+  const rows = rankMatches(state.index, state.session, {
+    offset: state.rendered,
+    limit: PAGE,
+    domain: state.domain,
+    hints: currentHints(),
+    query: state.query,
+    hintedOnly: state.hintedOnly,
+  });
+  if (!rows.length) return;
+  paintRows(list, rows, { append: true });
+}
+
+function render(query) {
+  const list = doc?.getElementById("cd-ep-list");
+  if (!list) return false;
+  // A different list element means a freshly opened dialog: that is the moment
+  // to look at the entity universe again.
+  const opened = state.list !== list;
+  state.list = list;
+  // A filter belongs to the picker it was set in: carrying it into the next
+  // field would hide most of the list for no visible reason.
+  if (opened) {
+    state.domain = "";
+    state.hintedOnly = false;
+  }
+  state.rendering = true;
+  try {
+    const index = ensureIndex({ refresh: opened });
+    if (!index?.size) return false;
+    const parts = dialogParts(list);
+    state.query = clean(query);
+    const result = searchEntityIndex(index, state.query, {
+      limit: PAGE,
+      domain: state.domain,
+      hints: currentHints(),
+      session: state.session,
+      withDomains: true,
+      hintedOnly: state.hintedOnly,
+    });
+    state.matched = result.matched;
+    state.filtered = result.filtered;
+    paintRows(list, result.rows);
+    paintStatus(parts?.status, result);
+    paintChips(parts?.chips, result.domains, result.hinted);
+    list.scrollTop = 0;
+    return true;
+  } finally {
+    state.rendering = false;
+  }
+}
+
+/* ── Keyboard ─────────────────────────────────────────────────────────────── */
+
+function moveActive(delta) {
+  const rows = state.list?.querySelectorAll?.(".dm-ep-row");
+  if (!rows?.length) return;
+  const next = Math.min(rows.length - 1, Math.max(0, state.active + delta));
+  rows[state.active]?.classList.remove("is-active");
+  state.active = next;
+  const row = rows[next];
+  row.classList.add("is-active");
+  row.scrollIntoView?.({ block: "nearest" });
+  if (next >= rows.length - 3) appendPage();
+}
+
+function onSearchKeydown(event) {
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    moveActive(state.active < 0 ? 0 : 1);
+    return;
+  }
+  if (event.key === "ArrowUp") {
+    event.preventDefault();
+    moveActive(-1);
+    return;
+  }
+  if (event.key === "Enter") {
+    const rows = state.list?.querySelectorAll?.(".dm-ep-row");
+    const row = rows?.[state.active >= 0 ? state.active : 0];
+    if (!row) return;
+    event.preventDefault();
+    root.cdEpChoose?.(row.dataset.entity);
+    return;
+  }
+  if (event.key === "Escape") {
+    doc?.getElementById("cd-entpick")?.remove();
+  }
+}
+
+/* ── Installation ─────────────────────────────────────────────────────────── */
+
+function installFilter() {
+  const legacy = root.cdEpFilter;
+  if (typeof legacy === "function" && legacy.__dmFastEntitySearch) return false;
+  const fast = function cdEpFilter(query) {
+    try {
+      if (render(query)) return;
+    } catch (_error) {}
+    /* Never leave the picker without a list: if anything above fails the
+     * vendored filter still paints exactly what it always did. */
+    try {
+      legacy?.call(this, query);
+    } catch (_ignore) {}
+  };
+  fast.__dmFastEntitySearch = true;
+  fast.__dmPrevious = legacy;
+  root.cdEpFilter = fast;
+  return true;
+}
+
+/* Opening a picker on a cold list used to mean waiting for a WebSocket round
+ * trip, then watching the list swap under the finger when the full inventory
+ * arrived. Warming both the inventory and the index while the editor is open
+ * moves that work off the interaction. */
+function warmUp() {
+  if (state.warmed) return;
+  state.warmed = true;
+  const build = () => {
+    try {
+      ensureIndex({ refresh: true });
+    } catch (_error) {}
+  };
+  try {
+    if (typeof root.cdLoadAllEntitiesForPicker === "function") {
+      root.cdLoadAllEntitiesForPicker((full) => {
+        if (Array.isArray(full) && full.length && !Array.isArray(root._cdEpAll)) root._cdEpAll = full;
+        build();
+      });
+      return;
+    }
+  } catch (_error) {}
+  build();
+}
+
+function scheduleWarmUp() {
+  if (state.warmed) return;
+  const run = () => warmUp();
+  if (typeof root.requestIdleCallback === "function") root.requestIdleCallback(run, { timeout: 4000 });
+  else root.setTimeout?.(run, 1200);
+}
+
+function installStyles() {
+  installStyle(
+    "dm-entity-search-style",
+    `
+    #cd-entpick .dm-ep-status{padding:0 4px 6px;color:var(--text-dim,#64748b);font-size:10.5px;font-weight:700}
+    #cd-entpick .dm-ep-chips{display:flex;flex-wrap:wrap;gap:5px;margin-bottom:8px}
+    #cd-entpick .dm-ep-chips[hidden]{display:none}
+    #cd-entpick .dm-ep-chip{padding:4px 10px;border:1px solid rgba(148,163,184,.28);border-radius:999px;background:rgba(148,163,184,.10);color:var(--text-dim,#64748b);font-size:10.5px;font-weight:800;cursor:pointer}
+    #cd-entpick .dm-ep-chip.is-on{border-color:rgba(14,165,233,.42);background:rgba(14,165,233,.14);color:#0284c7}
+    #cd-entpick .dm-ep-row{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:9px 12px;border-radius:12px;background:rgba(148,163,184,.08);color:var(--text,#0f172a);font-size:12.5px;cursor:pointer}
+    #cd-entpick .dm-ep-row[data-hinted="true"]{background:rgba(14,165,233,.12);box-shadow:inset 0 0 0 1px rgba(14,165,233,.22)}
+    #cd-entpick .dm-ep-row.is-active{background:rgba(14,165,233,.22);box-shadow:inset 0 0 0 2px rgba(14,165,233,.45)}
+    #cd-entpick .dm-ep-main{display:flex;flex-direction:column;gap:2px;min-width:0}
+    #cd-entpick .dm-ep-name{overflow:hidden;font-weight:800;text-overflow:ellipsis;white-space:nowrap}
+    #cd-entpick .dm-ep-id{overflow:hidden;color:var(--text-dim,#64748b);font-family:monospace;font-size:10px;text-overflow:ellipsis;white-space:nowrap}
+    #cd-entpick .dm-ep-meta{display:flex;align-items:center;gap:6px;flex:0 0 auto;color:var(--text-dim,#64748b);font-size:10px;font-weight:800;white-space:nowrap}
+    #cd-entpick .dm-ep-value{color:#0284c7}
+    #cd-entpick .dm-ep-empty{padding:20px;color:var(--text-dim,#64748b);font-weight:700;text-align:center}
+  `,
+  );
+}
+
+export function installEntitySearchSection() {
+  if (!doc || state.installed) return false;
+  state.installed = true;
+  installStyles();
+  installFilter();
+  for (const event of ["dashboardmodern:legacy-ready", "dashboardmodern:runtime-ready"]) {
+    root.addEventListener?.(event, installFilter);
+  }
+  /* The warm-up asks Home Assistant for the whole entity inventory, so it is
+   * tied to the user heading for the configuration — not to opening the
+   * dashboard, which most of the time never needs that list at all. */
+  doc.addEventListener(
+    "click",
+    (event) => {
+      if (
+        !event.target?.closest?.(
+          "#cd-app-menu,#editor-modal,.ed-tab,[data-dm-edit-kind],#setup-wizard,.dm-entity-picker",
+        )
+      ) {
+        return;
+      }
+      installFilter();
+      scheduleWarmUp();
+    },
+    true,
+  );
+  return true;
+}
+
+installEntitySearchSection();

--- a/custom_components/dashboardmodern/frontend/src/sections/ev-showcase-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/ev-showcase-section.js
@@ -1,0 +1,535 @@
+// DM-FIX-20260817D
+/* EV section redesign — "Vetrina".
+ *
+ * Reskins the EV page around the vehicle photo: the hero becomes a framed
+ * showcase card with soft corners and a coloured shadow, the battery moves out
+ * of the photo into a charge ring, and every block below turns into a floating
+ * card on the light surface the rest of the dashboard already uses.
+ *
+ * Contracts preserved on purpose — the legacy runtime keeps owning behaviour:
+ * - the photo is still `#ev-mod-car-img` inside `#lm-hero-card`, so the image
+ *   resolver in `ev-section.js` and the idle/plugged swap keep working;
+ * - `#ev-mod-batt-fill` keeps its width, its `--batt-col` and its
+ *   `low` / `mid` classes: the ring reads that element instead of recomputing
+ *   the state of charge, so there is one owner of the battery value;
+ * - `#lm-charge-badge` stays inside the hero with `#lm-dot` and
+ *   `#lm-stato-txt`, so the inline colours the render loop writes per EVSE
+ *   state (grey / amber / cyan / red) still land, and `.lm-charging` on the
+ *   hero keeps meaning what it meant;
+ * - the mode buttons keep the `.evcc-mode-btn` + `m-btn-*` contract and their
+ *   `setEVMode()` calls, and keep the four inline colours already configured in
+ *   the markup (#e11d48, #059669, #d97706, #0284c7);
+ * - the rows added next to the ring carry the legacy value classes
+ *   (`v-ev-pow`, `v-ev-remain`, `v-auto-limite`), which the render loop fills
+ *   through `querySelectorAll`, so no value is computed here;
+ * - the vehicle picker is still built by `renderVehicleSelector()` in
+ *   `ev-section.js` and filled by `applyEvAppearance()` in
+ *   `personalization-section.js`: this module only restyles the cards.
+ *
+ * The page accent stays green; only the target card and the mode buttons take
+ * the colour of the active EVCC mode, mirrored onto `#page-ev` as
+ * `data-dm-ev-mode` from whichever `.evcc-mode-btn` carries `.active`.
+ */
+import { clean, doc, installStyle, root, t } from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_EV_SHOWCASE__";
+const STYLE_ID = "dm-ev-showcase-style";
+const state = (root[KEY] ||= { installed: false, listeners: false, frame: 0 });
+
+const ARC_RADIUS = 50;
+const ARC_LENGTH = 2 * Math.PI * ARC_RADIUS;
+const MODE_IDS = Object.freeze(["off", "pv", "minpv", "now"]);
+
+const ICONS = Object.freeze({
+  bolt: '<path d="M13.2 2.8 5.6 13.4h5.3l-.9 7.8 8.4-10.6h-5.3l.1-7.8Z"/>',
+  clock: '<circle cx="12" cy="12" r="8.6"/><path d="M12 6.9V12l3.4 2"/>',
+  target: '<circle cx="12" cy="12" r="8.4"/><circle cx="12" cy="12" r="4.4"/><circle cx="12" cy="12" r="1"/>',
+  plug: '<path d="M9 2.8v5.4M15 2.8v5.4M6.6 8.2h10.8v3a5.4 5.4 0 0 1-10.8 0v-3ZM12 16.6v4.6"/>',
+  route: '<circle cx="12" cy="12" r="9"/><path d="M15.6 8.4 13 13l-4.6 2.6L11 11l4.6-2.6Z"/>',
+  road: '<path d="M6.4 21 8.6 3M17.6 21 15.4 3M12 4.4v3M12 10.6v3M12 16.8v3"/>',
+  batt: '<rect x="2.4" y="7.4" width="16.4" height="9.2" rx="2.4"/><path d="M21.6 10.6v2.8M5.6 10.6v2.8M9 10.6v2.8"/>',
+  thermo: '<path d="M14 14.4V5.2a2 2 0 1 0-4 0v9.2a3.9 3.9 0 1 0 4 0Z"/>',
+  sun: '<circle cx="12" cy="12" r="4.2"/><path d="M12 2.6v2.2M12 19.2v2.2M4.2 12H2M22 12h-2.2M6.3 6.3 4.8 4.8M19.2 19.2l-1.5-1.5M17.7 6.3l1.5-1.5M4.8 19.2l1.5-1.5"/>',
+  cloudsun:
+    '<circle cx="8.4" cy="8" r="3.2"/><path d="M8.4 2.4v1.4M3.6 8H2.2M4.9 4.5 3.9 3.5M12.9 4.5l1-1M11.2 14.6a3.4 3.4 0 0 1 6.6-1 2.9 2.9 0 0 1-.5 5.8h-6.4a2.4 2.4 0 0 1 .3-4.8Z"/>',
+  rocket:
+    '<path d="M12.6 3.4c3.4 1.4 5.6 4.6 6 8.4l-4.4 4.4-4.4-4.4 2.8-8.4Z"/><path d="M9.8 11.8 5.4 13l2 2M14.2 16.2 13 20.6l-2-2M9 18c-1 1-3 1.6-3 1.6s.6-2 1.6-3"/>',
+  stop: '<circle cx="12" cy="12" r="8.6"/><path d="M9 9h6v6H9z"/>',
+});
+
+/* Stat tiles are static markup: the emoji is decoration, so it can be swapped
+   for a line icon keyed on the entity the tile opens in the history popup. */
+const STAT_ICONS = Object.freeze({
+  "dm.ev_tensione_wallbox": "plug",
+  "dm.ev_km_dall_ultima_ricarica": "route",
+  "dm.ev_odometro": "road",
+  "dm.ev_prelievo_ac_totale_auto": "batt",
+  "dm.ev_temperatura_wallbox": "thermo",
+});
+
+const MODE_ICONS = Object.freeze({ off: "stop", pv: "sun", minpv: "cloudsun", now: "rocket" });
+
+function icon(name, size = 20) {
+  const body = ICONS[name];
+  if (!body) return "";
+  return `<svg class="dm-evv-ico" viewBox="0 0 24 24" width="${size}" height="${size}" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${body}</svg>`;
+}
+
+/* ── readers ──────────────────────────────────────────────────────────── */
+
+/** Mode currently marked active by the legacy runtime, "" when none is. */
+export function evActiveMode(scope = doc) {
+  const active = scope?.querySelector?.(".evcc-mode-btn.active");
+  const id = clean(active?.id);
+  const mode = id.startsWith("m-btn-") ? id.slice(6) : "";
+  return MODE_IDS.includes(mode) ? mode : "";
+}
+
+/** State of charge, read from the bar the legacy render loop already writes. */
+export function batteryLevel(scope = doc) {
+  const fill = scope?.getElementById?.("ev-mod-batt-fill");
+  const width = Number.parseFloat(clean(fill?.style?.width));
+  if (!Number.isFinite(width)) return null;
+  return Math.max(0, Math.min(100, width));
+}
+
+/** Dash pair drawing `level` percent of the ring. */
+export function arcDash(level, circumference = ARC_LENGTH) {
+  const value = Number.isFinite(level) ? Math.max(0, Math.min(100, level)) : 0;
+  const drawn = (value / 100) * circumference;
+  return `${drawn.toFixed(1)} ${(circumference - drawn).toFixed(1)}`;
+}
+
+/* ── mount ────────────────────────────────────────────────────────────── */
+
+function powerMarkup() {
+  return `
+    <div class="dm-evv-gauge">
+      <svg viewBox="0 0 120 120" aria-hidden="true">
+        <circle class="dm-evv-arc-track" cx="60" cy="60" r="${ARC_RADIUS}" fill="none" stroke-width="9"/>
+        <circle class="dm-evv-arc" cx="60" cy="60" r="${ARC_RADIUS}" fill="none" stroke-width="9" stroke-linecap="round" stroke-dasharray="0 ${ARC_LENGTH.toFixed(1)}"/>
+      </svg>
+    </div>
+    <div class="dm-evv-rows">
+      <div class="dm-evv-row">${icon("bolt", 17)}<span class="dm-evv-row-lbl">${t("Potenza", "Power")}</span><span class="dm-evv-row-val v-ev-pow">—</span></div>
+      <div class="dm-evv-row">${icon("clock", 17)}<span class="dm-evv-row-lbl">${t("Tempo stimato", "Time left")}</span><span class="dm-evv-row-val v-ev-remain">—</span></div>
+      <div class="dm-evv-row">${icon("target", 17)}<span class="dm-evv-row-lbl">${t("Autonomia al target", "Range at target")}</span><span class="dm-evv-row-val v-auto-limite">—</span></div>
+    </div>`;
+}
+
+/**
+ * Move the battery block out of the photo and into the charge ring. The node is
+ * moved, never copied, so `#ev-mod-batt-fill` keeps its single owner.
+ */
+function mountPower(hero) {
+  const shell = hero.parentElement;
+  if (!shell) return null;
+  let power = shell.querySelector(":scope > .dm-evv-power");
+  if (power) return power;
+  power = doc.createElement("div");
+  power.className = "dm-evv-power";
+  power.innerHTML = powerMarkup();
+  hero.insertAdjacentElement("afterend", power);
+  const battery = hero.querySelector(":scope > .lm-batt-section");
+  if (battery) power.querySelector(".dm-evv-gauge")?.append(battery);
+  // Seed each row from the value the page already shows, so the card does not
+  // flash "—" while waiting for the next pass of the legacy render loop.
+  for (const value of power.querySelectorAll(".dm-evv-row-val")) {
+    const twin = [...doc.querySelectorAll(`.${[...value.classList].pop()}`)].find(
+      (node) => node !== value && clean(node.textContent),
+    );
+    if (twin) value.textContent = twin.textContent;
+  }
+  return power;
+}
+
+function mountStatIcons(page) {
+  for (const tile of page.querySelectorAll(".lm-stat-card")) {
+    const glyph = tile.querySelector(".lm-stat-icon");
+    if (!glyph || glyph.dataset.dmEvvIcon) continue;
+    const call = clean(tile.getAttribute("onclick"));
+    const entity = call.match(/dm\.ev_[a-z0-9_]+/)?.[0] || "";
+    const name = STAT_ICONS[entity] || (tile.querySelector(".v-auto-limite") ? "target" : "");
+    if (!name) continue;
+    glyph.dataset.dmEvvIcon = name;
+    glyph.innerHTML = icon(name, 18);
+  }
+}
+
+function mountModeButtons(page) {
+  for (const mode of MODE_IDS) {
+    const button = page.querySelector(`#m-btn-${mode}`);
+    if (!button || button.dataset.dmEvvMode) continue;
+    button.dataset.dmEvvMode = mode;
+    const glyph = button.querySelector(".ev-ic");
+    if (glyph) glyph.innerHTML = icon(MODE_ICONS[mode], 21);
+    const effect = doc.createElement("span");
+    effect.className = "dm-evv-fx";
+    effect.setAttribute("aria-hidden", "true");
+    button.prepend(effect);
+  }
+}
+
+/* ── render ───────────────────────────────────────────────────────────── */
+
+export function renderEvShowcase() {
+  const page = doc?.getElementById?.("page-ev");
+  const hero = doc?.getElementById?.("lm-hero-card");
+  if (!page || !hero) return false;
+  page.classList.add("dm-evv");
+  hero.parentElement?.classList.add("dm-evv-shell");
+  const power = mountPower(hero);
+  mountStatIcons(page);
+  mountModeButtons(page);
+
+  const mode = evActiveMode(doc);
+  if (page.dataset.dmEvMode !== mode) page.dataset.dmEvMode = mode;
+
+  const arc = power?.querySelector(".dm-evv-arc");
+  if (arc) {
+    const level = batteryLevel(doc);
+    const dash = arcDash(level ?? 0);
+    if (arc.getAttribute("stroke-dasharray") !== dash) arc.setAttribute("stroke-dasharray", dash);
+    const fill = doc.getElementById("ev-mod-batt-fill");
+    const colour = clean(fill?.style?.getPropertyValue("--batt-col")) || "#16a34a";
+    if (arc.getAttribute("stroke") !== colour) arc.setAttribute("stroke", colour);
+  }
+  return true;
+}
+
+export function scheduleEvShowcase() {
+  if (state.frame) return;
+  const run = () => {
+    state.frame = 0;
+    renderEvShowcase();
+  };
+  state.frame = root.requestAnimationFrame?.(run) || root.setTimeout?.(run, 0) || 0;
+}
+
+function evVisible() {
+  return Boolean(doc?.getElementById("page-ev")?.classList.contains("active"));
+}
+
+export function installEvShowcaseSection() {
+  if (!doc) return;
+  installStyle(STYLE_ID, evShowcaseCss());
+  if (!state.listeners) {
+    state.listeners = true;
+    for (const eventName of [
+      "dashboardmodern:legacy-ready",
+      "dashboardmodern:runtime-ready",
+      "pageshow",
+    ]) {
+      root.addEventListener?.(eventName, scheduleEvShowcase);
+    }
+    // The mode buttons repaint through the legacy render loop, so the mirrored
+    // attribute is refreshed on the same events instead of on a timer.
+    root.addEventListener?.("dashboardmodern:state-changed", () => {
+      if (evVisible()) scheduleEvShowcase();
+    });
+    doc.addEventListener(
+      "click",
+      (event) => {
+        if (event.target?.closest?.('.evcc-mode-btn,[data-tab="ev"],[data-page="ev"]')) {
+          root.queueMicrotask?.(scheduleEvShowcase);
+        }
+      },
+      true,
+    );
+  }
+  state.installed = true;
+  renderEvShowcase();
+}
+
+/* ── styles ───────────────────────────────────────────────────────────── */
+
+function evShowcaseCss() {
+  return `
+#page-ev.dm-evv{
+  --evv-surface:var(--card-bg,#fff);
+  --evv-surface-2:var(--surface-2,#f8fafc);
+  --evv-text:var(--text,#0c1420);
+  --evv-dim:var(--text-dim,#64748b);
+  --evv-green:#16a34a;--evv-green-rgb:22,163,74;--evv-green-deep:#15803d;
+  --evv-r:26px;--evv-r-s:18px;
+  --evv-shadow:0 20px 38px -26px rgba(10,26,44,.55),0 2px 6px -3px rgba(10,26,44,.12);
+  --evv-shadow-s:0 16px 30px -24px rgba(10,26,44,.6),0 2px 5px -3px rgba(10,26,44,.12);
+  --evv-mode:#94a3b8;--evv-mode-rgb:148,163,184;
+}
+/* the four EVCC colours already configured on the buttons */
+#page-ev.dm-evv[data-dm-ev-mode="off"]{--evv-mode:#e11d48;--evv-mode-rgb:225,29,72}
+#page-ev.dm-evv[data-dm-ev-mode="pv"]{--evv-mode:#059669;--evv-mode-rgb:5,150,105}
+#page-ev.dm-evv[data-dm-ev-mode="minpv"]{--evv-mode:#d97706;--evv-mode-rgb:217,119,6}
+#page-ev.dm-evv[data-dm-ev-mode="now"]{--evv-mode:#0284c7;--evv-mode-rgb:2,132,199}
+#page-ev.dm-evv .dm-evv-shell{display:grid!important;gap:14px!important}
+#page-ev.dm-evv .dm-evv-ico{display:block;flex:0 0 auto}
+
+/* ── vehicle picker ───────────────────────────────────────────────────── */
+#page-ev.dm-evv #ev-car-picker.dm-vehicle-profile-host{
+  width:auto!important;max-width:1000px!important;margin:0 auto 12px!important;
+  display:grid!important;gap:10px!important
+}
+#page-ev.dm-evv .dm-ev-brand-badge{
+  display:flex!important;align-items:center!important;gap:11px!important;
+  padding:0 2px!important;color:var(--evv-text)!important
+}
+#page-ev.dm-evv .dm-ev-brand-badge .dm-car-brand{
+  width:44px!important;max-width:44px!important;height:34px!important;
+  padding:5px!important;border-radius:12px!important;background:var(--evv-surface-2)!important;
+  box-shadow:var(--evv-shadow-s)!important
+}
+#page-ev.dm-evv .dm-ev-brand-copy{display:grid!important;gap:1px!important;min-width:0!important}
+#page-ev.dm-evv .dm-ev-brand-copy b{font-size:16px!important;font-weight:700!important;letter-spacing:-.02em!important}
+#page-ev.dm-evv .dm-ev-brand-copy small{font-size:11px!important;font-weight:600!important;color:var(--evv-dim)!important}
+#page-ev.dm-evv .dm-vehicle-profile-tabs{
+  display:flex!important;flex-wrap:nowrap!important;justify-content:flex-start!important;
+  gap:9px!important;overflow-x:auto!important;padding:2px 2px 6px!important;scrollbar-width:none!important
+}
+#page-ev.dm-evv .dm-vehicle-profile-tabs::-webkit-scrollbar{display:none!important}
+#page-ev.dm-evv .dm-vehicle-profile-card{
+  grid-template-columns:44px minmax(0,max-content) 18px!important;
+  align-items:center!important;gap:10px!important;min-height:0!important;
+  padding:8px 12px 8px 8px!important;border:1.5px solid transparent!important;
+  border-radius:var(--evv-r-s)!important;background:var(--evv-surface)!important;
+  box-shadow:var(--evv-shadow-s)!important;
+  transition:transform .25s cubic-bezier(.34,1.4,.5,1),border-color .25s ease,box-shadow .25s ease!important
+}
+#page-ev.dm-evv .dm-vehicle-profile-card:hover{transform:translateY(-2px)!important}
+#page-ev.dm-evv .dm-vehicle-profile-icon{
+  width:44px!important;min-width:44px!important;height:34px!important;
+  border-radius:11px!important;background:var(--evv-surface-2)!important;place-items:center!important
+}
+#page-ev.dm-evv .dm-vehicle-profile-icon .dm-car-brand{width:34px!important;max-width:34px!important;height:24px!important;margin:0!important}
+#page-ev.dm-evv .dm-vehicle-profile-copy{align-content:center!important;padding:0!important}
+#page-ev.dm-evv .dm-vehicle-profile-copy strong{font-size:13px!important;font-weight:700!important;letter-spacing:-.012em!important}
+#page-ev.dm-evv .dm-vehicle-profile-copy small{font-size:10.5px!important;font-weight:600!important}
+#page-ev.dm-evv .dm-vehicle-profile-card.active{
+  border-color:var(--evv-green)!important;background:var(--evv-surface)!important;
+  box-shadow:0 14px 24px -14px rgba(var(--evv-green-rgb),.75)!important
+}
+#page-ev.dm-evv .dm-vehicle-profile-card.active .dm-vehicle-profile-icon{background:rgba(var(--evv-green-rgb),.12)!important}
+#page-ev.dm-evv .dm-vehicle-profile-check{width:18px!important;height:18px!important;background:var(--evv-green)!important;font-size:10px!important}
+
+/* ── hero: the photo in its frame ─────────────────────────────────────── */
+#page-ev.dm-evv .lm-hero{
+  min-height:0!important;height:clamp(212px,44vw,290px)!important;
+  border-radius:var(--evv-r)!important;margin-bottom:0!important;
+  background:linear-gradient(180deg,#fff,#eaf1f8)!important;
+  box-shadow:0 26px 44px -28px rgba(10,26,44,.6),0 2px 6px -3px rgba(10,26,44,.14)!important
+}
+#page-ev.dm-evv .lm-hero::after,#page-ev.dm-evv .lm-hero.lm-charging::after{
+  background:linear-gradient(to bottom,rgba(6,14,22,.16) 0%,rgba(6,14,22,0) 34%,rgba(6,14,22,.12) 100%)!important;
+  animation:none!important
+}
+/* The badge lives inside .lm-hero-top, so the row stays and only the brand
+   caption goes: the photo already sits under the brand badge of the picker. */
+#page-ev.dm-evv .lm-hero-top{padding:13px 13px 0!important}
+#page-ev.dm-evv .lm-brand{display:none!important}
+#page-ev.dm-evv .lm-hero-bg{object-position:center center!important}
+/* the badge keeps the inline colours the render loop writes per EVSE state */
+#page-ev.dm-evv .lm-charge-badge{
+  opacity:1!important;transform:none!important;padding:7px 13px!important;border-radius:999px!important;
+  font-size:11px!important;letter-spacing:.04em!important;backdrop-filter:blur(8px)!important;
+  box-shadow:0 8px 20px rgba(6,14,22,.28)!important
+}
+/* no photo configured yet: a quiet placeholder instead of an empty slab */
+#page-ev.dm-evv .lm-hero[data-ev-image="missing"]{
+  height:clamp(150px,30vw,196px)!important;
+  background:
+    radial-gradient(120% 90% at 50% 118%,rgba(var(--evv-green-rgb),.13) 0%,transparent 62%),
+    linear-gradient(180deg,#fff,#eef4f9)!important
+}
+#page-ev.dm-evv .lm-hero[data-ev-image="missing"]::before{
+  content:"";position:absolute;inset:0;z-index:1;opacity:.16;
+  background:no-repeat center/auto 42% url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%230c1420' stroke-width='1.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3 13.4 4.9 8.5A3 3 0 0 1 7.7 6.6h8.6a3 3 0 0 1 2.8 1.9l1.9 4.9M3 13.4h18M3 13.4V17h3.2v-3.6M20.8 13.4V17h-3.2v-3.6'/%3E%3C/svg%3E")
+}
+
+/* ── charge ring ──────────────────────────────────────────────────────── */
+#page-ev.dm-evv .dm-evv-power{
+  display:flex;align-items:center;gap:16px;padding:16px;
+  background:var(--evv-surface);border-radius:var(--evv-r);box-shadow:var(--evv-shadow)
+}
+#page-ev.dm-evv .dm-evv-gauge{position:relative;width:116px;height:116px;flex:0 0 116px}
+#page-ev.dm-evv .dm-evv-gauge>svg{width:100%;height:100%;transform:rotate(-90deg)}
+#page-ev.dm-evv .dm-evv-arc-track{stroke:color-mix(in srgb,var(--evv-text) 10%,transparent)}
+#page-ev.dm-evv .dm-evv-arc{transition:stroke-dasharray 1s cubic-bezier(.2,.8,.25,1),stroke .4s ease}
+/* the battery block, moved here from inside the photo */
+#page-ev.dm-evv .dm-evv-gauge .lm-batt-section{
+  position:absolute!important;inset:0!important;z-index:1!important;padding:0!important;
+  display:grid!important;place-content:center!important;text-align:center!important
+}
+#page-ev.dm-evv .dm-evv-gauge .lm-batt-header{
+  display:flex!important;flex-direction:column-reverse!important;align-items:center!important;
+  justify-content:center!important;gap:2px!important;margin:0!important
+}
+#page-ev.dm-evv .dm-evv-gauge .lm-batt-lbl{
+  font-size:9px!important;font-weight:800!important;letter-spacing:.14em!important;color:var(--evv-dim)!important
+}
+#page-ev.dm-evv .dm-evv-gauge .lm-batt-soc{
+  font-family:inherit!important;font-size:34px!important;font-weight:300!important;
+  letter-spacing:-.045em!important;color:var(--evv-text)!important;line-height:1!important
+}
+#page-ev.dm-evv .dm-evv-gauge .lm-batt-soc small{font-size:15px!important;color:var(--evv-dim)!important;opacity:1!important}
+#page-ev.dm-evv .dm-evv-gauge .lm-batt-track{display:none!important}
+#page-ev.dm-evv .dm-evv-rows{flex:1;min-width:0;display:grid;gap:10px}
+#page-ev.dm-evv .dm-evv-row{display:flex;align-items:center;gap:9px}
+#page-ev.dm-evv .dm-evv-row .dm-evv-ico{color:var(--evv-green-deep)}
+#page-ev.dm-evv .dm-evv-row-lbl{font-size:11.5px;font-weight:600;color:var(--evv-dim)}
+#page-ev.dm-evv .dm-evv-row-val{
+  margin-left:auto;font-family:'Oswald',sans-serif;font-size:17px;font-weight:700;
+  color:var(--evv-text);white-space:nowrap
+}
+#page-ev.dm-evv .dm-evv-row:first-child .dm-evv-row-val{color:var(--evv-green-deep)}
+
+/* ── KPI tiles ────────────────────────────────────────────────────────── */
+#page-ev.dm-evv .lm-kpi-row{gap:12px!important;margin-bottom:0!important}
+#page-ev.dm-evv .lm-kpi-card{
+  padding:14px 13px!important;border:0!important;border-radius:var(--evv-r-s)!important;
+  background:var(--evv-surface)!important;box-shadow:var(--evv-shadow-s)!important;gap:0!important
+}
+#page-ev.dm-evv .lm-kpi-card:hover{transform:translateY(-3px)!important;box-shadow:0 22px 34px -22px rgba(10,26,44,.6)!important}
+#page-ev.dm-evv .lm-kpi-icon{display:none!important}
+#page-ev.dm-evv .lm-kpi-lbl{order:-1!important;font-size:9.5px!important;letter-spacing:.07em!important}
+#page-ev.dm-evv .lm-kpi-val{margin-top:9px!important;font-size:22px!important;font-weight:700!important;letter-spacing:-.02em!important}
+
+/* ── session ──────────────────────────────────────────────────────────── */
+#page-ev.dm-evv .lm-session-card,
+#page-ev.dm-evv .lm-evcc-card{
+  padding:16px!important;border:0!important;border-radius:var(--evv-r)!important;
+  background:var(--evv-surface)!important;box-shadow:var(--evv-shadow)!important;margin-bottom:0!important
+}
+#page-ev.dm-evv .lm-session-title,#page-ev.dm-evv .lm-evcc-title{
+  font-size:9.5px!important;letter-spacing:.16em!important;margin-bottom:14px!important
+}
+#page-ev.dm-evv .lm-sess-kpi{
+  border:0!important;border-radius:var(--evv-r-s)!important;background:var(--evv-surface-2)!important;padding:13px!important
+}
+#page-ev.dm-evv .lm-sess-kpi-val{font-size:24px!important}
+#page-ev.dm-evv .lm-solar-track{height:6px!important;background:var(--evv-surface-2)!important}
+#page-ev.dm-evv .lm-solar-pct{color:var(--evv-green-deep)!important}
+
+/* ── stats ────────────────────────────────────────────────────────────── */
+#page-ev.dm-evv .lm-stats-grid{gap:12px!important;margin-bottom:0!important}
+#page-ev.dm-evv .lm-stat-card{
+  padding:12px!important;border:0!important;border-radius:var(--evv-r-s)!important;
+  background:var(--evv-surface)!important;box-shadow:var(--evv-shadow-s)!important
+}
+#page-ev.dm-evv .lm-stat-card:hover{transform:translateY(-3px)!important;box-shadow:0 22px 34px -22px rgba(10,26,44,.6)!important}
+#page-ev.dm-evv .lm-stat-icon{
+  width:32px!important;height:32px!important;border:0!important;border-radius:12px!important;
+  background:rgba(var(--evv-green-rgb),.13)!important;color:var(--evv-green-deep)!important
+}
+#page-ev.dm-evv .lm-stat-lbl{font-size:9.5px!important;letter-spacing:.05em!important}
+#page-ev.dm-evv .lm-stat-val{font-size:16px!important}
+
+/* ── target: takes the colour of the active mode ──────────────────────── */
+#page-ev.dm-evv .lm-target-card{
+  padding:15px 16px!important;border:0!important;border-radius:var(--evv-r)!important;margin-bottom:0!important;
+  background:linear-gradient(120deg,var(--evv-mode),color-mix(in srgb,var(--evv-mode) 58%,#0b1a2a))!important;
+  box-shadow:0 22px 34px -22px rgba(var(--evv-mode-rgb),.95)!important;
+  transition:background .55s ease,box-shadow .55s ease!important
+}
+#page-ev.dm-evv .lm-target-icon{display:none!important}
+#page-ev.dm-evv .lm-target-lbl{color:rgba(255,255,255,.82)!important;font-size:10.5px!important}
+#page-ev.dm-evv .lm-target-val{color:#fff!important;font-size:20px!important}
+#page-ev.dm-evv .lm-target-select{
+  min-width:88px!important;border:1px solid rgba(255,255,255,.38)!important;border-radius:13px!important;
+  background:rgba(255,255,255,.22)!important;color:#fff!important;padding:9px 12px!important;
+  font-size:13px!important;text-align:center!important
+}
+#page-ev.dm-evv .lm-target-select option{color:#0c1420!important}
+
+/* ── EVCC console ─────────────────────────────────────────────────────── */
+#page-ev.dm-evv .lm-evcc-grid{gap:8px!important}
+#page-ev.dm-evv .lm-evcc-btn{
+  position:relative!important;overflow:hidden!important;
+  padding:14px 4px 12px!important;border-radius:var(--evv-r-s)!important;
+  border:1.5px solid rgba(0,0,0,0)!important;
+  background:var(--btn-bg,var(--evv-surface-2))!important;color:var(--btn-col,var(--evv-dim))!important;
+  box-shadow:inset 0 0 0 1.5px color-mix(in srgb,var(--btn-col,#94a3b8) 32%,transparent)!important
+}
+#page-ev.dm-evv .lm-evcc-btn .ev-ic{
+  display:grid!important;place-items:center!important;font-size:0!important;color:inherit!important
+}
+#page-ev.dm-evv .lm-evcc-btn .ev-lbl{color:inherit!important;font-size:9.5px!important;letter-spacing:.04em!important}
+#page-ev.dm-evv .lm-evcc-btn.active{
+  background:var(--btn-col)!important;color:#fff!important;
+  box-shadow:0 16px 26px -14px color-mix(in srgb,var(--btn-col) 95%,transparent)!important
+}
+#page-ev.dm-evv .lm-evcc-btn.active .ev-ic,#page-ev.dm-evv .lm-evcc-btn.active .ev-lbl{color:#fff!important}
+#page-ev.dm-evv .lm-evcc-btn.active .ev-ic{filter:none!important}
+#page-ev.dm-evv .dm-evv-fx{position:absolute;inset:0;z-index:0;opacity:0;pointer-events:none;transition:opacity .4s ease}
+#page-ev.dm-evv .lm-evcc-btn.active .dm-evv-fx{opacity:1}
+#page-ev.dm-evv .lm-evcc-btn .ev-ic,#page-ev.dm-evv .lm-evcc-btn .ev-lbl{position:relative;z-index:1}
+/* off — a ring that widens and fades: stopped, not broken */
+#page-ev.dm-evv #m-btn-off .dm-evv-fx::before{
+  content:"";position:absolute;left:50%;top:42%;width:52px;height:52px;margin:-26px 0 0 -26px;
+  border-radius:50%;border:2px solid rgba(255,255,255,.6);opacity:0
+}
+#page-ev.dm-evv #m-btn-off.active .dm-evv-fx::before{animation:dmEvvOffRing 3.4s ease-out infinite}
+/* pv — sun rays turning slowly behind the icon */
+#page-ev.dm-evv #m-btn-pv .dm-evv-fx::before{
+  content:"";position:absolute;left:50%;top:42%;width:104px;height:104px;margin:-52px 0 0 -52px;
+  background:repeating-conic-gradient(rgba(255,255,255,.34) 0deg 12deg,transparent 12deg 45deg);
+  -webkit-mask-image:radial-gradient(circle,transparent 16px,#000 20px,#000 36px,transparent 42px);
+  mask-image:radial-gradient(circle,transparent 16px,#000 20px,#000 36px,transparent 42px)
+}
+#page-ev.dm-evv #m-btn-pv.active .dm-evv-fx::before{animation:dmEvvSpin 11s linear infinite}
+/* minpv — a cloud crossing the sun: the grid minimum backing the solar */
+#page-ev.dm-evv #m-btn-minpv .dm-evv-fx::before{
+  content:"";position:absolute;top:24%;left:-45%;width:44px;height:14px;border-radius:999px;
+  background:rgba(255,255,255,.5);
+  box-shadow:11px -6px 0 -2px rgba(255,255,255,.5),-12px -3px 0 -4px rgba(255,255,255,.45);opacity:0
+}
+#page-ev.dm-evv #m-btn-minpv.active .dm-evv-fx::before{animation:dmEvvCloud 6.5s linear infinite}
+/* now — two speed trails */
+#page-ev.dm-evv #m-btn-now .dm-evv-fx::before,
+#page-ev.dm-evv #m-btn-now .dm-evv-fx::after{
+  content:"";position:absolute;left:-32%;width:34px;height:2px;border-radius:2px;opacity:0;
+  background:linear-gradient(90deg,transparent,rgba(255,255,255,.85),transparent)
+}
+#page-ev.dm-evv #m-btn-now .dm-evv-fx::before{top:32%}
+#page-ev.dm-evv #m-btn-now .dm-evv-fx::after{top:58%}
+#page-ev.dm-evv #m-btn-now.active .dm-evv-fx::before{animation:dmEvvZoom 1.5s linear infinite}
+#page-ev.dm-evv #m-btn-now.active .dm-evv-fx::after{animation:dmEvvZoom 1.5s linear infinite .45s}
+
+@keyframes dmEvvOffRing{0%{transform:scale(.5);opacity:.85}70%{opacity:0}100%{transform:scale(1.5);opacity:0}}
+@keyframes dmEvvSpin{to{transform:rotate(360deg)}}
+@keyframes dmEvvCloud{0%{left:-45%;opacity:0}12%{opacity:1}80%{opacity:1}100%{left:115%;opacity:0}}
+@keyframes dmEvvZoom{0%{left:-32%;opacity:0}20%{opacity:1}75%{opacity:1}100%{left:104%;opacity:0}}
+
+/* ── responsive ───────────────────────────────────────────────────────── */
+@media(max-width:620px){
+  #page-ev.dm-evv{--evv-r:22px;--evv-r-s:16px}
+  #page-ev.dm-evv .dm-evv-power{gap:13px;padding:14px}
+  #page-ev.dm-evv .dm-evv-gauge{width:96px;height:96px;flex:0 0 96px}
+  #page-ev.dm-evv .dm-evv-gauge .lm-batt-soc{font-size:28px!important}
+  #page-ev.dm-evv .dm-evv-row-lbl{font-size:11px}
+  #page-ev.dm-evv .dm-evv-row-val{font-size:15.5px}
+  #page-ev.dm-evv .lm-kpi-val{font-size:19px!important}
+}
+
+/* ── dark theme ───────────────────────────────────────────────────────── */
+[data-theme="dark"] #page-ev.dm-evv{
+  --evv-shadow:0 22px 40px -26px rgba(0,0,0,.75),0 2px 6px -3px rgba(0,0,0,.5);
+  --evv-shadow-s:0 16px 30px -24px rgba(0,0,0,.7),0 2px 5px -3px rgba(0,0,0,.45);
+}
+[data-theme="dark"] #page-ev.dm-evv .lm-hero{background:linear-gradient(180deg,#16202c,#0d1620)!important}
+[data-theme="dark"] #page-ev.dm-evv .dm-evv-gauge .lm-batt-soc{color:#e9f0f7!important}
+[data-theme="dark"] #page-ev.dm-evv .lm-stat-icon{background:rgba(var(--evv-green-rgb),.2)!important;color:#4ade80!important}
+[data-theme="dark"] #page-ev.dm-evv .dm-evv-row .dm-evv-ico,
+[data-theme="dark"] #page-ev.dm-evv .dm-evv-row:first-child .dm-evv-row-val,
+[data-theme="dark"] #page-ev.dm-evv .lm-solar-pct{color:#4ade80!important}
+
+/* ── motion ───────────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion:reduce){
+  #page-ev.dm-evv *,#page-ev.dm-evv *::before,#page-ev.dm-evv *::after{animation:none!important;transition:none!important}
+}
+`;
+}
+
+if (doc?.readyState === "loading") {
+  doc.addEventListener("DOMContentLoaded", installEvShowcaseSection, { once: true });
+} else {
+  installEvShowcaseSection();
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/icon-engine-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/icon-engine-section.js
@@ -2,11 +2,13 @@
 import {
   ACTION_ICON_CATALOG,
   CAR_BRANDS,
+  LOAD_ICON_CATALOG,
   ROOM_CATALOG,
   ROOM_GLYPHS,
   actionCatalogMatch,
   carBrandVisual,
   directEmoji,
+  loadGlyph,
   roomGlyph,
 } from "../core/personalization-catalog.js";
 import { clean, doc, esc, installStyle, root, t } from "./shared.js";
@@ -41,6 +43,7 @@ function normalizeKind(value) {
   const kind = clean(value).toLowerCase();
   if (["room", "rooms", "stanza", "stanze"].includes(kind)) return "room";
   if (["car", "cars", "vehicle", "brand"].includes(kind)) return "car";
+  if (["load", "loads", "carico", "carichi"].includes(kind)) return "load";
   return "action";
 }
 
@@ -61,6 +64,7 @@ function canonicalRoomGlyph(value) {
 export function iconGlyph(kind, value) {
   const normalized = normalizeKind(kind);
   if (normalized === "room") return canonicalRoomGlyph(value);
+  if (normalized === "load") return loadGlyph(value);
   if (normalized === "action") return actionGlyph(value);
   return "🚘";
 }
@@ -141,6 +145,20 @@ function rowsFor(kind) {
       visual: iconGlyphMarkup("room", item.mdi, { size: 31 }),
     }));
   }
+  if (normalized === "load") {
+    return LOAD_ICON_CATALOG.map((item) => ({
+      value: item.mdi,
+      label: english ? item.en : item.it,
+      search: `${item.it} ${item.en} ${item.keywords} ${item.id} ${item.mdi}`.toLowerCase(),
+      glyph: item.glyph,
+      size: 36,
+      group:
+        item.group === "room"
+          ? t("Aree della casa", "Areas of the home")
+          : t("Apparecchi e impianti", "Appliances and plants"),
+      visual: iconGlyphMarkup("load", item.mdi, { size: 36 }),
+    }));
+  }
   return ACTION_ICON_CATALOG.map((item) => ({
     value: item.mdi,
     label: english ? item.en : item.it,
@@ -165,6 +183,13 @@ function pickerCopy(kind) {
       icon: "😀",
       title: t("Scegli l'icona", "Choose icon"),
       placeholder: t("Cerca (es. acqua, porta, fuoco)…", "Search (e.g. water, door, fire)…"),
+    };
+  }
+  if (normalized === "load") {
+    return {
+      icon: "🔌",
+      title: t("Scegli icona del carico", "Choose load icon"),
+      placeholder: t("Cerca (es. cucina, forno, garage)…", "Search (e.g. kitchen, oven, garage)…"),
     };
   }
   return {
@@ -194,6 +219,50 @@ function pointerCanAutofocus() {
   }
 }
 
+function optionMarkup(item, index, kind) {
+  const owned =
+    kind === "car"
+      ? ""
+      : ` data-dm-icon-engine-owner="single" data-dm-icon-engine-glyph-value="${esc(item.glyph)}" style="--dm-icon-engine-glyph-size:${item.size}px"`;
+  const label = kind === "room" ? "" : `<b>${esc(item.label)}</b>`;
+  return `<button type="button" class="dm-picker-option${kind === "room" ? " dm-beta17-room-option" : ""}" data-index="${index}" data-search-text="${esc(item.search)}" aria-label="${esc(item.label)}" title="${esc(item.label)}"><span class="dm-picker-visual"${owned}>${item.visual}</span>${label}</button>`;
+}
+
+/* One tile per catalogue entry, with a heading wherever the group changes: a
+ * catalogue long enough to cover a whole house buries what is being looked for
+ * if it is drawn as one flat grid. Catalogues without groups are unchanged. */
+function gridMarkup(rows, kind) {
+  const parts = [];
+  let group = "";
+  rows.forEach((item, index) => {
+    if (item.group && item.group !== group) {
+      group = item.group;
+      parts.push(`<h4 class="dm-picker-group">${esc(group)}</h4>`);
+    }
+    parts.push(optionMarkup(item, index, kind));
+  });
+  return parts.join("");
+}
+
+/* A heading whose whole group was filtered out would otherwise sit above the
+ * next group's tiles and mislabel them. */
+function syncPickerGroups(modal) {
+  const grid = modal.querySelector(".dm-picker-grid");
+  if (!grid) return;
+  let heading = null;
+  let visible = 0;
+  for (const node of [...grid.children]) {
+    if (node.classList.contains("dm-picker-group")) {
+      if (heading) heading.hidden = visible === 0;
+      heading = node;
+      visible = 0;
+      continue;
+    }
+    if (!node.hidden) visible += 1;
+  }
+  if (heading) heading.hidden = visible === 0;
+}
+
 export function openIconPicker(input, kind = "action", options = {}) {
   if (!doc || !input) return false;
   const normalized = normalizeKind(kind);
@@ -208,11 +277,7 @@ export function openIconPicker(input, kind = "action", options = {}) {
   modal.dataset.dmSingleGlyphOwner = "true";
   modal.dataset.dmBeta17Picker = normalized;
   modal.dataset.dmBeta12Colored = "true";
-  modal.innerHTML = `<section class="dm-section-dialog dm-picker-dialog" role="dialog" aria-modal="true"><header><strong>${copy.icon} ${copy.title}</strong><button type="button" data-close aria-label="${t("Chiudi", "Close")}">✕</button></header><div class="dm-picker-search"><input class="ed-input" type="search" placeholder="🔎 ${esc(copy.placeholder)}" data-search></div><div class="dm-picker-grid">${rows
-    .map(
-      (item, index) => `<button type="button" class="dm-picker-option${normalized === "room" ? " dm-beta17-room-option" : ""}" data-index="${index}" data-search-text="${esc(item.search)}" aria-label="${esc(item.label)}" title="${esc(item.label)}"><span class="dm-picker-visual"${normalized === "car" ? "" : ` data-dm-icon-engine-owner="single" data-dm-icon-engine-glyph-value="${esc(item.glyph)}" style="--dm-icon-engine-glyph-size:${item.size}px"`}>${item.visual}</span>${normalized === "action" || normalized === "car" ? `<b>${esc(item.label)}</b>` : ""}</button>`,
-    )
-    .join("")}</div></section>`;
+  modal.innerHTML = `<section class="dm-section-dialog dm-picker-dialog" role="dialog" aria-modal="true"><header><strong>${copy.icon} ${copy.title}</strong><button type="button" data-close aria-label="${t("Chiudi", "Close")}">✕</button></header><div class="dm-picker-search"><input class="ed-input" type="search" placeholder="🔎 ${esc(copy.placeholder)}" data-search></div><div class="dm-picker-grid">${gridMarkup(rows, normalized)}</div></section>`;
   doc.body.append(modal);
 
   const close = () => modal.remove();
@@ -226,6 +291,7 @@ export function openIconPicker(input, kind = "action", options = {}) {
     modal.querySelectorAll(".dm-picker-option").forEach((button) => {
       button.hidden = Boolean(query) && !clean(button.dataset.searchText).includes(query);
     });
+    syncPickerGroups(modal);
   });
   modal.querySelectorAll(".dm-picker-option").forEach((button) => {
     button.addEventListener("click", () => {
@@ -491,7 +557,11 @@ function installStyles() {
       #dm-visual-picker[data-dm-icon-engine="single-owner"] .dm-picker-grid{display:grid!important;gap:8px!important;padding:6px 16px 18px!important;max-height:60dvh!important;overflow:auto!important;overscroll-behavior:contain!important}
       #dm-visual-picker[data-dm-icon-engine="single-owner"][data-kind="room"] .dm-picker-grid{grid-template-columns:repeat(7,minmax(0,1fr))!important}
       #dm-visual-picker[data-dm-icon-engine="single-owner"][data-kind="action"] .dm-picker-grid,
+      #dm-visual-picker[data-dm-icon-engine="single-owner"][data-kind="load"] .dm-picker-grid,
       #dm-visual-picker[data-dm-icon-engine="single-owner"][data-kind="car"] .dm-picker-grid{grid-template-columns:repeat(3,minmax(0,1fr))!important}
+      #dm-visual-picker[data-dm-icon-engine="single-owner"] .dm-picker-group{grid-column:1/-1!important;margin:10px 2px 2px!important;font-size:11px!important;font-weight:900!important;letter-spacing:1.2px!important;text-transform:uppercase!important;color:var(--secondary-text-color,#64748b)!important}
+      #dm-visual-picker[data-dm-icon-engine="single-owner"] .dm-picker-group:first-child{margin-top:0!important}
+      #dm-visual-picker[data-dm-icon-engine="single-owner"] .dm-picker-group[hidden]{display:none!important}
       #dm-visual-picker[data-dm-icon-engine="single-owner"] .dm-picker-option{box-sizing:border-box!important;min-width:0!important;min-height:94px!important;padding:9px 6px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:15px!important;background:var(--ha-card-background,var(--card-background-color,#fff))!important;color:var(--text,#0f172a)!important;transform:none!important;transition:border-color .12s ease,box-shadow .12s ease!important}
       #dm-visual-picker[data-dm-icon-engine="single-owner"][data-kind="room"] .dm-picker-option{min-height:54px!important;padding:5px!important}
       #dm-visual-picker[data-dm-icon-engine="single-owner"] .dm-picker-option[hidden]{display:none!important}
@@ -505,7 +575,8 @@ function installStyles() {
         #dm-visual-picker[data-dm-icon-engine="single-owner"] .dm-picker-dialog{width:calc(100vw - 12px)!important;max-height:92dvh!important}
         #dm-visual-picker[data-dm-icon-engine="single-owner"] .dm-picker-grid{padding:5px 9px 14px!important;gap:6px!important;max-height:64dvh!important}
         #dm-visual-picker[data-dm-icon-engine="single-owner"][data-kind="room"] .dm-picker-option{min-height:48px!important;border-radius:12px!important}
-        #dm-visual-picker[data-dm-icon-engine="single-owner"][data-kind="action"] .dm-picker-option{min-height:92px!important;border-radius:14px!important}
+        #dm-visual-picker[data-dm-icon-engine="single-owner"][data-kind="action"] .dm-picker-option,
+        #dm-visual-picker[data-dm-icon-engine="single-owner"][data-kind="load"] .dm-picker-option{min-height:92px!important;border-radius:14px!important}
       }
     `,
   );

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -26,6 +26,7 @@ import { installLightsAlertsSection } from "./lights-alerts-section.js";
 import { installAlertsSection } from "./alerts-section.js";
 import { installLiveUiSection } from "./live-ui-section.js";
 import { installSecurityShowcaseSection } from "./security-showcase-section.js";
+import { installClimateThermalSection } from "./climate-thermal-section.js";
 import { installNavigationSection } from "./navigation-section.js";
 import { installUnifiedEditorsSection } from "./unified-editors-section.js";
 import { installEntitySearchSection } from "./entity-search-section.js";
@@ -631,6 +632,7 @@ export function installSectionRuntime() {
     // owner starts filling the thumbnails, so the first paint is already the new
     // wall instead of the legacy cards.
     installSecurityShowcaseSection();
+    installClimateThermalSection();
     installLiveUiSection();
     installNavigationSection();
     installUnifiedEditorsSection();
@@ -673,6 +675,7 @@ export function installSectionRuntime() {
         "lights",
         "alerts",
         "security-showcase",
+        "climate-thermal",
         "live-ui",
         "navigation",
         "unified-editors",

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -33,6 +33,7 @@ import { installReportEditorSection } from "./report-editor-section.js";
 import { installShutterSection } from "./shutter-section.js";
 import { installPoolIrrigationSceneSection } from "./pool-irrigation-scene-section.js";
 import { installEvSection } from "./ev-section.js";
+import { installSolarThermalDesignSection } from "./solar-thermal-design-section.js";
 import { installLegacySections, LEGACY_SECTION_KEYS } from "./legacy-sections-registry.js";
 import { allStates, clean, english, section, wrapFunction } from "./shared.js";
 
@@ -631,6 +632,7 @@ export function installSectionRuntime() {
     installShutterSection();
     installPoolIrrigationSceneSection();
     installEvSection();
+    installSolarThermalDesignSection();
     installBeta27ReleaseStability();
 
     root[RUNTIME_KEY] = Object.freeze({
@@ -666,6 +668,7 @@ export function installSectionRuntime() {
         "shutters",
         "pool-irrigation-scene",
         "ev",
+        "solar-thermal-design",
         "beta27-release-stability",
       ]),
       registry: root.__DASHBOARDMODERN_SECTIONS__,

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -32,6 +32,7 @@ import { installEditorCrudSection } from "./editor-crud-section.js";
 import { installEditorContractsSection } from "./editor-contracts-section.js";
 import { installReportEditorSection } from "./report-editor-section.js";
 import { installShutterSection } from "./shutter-section.js";
+import { installShutterSceneSection } from "./shutter-scene-section.js";
 import { installPoolIrrigationSceneSection } from "./pool-irrigation-scene-section.js";
 import { installEvSection } from "./ev-section.js";
 import { installSolarThermalDesignSection } from "./solar-thermal-design-section.js";
@@ -635,6 +636,7 @@ export function installSectionRuntime() {
     installEditorContractsSection();
     installReportEditorSection();
     installShutterSection();
+    installShutterSceneSection();
     installPoolIrrigationSceneSection();
     installEvSection();
     installSolarThermalDesignSection();

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -25,6 +25,7 @@ import { installApplianceEditorSection } from "./appliance-editor-section.js";
 import { installLightsAlertsSection } from "./lights-alerts-section.js";
 import { installAlertsSection } from "./alerts-section.js";
 import { installLiveUiSection } from "./live-ui-section.js";
+import { installSecurityShowcaseSection } from "./security-showcase-section.js";
 import { installNavigationSection } from "./navigation-section.js";
 import { installUnifiedEditorsSection } from "./unified-editors-section.js";
 import { installEditorCrudSection } from "./editor-crud-section.js";
@@ -623,6 +624,10 @@ export function installSectionRuntime() {
     installApplianceEditorSection();
     installLightsAlertsSection();
     installAlertsSection();
+    // The redesigned Security page must own #cam-grid before the live-ui camera
+    // owner starts filling the thumbnails, so the first paint is already the new
+    // wall instead of the legacy cards.
+    installSecurityShowcaseSection();
     installLiveUiSection();
     installNavigationSection();
     installUnifiedEditorsSection();
@@ -659,6 +664,7 @@ export function installSectionRuntime() {
         "appliance-editor",
         "lights",
         "alerts",
+        "security-showcase",
         "live-ui",
         "navigation",
         "unified-editors",

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -28,6 +28,7 @@ import { installLiveUiSection } from "./live-ui-section.js";
 import { installSecurityShowcaseSection } from "./security-showcase-section.js";
 import { installNavigationSection } from "./navigation-section.js";
 import { installUnifiedEditorsSection } from "./unified-editors-section.js";
+import { installEntitySearchSection } from "./entity-search-section.js";
 import { installEditorCrudSection } from "./editor-crud-section.js";
 import { installEditorContractsSection } from "./editor-contracts-section.js";
 import { installReportEditorSection } from "./report-editor-section.js";
@@ -633,6 +634,7 @@ export function installSectionRuntime() {
     installLiveUiSection();
     installNavigationSection();
     installUnifiedEditorsSection();
+    installEntitySearchSection();
     installEditorCrudSection();
     installEditorContractsSection();
     installReportEditorSection();
@@ -674,6 +676,7 @@ export function installSectionRuntime() {
         "live-ui",
         "navigation",
         "unified-editors",
+        "entity-search",
         "editor-crud",
         "editor-contracts",
         "report-editor",

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -35,6 +35,7 @@ import { installShutterSection } from "./shutter-section.js";
 import { installShutterSceneSection } from "./shutter-scene-section.js";
 import { installPoolIrrigationSceneSection } from "./pool-irrigation-scene-section.js";
 import { installEvSection } from "./ev-section.js";
+import { installEvShowcaseSection } from "./ev-showcase-section.js";
 import { installSolarThermalDesignSection } from "./solar-thermal-design-section.js";
 import { installLegacySections, LEGACY_SECTION_KEYS } from "./legacy-sections-registry.js";
 import { allStates, clean, english, section, wrapFunction } from "./shared.js";
@@ -639,6 +640,9 @@ export function installSectionRuntime() {
     installShutterSceneSection();
     installPoolIrrigationSceneSection();
     installEvSection();
+    // The skin installs after the EV owner so the vehicle picker it restyles is
+    // already mounted, and re-renders itself on the same runtime events.
+    installEvShowcaseSection();
     installSolarThermalDesignSection();
     installBeta27ReleaseStability();
 
@@ -676,6 +680,7 @@ export function installSectionRuntime() {
         "shutters",
         "pool-irrigation-scene",
         "ev",
+        "ev-showcase",
         "solar-thermal-design",
         "beta27-release-stability",
       ]),

--- a/custom_components/dashboardmodern/frontend/src/sections/security-showcase-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/security-showcase-section.js
@@ -1,0 +1,775 @@
+// DM-FIX-20260817C
+/* Security section redesign.
+ *
+ * Rebuilds the Sicurezza page as an operations console: a masthead, one alarm
+ * console with a radar-style status orb, and the cameras as light cards that
+ * match the rest of the dashboard. Only the video area itself stays dark, which
+ * is the letterbox of the frame rather than a panel behind the cards.
+ *
+ * Contracts preserved on purpose — the legacy runtime keeps owning behaviour:
+ * - the alarm console is still `#alarm-stage`, so the legacy render loop keeps
+ *   toggling `.armed` / `.triggered`, writing `--al-col` / `--al-rgb` /
+ *   `--al-soft` and hiding the block when the alarm is not mapped;
+ * - `#alarm-icon-new`, `#alarm-state-text-new` and `#alarm-state-timer` (with
+ *   its `.show` class) keep the same ids, and the mode buttons keep the
+ *   `.alarm-mode-btn[data-mode]` contract plus their `promptPinAndSet()` calls,
+ *   so the PIN keypad flow is untouched;
+ * - camera tiles stay `.cam-card` inside `#cam-grid` with `<img id="cam-…">`
+ *   and `.cam-time`, which is what `refreshCameras()` / the live-ui camera
+ *   owner / `updateCamClocks()` write into;
+ * - opening a camera still goes through `apriCamera(slug, title)`, so WebRTC →
+ *   HLS → MJPEG → polling, the audio panel and `toggleFullScreenCam()` behave
+ *   exactly as before.
+ *
+ * "Protetto / Intrusione" is rendered from the legacy `.armed` / `.triggered`
+ * classes in pure CSS, so no alarm logic is duplicated here.
+ */
+import {
+  allStates,
+  clean,
+  doc,
+  english,
+  esc,
+  installStyle,
+  readJson,
+  root,
+  section,
+  t,
+} from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_SECURITY_SHOWCASE__";
+const STYLE_ID = "dm-security-showcase-style";
+const state = (root[KEY] ||= { installed: false, listeners: false });
+
+const OFFLINE_STATES = new Set(["", "unavailable", "unknown", "none", "null"]);
+
+const ICONS = Object.freeze({
+  shield:
+    '<svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 3.2 5 6v5.3c0 4.3 2.9 8.3 7 9.5 4.1-1.2 7-5.2 7-9.5V6l-7-2.8Z" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/><path d="m9.2 12.1 2 2 3.6-3.9" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+  camera:
+    '<svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M3.5 8.6 17 5.2l1.5 5.2L5 13.8 3.5 8.6Z" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/><path d="M18.5 10.4 21.4 9l.9 3.2-2.9.9" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/><path d="M6.6 13.4 8 18.6" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/><circle cx="8" cy="19.4" r="1.6" stroke="currentColor" stroke-width="1.7"/></svg>',
+  expand:
+    '<svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M9.5 4.5H4.5V9.5M14.5 4.5h5v5M9.5 19.5h-5v-5M14.5 19.5h5v-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+  signal:
+    '<svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M4.8 4.8 19.2 19.2" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/><path d="M12 15.6a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z" fill="currentColor"/><path d="M7.6 12.4a6.2 6.2 0 0 1 3-1.7M16.4 12.4a6.2 6.2 0 0 0-2.3-1.5M4.6 9.2a10.6 10.6 0 0 1 3.6-2.2M19.4 9.2a10.6 10.6 0 0 0-4.6-2.4" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>',
+});
+
+const copy = () => ({
+  title: sectionName(),
+  subtitle: t("Antifurto e videosorveglianza", "Alarm system and video surveillance"),
+  alarmCap: t("Stato antifurto", "Alarm status"),
+  loading: t("CARICAMENTO", "LOADING"),
+  away: t("Fuori", "Away"),
+  awayHint: t("Inserimento totale", "Full arm"),
+  night: t("Notte", "Night"),
+  nightHint: t("Perimetro attivo", "Perimeter"),
+  disarm: t("Sblocca", "Disarm"),
+  disarmHint: t("Disinserisci", "Turn off"),
+  cctv: t("Videosorveglianza", "Video surveillance"),
+  rec: "REC",
+  live: "LIVE",
+  noSignal: t("Nessun segnale", "No signal"),
+  channelsOne: t("1 canale", "1 channel"),
+  channels: (value) => t(`${value} canali`, `${value} channels`),
+  activeCount: (value) => t(`${value} attivi`, `${value} live`),
+  offlineCount: (value) => t(`${value} offline`, `${value} offline`),
+  cctvOn: t("TVCC attivo", "CCTV live"),
+  cctvOff: t("TVCC offline", "CCTV offline"),
+  cctvNone: t("TVCC non configurato", "CCTV not configured"),
+  empty: t("Nessuna telecamera configurata", "No camera configured"),
+  emptyHint: t(
+    "Aggiungi le tue telecamere dalla Configurazione: appariranno qui con anteprima live.",
+    "Add your cameras from Configuration: they will show up here with a live preview.",
+  ),
+  emptyCta: t("Apri configurazione", "Open configuration"),
+  openCamera: t("Apri la telecamera", "Open camera"),
+});
+
+function sectionName() {
+  const names = readJson("cd_section_names", {});
+  const custom = clean(names?.security);
+  return custom || t("Sicurezza", "Security");
+}
+
+/* ── data ─────────────────────────────────────────────────────────────── */
+
+export function securityCameras() {
+  if (typeof root.getCameras === "function") {
+    try {
+      const values = root.getCameras();
+      if (Array.isArray(values)) return values;
+    } catch (_error) {}
+  }
+  const canonical = section("cameras", null);
+  const values = Array.isArray(canonical) && canonical.length ? canonical : readJson("cd_cameras", []);
+  return Array.isArray(values) ? values : [];
+}
+
+export function cameraSlug(camera, index) {
+  if (typeof root.camSlug === "function") {
+    try {
+      const value = clean(root.camSlug(camera, index));
+      if (value) return value;
+    } catch (_error) {}
+  }
+  const entity = clean(camera?.entity || camera?.camera_entity || camera?.cam);
+  return `cam-${entity.includes(".") ? entity.split(".")[1] : `x${index}`}`;
+}
+
+export function cameraOffline(entity, states = allStates()) {
+  const value = clean(states?.[clean(entity)]?.state).toLowerCase();
+  return OFFLINE_STATES.has(value);
+}
+
+function cameraModels(cameras = securityCameras()) {
+  return cameras.map((camera, index) => {
+    const entity = clean(camera?.entity || camera?.camera_entity || camera?.cam);
+    const name = clean(camera?.name) || entity || `CAM ${index + 1}`;
+    const channel = String(index + 1).padStart(2, "0");
+    return {
+      slug: cameraSlug(camera, index),
+      entity,
+      name,
+      channel,
+      // Keep the legacy popup heading so the detail modal title is unchanged.
+      title: `CAM ${channel} // ${name.toUpperCase()}`,
+    };
+  });
+}
+
+/* ── markup ───────────────────────────────────────────────────────────── */
+
+function modeButton({ mode, service, icon, label, hint }) {
+  return `<button type="button" class="alarm-mode-btn dm-sec-mode" data-mode="${mode}" onclick="promptPinAndSet('${service}')">
+      <span class="dm-sec-mode-ic" aria-hidden="true">${icon}</span>
+      <span class="dm-sec-mode-tx">${esc(label)}</span>
+      <span class="dm-sec-mode-hint">${esc(hint)}</span>
+    </button>`;
+}
+
+function skeletonMarkup(labels) {
+  return `<div class="dm-sec-shell" data-dm-lang="${english() ? "en" : "it"}">
+  <div class="dm-sec-mast">
+    <span class="dm-sec-mast-ic" aria-hidden="true">${ICONS.shield}</span>
+    <div class="dm-sec-mast-copy">
+      <h2>${esc(labels.title)}</h2>
+      <p>${esc(labels.subtitle)}</p>
+    </div>
+    <span class="dm-sec-pill" data-dm-cctv-pill data-live="0"><i aria-hidden="true"></i><b>${esc(labels.cctvNone)}</b></span>
+  </div>
+
+  <section class="dm-sec-alarm" id="alarm-stage">
+    <span class="dm-sec-ridge" aria-hidden="true"></span>
+    <span class="dm-sec-mesh" aria-hidden="true"></span>
+    <div class="dm-sec-readout">
+      <span class="dm-sec-orb" aria-hidden="true">
+        <span class="dm-sec-orb-track"></span>
+        <span class="dm-sec-orb-sweep"></span>
+        <span class="dm-sec-orb-core"><span id="alarm-icon-new">🛡️</span></span>
+        <span class="dm-sec-beacon" id="alarm-status-dot"></span>
+      </span>
+      <div class="dm-sec-readout-copy">
+        <span class="dm-sec-cap">${esc(labels.alarmCap)}</span>
+        <strong id="alarm-state-text-new">${esc(labels.loading)}</strong>
+        <span class="dm-sec-readout-meta">
+          <span class="dm-sec-chip"></span>
+          <span class="dm-sec-timer" id="alarm-state-timer"></span>
+        </span>
+      </div>
+    </div>
+    <div class="dm-sec-modes">
+      ${modeButton({ mode: "away", service: "alarm_arm_away", icon: "🏠", label: labels.away, hint: labels.awayHint })}
+      ${modeButton({ mode: "night", service: "alarm_arm_night", icon: "🌙", label: labels.night, hint: labels.nightHint })}
+      ${modeButton({ mode: "disarm", service: "alarm_disarm", icon: "🔓", label: labels.disarm, hint: labels.disarmHint })}
+    </div>
+  </section>
+
+  <section class="dm-sec-cctv">
+    <div class="dm-sec-cctv-head">
+      <span class="dm-sec-cctv-ic" aria-hidden="true">${ICONS.camera}</span>
+      <h3>${esc(labels.cctv)}</h3>
+      <span class="dm-sec-rec"><i aria-hidden="true"></i>${esc(labels.rec)}</span>
+      <span class="dm-sec-cctv-meta" data-dm-cam-meta></span>
+      <span class="dm-sec-clock cam-time">--:--:--</span>
+    </div>
+    <div class="cam-grid dm-sec-grid" id="cam-grid"></div>
+    <div class="dm-sec-empty" data-dm-cam-empty hidden>
+      <span class="dm-sec-empty-ic" aria-hidden="true">${ICONS.camera}</span>
+      <strong>${esc(labels.empty)}</strong>
+      <p>${esc(labels.emptyHint)}</p>
+      <button type="button" class="dm-sec-empty-cta" data-dm-open-config>${esc(labels.emptyCta)}</button>
+    </div>
+  </section>
+</div>`;
+}
+
+function cardMarkup(model, labels) {
+  return `<article class="cam-card dm-cam" data-dm-cam="${esc(model.slug)}" data-dm-entity="${esc(model.entity)}" data-dm-title="${esc(model.title)}" role="button" tabindex="0" aria-label="${esc(labels.openCamera)}: ${esc(model.name)}">
+      <div class="dm-cam-feed">
+        <img id="${esc(model.slug)}" alt="" decoding="async">
+        <span class="dm-cam-scan" aria-hidden="true"></span>
+        <span class="dm-cam-frame" aria-hidden="true"></span>
+        <div class="dm-cam-top">
+          <span class="dm-cam-live"><i aria-hidden="true"></i>${esc(labels.live)}</span>
+          <span class="dm-cam-ch">CH${esc(model.channel)}</span>
+        </div>
+        <span class="dm-cam-open" aria-hidden="true">${ICONS.expand}</span>
+        <div class="dm-cam-off">
+          <span class="dm-cam-off-ic" aria-hidden="true">${ICONS.signal}</span>
+          <b>${esc(labels.noSignal)}</b>
+        </div>
+      </div>
+      <footer class="dm-cam-foot">
+        <span class="dm-cam-name">${esc(model.name)}</span>
+        <span class="dm-cam-time cam-time" id="time-${esc(model.slug.replace(/^cam-/, ""))}">--:--:--</span>
+      </footer>
+    </article>`;
+}
+
+/* ── rendering ────────────────────────────────────────────────────────── */
+
+function ensureSkeleton(host, labels) {
+  if (host.querySelector(":scope > .dm-sec-shell")) return false;
+  const backButton = host.querySelector(":scope > .back-home-btn");
+  host.innerHTML = skeletonMarkup(labels);
+  if (backButton) host.insertBefore(backButton, host.firstChild);
+  return true;
+}
+
+function cardsSignature(models) {
+  return JSON.stringify(models.map((model) => [model.slug, model.entity, model.name, model.channel]));
+}
+
+/**
+ * Rebuild the camera wall only when the configured cameras really changed.
+ * A blind innerHTML rewrite would drop every `<img>` already holding a live
+ * frame, so the wall would flash grey on every Home Assistant state event.
+ */
+function syncCards(grid, models, labels) {
+  const legacyCards = grid.querySelector(":scope > .cam-card:not(.dm-cam)");
+  const signature = cardsSignature(models);
+  if (!legacyCards && grid._sig === signature) return false;
+  grid.innerHTML = models.map((model) => cardMarkup(model, labels)).join("");
+  grid._sig = signature;
+  return true;
+}
+
+export function renderSecurity() {
+  const host = doc?.getElementById?.("page-security");
+  if (!host) return false;
+  const labels = copy();
+  ensureSkeleton(host, labels);
+  const shell = host.querySelector(":scope > .dm-sec-shell");
+  const grid = doc.getElementById("cam-grid");
+  if (!shell || !grid) return false;
+
+  const models = cameraModels();
+  syncCards(grid, models, labels);
+
+  const states = allStates();
+  let online = 0;
+  for (const card of grid.querySelectorAll(":scope > .dm-cam")) {
+    const offline = cameraOffline(card.dataset.dmEntity, states);
+    card.classList.toggle("is-off", offline);
+    if (!offline) online += 1;
+  }
+
+  const total = models.length;
+  const empty = shell.querySelector("[data-dm-cam-empty]");
+  if (empty) empty.hidden = total > 0;
+  grid.hidden = total === 0;
+  shell.querySelector(".dm-sec-cctv")?.classList.toggle("is-empty", total === 0);
+
+  const meta = shell.querySelector("[data-dm-cam-meta]");
+  if (meta) {
+    const channels = total === 1 ? labels.channelsOne : labels.channels(total);
+    const detail = online === total ? labels.activeCount(online) : labels.offlineCount(total - online);
+    meta.textContent = total ? `${channels} · ${detail}` : "";
+  }
+
+  const pill = shell.querySelector("[data-dm-cctv-pill]");
+  if (pill) {
+    const live = total > 0 && online > 0;
+    pill.dataset.live = live ? "1" : "0";
+    const text = pill.querySelector("b");
+    if (text) text.textContent = total === 0 ? labels.cctvNone : live ? labels.cctvOn : labels.cctvOff;
+  }
+  return true;
+}
+
+/* ── wiring ───────────────────────────────────────────────────────────── */
+
+function securityVisible() {
+  return Boolean(doc?.getElementById("page-security")?.classList.contains("active"));
+}
+
+function openCamera(card) {
+  const slug = clean(card?.dataset?.dmCam);
+  if (!slug || typeof root.apriCamera !== "function") return;
+  root.apriCamera(slug, clean(card.dataset.dmTitle));
+}
+
+function onShellClick(event) {
+  const target = event.target;
+  if (target?.closest?.("[data-dm-open-config]")) {
+    event.preventDefault();
+    root.apriConfigEntita?.();
+    return;
+  }
+  const card = target?.closest?.(".dm-cam[data-dm-cam]");
+  if (card) openCamera(card);
+}
+
+function onShellKeydown(event) {
+  if (event.key !== "Enter" && event.key !== " ") return;
+  const card = event.target?.closest?.(".dm-cam[data-dm-cam]");
+  if (!card) return;
+  event.preventDefault();
+  openCamera(card);
+}
+
+/**
+ * The legacy `buildCamCards` is still called by `dmSaveCameras`, by the store
+ * render coordinator and by the live-ui camera owner. Route all of them to the
+ * redesigned wall so no caller can repaint the legacy markup underneath it.
+ */
+function installOverrides() {
+  const current = root.buildCamCards;
+  if (typeof current !== "function" || !current.__dmSecurityShowcase) {
+    function buildCamCardsShowcase() {
+      return renderSecurity();
+    }
+    buildCamCardsShowcase.__dmSecurityShowcase = true;
+    buildCamCardsShowcase.__dmPrevious = current;
+    root.buildCamCards = buildCamCardsShowcase;
+  }
+  const currentRender = root.renderSecurity;
+  if (typeof currentRender !== "function" || !currentRender.__dmSecurityShowcase) {
+    function renderSecurityShowcase() {
+      return renderSecurity();
+    }
+    renderSecurityShowcase.__dmSecurityShowcase = true;
+    renderSecurityShowcase.__dmPrevious = currentRender;
+    root.renderSecurity = renderSecurityShowcase;
+  }
+}
+
+export function installSecurityShowcaseSection() {
+  if (!doc) return;
+  installStyle(STYLE_ID, securityCss());
+  installOverrides();
+  if (!state.listeners) {
+    state.listeners = true;
+    doc.addEventListener("click", onShellClick);
+    doc.addEventListener("keydown", onShellKeydown);
+    for (const eventName of [
+      "dashboardmodern:legacy-ready",
+      "dashboardmodern:runtime-ready",
+      "pageshow",
+    ]) {
+      root.addEventListener?.(eventName, () => {
+        installOverrides();
+        renderSecurity();
+      });
+    }
+    // The legacy runtime registered its own `buildCamCards` on DOMContentLoaded
+    // with a direct function reference, so the override above cannot intercept
+    // that one call. Re-render right after it to reclaim the wall.
+    if (doc.readyState === "loading") {
+      doc.addEventListener("DOMContentLoaded", () => renderSecurity(), { once: true });
+    }
+    // Event-driven only: the camera frames keep arriving from the live-ui
+    // camera owner and the clock from the legacy `updateCamClocks()` timer.
+    root.addEventListener?.("dashboardmodern:state-changed", () => {
+      if (securityVisible()) renderSecurity();
+    });
+    doc.addEventListener(
+      "click",
+      (event) => {
+        if (event.target?.closest?.('[data-tab="security"]')) {
+          root.queueMicrotask?.(() => renderSecurity());
+        }
+      },
+      true,
+    );
+  }
+  state.installed = true;
+  renderSecurity();
+}
+
+/* ── styles ───────────────────────────────────────────────────────────── */
+
+function securityCss() {
+  return `
+.dm-sec-shell,.dm-sec-shell *,.dm-sec-shell *::before,.dm-sec-shell *::after{box-sizing:border-box}
+.dm-sec-shell{
+  --dm-sec-cyan:#22d3ee;--dm-sec-cyan-deep:#0284c7;
+  --dm-sec-card:var(--card-bg,#fff);--dm-sec-border:var(--card-border,#e8edf3);
+  --dm-sec-text:var(--text,#0f172a);--dm-sec-dim:var(--text-dim,#64748b);
+  --dm-sec-mono:'Share Tech Mono','Monaco',ui-monospace,monospace;
+  display:flex;flex-direction:column;gap:20px;
+  width:100%;max-width:1250px;margin:0 auto;padding:2px;color:var(--dm-sec-text)
+}
+
+/* ── masthead (a row, not another box) ───────────────────────────────── */
+.dm-sec-mast{display:flex;align-items:center;gap:14px;flex-wrap:wrap;padding:2px 4px 0}
+.dm-sec-mast-ic{
+  width:50px;height:50px;flex:0 0 50px;display:grid;place-items:center;border-radius:16px;
+  background:linear-gradient(140deg,#ffe4e6,#fee2e2 50%,#e0f2fe);color:#be123c;
+  box-shadow:inset 0 0 0 1px rgba(190,18,60,.16)
+}
+.dm-sec-mast-ic svg{width:27px;height:27px}
+.dm-sec-mast-copy{min-width:0;flex:1}
+.dm-sec-mast-copy h2{
+  margin:0;font-family:'Oswald',sans-serif;font-weight:700;
+  font-size:clamp(24px,3.2vw,33px);line-height:1.06;letter-spacing:1.4px;text-transform:uppercase
+}
+.dm-sec-mast-copy p{margin:2px 0 0;font-size:12.5px;font-weight:600;color:var(--dm-sec-dim)}
+.dm-sec-pill{
+  display:inline-flex;align-items:center;gap:9px;height:36px;padding:0 15px;border-radius:999px;
+  border:1px solid var(--dm-sec-border);background:var(--surface-3,#f1f5f9);color:var(--dm-sec-dim);
+  font-family:var(--dm-sec-mono);font-size:11px;letter-spacing:1.4px;text-transform:uppercase;white-space:nowrap
+}
+.dm-sec-pill i{width:8px;height:8px;border-radius:50%;background:currentColor;flex:0 0 8px}
+.dm-sec-pill[data-live="1"]{
+  border-color:rgba(6,182,212,.32);background:rgba(6,182,212,.10);color:var(--dm-sec-cyan-deep)
+}
+.dm-sec-pill[data-live="1"] i{background:#06b6d4;animation:dmSecPing 2s ease-out infinite}
+
+/* ── alarm console ───────────────────────────────────────────────────── */
+.dm-sec-alarm{
+  --al-col:#059669;--al-rgb:5,150,105;
+  position:relative;overflow:hidden;isolation:isolate;
+  padding:28px;border-radius:28px;
+  border:1px solid rgba(var(--al-rgb),.24);
+  background:
+    radial-gradient(108% 128% at 92% -18%,rgba(var(--al-rgb),.15),transparent 55%),
+    radial-gradient(86% 116% at 2% 116%,rgba(var(--al-rgb),.09),transparent 58%),
+    var(--dm-sec-card);
+  box-shadow:0 18px 46px rgba(15,23,42,.09);
+  transition:border-color .6s ease,box-shadow .6s ease,background .6s ease
+}
+/* state ridge along the top edge */
+.dm-sec-ridge{
+  position:absolute;top:0;left:0;right:0;height:3px;z-index:3;overflow:hidden;
+  background:linear-gradient(90deg,transparent,rgba(var(--al-rgb),.55) 18%,rgb(var(--al-rgb)) 50%,rgba(var(--al-rgb),.55) 82%,transparent)
+}
+.dm-sec-ridge::after{
+  content:"";position:absolute;top:0;bottom:0;width:22%;
+  background:linear-gradient(90deg,transparent,rgba(255,255,255,.9),transparent);opacity:0
+}
+.dm-sec-alarm.armed .dm-sec-ridge::after{opacity:.8;animation:dmSecRidge 3.4s linear infinite}
+.dm-sec-alarm.triggered .dm-sec-ridge::after{opacity:.9;animation:dmSecRidge 1.1s linear infinite}
+/* faint measurement mesh — the console texture */
+.dm-sec-mesh{
+  position:absolute;inset:0;z-index:0;pointer-events:none;opacity:0;transition:opacity .6s ease;
+  background-image:radial-gradient(rgba(var(--al-rgb),.30) 1px,transparent 1px);
+  background-size:17px 17px;
+  -webkit-mask-image:linear-gradient(115deg,rgba(0,0,0,.85),transparent 58%);
+  mask-image:linear-gradient(115deg,rgba(0,0,0,.85),transparent 58%)
+}
+.dm-sec-alarm.armed .dm-sec-mesh,.dm-sec-alarm.triggered .dm-sec-mesh{opacity:1}
+
+.dm-sec-readout{position:relative;z-index:1;display:flex;align-items:center;gap:22px}
+
+/* radar orb: dashed perimeter + rotating sweep while the system is armed */
+.dm-sec-orb{position:relative;width:106px;height:106px;flex:0 0 106px;display:grid;place-items:center}
+.dm-sec-orb-track{
+  position:absolute;inset:0;border-radius:50%;
+  border:2px dashed rgba(var(--al-rgb),.40);transition:border-color .5s ease
+}
+.dm-sec-orb-sweep{
+  position:absolute;inset:6px;border-radius:50%;opacity:0;transition:opacity .5s ease;
+  background:conic-gradient(from 0deg,rgba(var(--al-rgb),.85),rgba(var(--al-rgb),.10) 26%,transparent 44%);
+  /* an annulus, so the sweep reads as a radar arm instead of a filled disc */
+  -webkit-mask-image:radial-gradient(closest-side,transparent 76%,#000 78%);
+  mask-image:radial-gradient(closest-side,transparent 76%,#000 78%)
+}
+.dm-sec-orb-core{
+  position:relative;z-index:2;width:74px;height:74px;border-radius:50%;
+  display:grid;place-items:center;font-size:31px;line-height:1;
+  background:var(--dm-sec-card);
+  box-shadow:0 10px 26px rgba(var(--al-rgb),.26),inset 0 0 0 2px rgba(var(--al-rgb),.34)
+}
+.dm-sec-orb-core>span{filter:drop-shadow(0 3px 9px rgba(var(--al-rgb),.30))}
+.dm-sec-alarm.armed .dm-sec-orb-track{animation:dmSecSpin 22s linear infinite}
+.dm-sec-alarm.armed .dm-sec-orb-sweep{opacity:1;animation:dmSecSpin 4.5s linear infinite}
+.dm-sec-alarm.triggered .dm-sec-orb-track{border-style:solid;animation:dmSecSpin 4s linear infinite}
+.dm-sec-alarm.triggered .dm-sec-orb-sweep{opacity:1;animation:dmSecSpin 1.1s linear infinite}
+.dm-sec-alarm.triggered .dm-sec-orb-core{animation:dmSecShout 1.1s ease-in-out infinite}
+.dm-sec-beacon{
+  position:absolute;top:6px;right:6px;z-index:3;width:15px;height:15px;border-radius:50%;
+  background:var(--al-col);border:3px solid var(--dm-sec-card);
+  box-shadow:0 0 0 0 rgba(var(--al-rgb),.6);animation:dmSecPing 2s ease-out infinite
+}
+
+.dm-sec-readout-copy{flex:1;min-width:0;display:flex;flex-direction:column;gap:5px}
+.dm-sec-cap{
+  font-family:var(--dm-sec-mono);font-size:11px;letter-spacing:2.2px;
+  text-transform:uppercase;color:var(--dm-sec-dim)
+}
+.dm-sec-readout-copy>strong{
+  font-family:'Oswald',sans-serif;font-size:clamp(27px,4.4vw,40px);font-weight:700;
+  line-height:1.02;letter-spacing:1px;text-transform:uppercase;color:var(--al-col);
+  transition:color .5s ease
+}
+.dm-sec-readout-meta{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-top:4px}
+.dm-sec-chip{
+  display:inline-flex;align-items:center;gap:7px;height:27px;padding:0 13px;border-radius:999px;
+  background:rgba(var(--al-rgb),.12);border:1px solid rgba(var(--al-rgb),.26);color:rgb(var(--al-rgb));
+  font-family:var(--dm-sec-mono);font-size:10.5px;letter-spacing:1.5px;text-transform:uppercase
+}
+.dm-sec-chip::before{content:"";width:6px;height:6px;border-radius:50%;background:currentColor;flex:0 0 6px}
+.dm-sec-chip::after{content:"Non protetto"}
+.dm-sec-alarm.armed .dm-sec-chip::after{content:"Protetto"}
+.dm-sec-alarm.triggered .dm-sec-chip::after{content:"Intrusione"}
+[data-dm-lang="en"] .dm-sec-chip::after{content:"Unprotected"}
+[data-dm-lang="en"] .dm-sec-alarm.armed .dm-sec-chip::after{content:"Protected"}
+[data-dm-lang="en"] .dm-sec-alarm.triggered .dm-sec-chip::after{content:"Intrusion"}
+.dm-sec-timer{
+  display:none;align-items:center;font-family:var(--dm-sec-mono);font-size:11.5px;letter-spacing:.9px;
+  color:var(--dm-sec-dim);text-transform:uppercase
+}
+.dm-sec-timer.show{display:inline-flex}
+
+/* keypad — keeps the legacy .alarm-mode-btn contract */
+.dm-sec-modes{
+  position:relative;z-index:1;display:grid;grid-template-columns:repeat(3,1fr);gap:6px;
+  margin-top:24px;padding:6px;border-radius:20px;
+  background:var(--surface-2,#f8fafc);border:1px solid var(--dm-sec-border);
+  box-shadow:inset 0 2px 8px rgba(15,23,42,.05)
+}
+.dm-sec-modes .alarm-mode-btn{
+  --btn-rgb:100,116,139;
+  display:flex;flex-direction:column;align-items:center;gap:7px;
+  padding:15px 8px 13px;border-radius:15px;border:1px solid transparent;background:transparent;
+  color:var(--dm-sec-dim);cursor:pointer;transform:none;
+  transition:background .28s ease,color .28s ease,border-color .28s ease,box-shadow .28s ease,transform .28s cubic-bezier(.16,1,.3,1)
+}
+.dm-sec-modes .alarm-mode-btn[data-mode="away"]{--btn-rgb:225,29,72}
+.dm-sec-modes .alarm-mode-btn[data-mode="night"]{--btn-rgb:124,58,237}
+.dm-sec-modes .alarm-mode-btn[data-mode="disarm"]{--btn-rgb:5,150,105}
+.dm-sec-modes .alarm-mode-btn:hover{background:var(--dm-sec-card);color:var(--dm-sec-text)}
+.dm-sec-modes .alarm-mode-btn:active{transform:scale(.97)}
+.dm-sec-modes .alarm-mode-btn:focus-visible{outline:2px solid rgb(var(--btn-rgb));outline-offset:2px}
+.dm-sec-modes .alarm-mode-btn.active{
+  background:var(--dm-sec-card);border-color:rgba(var(--btn-rgb),.32);color:rgb(var(--btn-rgb));
+  box-shadow:0 10px 24px rgba(var(--btn-rgb),.22);transform:translateY(-2px)
+}
+.dm-sec-mode-ic{
+  width:40px;height:40px;display:grid;place-items:center;border-radius:13px;font-size:20px;line-height:1;
+  background:rgba(var(--btn-rgb),.10);filter:grayscale(.5) opacity(.72);transition:.28s ease
+}
+.dm-sec-modes .alarm-mode-btn.active .dm-sec-mode-ic{
+  filter:none;background:rgba(var(--btn-rgb),.17);transform:scale(1.06)
+}
+.dm-sec-mode-tx{font-size:12.5px;font-weight:900;letter-spacing:.8px;text-transform:uppercase}
+.dm-sec-mode-hint{
+  font-family:var(--dm-sec-mono);font-size:9.5px;letter-spacing:1px;text-transform:uppercase;
+  color:var(--dm-sec-dim);opacity:.85
+}
+
+/* ── cameras ─────────────────────────────────────────────────────────── */
+.dm-sec-cctv{display:flex;flex-direction:column;gap:14px}
+.dm-sec-cctv-head{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:0 4px}
+.dm-sec-cctv-ic{
+  width:32px;height:32px;flex:0 0 32px;display:grid;place-items:center;border-radius:10px;
+  background:rgba(6,182,212,.12);color:var(--dm-sec-cyan-deep)
+}
+.dm-sec-cctv-ic svg{width:19px;height:19px}
+.dm-sec-cctv-head h3{
+  margin:0;font-family:'Oswald',sans-serif;font-size:17px;font-weight:700;letter-spacing:2px;
+  text-transform:uppercase;color:var(--dm-sec-text)
+}
+.dm-sec-rec{
+  display:inline-flex;align-items:center;gap:6px;padding:3px 9px;border-radius:7px;
+  border:1px solid rgba(225,29,72,.28);background:rgba(225,29,72,.08);color:#be123c;
+  font-family:var(--dm-sec-mono);font-size:10px;letter-spacing:1.6px
+}
+.dm-sec-rec i{width:6px;height:6px;border-radius:50%;background:#e11d48;animation:dmSecBlink 1.6s steps(1) infinite}
+.dm-sec-cctv-meta{
+  font-family:var(--dm-sec-mono);font-size:11px;letter-spacing:1.4px;text-transform:uppercase;
+  color:var(--dm-sec-dim)
+}
+.dm-sec-clock{
+  margin-left:auto;font-family:var(--dm-sec-mono);font-size:12.5px;letter-spacing:1.6px;
+  color:var(--dm-sec-dim);padding:4px 11px;border-radius:9px;
+  background:var(--surface-3,#f1f5f9);border:1px solid var(--dm-sec-border)
+}
+.dm-sec-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(288px,1fr));gap:16px}
+.dm-sec-grid[hidden]{display:none}
+.dm-sec-cctv.is-empty .dm-sec-rec{display:none}
+
+.dm-sec-grid .cam-card.dm-cam{
+  position:relative;display:flex;flex-direction:column;overflow:hidden;cursor:pointer;
+  border:1px solid var(--dm-sec-border);border-radius:20px;background:var(--dm-sec-card);
+  box-shadow:0 12px 30px rgba(15,23,42,.07);
+  transition:transform .35s cubic-bezier(.16,1,.3,1),box-shadow .35s ease,border-color .35s ease
+}
+.dm-sec-grid .cam-card.dm-cam:hover{
+  transform:translateY(-4px);border-color:rgba(6,182,212,.38);
+  box-shadow:0 22px 44px rgba(15,23,42,.14)
+}
+.dm-sec-grid .cam-card.dm-cam:focus-visible{outline:3px solid rgba(6,182,212,.55);outline-offset:3px}
+
+/* the feed keeps its own dark letterbox: that is the video, not a panel */
+.dm-cam-feed{position:relative;width:100%;padding-top:56.25%;overflow:hidden;background:#0b1220}
+.dm-cam-feed>img{
+  position:absolute;inset:0;width:100%;height:100%;object-fit:cover;z-index:1;
+  transition:transform .6s cubic-bezier(.16,1,.3,1),filter .35s ease
+}
+.dm-cam:hover .dm-cam-feed>img{transform:scale(1.05)}
+/* interlaced scan texture — very faint, reads as a monitor rather than a photo */
+.dm-cam-scan{
+  position:absolute;inset:0;z-index:2;pointer-events:none;opacity:.16;
+  background:repeating-linear-gradient(180deg,rgba(255,255,255,.14) 0 1px,transparent 1px 3px)
+}
+.dm-cam-frame{position:absolute;inset:9px;z-index:3;pointer-events:none;opacity:.45;transition:opacity .35s ease}
+.dm-cam-frame::before,.dm-cam-frame::after{
+  content:"";position:absolute;width:15px;height:15px;border:2px solid rgba(226,238,251,.8)
+}
+.dm-cam-frame::before{bottom:0;left:0;border-right:0;border-top:0}
+.dm-cam-frame::after{bottom:0;right:0;border-left:0;border-top:0}
+.dm-cam:hover .dm-cam-frame{opacity:.85}
+.dm-cam-top{
+  position:absolute;top:0;left:0;right:0;z-index:4;display:flex;align-items:center;
+  justify-content:space-between;gap:8px;padding:10px 11px;
+  background:linear-gradient(180deg,rgba(2,6,15,.72),transparent)
+}
+.dm-cam-live{
+  display:inline-flex;align-items:center;gap:6px;padding:3px 9px;border-radius:6px;
+  background:rgba(2,6,15,.5);border:1px solid rgba(248,113,113,.5);color:#fecaca;
+  font-family:var(--dm-sec-mono);font-size:9.5px;letter-spacing:1.5px;
+  backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px)
+}
+.dm-cam-live i{width:5px;height:5px;flex:0 0 5px;border-radius:50%;background:#f87171;animation:dmSecBlink 1.6s steps(1) infinite}
+.dm-cam-ch{
+  font-family:var(--dm-sec-mono);font-size:10.5px;letter-spacing:1.4px;color:rgba(226,238,251,.88);
+  padding:3px 8px;border-radius:6px;background:rgba(2,6,15,.45);
+  backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px)
+}
+/* labels ride on the frame like a real CCTV overlay instead of a white footer */
+.dm-cam-foot{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:12px 15px}
+.dm-cam-name{
+  min-width:0;font-size:13px;font-weight:900;letter-spacing:.7px;text-transform:uppercase;
+  color:var(--dm-sec-text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis
+}
+.dm-cam-time{
+  flex:0 0 auto;font-family:var(--dm-sec-mono);font-size:11px;letter-spacing:1.1px;color:var(--dm-sec-dim);
+  padding:4px 9px;border-radius:8px;background:var(--surface-3,#f1f5f9);border:1px solid var(--dm-sec-border)
+}
+.dm-cam-open{
+  position:absolute;top:50%;left:50%;z-index:5;width:52px;height:52px;border-radius:15px;
+  display:grid;place-items:center;color:#04121a;background:rgba(34,211,238,.94);
+  box-shadow:0 14px 30px rgba(8,145,178,.5);opacity:0;
+  transform:translate(-50%,-50%) scale(.82);
+  transition:opacity .3s ease,transform .3s cubic-bezier(.16,1,.3,1)
+}
+.dm-cam-open svg{width:22px;height:22px}
+.dm-cam:hover .dm-cam-open,.dm-cam:focus-visible .dm-cam-open{opacity:1;transform:translate(-50%,-50%) scale(1)}
+.dm-cam-off{
+  position:absolute;inset:0;z-index:6;display:none;flex-direction:column;align-items:center;
+  justify-content:center;gap:9px;color:#fca5a5;
+  background:
+    linear-gradient(180deg,rgba(9,14,24,.86),rgba(9,14,24,.94)),
+    repeating-linear-gradient(45deg,rgba(248,113,113,.09) 0 10px,transparent 10px 20px)
+}
+.dm-cam-off svg{width:25px;height:25px}
+.dm-cam-off b{font-family:var(--dm-sec-mono);font-size:11px;letter-spacing:2.2px;text-transform:uppercase}
+.dm-cam.is-off .dm-cam-off{display:flex}
+.dm-cam.is-off .dm-cam-feed>img{filter:grayscale(1) brightness(.35)}
+.dm-cam.is-off .dm-cam-live,.dm-cam.is-off .dm-cam-open,.dm-cam.is-off .dm-cam-scan{display:none}
+.dm-cam.is-off .dm-cam-name{color:var(--dm-sec-dim)}
+
+/* empty state */
+.dm-sec-empty{
+  display:flex;flex-direction:column;align-items:center;gap:10px;text-align:center;
+  padding:40px 24px;border-radius:22px;border:1.5px dashed var(--dm-sec-border);
+  background:var(--surface-2,#f8fafc);color:var(--dm-sec-dim)
+}
+.dm-sec-empty[hidden]{display:none}
+.dm-sec-empty-ic{
+  width:52px;height:52px;display:grid;place-items:center;border-radius:15px;
+  background:rgba(6,182,212,.10);color:var(--dm-sec-cyan-deep)
+}
+.dm-sec-empty-ic svg{width:28px;height:28px}
+.dm-sec-empty strong{font-size:15.5px;font-weight:900;color:var(--dm-sec-text);letter-spacing:.3px}
+.dm-sec-empty p{margin:0;max-width:430px;font-size:12.5px;font-weight:600;line-height:1.5}
+.dm-sec-empty-cta{
+  margin-top:6px;padding:11px 22px;border:none;border-radius:13px;cursor:pointer;
+  font-family:'Oswald',sans-serif;font-size:13px;font-weight:700;letter-spacing:1.2px;text-transform:uppercase;
+  color:#fff;background:linear-gradient(135deg,#06b6d4,#0284c7);box-shadow:0 12px 26px rgba(6,182,212,.30);
+  transition:transform .28s cubic-bezier(.16,1,.3,1),box-shadow .28s ease
+}
+.dm-sec-empty-cta:hover{transform:translateY(-2px);box-shadow:0 16px 32px rgba(6,182,212,.40)}
+.dm-sec-empty-cta:active{transform:scale(.97)}
+
+/* ── responsive ──────────────────────────────────────────────────────── */
+/* Wide screens read better as "state on the left, keypad on the right"
+   than as one full-width status line above a very wide keypad. */
+@media(min-width:1000px){
+  .dm-sec-alarm{
+    display:grid;grid-template-columns:minmax(0,1fr) minmax(370px,.82fr);
+    align-items:center;gap:30px;padding:30px
+  }
+  .dm-sec-modes{margin-top:0}
+}
+@media(max-width:900px){
+  .dm-sec-grid{grid-template-columns:repeat(auto-fill,minmax(240px,1fr))}
+}
+@media(max-width:640px){
+  .dm-sec-shell{gap:15px}
+  .dm-sec-mast-ic{width:44px;height:44px;flex:0 0 44px;border-radius:14px}
+  .dm-sec-mast-ic svg{width:23px;height:23px}
+  .dm-sec-pill{height:32px;padding:0 12px;font-size:10px;order:3;flex:0 0 auto}
+  .dm-sec-alarm{padding:20px 18px 18px;border-radius:24px}
+  .dm-sec-readout{gap:15px}
+  .dm-sec-orb{width:78px;height:78px;flex:0 0 78px}
+  .dm-sec-orb-core{width:56px;height:56px;font-size:24px}
+  .dm-sec-beacon{width:13px;height:13px;top:2px;right:2px}
+  .dm-sec-modes{margin-top:18px;gap:5px;padding:5px;border-radius:17px}
+  .dm-sec-modes .alarm-mode-btn{padding:11px 3px 10px;gap:6px}
+  .dm-sec-mode-ic{width:34px;height:34px;font-size:17px;border-radius:11px}
+  .dm-sec-mode-tx{font-size:11px}
+  .dm-sec-mode-hint{display:none}
+  .dm-sec-cctv-head h3{font-size:15px;letter-spacing:1.6px}
+  /* second line: channel count on the left, clock pushed to the right */
+  .dm-sec-cctv-meta{order:4;flex:1 1 auto}
+  .dm-sec-clock{order:5;font-size:11.5px;padding:3px 9px}
+  .dm-sec-grid{grid-template-columns:1fr;gap:12px}
+}
+
+/* ── dark theme ──────────────────────────────────────────────────────── */
+[data-theme="dark"] .dm-sec-mast-ic{
+  background:linear-gradient(140deg,rgba(225,29,72,.24),rgba(14,165,233,.18));color:#fda4af;
+  box-shadow:inset 0 0 0 1px rgba(244,63,94,.22)
+}
+[data-theme="dark"] .dm-sec-alarm{box-shadow:0 20px 48px rgba(0,0,0,.42)}
+[data-theme="dark"] .dm-sec-pill[data-live="1"]{background:rgba(6,182,212,.16);color:#7dd3fc;border-color:rgba(6,182,212,.34)}
+[data-theme="dark"] .dm-sec-modes{box-shadow:inset 0 2px 10px rgba(0,0,0,.28)}
+[data-theme="dark"] .dm-sec-modes .alarm-mode-btn:hover{background:var(--surface-3,#212d4c)}
+[data-theme="dark"] .dm-sec-modes .alarm-mode-btn.active{background:var(--surface-3,#212d4c)}
+[data-theme="dark"] .dm-sec-grid .cam-card.dm-cam{box-shadow:0 14px 34px rgba(0,0,0,.36)}
+[data-theme="dark"] .dm-sec-grid .cam-card.dm-cam:hover{box-shadow:0 24px 50px rgba(0,0,0,.48)}
+[data-theme="dark"] .dm-sec-cctv-ic{background:rgba(6,182,212,.18);color:#7dd3fc}
+[data-theme="dark"] .dm-sec-rec{border-color:rgba(244,63,94,.34);background:rgba(244,63,94,.12);color:#fda4af}
+[data-theme="dark"] .dm-sec-rec i{background:#fb7185}
+[data-theme="dark"] .dm-sec-empty-ic{background:rgba(6,182,212,.16);color:#7dd3fc}
+
+/* ── motion ──────────────────────────────────────────────────────────── */
+@keyframes dmSecPing{0%{box-shadow:0 0 0 0 rgba(var(--al-rgb,6,182,212),.55)}70%{box-shadow:0 0 0 9px rgba(var(--al-rgb,6,182,212),0)}100%{box-shadow:0 0 0 0 rgba(var(--al-rgb,6,182,212),0)}}
+@keyframes dmSecSpin{to{transform:rotate(360deg)}}
+@keyframes dmSecShout{0%,100%{box-shadow:0 10px 26px rgba(var(--al-rgb),.26),inset 0 0 0 2px rgba(var(--al-rgb),.34)}50%{box-shadow:0 10px 30px rgba(var(--al-rgb),.5),inset 0 0 0 3px rgba(var(--al-rgb),.7)}}
+@keyframes dmSecRidge{0%{transform:translateX(-120%)}100%{transform:translateX(560%)}}
+@keyframes dmSecBlink{0%,49%{opacity:1}50%,100%{opacity:.15}}
+@media (prefers-reduced-motion:reduce){
+  .dm-sec-shell *,.dm-sec-shell *::before,.dm-sec-shell *::after{animation:none!important;transition:none!important}
+}
+`;
+}
+
+if (doc?.readyState === "loading") {
+  doc.addEventListener("DOMContentLoaded", installSecurityShowcaseSection, { once: true });
+} else {
+  installSecurityShowcaseSection();
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/shared.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shared.js
@@ -239,6 +239,28 @@ export function installStyle(id, css) {
   return true;
 }
 
+/* One rule for the small label above the reading, wherever a card is drawn.
+ *
+ * It used to have three writers: the renderers wrote the generic word at
+ * creation, the Beta 17 repair pass wrote the room's custom name on every card
+ * of that room, and the Beta 27 sync wrote it per association. They disagreed,
+ * so the label flipped between "Temperatura" and the custom name on every
+ * repaint — and a real install repaints on every sensor update. The custom name
+ * belongs to one association: the first one takes the room's name, an extra
+ * probe takes its own, and anything unnamed falls back to the plain word. */
+export function temperatureCardLabels(room = {}, entry = {}) {
+  const id = clean(entry.id);
+  const primary = !id || id === "primary";
+  const temperature = primary
+    ? clean(room.temp_name || room.temperature_name)
+    : clean(entry.name);
+  const humidity = primary ? clean(room.hum_name || room.humidity_name) : "";
+  return {
+    temperature: temperature || (english() ? "Temperature" : "Temperatura"),
+    humidity: humidity || (english() ? "Humidity" : "Umidità"),
+  };
+}
+
 /* The comfort pill next to a room name is sized for a word like CALDO. The
  * unavailable state is the only label long enough to paint out of that pill and
  * over the room name beside it, so the pill carries a short form while the full

--- a/custom_components/dashboardmodern/frontend/src/sections/shutter-scene-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shutter-scene-section.js
@@ -1,0 +1,461 @@
+import { allStates, clean, doc, esc, installStyle, root, t } from "./shared.js";
+
+// Single paint owner for the Tapparelle page.
+//
+// The legacy runtime keeps every entity, service call and timer: this module
+// only replaces renderTapparelle so the page draws a summary header, per-room
+// headings and a card that carries a real position track next to the window,
+// instead of a flat grid of windows with three arrow buttons. Commands still
+// travel through the legacy cdTappCmd handler, which is what keeps the service
+// domain and the vibration feedback identical to before.
+//
+// The window itself is skinned by shutter-section.js, which stays the owner of
+// the first-paint geometry and of every legacy class this module reuses
+// (.tapp-card, .tapp-win, .tapp-shutter, .tapp-state, .tapp-pos, .tapp-btn).
+// That split is deliberate: if this owner never installs — an older runtime
+// without renderTapparelle, for instance — the legacy markup still paints with
+// the same skin instead of falling back to the raw 2015 stylesheet.
+//
+// The legacy loop repaints the page every 2s while it is visible. Rewriting
+// innerHTML on each tick would fight the position track under the user's
+// finger, so markup is built once per structural signature and afterwards only
+// the values that changed are written.
+const KEY = "__DASHBOARDMODERN_SHUTTER_SCENE_SECTION__";
+const MARKER = "__dmShutterSceneOwner";
+const STYLE_ID = "dm-shutter-scene-style";
+const SUPPORT_SET_POSITION = 4;
+const SLAT_COUNT = 8;
+// How long a card keeps the position the user just asked for. Home Assistant
+// reports the old position until the motor reaches the new one, so without this
+// the track would snap back under the finger on the very next 2s repaint.
+const GRAB_MS = 8000;
+
+const state = (root[KEY] ||= {
+  installed: false,
+  frame: 0,
+  signature: "",
+  grabbed: new Map(),
+});
+
+/* ──────────────────────────────── model ─────────────────────────────────── */
+
+function configuredCovers() {
+  const legacy = root.getTapparelle?.();
+  if (Array.isArray(legacy)) return legacy;
+  const stored = root.dashboardStore?.()?.getSection?.("covers");
+  return Array.isArray(stored) ? stored : [];
+}
+
+function floorOrder() {
+  const names = root.cdFloorNames?.();
+  return Array.isArray(names) ? names : [];
+}
+
+function coverView(item = {}) {
+  const entity = clean(item.entity || item.entities?.[0]);
+  if (!entity) return null;
+  const current = allStates()[entity];
+  const status = clean(current?.state).toLowerCase() || "unknown";
+  const raw = current?.attributes?.current_position;
+  const reported = raw == null ? null : Math.max(0, Math.min(100, Number(raw)));
+  const hasPosition = Number.isFinite(reported);
+  const features = Number(current?.attributes?.supported_features) || 0;
+  const grab = state.grabbed.get(entity);
+  const position = grab ? grab.position : hasPosition ? reported : status === "open" ? 100 : status === "closed" ? 0 : 50;
+  const room = clean(item.room);
+  return {
+    entity,
+    name: clean(item.name) || clean(current?.attributes?.friendly_name) || entity,
+    room,
+    floor: clean(root.cdRoomFloorOf?.(room)),
+    status,
+    position: Math.round(position),
+    hasPosition: hasPosition || Boolean(grab),
+    settable: Boolean(features & SUPPORT_SET_POSITION),
+    moving: status === "opening" || status === "closing",
+  };
+}
+
+function coverList() {
+  const views = configuredCovers().map(coverView).filter(Boolean);
+  const floors = floorOrder();
+  const rank = (floor) => {
+    const index = floors.indexOf(floor);
+    return index < 0 ? Number.MAX_SAFE_INTEGER : index;
+  };
+  if (!views.some((view) => view.room)) return views;
+  return views.sort((a, b) => {
+    if (rank(a.floor) !== rank(b.floor)) return rank(a.floor) - rank(b.floor);
+    const left = a.room || "￿";
+    const right = b.room || "￿";
+    return left === right ? 0 : left < right ? -1 : 1;
+  });
+}
+
+function groupKey(view) {
+  return `${view.floor}|${view.room}`;
+}
+
+function groupLabel(view) {
+  if (!view.room) return t("Senza stanza", "No room");
+  return view.floor ? `${view.floor} · ${view.room}` : view.room;
+}
+
+/**
+ * Everything that changes the shape of the page, as opposed to a value inside
+ * it. A new cover, a rename, a room move or a cover that starts reporting a
+ * settable position rebuilds the markup; a position or a state change does not.
+ */
+function signature(views) {
+  return views
+    .map((view) => [view.entity, view.name, view.floor, view.room, view.settable].join("~"))
+    .join("|");
+}
+
+function statusLabel(view) {
+  if (view.status === "opening") return t("In apertura", "Opening");
+  if (view.status === "closing") return t("In chiusura", "Closing");
+  if (view.status === "open") return t("Aperta", "Open");
+  if (view.status === "closed") return t("Chiusa", "Closed");
+  return t("Sconosciuta", "Unknown");
+}
+
+function summaryText(views) {
+  const moving = views.filter((view) => view.moving).length;
+  const open = views.filter((view) => !view.moving && view.position > 0).length;
+  const closed = views.length - moving - open;
+  const parts = [];
+  if (open) parts.push(open === 1 ? t("1 aperta", "1 open") : t(`${open} aperte`, `${open} open`));
+  if (closed) parts.push(closed === 1 ? t("1 chiusa", "1 closed") : t(`${closed} chiuse`, `${closed} closed`));
+  if (moving) parts.push(moving === 1 ? t("1 in movimento", "1 moving") : t(`${moving} in movimento`, `${moving} moving`));
+  return parts.join(" · ");
+}
+
+/* ─────────────────────────────── markup ─────────────────────────────────── */
+
+function heroMarkup() {
+  return `<section class="dm-tapp-hero" data-dm-tapp-hero role="group" aria-labelledby="dm-tapp-hero-title">
+    <div class="dm-tapp-hero-icon" aria-hidden="true">🪟</div>
+    <div class="dm-tapp-hero-text">
+      <div class="dm-tapp-hero-title" id="dm-tapp-hero-title" role="heading" aria-level="2">${esc(t("Tapparelle", "Shutters"))}</div>
+      <div class="dm-tapp-hero-sub" data-dm-tapp-summary></div>
+    </div>
+    <div class="dm-tapp-hero-actions">
+      <button type="button" class="tapp-btn dm-tapp-all" data-all="1" data-svc="open_cover" onclick="cdTappCmd(this)">▲ ${esc(t("Apri tutte", "Open all"))}</button>
+      <button type="button" class="tapp-btn dm-tapp-all" data-all="1" data-svc="close_cover" onclick="cdTappCmd(this)">▼ ${esc(t("Chiudi tutte", "Close all"))}</button>
+    </div>
+  </section>`;
+}
+
+function groupMarkup(view, count) {
+  const suffix = count === 1 ? t("tapparella", "shutter") : t("tapparelle", "shutters");
+  return `<div class="dm-tapp-group" role="heading" aria-level="3">
+    <span class="dm-tapp-group-label">${esc(groupLabel(view))}</span>
+    <span class="dm-tapp-group-count">${count} ${esc(suffix)}</span>
+  </div>`;
+}
+
+/**
+ * The track is always drawn, so a cover that cannot be sent to a position still
+ * shows one and every card in a row keeps the same window width. Only a cover
+ * that reports SET_POSITION gets the input that makes it draggable.
+ */
+function trackMarkup(view) {
+  if (!view.settable) return `<div class="dm-tapp-track" data-dm-static aria-hidden="true"></div>`;
+  const label = t(`Posizione di ${view.name}`, `Position of ${view.name}`);
+  return `<div class="dm-tapp-track">
+    <input class="dm-tapp-range" type="range" min="0" max="100" step="1" value="${view.position}"
+      aria-label="${esc(label)}" data-dm-position>
+  </div>`;
+}
+
+function cardMarkup(view) {
+  const slats = `<i></i>`.repeat(SLAT_COUNT);
+  return `<article class="tapp-card dm-tapp-card" data-tapp="${esc(view.entity)}" data-dm-shutter-card>
+    <div class="tapp-head dm-tapp-head">
+      <span class="dm-tapp-title">
+        <span class="tapp-name">${esc(view.name)}</span>
+        ${view.room ? `<span class="dm-tapp-room">${esc(view.room)}</span>` : ""}
+      </span>
+      <span class="tapp-state" data-dm-state></span>
+    </div>
+    <div class="dm-tapp-stage">
+      <div class="tapp-win">
+        <div class="tapp-glass"></div>
+        <div class="tapp-shutter" data-dm-panel>${slats}</div>
+      </div>
+      ${trackMarkup(view)}
+    </div>
+    <div class="dm-tapp-spill" aria-hidden="true"></div>
+    <div class="tapp-pos" data-dm-readout></div>
+    <div class="tapp-ctl">
+      <button type="button" class="tapp-btn" data-svc="open_cover" onclick="cdTappCmd(this)" aria-label="${esc(t("Apri", "Open"))}">▲</button>
+      <button type="button" class="tapp-btn" data-svc="stop_cover" onclick="cdTappCmd(this)" aria-label="${esc(t("Ferma", "Stop"))}">■</button>
+      <button type="button" class="tapp-btn" data-svc="close_cover" onclick="cdTappCmd(this)" aria-label="${esc(t("Chiudi", "Close"))}">▼</button>
+    </div>
+  </article>`;
+}
+
+function gridMarkup(views) {
+  const grouped = views.some((view) => view.room);
+  let markup = heroMarkup();
+  let lastKey = null;
+  views.forEach((view) => {
+    if (grouped && groupKey(view) !== lastKey) {
+      lastKey = groupKey(view);
+      markup += groupMarkup(view, views.filter((other) => groupKey(other) === lastKey).length);
+    }
+    markup += cardMarkup(view);
+  });
+  return markup;
+}
+
+/* ──────────────────────────────── paint ─────────────────────────────────── */
+
+function syncCard(card, view) {
+  card.style.setProperty("--tapp-open", String(view.position / 100));
+
+  const badge = card.querySelector("[data-dm-state]");
+  if (badge) {
+    badge.className = `tapp-state tapp-st-${view.status}`;
+    badge.textContent = statusLabel(view);
+  }
+
+  const panel = card.querySelector("[data-dm-panel]");
+  if (panel) {
+    panel.className = `tapp-shutter${view.status === "opening" ? " opening" : ""}${view.status === "closing" ? " closing" : ""}`;
+    panel.style.height = `${100 - view.position}%`;
+  }
+
+  const readout = card.querySelector("[data-dm-readout]");
+  if (readout) readout.textContent = view.hasPosition ? `${view.position}%` : "";
+
+  const range = card.querySelector("[data-dm-position]");
+  // Never write over a track the user is holding: doc.activeElement covers the
+  // keyboard and the in-flight drag, the grab window covers the seconds the
+  // motor needs before Home Assistant reports the position that was asked for.
+  if (range && range !== doc.activeElement && !state.grabbed.has(view.entity)) {
+    range.value = String(view.position);
+  }
+}
+
+function renderShutters() {
+  const grid = doc?.getElementById("tapp-grid");
+  if (!grid) return;
+  const views = coverList();
+
+  if (!views.length) {
+    state.signature = "";
+    grid.innerHTML = `<div class="ed-empty dm-tapp-empty">${esc(t("Nessuna tapparella configurata", "No shutter configured"))}</div>`;
+    return;
+  }
+
+  const current = signature(views);
+  if (state.signature !== current || !grid.querySelector("[data-dm-shutter-card]")) {
+    state.signature = current;
+    grid.innerHTML = gridMarkup(views);
+  }
+
+  const summary = grid.querySelector("[data-dm-tapp-summary]");
+  if (summary) summary.textContent = summaryText(views);
+
+  views.forEach((view) => {
+    const card = grid.querySelector(`[data-dm-shutter-card][data-tapp="${CSS.escape(view.entity)}"]`);
+    if (card) syncCard(card, view);
+  });
+}
+
+function paint() {
+  state.frame = 0;
+  installRenderOwner();
+  renderShutters();
+}
+
+function schedule() {
+  if (state.frame) return;
+  state.frame = root.requestAnimationFrame?.(paint) || root.setTimeout?.(paint, 0) || 0;
+}
+
+function installRenderOwner() {
+  const current = root.renderTapparelle;
+  if (typeof current === "function" && current[MARKER]) return;
+  function owned(...args) {
+    renderShutters(...args);
+  }
+  owned[MARKER] = true;
+  owned.__dmPrevious = current;
+  root.renderTapparelle = owned;
+}
+
+/* ───────────────────────────── interaction ──────────────────────────────── */
+
+function grab(entity, position) {
+  const previous = state.grabbed.get(entity);
+  if (previous?.timeout) root.clearTimeout?.(previous.timeout);
+  const pending = { position };
+  pending.timeout = root.setTimeout?.(() => {
+    if (state.grabbed.get(entity) !== pending) return;
+    state.grabbed.delete(entity);
+    schedule();
+  }, GRAB_MS) || 0;
+  state.grabbed.set(entity, pending);
+}
+
+function cardOf(node) {
+  return node?.closest?.("[data-dm-shutter-card]");
+}
+
+/**
+ * Dragging repaints the card straight away instead of waiting for Home
+ * Assistant, so the shutter follows the finger. Only the release sends the
+ * command.
+ */
+function previewPosition(range) {
+  const card = cardOf(range);
+  if (!card) return;
+  const position = Math.max(0, Math.min(100, Math.round(Number(range.value) || 0)));
+  grab(clean(card.dataset.tapp), position);
+  card.style.setProperty("--tapp-open", String(position / 100));
+  const panel = card.querySelector("[data-dm-panel]");
+  if (panel) panel.style.height = `${100 - position}%`;
+  const readout = card.querySelector("[data-dm-readout]");
+  if (readout) readout.textContent = `${position}%`;
+}
+
+async function commitPosition(range) {
+  const card = cardOf(range);
+  const entity = clean(card?.dataset.tapp);
+  if (!entity) return;
+  const position = Math.max(0, Math.min(100, Math.round(Number(range.value) || 0)));
+  grab(entity, position);
+  try {
+    await root.dmCallHaService?.("cover", "set_cover_position", {
+      entity_id: entity,
+      position,
+    });
+  } catch (error) {
+    root.console?.error?.("[DashboardModern] shutter position", error);
+  }
+  schedule();
+}
+
+function installListeners() {
+  if (!doc) return;
+  doc.addEventListener("input", (event) => {
+    const range = event.target?.closest?.("[data-dm-position]");
+    if (range) previewPosition(range);
+  });
+  doc.addEventListener("change", (event) => {
+    const range = event.target?.closest?.("[data-dm-position]");
+    if (range) commitPosition(range);
+  });
+  doc.addEventListener("click", (event) => {
+    if (event.target?.closest?.("#page-tapparelle .tapp-btn")) root.queueMicrotask?.(schedule);
+  });
+  for (const eventName of [
+    "dashboardmodern:legacy-ready",
+    "dashboardmodern:runtime-ready",
+    "dashboardmodern:persistence-restored",
+    "dashboardmodern:config-reset",
+    "dashboardmodern:state-changed",
+  ]) {
+    root.addEventListener?.(eventName, schedule);
+  }
+}
+
+/* ──────────────────────────────── styles ────────────────────────────────── */
+
+function installStyles() {
+  installStyle(STYLE_ID, `
+    /* Structure only. Every legacy class this page reuses keeps its skin — and
+       its first-paint geometry — in shutter-section.js. */
+    html body #page-tapparelle#page-tapparelle .dm-tapp-hero{
+      grid-column:1/-1!important;display:flex!important;align-items:center!important;gap:14px!important;flex-wrap:wrap!important;
+      box-sizing:border-box!important;margin:0 0 4px!important;padding:16px 18px!important;
+      border:1px solid var(--tapp-border)!important;border-radius:22px!important;background:var(--tapp-surface)!important;
+      box-shadow:var(--tapp-shadow)!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-hero-icon{
+      display:grid!important;place-items:center!important;flex:0 0 auto!important;width:48px!important;height:48px!important;
+      border-radius:16px!important;background:var(--tapp-run-bg)!important;border:1px solid var(--tapp-run-line)!important;font-size:24px!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-hero-text{flex:1 1 190px!important;min-width:0!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-hero-title{
+      margin:0!important;color:var(--tapp-text)!important;font-size:19px!important;font-weight:950!important;letter-spacing:.2px!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-hero-sub{
+      margin:3px 0 0!important;color:var(--tapp-dim)!important;font-size:12px!important;font-weight:800!important;letter-spacing:.5px!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-hero-actions{display:flex!important;gap:10px!important;flex:0 1 auto!important;flex-wrap:wrap!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-hero-actions .tapp-btn{flex:0 1 auto!important}
+
+    html body #page-tapparelle#page-tapparelle .dm-tapp-group{
+      grid-column:1/-1!important;display:flex!important;align-items:center!important;gap:10px!important;
+      margin:10px 2px 0!important;padding:0!important;color:var(--tapp-dim)!important;
+      font-size:11px!important;font-weight:900!important;letter-spacing:1.5px!important;text-transform:uppercase!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-group-count{
+      flex:0 0 auto!important;padding:2px 9px!important;border:1px solid var(--tapp-pill-line)!important;border-radius:999px!important;
+      background:var(--tapp-pill)!important;font-size:10px!important;letter-spacing:.6px!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-group::after{
+      content:""!important;flex:1 1 auto!important;height:1px!important;order:9!important;
+      background:linear-gradient(90deg,var(--tapp-border),transparent)!important}
+
+    html body #page-tapparelle#page-tapparelle .dm-tapp-title{display:flex!important;flex-direction:column!important;gap:1px!important;min-width:0!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-room{
+      overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important;
+      color:var(--tapp-dim)!important;font-size:10px!important;font-weight:900!important;letter-spacing:1px!important;text-transform:uppercase!important}
+
+    html body #page-tapparelle#page-tapparelle .dm-tapp-stage{display:flex!important;align-items:stretch!important;gap:10px!important;min-width:0!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-stage .tapp-win{flex:1 1 auto!important;min-width:0!important}
+
+    /* The track is the window in miniature: the shut part of the gradient is the
+       panel, the open part is the sky, and the thumb rides the closing edge. */
+    html body #page-tapparelle#page-tapparelle .dm-tapp-track{
+      position:relative!important;flex:0 0 34px!important;box-sizing:border-box!important;height:132px!important;
+      border:1px solid var(--tapp-pill-line)!important;border-radius:13px!important;overflow:hidden!important;
+      background:linear-gradient(180deg,var(--tapp-slat-base) 0 calc((1 - var(--tapp-open,0)) * 100%),var(--tapp-track-sky) calc((1 - var(--tapp-open,0)) * 100%) 100%)!important;
+      box-shadow:inset 0 1px 3px rgba(15,23,42,.28)!important;touch-action:none!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-track[data-dm-static]{opacity:.55!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-range{
+      position:absolute!important;left:50%!important;top:50%!important;box-sizing:border-box!important;
+      width:132px!important;height:34px!important;margin:0!important;padding:0!important;border:0!important;
+      transform:translate(-50%,-50%) rotate(-90deg)!important;appearance:none!important;-webkit-appearance:none!important;
+      background:transparent!important;cursor:ns-resize!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-range::-webkit-slider-runnable-track{height:34px;background:transparent;border:0}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-range::-webkit-slider-thumb{
+      -webkit-appearance:none;width:22px;height:14px;border-radius:5px;border:1px solid rgba(15,23,42,.35);
+      background:linear-gradient(180deg,#fdfeff,#c9d3e0);box-shadow:0 2px 5px rgba(15,23,42,.4)}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-range::-moz-range-track{height:34px;background:transparent;border:0}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-range::-moz-range-thumb{
+      width:22px;height:14px;border-radius:5px;border:1px solid rgba(15,23,42,.35);
+      background:linear-gradient(180deg,#fdfeff,#c9d3e0);box-shadow:0 2px 5px rgba(15,23,42,.4)}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-range:focus-visible{outline:3px solid color-mix(in srgb,var(--tapp-accent) 55%,transparent)!important;outline-offset:2px!important}
+
+    /* Daylight reaching the room, as much of it as the shutter lets through. */
+    html body #page-tapparelle#page-tapparelle .dm-tapp-spill{
+      height:12px!important;margin:-6px 10px -4px!important;border-radius:0 0 16px 16px!important;
+      background:radial-gradient(62% 100% at 50% 0,var(--tapp-spill),transparent 72%)!important;
+      opacity:var(--tapp-open,0)!important;pointer-events:none!important}
+
+    html body #page-tapparelle#page-tapparelle .dm-tapp-empty{grid-column:1/-1!important}
+
+    @media(max-width:560px){
+      html body #page-tapparelle#page-tapparelle .dm-tapp-hero{padding:14px!important;gap:12px!important}
+      html body #page-tapparelle#page-tapparelle .dm-tapp-hero-actions{flex:1 1 100%!important}
+      html body #page-tapparelle#page-tapparelle .dm-tapp-hero-actions .tapp-btn{flex:1 1 0!important}
+    }
+  `);
+}
+
+export function installShutterSceneSection() {
+  if (!doc) return;
+  installStyles();
+  installRenderOwner();
+  if (!state.installed) {
+    state.installed = true;
+    installListeners();
+  }
+  schedule();
+}
+
+if (doc?.readyState === "loading") {
+  doc.addEventListener("DOMContentLoaded", installShutterSceneSection, { once: true });
+} else {
+  installShutterSceneSection();
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/shutter-scene-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shutter-scene-section.js
@@ -133,6 +133,30 @@ function summaryText(views) {
 
 /* ─────────────────────────────── markup ─────────────────────────────────── */
 
+/**
+ * The way back home, kept identical to the button the legacy runtime injects
+ * into every other page — same class, same label, same behaviour, so it looks
+ * and acts like the one on Clima or Temperature.
+ *
+ * It is rendered as the first item of the grid rather than left where the
+ * legacy runtime puts it, which is as a direct child of the page section. That
+ * position sits against the left edge of the viewport while the cards sit in a
+ * centred column: on a 1440px screen the two were 180px apart. As a grid item
+ * it lines up with the header and the cards at every width and column count.
+ */
+function backHomeMarkup() {
+  return `<button type="button" class="back-home-btn dm-tapp-back" onclick="document.querySelector('[data-tab=&quot;home&quot;]').click(); if(navigator.vibrate)navigator.vibrate(5);">
+    <span class="bh-icon">←</span><span>${esc(t("Home", "Home"))}</span>
+  </button>`;
+}
+
+/** The legacy runtime's own copy, which would otherwise show up twice. */
+function dropLegacyBackHome() {
+  doc?.getElementById("page-tapparelle")
+    ?.querySelectorAll(":scope > .back-home-btn")
+    .forEach((button) => button.remove());
+}
+
 function heroMarkup() {
   return `<section class="dm-tapp-hero" data-dm-tapp-hero role="group" aria-labelledby="dm-tapp-hero-title">
     <div class="dm-tapp-hero-icon" aria-hidden="true">🪟</div>
@@ -198,7 +222,7 @@ function cardMarkup(view) {
 
 function gridMarkup(views) {
   const grouped = views.some((view) => view.room);
-  let markup = heroMarkup();
+  let markup = backHomeMarkup() + heroMarkup();
   let lastKey = null;
   views.forEach((view) => {
     if (grouped && groupKey(view) !== lastKey) {
@@ -242,11 +266,12 @@ function syncCard(card, view) {
 function renderShutters() {
   const grid = doc?.getElementById("tapp-grid");
   if (!grid) return;
+  dropLegacyBackHome();
   const views = coverList();
 
   if (!views.length) {
     state.signature = "";
-    grid.innerHTML = `<div class="ed-empty dm-tapp-empty">${esc(t("Nessuna tapparella configurata", "No shutter configured"))}</div>`;
+    grid.innerHTML = `${backHomeMarkup()}<div class="ed-empty dm-tapp-empty">${esc(t("Nessuna tapparella configurata", "No shutter configured"))}</div>`;
     return;
   }
 
@@ -434,6 +459,7 @@ function installStyles() {
       opacity:var(--tapp-open,0)!important;pointer-events:none!important}
 
     html body #page-tapparelle#page-tapparelle .dm-tapp-empty{grid-column:1/-1!important}
+    html body #page-tapparelle#page-tapparelle .back-home-btn.dm-tapp-back{grid-column:1/-1!important;justify-self:start!important;margin:0 0 4px!important}
 
     @media(max-width:560px){
       html body #page-tapparelle#page-tapparelle .dm-tapp-hero{padding:14px!important;gap:12px!important}

--- a/custom_components/dashboardmodern/frontend/src/sections/shutter-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shutter-section.js
@@ -299,18 +299,150 @@ function installStyles() {
     .dm-shutter-actions button[data-shutter-service="stop_cover"]{background:var(--ha-card-background,var(--card-bg,#fff))!important}
     .dm-shutter-actions button[data-shutter-service="close_cover"]{background:var(--accent-color,var(--accent,#0ea5e9))!important;color:#fff!important}
     .dm-shutter-actions button:disabled{cursor:wait!important;opacity:.65!important}
+    .dm-shutter-actions button:not(:disabled):hover{filter:brightness(1.05)!important}
+    .dm-shutter-actions button:not(:disabled):active{transform:translateY(1px)!important}
+    .dm-shutter-actions button:focus-visible{outline:3px solid color-mix(in srgb,var(--accent-color,var(--accent,#0ea5e9)) 55%,transparent)!important;outline-offset:2px!important}
 
-    /* First paint is already the final Beta9 geometry. This section no longer
-       decorates or wraps renderTapparelle; these static rules only prevent the
-       legacy base CSS from appearing underneath while Beta9's bounded polish
-       applies the same values. */
-    html body #page-tapparelle#page-tapparelle{animation:none!important;transform:none!important;opacity:1!important}
-    html body #page-tapparelle#page-tapparelle #tapp-grid{display:grid!important;grid-template-columns:repeat(auto-fit,minmax(280px,360px))!important;justify-content:center!important;align-items:start!important;gap:14px!important}
-    html body #page-tapparelle#page-tapparelle .tapp-card{box-sizing:border-box!important;width:100%!important;max-width:360px!important;min-height:0!important;padding:14px!important;gap:10px!important;border-radius:20px!important;animation:none!important;transform:none!important}
-    html body #page-tapparelle#page-tapparelle .tapp-win{box-sizing:border-box!important;height:132px!important;min-height:132px!important;max-height:132px!important;margin:0!important;border-radius:17px!important;animation:none!important;transform:none!important}
-    html body #page-tapparelle#page-tapparelle .tapp-shutter{animation:none!important;filter:none!important;transition:height .55s cubic-bezier(.2,.8,.2,1)!important}
-    html body #page-tapparelle#page-tapparelle .tapp-shutter i{animation:none!important;filter:none!important;transform:none!important}
-    @media(max-width:560px){html body #page-tapparelle#page-tapparelle #tapp-grid{grid-template-columns:minmax(0,360px)!important;justify-content:center!important}html body #page-tapparelle#page-tapparelle .tapp-card{max-width:360px!important}}
+    /* ── Tapparelle page ─────────────────────────────────────────────────
+       First paint is already the final Beta9 geometry. This section no longer
+       decorates or wraps renderTapparelle: the legacy grid rewrites its own
+       innerHTML every two seconds, so the whole skin is static CSS that
+       survives each repaint without a single DOM pass, and Beta9's bounded
+       polish keeps re-applying the same geometry values underneath.
+
+       Everything below the geometry is paint only. The window is drawn as a
+       real one — frame, mullion, sky, sun and hills behind the glass, roller
+       box at the top — and the shutter itself carries the slat texture as a
+       repeating background anchored to its bottom edge. That anchoring is
+       what makes the legacy slat elements redundant: they stack from the bottom
+       and stop after eight of them, which used to leave the top of a fully
+       closed shutter transparent. The background fills the whole panel at any
+       height, so the slats only need to stop painting. */
+    html body #page-tapparelle#page-tapparelle{animation:none!important;transform:none!important;opacity:1!important;
+      --tapp-accent:#0ea5e9;
+      --tapp-text:var(--text,#0f172a);
+      --tapp-dim:var(--text-dim,#64748b);
+      --tapp-surface:linear-gradient(168deg,rgba(255,255,255,.97),rgba(237,245,255,.93));
+      --tapp-border:rgba(148,163,184,.30);
+      --tapp-shadow:0 1px 2px rgba(15,23,42,.05),0 12px 28px -14px rgba(15,23,42,.32);
+      --tapp-shadow-hover:0 2px 5px rgba(15,23,42,.07),0 20px 44px -18px rgba(2,132,199,.45);
+      --tapp-shadow-live:0 1px 2px rgba(15,23,42,.05),0 16px 36px -18px rgba(2,132,199,.55);
+      --tapp-frame:#dbe3ee;
+      --tapp-mullion:linear-gradient(90deg,transparent calc(50% - 2px),rgba(226,232,240,.92) calc(50% - 2px) calc(50% + 2px),transparent calc(50% + 2px));
+      --tapp-guides:linear-gradient(90deg,rgba(233,239,247,.70) 0 2px,rgba(15,23,42,.16) 2px 4px,transparent 4px),linear-gradient(270deg,rgba(233,239,247,.70) 0 2px,rgba(15,23,42,.16) 2px 4px,transparent 4px);
+      --tapp-stars:none;
+      --tapp-clouds:radial-gradient(27px 11px at 25% 33%,rgba(255,255,255,.92),transparent 70%),radial-gradient(19px 8px at 34% 36%,rgba(255,255,255,.82),transparent 70%),radial-gradient(15px 7px at 17% 37%,rgba(255,255,255,.72),transparent 70%);
+      --tapp-sun:radial-gradient(circle at 78% 25%,#fffdf0 0 4.5%,rgba(255,241,170,.92) 6%,rgba(255,223,130,.42) 15%,rgba(255,223,130,0) 32%);
+      --tapp-trees:radial-gradient(11px 13px at 64% 79%,#2b8f59 0 64%,transparent 65%),radial-gradient(8px 10px at 71% 82%,#217a48 0 64%,transparent 65%),radial-gradient(7px 8px at 57% 83%,#37a367 0 64%,transparent 65%);
+      --tapp-hill-a:radial-gradient(140% 64% at 4% 112%,#8ee7b0 0 62%,transparent 63%);
+      --tapp-hill-b:radial-gradient(120% 58% at 92% 116%,#3fbc7c 0 60%,transparent 61%);
+      --tapp-sky:linear-gradient(180deg,#4fbcf6,#a2dcfb 46%,#e8f6fe);
+      --tapp-box:linear-gradient(180deg,#f4f7fb 0 2px,#e2e9f2 2px 5px,#c8d2df 5px 6px,#dfe6ef 6px 8px,#a9b5c5 8px 10px,rgba(15,23,42,.38) 10px 11px);
+      --tapp-slat:linear-gradient(180deg,#fdfeff 0 1px,#eaf0f7 1px 4px,#c6d1df 4px 9px,#9daabc 9px 11px,rgba(15,23,42,.34) 11px 12px);
+      --tapp-slat-base:#b7c2d1;
+      --tapp-rail:linear-gradient(180deg,#b3bdcc 0 2px,#7d8898 2px 5px,#4d5766 5px 7px);
+      --tapp-grip:radial-gradient(20px 3px at 50% 50%,rgba(15,23,42,.5),transparent 72%);
+      --tapp-pill:rgba(148,163,184,.13);
+      --tapp-pill-line:rgba(148,163,184,.30);
+      --tapp-ok-fg:#0f9d6e;--tapp-ok-bg:rgba(16,185,129,.14);--tapp-ok-line:rgba(16,185,129,.34);
+      --tapp-off-fg:#5b6b82;--tapp-off-bg:rgba(100,116,139,.14);--tapp-off-line:rgba(100,116,139,.30);
+      --tapp-run-fg:#0284c7;--tapp-run-bg:rgba(14,165,233,.15);--tapp-run-line:rgba(14,165,233,.36);
+      --tapp-up-bg:linear-gradient(160deg,#e6f5ff,#bfe6fb);--tapp-up-fg:#0369a1;--tapp-up-line:rgba(14,165,233,.36);
+      --tapp-stop-bg:linear-gradient(160deg,#fff,#eef2f8);--tapp-stop-fg:#475569;--tapp-stop-line:rgba(148,163,184,.44);
+      --tapp-down-bg:linear-gradient(160deg,#0ea5e9,#0369a1);--tapp-down-fg:#fff;--tapp-down-line:rgba(3,105,161,.55)}
+    html[data-theme="dark"] body #page-tapparelle#page-tapparelle,html body.dark-theme #page-tapparelle#page-tapparelle{
+      --tapp-surface:linear-gradient(168deg,rgba(32,43,68,.96),rgba(19,27,46,.95));
+      --tapp-border:rgba(148,163,184,.20);
+      --tapp-shadow:0 1px 2px rgba(0,0,0,.45),0 14px 32px -16px rgba(0,0,0,.75);
+      --tapp-shadow-hover:0 2px 6px rgba(0,0,0,.5),0 22px 48px -20px rgba(14,165,233,.5);
+      --tapp-shadow-live:0 1px 2px rgba(0,0,0,.45),0 18px 40px -20px rgba(56,189,248,.55);
+      --tapp-frame:#3d4a61;
+      --tapp-mullion:linear-gradient(90deg,transparent calc(50% - 2px),rgba(71,85,105,.95) calc(50% - 2px) calc(50% + 2px),transparent calc(50% + 2px));
+      --tapp-guides:linear-gradient(90deg,rgba(100,116,139,.6) 0 2px,rgba(0,0,0,.4) 2px 4px,transparent 4px),linear-gradient(270deg,rgba(100,116,139,.6) 0 2px,rgba(0,0,0,.4) 2px 4px,transparent 4px);
+      --tapp-stars:radial-gradient(1.4px 1.4px at 17% 27%,rgba(255,255,255,.9),transparent),radial-gradient(1.2px 1.2px at 34% 13%,rgba(255,255,255,.7),transparent),radial-gradient(1.3px 1.3px at 55% 31%,rgba(255,255,255,.6),transparent),radial-gradient(1.1px 1.1px at 24% 47%,rgba(255,255,255,.5),transparent);
+      --tapp-clouds:none;
+      --tapp-sun:radial-gradient(circle at 78% 24%,rgba(248,250,252,.96) 0 4.5%,rgba(203,213,225,.32) 8%,rgba(203,213,225,0) 26%);
+      --tapp-trees:radial-gradient(11px 13px at 64% 79%,#0b3a20 0 64%,transparent 65%),radial-gradient(8px 10px at 71% 82%,#072b17 0 64%,transparent 65%),radial-gradient(7px 8px at 57% 83%,#0f4527 0 64%,transparent 65%);
+      --tapp-hill-a:radial-gradient(140% 64% at 4% 112%,#14532d 0 62%,transparent 63%);
+      --tapp-hill-b:radial-gradient(120% 58% at 92% 116%,#052e16 0 60%,transparent 61%);
+      --tapp-sky:linear-gradient(180deg,#070f24,#12274a 52%,#1e4370);
+      --tapp-box:linear-gradient(180deg,#454f64 0 2px,#333d50 2px 5px,#222b3b 5px 6px,#303a4c 6px 8px,#1b2331 8px 10px,rgba(0,0,0,.65) 10px 11px);
+      --tapp-slat:linear-gradient(180deg,#7c8ca6 0 1px,#5d6c85 1px 4px,#41506a 4px 9px,#2d3950 9px 11px,rgba(0,0,0,.58) 11px 12px);
+      --tapp-slat-base:#39455a;
+      --tapp-rail:linear-gradient(180deg,#5a6779 0 2px,#3b4557 2px 5px,#1b222e 5px 7px);
+      --tapp-grip:radial-gradient(20px 3px at 50% 50%,rgba(0,0,0,.65),transparent 72%);
+      --tapp-pill:rgba(148,163,184,.14);--tapp-pill-line:rgba(148,163,184,.24);
+      --tapp-ok-fg:#34d399;--tapp-ok-bg:rgba(16,185,129,.16);--tapp-ok-line:rgba(52,211,153,.34);
+      --tapp-off-fg:#a8b6cc;--tapp-off-bg:rgba(148,163,184,.16);--tapp-off-line:rgba(148,163,184,.28);
+      --tapp-run-fg:#7dd3fc;--tapp-run-bg:rgba(14,165,233,.18);--tapp-run-line:rgba(56,189,248,.38);
+      --tapp-up-bg:linear-gradient(160deg,rgba(12,74,110,.9),rgba(7,89,133,.9));--tapp-up-fg:#bae6fd;--tapp-up-line:rgba(56,189,248,.40);
+      --tapp-stop-bg:linear-gradient(160deg,rgba(51,65,85,.92),rgba(30,41,59,.92));--tapp-stop-fg:#cbd5e1;--tapp-stop-line:rgba(148,163,184,.30);
+      --tapp-down-bg:linear-gradient(160deg,#0ea5e9,#0c4a6e);--tapp-down-fg:#f0f9ff;--tapp-down-line:rgba(56,189,248,.5)}
+
+    html body #page-tapparelle#page-tapparelle #tapp-grid{display:grid!important;grid-template-columns:repeat(auto-fit,minmax(280px,360px))!important;justify-content:center!important;align-items:start!important;gap:14px!important;padding:12px 4px 26px!important}
+
+    /* Legacy renderTapparelle emits two inline-styled full-width rows into the
+       grid: the "open/close everything" bar, recognised by its buttons, and one
+       label per room. Neither carries a class, so both are matched on the one
+       inline declaration they do have. */
+    html body #page-tapparelle#page-tapparelle #tapp-grid>div:has(>.tapp-btn[data-all]){display:flex!important;flex-wrap:wrap!important;justify-content:center!important;gap:10px!important;margin:0 0 2px!important;padding:0!important}
+    html body #page-tapparelle#page-tapparelle #tapp-grid>div[style*="grid-column"]:not(.ed-empty):not(:has(.tapp-btn)){display:flex!important;align-items:center!important;gap:10px!important;margin:8px 2px 0!important;padding:0!important;opacity:1!important;color:var(--tapp-dim)!important;font-size:11px!important;font-weight:900!important;letter-spacing:1.5px!important;text-transform:uppercase!important}
+    html body #page-tapparelle#page-tapparelle #tapp-grid>div[style*="grid-column"]:not(.ed-empty):not(:has(.tapp-btn))::after{content:""!important;flex:1 1 auto!important;height:1px!important;background:linear-gradient(90deg,var(--tapp-border),transparent)!important}
+    html body #page-tapparelle#page-tapparelle #tapp-grid>.ed-empty{padding:34px 18px!important;border:1px dashed var(--tapp-border)!important;border-radius:20px!important;color:var(--tapp-dim)!important;font-weight:800!important;text-align:center!important}
+
+    html body #page-tapparelle#page-tapparelle .tapp-card{box-sizing:border-box!important;width:100%!important;max-width:360px!important;min-height:0!important;padding:14px!important;gap:10px!important;border-radius:20px!important;animation:none!important;transform:none!important;position:relative!important;overflow:hidden!important;border:1px solid var(--tapp-border)!important;background:var(--tapp-surface)!important;box-shadow:var(--tapp-shadow)!important;transition:box-shadow .24s ease,border-color .24s ease!important}
+    html body #page-tapparelle#page-tapparelle .tapp-card::before{content:""!important;position:absolute!important;inset:0 0 auto!important;height:3px!important;background:linear-gradient(90deg,transparent,var(--tapp-accent),transparent);background-size:55% 100%;background-repeat:no-repeat;background-position:50% 0;opacity:.5!important}
+    html body #page-tapparelle#page-tapparelle .tapp-card:hover{border-color:color-mix(in srgb,var(--tapp-accent) 42%,transparent)!important;box-shadow:var(--tapp-shadow-hover)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-card:has(.tapp-st-open)::before{background:linear-gradient(90deg,transparent,var(--tapp-ok-fg),transparent);background-size:55% 100%;background-repeat:no-repeat;background-position:50% 0;opacity:.62!important}
+    html body #page-tapparelle#page-tapparelle .tapp-card:has(.tapp-st-closed)::before{opacity:.24!important}
+    html body #page-tapparelle#page-tapparelle .tapp-card:has(.tapp-st-opening),html body #page-tapparelle#page-tapparelle .tapp-card:has(.tapp-st-closing){border-color:var(--tapp-run-line)!important;box-shadow:var(--tapp-shadow-live)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-card:has(.tapp-st-opening)::before,html body #page-tapparelle#page-tapparelle .tapp-card:has(.tapp-st-closing)::before{opacity:1!important;animation:dmTappSweep 1.8s linear infinite!important}
+    @keyframes dmTappSweep{0%{background-position:-60% 0}100%{background-position:160% 0}}
+
+    html body #page-tapparelle#page-tapparelle .tapp-head{gap:8px!important;min-height:26px!important}
+    html body #page-tapparelle#page-tapparelle .tapp-name{min-width:0!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important;color:var(--tapp-text)!important;font-size:14.5px!important;font-weight:900!important;letter-spacing:.2px!important}
+    html body #page-tapparelle#page-tapparelle .tapp-state{display:inline-flex!important;align-items:center!important;gap:6px!important;flex:0 0 auto!important;padding:4px 10px!important;border:1px solid transparent!important;border-radius:999px!important;font-size:10px!important;font-weight:900!important;letter-spacing:.8px!important;text-transform:uppercase!important;white-space:nowrap!important;background:var(--tapp-off-bg)!important;border-color:var(--tapp-off-line)!important;color:var(--tapp-off-fg)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-state::before{content:""!important;flex:0 0 auto!important;width:6px!important;height:6px!important;border-radius:50%!important;background:currentColor!important;box-shadow:0 0 0 3px color-mix(in srgb,currentColor 20%,transparent)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-st-open{background:var(--tapp-ok-bg)!important;border-color:var(--tapp-ok-line)!important;color:var(--tapp-ok-fg)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-st-closed{background:var(--tapp-off-bg)!important;border-color:var(--tapp-off-line)!important;color:var(--tapp-off-fg)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-st-opening,html body #page-tapparelle#page-tapparelle .tapp-st-closing{background:var(--tapp-run-bg)!important;border-color:var(--tapp-run-line)!important;color:var(--tapp-run-fg)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-st-opening::before,html body #page-tapparelle#page-tapparelle .tapp-st-closing::before{animation:dmTappPulse 1.2s ease-in-out infinite!important}
+    @keyframes dmTappPulse{0%,100%{opacity:1}50%{opacity:.2}}
+
+    html body #page-tapparelle#page-tapparelle .tapp-win{box-sizing:border-box!important;height:132px!important;min-height:132px!important;max-height:132px!important;margin:0!important;border-radius:17px!important;animation:none!important;transform:none!important;position:relative!important;overflow:hidden!important;border:4px solid var(--tapp-frame)!important;background:var(--tapp-mullion),var(--tapp-clouds),var(--tapp-stars),var(--tapp-sun),var(--tapp-trees),var(--tapp-hill-a),var(--tapp-hill-b),var(--tapp-sky)!important;box-shadow:inset 0 0 0 1px rgba(15,23,42,.16),0 6px 16px -11px rgba(15,23,42,.6)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-win::before{content:""!important;position:absolute!important;inset:0 0 auto!important;height:11px!important;z-index:5!important;background:var(--tapp-box)!important;box-shadow:0 4px 8px -3px rgba(15,23,42,.5)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-win::after{content:""!important;position:absolute!important;inset:0!important;z-index:6!important;pointer-events:none!important;border-radius:13px!important;background:var(--tapp-guides)!important;box-shadow:inset 0 0 0 1px rgba(255,255,255,.5),inset 0 14px 22px -16px rgba(15,23,42,.55),inset 0 -8px 14px -10px rgba(15,23,42,.45)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-glass{position:absolute!important;inset:0!important;z-index:1!important;background:linear-gradient(116deg,rgba(255,255,255,.5) 0 11%,rgba(255,255,255,0) 12% 27%,rgba(255,255,255,.28) 28% 35%,rgba(255,255,255,0) 36%)!important}
+
+    /* The slat texture is repeated by the panel itself and anchored to its
+       bottom edge, so it stays aligned with the closing edge at every height.
+       Beta9 pins animation:none on the panel to stop the legacy slat flicker;
+       an inline declaration cannot reach a pseudo-element, which is why the
+       travelling texture and the bottom rail live on ::before and ::after. */
+    html body #page-tapparelle#page-tapparelle .tapp-shutter{animation:none!important;filter:none!important;transition:height .55s cubic-bezier(.2,.8,.2,1)!important;z-index:3!important;background:var(--tapp-rail) left bottom/100% 7px no-repeat,var(--tapp-slat) left bottom/100% 12px repeat-y var(--tapp-slat-base)!important;box-shadow:0 8px 14px -6px rgba(15,23,42,.55)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-shutter::before{content:""!important;position:absolute!important;inset:0!important;z-index:1!important;background:var(--tapp-slat) left bottom/100% 12px repeat-y var(--tapp-slat-base)}
+    html body #page-tapparelle#page-tapparelle .tapp-shutter::after{content:""!important;position:absolute!important;inset:auto 0 0!important;height:7px!important;z-index:2!important;background:var(--tapp-grip),var(--tapp-rail)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-shutter.closing::before{animation:dmTappRoll .9s linear infinite!important}
+    html body #page-tapparelle#page-tapparelle .tapp-shutter.opening::before{animation:dmTappRoll .9s linear infinite reverse!important}
+    @keyframes dmTappRoll{from{background-position-y:100%}to{background-position-y:calc(100% + 12px)}}
+    html body #page-tapparelle#page-tapparelle .tapp-shutter i{animation:none!important;filter:none!important;transform:none!important;flex:0 0 12px!important;height:12px!important;background:none!important;border:0!important}
+
+    html body #page-tapparelle#page-tapparelle .tapp-pos{min-height:0!important;padding:0!important;opacity:1!important;color:var(--tapp-dim)!important;font-size:11px!important}
+    html body #page-tapparelle#page-tapparelle .tapp-pos:not(:empty){display:inline-flex!important;align-self:center!important;align-items:center!important;gap:7px!important;padding:3px 12px!important;border:1px solid var(--tapp-pill-line)!important;border-radius:999px!important;background:var(--tapp-pill)!important;font-weight:900!important;letter-spacing:.9px!important;font-variant-numeric:tabular-nums!important}
+    html body #page-tapparelle#page-tapparelle .tapp-pos:not(:empty)::before{content:""!important;flex:0 0 auto!important;width:9px!important;height:9px!important;border:1px solid var(--tapp-pill-line)!important;border-radius:2px!important;background:var(--tapp-slat)!important;background-size:100% 3px!important}
+
+    html body #page-tapparelle#page-tapparelle .tapp-ctl{display:grid!important;grid-template-columns:repeat(3,minmax(0,1fr))!important;gap:8px!important}
+    html body #page-tapparelle#page-tapparelle .tapp-btn{display:inline-flex!important;align-items:center!important;justify-content:center!important;gap:7px!important;box-sizing:border-box!important;min-width:0!important;height:40px!important;min-height:40px!important;padding:0 10px!important;border:1px solid transparent!important;border-radius:13px!important;font-size:16px!important;font-weight:900!important;line-height:1!important;cursor:pointer!important;transition:filter .18s ease,box-shadow .18s ease,transform .12s ease!important}
+    html body #page-tapparelle#page-tapparelle .tapp-btn[data-svc="open_cover"]{background:var(--tapp-up-bg)!important;border-color:var(--tapp-up-line)!important;color:var(--tapp-up-fg)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.75),0 5px 12px -8px rgba(3,105,161,.7)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-btn[data-svc="stop_cover"]{background:var(--tapp-stop-bg)!important;border-color:var(--tapp-stop-line)!important;color:var(--tapp-stop-fg)!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.75),0 5px 12px -8px rgba(15,23,42,.45)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-btn[data-svc="close_cover"]{background:var(--tapp-down-bg)!important;border-color:var(--tapp-down-line)!important;color:var(--tapp-down-fg)!important;box-shadow:0 7px 15px -9px rgba(3,105,161,.9)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-btn[data-all]{flex:0 1 210px!important;height:46px!important;min-height:46px!important;padding:0 18px!important;border-radius:15px!important;font-size:13px!important;letter-spacing:.4px!important}
+    html body #page-tapparelle#page-tapparelle .tapp-btn:hover{filter:brightness(1.05)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-btn:active{transform:translateY(1px)!important;filter:brightness(.95)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-btn:focus-visible{outline:3px solid color-mix(in srgb,var(--tapp-accent) 55%,transparent)!important;outline-offset:2px!important}
+
+    @media(max-width:560px){html body #page-tapparelle#page-tapparelle #tapp-grid{grid-template-columns:minmax(0,360px)!important;justify-content:center!important}html body #page-tapparelle#page-tapparelle .tapp-card{max-width:360px!important}html body #page-tapparelle#page-tapparelle .tapp-btn[data-all]{flex:1 1 46%!important;padding:0 10px!important;font-size:12px!important}}
+    @media(prefers-reduced-motion:reduce){html body #page-tapparelle#page-tapparelle .tapp-card,html body #page-tapparelle#page-tapparelle .tapp-card::before,html body #page-tapparelle#page-tapparelle .tapp-state::before,html body #page-tapparelle#page-tapparelle .tapp-shutter,html body #page-tapparelle#page-tapparelle .tapp-shutter::before,html body #page-tapparelle#page-tapparelle .tapp-btn{animation:none!important;transition:none!important}}
     @media(max-width:640px){.dm-shutter-popup{padding:14px 12px!important}.dm-shutter-popup-card{width:calc(100% - 4px)!important;max-width:560px!important;max-height:84dvh!important;border-radius:22px!important}.dm-shutter-popup-header{min-height:60px!important;padding:10px 13px!important}.dm-shutter-popup-list{max-height:65dvh!important;padding:10px!important}.dm-shutter-popup-row{grid-template-columns:42px minmax(0,1fr)!important;gap:9px!important;padding:10px!important;border-radius:14px!important}.dm-shutter-actions{grid-column:1/-1!important;gap:5px!important}}
   `);
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/shutter-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shutter-section.js
@@ -340,6 +340,8 @@ function installStyles() {
       --tapp-box:linear-gradient(180deg,#f4f7fb 0 2px,#e2e9f2 2px 5px,#c8d2df 5px 6px,#dfe6ef 6px 8px,#a9b5c5 8px 10px,rgba(15,23,42,.38) 10px 11px);
       --tapp-slat:linear-gradient(180deg,#fdfeff 0 1px,#eaf0f7 1px 4px,#c6d1df 4px 9px,#9daabc 9px 11px,rgba(15,23,42,.34) 11px 12px);
       --tapp-slat-base:#b7c2d1;
+      --tapp-track-sky:#bfe6fb;
+      --tapp-spill:rgba(255,214,120,.80);
       --tapp-rail:linear-gradient(180deg,#b3bdcc 0 2px,#7d8898 2px 5px,#4d5766 5px 7px);
       --tapp-grip:radial-gradient(20px 3px at 50% 50%,rgba(15,23,42,.5),transparent 72%);
       --tapp-pill:rgba(148,163,184,.13);
@@ -369,6 +371,8 @@ function installStyles() {
       --tapp-box:linear-gradient(180deg,#454f64 0 2px,#333d50 2px 5px,#222b3b 5px 6px,#303a4c 6px 8px,#1b2331 8px 10px,rgba(0,0,0,.65) 10px 11px);
       --tapp-slat:linear-gradient(180deg,#7c8ca6 0 1px,#5d6c85 1px 4px,#41506a 4px 9px,#2d3950 9px 11px,rgba(0,0,0,.58) 11px 12px);
       --tapp-slat-base:#39455a;
+      --tapp-track-sky:#1e4370;
+      --tapp-spill:rgba(191,219,254,.42);
       --tapp-rail:linear-gradient(180deg,#5a6779 0 2px,#3b4557 2px 5px,#1b222e 5px 7px);
       --tapp-grip:radial-gradient(20px 3px at 50% 50%,rgba(0,0,0,.65),transparent 72%);
       --tapp-pill:rgba(148,163,184,.14);--tapp-pill-line:rgba(148,163,184,.24);

--- a/custom_components/dashboardmodern/frontend/src/sections/solar-thermal-design-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/solar-thermal-design-section.js
@@ -1,0 +1,1303 @@
+// Visual owner of the Solar Thermal page (#page-boiler).
+//
+// The legacy runtime keeps every behaviour: it writes probe temperatures, the
+// tank gradient variables, the pump/valve `active` classes, the comet flows and
+// the nine control buttons. This module never reads or writes Home Assistant
+// state and never touches an id, an onclick or a class the runtime toggles.
+//
+// What it owns is the scene. The synoptic is rebuilt as an isometric plant:
+// the collector sits high on the left on its roof plane, the storage cylinder
+// stands on the floor to the right, and the pipework runs on two 2:1 diagonals
+// plus verticals, which is what makes a flat drawing read as depth.
+//
+// Three things make that possible without touching behaviour:
+//
+//   * the stage gets a fixed aspect ratio and a container-relative unit, so one
+//     viewBox unit and one CSS pixel stay proportional at every width. That is
+//     what lets CSS hardware and SVG pipework share one coordinate system;
+//   * the pipe `d` attributes are rewritten to isometric routes. The runtime
+//     only ever toggles the `active` class on those paths by id, so their
+//     geometry is ours to own;
+//   * a portrait route set and viewBox swap in on narrow screens, driven by a
+//     media-query listener rather than polling or an observer.
+//
+// The only DOM it adds is hardware detail and the labelling the legacy markup
+// left empty: the two pump bodies (`.syn-pump` ships as an empty div), the
+// missing name labels on the solar-pump and recirculation buttons, the tank
+// probe captions, the heat-exchanger coil, the pipe highlights and the header
+// subtitle. It also lifts the collector readout out of the collector, so the
+// isometric transform skews the panel without skewing its digits. Every
+// insertion is idempotent and additive.
+import { doc, installStyle, root, t, wrapFunction } from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_SOLAR_THERMAL_DESIGN__";
+const STYLE_ID = "dm-solar-thermal-design";
+const SVG_NS = "http://www.w3.org/2000/svg";
+const COIL_TURNS = 7;
+const PORTRAIT_QUERY = "(max-width: 768px)";
+const state = (root[KEY] ||= { installed: false, frame: 0, query: null });
+
+// Isometric routes. Every diagonal is 2:1 and every riser is vertical, in the
+// viewBox units of the layout it belongs to.
+const LANDSCAPE = Object.freeze({
+  viewBox: "0 0 1000 600",
+  routes: Object.freeze({
+    "flow-sol-hot": "M 350 150 L 500 225 L 700 325",
+    "flow-sol-cold": "M 655 508 L 540 565 L 320 455 L 320 320 L 245 282 L 245 250",
+    "flow-ricircolo": "M 762 340 L 850 384 L 850 440 L 762 484",
+  }),
+});
+
+const PORTRAIT = Object.freeze({
+  viewBox: "0 0 640 700",
+  routes: Object.freeze({
+    "flow-sol-hot": "M 350 150 L 440 195 L 440 400",
+    "flow-sol-cold": "M 400 586 L 300 636 L 130 551 L 130 240 L 110 230 L 110 200",
+    "flow-ricircolo": "M 512 440 L 545 457 L 545 525 L 512 542",
+  }),
+});
+
+const PUMP_LABELS = [
+  ["syn-p-solare", () => t("Pompa Solare", "Solar Pump")],
+  ["syn-p-ricircolo", () => t("Ricircolo", "Recirculation")],
+];
+
+const BUTTON_LABELS = [
+  ["b-c-pompasol", () => t("Pompa Sol.", "Solar Pump")],
+  ["b-c-ricircolo", () => t("Ricircolo", "Recirc.")],
+];
+
+function stylesheet() {
+  const idle = t("Impianto in attesa", "System idle");
+  const recirculating = t("Ricircolo attivo", "Recirculation running");
+  const charging = t("Carico solare attivo", "Solar charging");
+  const safety = t("Limite di sicurezza", "Safety limit");
+
+  return `
+  /* ───────── design tokens, remapped once for the dark theme ───────── */
+  #page-boiler {
+    --st-panel:#ffffff;
+    --st-panel-2:#f8fafc;
+    --st-chip:#f1f5f9;
+    --st-line:#e6ecf4;
+    --st-ink:#0f172a;
+    --st-ink-dim:#64748b;
+    --st-floor-1:#eef3f9;
+    --st-floor-2:#cfdae7;
+    --st-stage-light:rgba(255,255,255,.92);
+    --st-vignette:rgba(15,23,42,.14);
+    --st-steel-hi:#ffffff;
+    --st-steel:#c6d1de;
+    --st-steel-mid:#9fb0c4;
+    --st-steel-dark:#5f6d82;
+    --st-rotor:#8ea0b6;
+    --st-glass:rgba(255,255,255,.94);
+    --st-glass-line:rgba(255,255,255,.95);
+    --st-lcd:linear-gradient(180deg, rgba(9,16,30,.94), rgba(2,6,16,.96));
+    --st-lcd-line:rgba(148,163,184,.40);
+    --st-shade:rgba(15,23,42,.26);
+  }
+  html[data-theme="dark"] #page-boiler {
+    --st-panel:#161f36;
+    --st-panel-2:#131c30;
+    --st-chip:#1f2a47;
+    --st-line:#263453;
+    --st-ink:#e6edf7;
+    --st-ink-dim:#92a4c2;
+    --st-floor-1:#16223a;
+    --st-floor-2:#0a1120;
+    --st-stage-light:rgba(148,163,184,.16);
+    --st-vignette:rgba(0,0,0,.50);
+    --st-steel-hi:#8ca0bb;
+    --st-steel:#56657f;
+    --st-steel-mid:#3b4860;
+    --st-steel-dark:#1c2436;
+    --st-rotor:#8296b3;
+    --st-glass:rgba(19,28,48,.92);
+    --st-glass-line:rgba(148,163,184,.24);
+    --st-shade:rgba(0,0,0,.55);
+  }
+
+  /* ───────── card shell: header is full-bleed, body keeps the padding ───────── */
+  #page-boiler .boiler-dashboard {
+    max-width:1120px;
+    padding:0;
+    border-radius:32px;
+    border:1px solid var(--st-line);
+    background:var(--st-panel);
+    box-shadow:0 30px 70px rgba(15,23,42,.10), 0 2px 6px rgba(15,23,42,.04);
+  }
+  html[data-theme="dark"] #page-boiler .boiler-dashboard {
+    box-shadow:0 30px 70px rgba(0,0,0,.45);
+  }
+
+  #page-boiler .boiler-header {
+    position:relative;
+    display:block;
+    margin:0;
+    padding:26px 30px 24px;
+    border-bottom:1px solid var(--st-line);
+    background:
+      radial-gradient(130% 190% at 88% -60%, rgba(249,115,22,.20), transparent 58%),
+      radial-gradient(95% 150% at 2% 130%, rgba(14,165,233,.15), transparent 60%),
+      var(--st-panel-2);
+    overflow:hidden;
+  }
+  /* Decorative sun disc; purely ornamental so it stays out of the a11y tree. */
+  #page-boiler .boiler-header::before {
+    content:"";
+    position:absolute;
+    top:-96px; right:-56px;
+    width:230px; height:230px;
+    border-radius:50%;
+    background:radial-gradient(circle at 42% 58%, rgba(251,191,36,.50), rgba(249,115,22,.18) 54%, transparent 74%);
+    filter:blur(3px);
+    pointer-events:none;
+  }
+  #page-boiler .boiler-header::after {
+    content:"";
+    position:absolute;
+    inset:auto 0 0 0;
+    height:2px;
+    background:linear-gradient(90deg, #f59e0b, #f97316 34%, #0ea5e9 78%, transparent);
+    opacity:.7;
+  }
+  #page-boiler .boiler-title {
+    position:relative;
+    font-size:clamp(21px, 3.3vw, 34px);
+    line-height:1.1;
+    letter-spacing:2px;
+    background:linear-gradient(100deg, #f97316, #f59e0b 42%, #0ea5e9 105%);
+    -webkit-background-clip:text;
+    background-clip:text;
+    -webkit-text-fill-color:transparent;
+  }
+  #page-boiler .dm-st-sub {
+    position:relative;
+    margin-top:7px;
+    font-size:11px;
+    font-weight:800;
+    letter-spacing:1.4px;
+    text-transform:uppercase;
+    color:var(--st-ink-dim);
+  }
+
+  /* Live status pill. Its text comes from the runtime's own "active" classes,
+     so this module keeps zero state logic. It only renders when :has() is
+     available, so unsupported engines get no label instead of a stale one. */
+  #page-boiler .dm-st-live { display:none; }
+  @supports selector(:has(*)) {
+    #page-boiler .dm-st-live {
+      position:relative;
+      display:inline-flex;
+      align-items:center;
+      gap:8px;
+      margin-top:14px;
+      padding:7px 15px 7px 12px;
+      border-radius:999px;
+      border:1px solid var(--st-line);
+      background:var(--st-panel);
+      box-shadow:0 6px 16px rgba(15,23,42,.07);
+      font-size:10.5px;
+      font-weight:900;
+      letter-spacing:1.3px;
+      text-transform:uppercase;
+      color:var(--st-ink-dim);
+    }
+    #page-boiler .dm-st-live::before {
+      content:"";
+      width:8px; height:8px;
+      border-radius:50%;
+      background:currentColor;
+      box-shadow:0 0 0 3px rgba(100,116,139,.16);
+    }
+    #page-boiler .dm-st-live::after { content:"${idle}"; }
+    #page-boiler:has(#syn-p-ricircolo.active) .dm-st-live {
+      color:#7c3aed;
+      border-color:rgba(124,58,237,.32);
+      background:rgba(124,58,237,.08);
+    }
+    #page-boiler:has(#syn-p-ricircolo.active) .dm-st-live::after { content:"${recirculating}"; }
+    #page-boiler:has(#syn-p-solare.active) .dm-st-live {
+      color:#c2410c;
+      border-color:rgba(234,88,12,.34);
+      background:rgba(234,88,12,.09);
+    }
+    #page-boiler:has(#syn-p-solare.active) .dm-st-live::after { content:"${charging}"; }
+    #page-boiler:has(#syn-p-solare.active) .dm-st-live::before { animation:dmStBreathe 1.9s ease-in-out infinite; }
+    #page-boiler:has(#syn-safety-icon.active) .dm-st-live {
+      color:#dc2626;
+      border-color:rgba(220,38,38,.38);
+      background:rgba(220,38,38,.10);
+    }
+    #page-boiler:has(#syn-safety-icon.active) .dm-st-live::after { content:"${safety}"; }
+  }
+  @keyframes dmStBreathe {
+    0%,100% { box-shadow:0 0 0 3px rgba(234,88,12,.20); }
+    50%     { box-shadow:0 0 0 7px rgba(234,88,12,0); }
+  }
+
+  /* ───────── the isometric stage ─────────
+     --st-u is one percent of the stage width and --v is one drawing unit, so
+     CSS hardware and the SVG pipework scale together. The vw fallback matches
+     the card's own max-width and padding; container units replace it wherever
+     they exist. */
+  #page-boiler .synoptic-stage {
+    --st-u:min(10.76px, calc(1vw - .84px));
+    --v:calc(var(--st-u) / 10);
+    aspect-ratio:5 / 3;
+    height:auto;
+    margin:22px 22px 16px;
+    border-radius:26px;
+    border:1px solid var(--st-line);
+    background:
+      radial-gradient(120% 86% at 50% -22%, var(--st-stage-light), transparent 60%),
+      radial-gradient(58% 52% at 24% 22%, rgba(251,191,36,.24), transparent 66%),
+      radial-gradient(52% 50% at 74% 74%, rgba(56,189,248,.14), transparent 68%),
+      linear-gradient(178deg, var(--st-floor-1), var(--st-floor-2));
+    box-shadow:inset 0 1px 0 rgba(255,255,255,.7), 0 18px 42px rgba(15,23,42,.08);
+  }
+  @supports (width: 1cqw) {
+    #page-boiler .synoptic-stage { container-type:inline-size; --st-u:1cqw; }
+  }
+  #page-boiler .synoptic-stage.dm-st-portrait {
+    aspect-ratio:64 / 70;
+    --v:calc(var(--st-u) / 6.4);
+  }
+  html[data-theme="dark"] #page-boiler .synoptic-stage {
+    box-shadow:inset 0 1px 0 rgba(148,163,184,.10), 0 18px 42px rgba(0,0,0,.40);
+  }
+  #page-boiler .synoptic-stage::before {
+    content:"";
+    position:absolute;
+    inset:0;
+    pointer-events:none;
+    background:radial-gradient(122% 104% at 50% 40%, transparent 42%, var(--st-vignette) 100%);
+  }
+
+  /* The pipe SVG carries preserveAspectRatio="none" and no geometry: as an
+     in-flow block it kept its intrinsic ratio, so the pipework landed above the
+     nodes that are positioned in percentages of the stage. Pinning it to the
+     stage box is what makes both coordinate systems agree. */
+  #page-boiler .syn-svg {
+    position:absolute;
+    inset:0;
+    width:100%;
+    height:100%;
+    z-index:1;
+  }
+  /* Three coaxial strokes read as a drawn steel tube: dark shell, brushed
+     body, specular line. The highlight path is injected next to each body. */
+  #page-boiler .syn-pipe-bg,
+  #page-boiler .syn-pipe-inner,
+  #page-boiler .dm-st-pipe-hi,
+  #page-boiler .syn-flow { stroke-linejoin:round; stroke-linecap:round; }
+  #page-boiler .syn-pipe-bg    { stroke:var(--st-steel-dark); stroke-width:22; opacity:.9; }
+  #page-boiler .syn-pipe-inner { stroke:var(--st-steel); stroke-width:15; }
+  #page-boiler .dm-st-pipe-hi  { fill:none; stroke:var(--st-steel-hi); stroke-width:4; opacity:.72; }
+  #page-boiler .syn-flow { stroke-width:10; stroke-dasharray:70 460; filter:drop-shadow(0 0 9px currentColor); }
+
+  /* ───────── nodes become anchor points, hardware hangs off them ───────── */
+  #page-boiler .syn-node-boiler {
+    width:0; height:0;
+    transform:none !important;
+    z-index:2;
+  }
+  #page-boiler .dm-st-node-collector { left:24% !important;   top:28.33% !important; }
+  #page-boiler .dm-st-node-tank      { left:70% !important;   top:65% !important; }
+  #page-boiler #syn-v-chiave         { left:50% !important;   top:37.5% !important; }
+  #page-boiler #syn-p-solare         { left:32% !important;   top:64.67% !important; }
+  #page-boiler #syn-p-ricircolo      { left:85% !important;   top:68.67% !important; }
+  /* The landscape rules are id-scoped, so the portrait overrides have to carry
+     the same id to win on specificity rather than on source order. */
+  #page-boiler .dm-st-portrait .dm-st-node-collector { left:31.25% !important; top:21.43% !important; }
+  #page-boiler .dm-st-portrait .dm-st-node-tank      { left:70.31% !important; top:67.14% !important; }
+  #page-boiler .dm-st-portrait #syn-v-chiave         { left:68.75% !important; top:27.86% !important; }
+  #page-boiler .dm-st-portrait #syn-p-solare         { left:20.31% !important; top:60% !important; }
+  #page-boiler .dm-st-portrait #syn-p-ricircolo      { left:85.16% !important; top:70.14% !important; }
+
+  /* Ground patch: a square skewed onto the isometric plane. */
+  #page-boiler .syn-node-boiler::after {
+    content:"";
+    position:absolute;
+    left:calc(var(--v) * -90);
+    width:calc(var(--v) * 180);
+    height:calc(var(--v) * 180);
+    transform:matrix(1, .5, -1, .5, 0, 0);
+    background:radial-gradient(ellipse at center, var(--st-shade), transparent 68%);
+    filter:blur(calc(var(--v) * 5));
+    z-index:-1;
+    pointer-events:none;
+  }
+  #page-boiler .dm-st-node-collector::after { top:calc(var(--v) * -8); opacity:.75; }
+  #page-boiler .dm-st-node-tank::after      { top:calc(var(--v) * 26); }
+
+  /* ───────── flat-plate collector, laid on the isometric plane ───────── */
+  #page-boiler .syn-solar-panel {
+    position:absolute;
+    left:calc(var(--v) * -75);
+    top:calc(var(--v) * -75);
+    width:calc(var(--v) * 150);
+    height:calc(var(--v) * 150);
+    overflow:visible;
+    border:none;
+    border-radius:calc(var(--v) * 5);
+    transform:matrix(1, .5, -1, .5, 0, 0);
+    transition:filter .4s ease, box-shadow .4s ease;
+    /* Aluminium frame with four mounting screws in the corners. */
+    background:
+      radial-gradient(circle at 9px 9px, #64748b 0 2px, transparent 3px),
+      radial-gradient(circle at calc(100% - 9px) 9px, #64748b 0 2px, transparent 3px),
+      radial-gradient(circle at 9px calc(100% - 9px), #64748b 0 2px, transparent 3px),
+      radial-gradient(circle at calc(100% - 9px) calc(100% - 9px), #64748b 0 2px, transparent 3px),
+      linear-gradient(135deg, #f8fafc, #d3dce7 46%, #93a3b8 100%);
+    box-shadow:
+      0 calc(var(--v) * 16) calc(var(--v) * 26) rgba(15,23,42,.30),
+      inset 0 0 0 1px rgba(255,255,255,.7);
+  }
+  #page-boiler .syn-solar-panel:hover { filter:brightness(1.05); }
+  #page-boiler .syn-solar-panel.active {
+    box-shadow:
+      0 calc(var(--v) * 16) calc(var(--v) * 30) rgba(180,83,9,.42),
+      0 0 0 1px rgba(245,158,11,.5),
+      inset 0 0 0 1px rgba(255,255,255,.8);
+  }
+  /* Absorber sheet with copper risers over the selective coating. */
+  #page-boiler .syn-solar-grid {
+    position:absolute;
+    inset:calc(var(--v) * 8);
+    border-radius:calc(var(--v) * 3);
+    overflow:hidden;
+    z-index:1;
+    background:
+      repeating-linear-gradient(90deg,
+        transparent 0 calc(var(--v) * 7),
+        rgba(120,53,15,.6) calc(var(--v) * 7) calc(var(--v) * 8),
+        rgba(217,119,6,.8) calc(var(--v) * 8) calc(var(--v) * 9.5),
+        rgba(251,191,36,.5) calc(var(--v) * 9.5) calc(var(--v) * 10),
+        transparent calc(var(--v) * 10) calc(var(--v) * 17)),
+      linear-gradient(150deg, #16283f 0%, #0a1220 48%, #101d31 100%);
+  }
+  /* Upper and lower manifolds. */
+  #page-boiler .syn-solar-grid::before,
+  #page-boiler .syn-solar-grid::after {
+    content:"";
+    position:absolute;
+    left:0; right:0;
+    height:calc(var(--v) * 7);
+    background:linear-gradient(180deg, #fbbf24, #b45309 70%, #78350f);
+    box-shadow:0 1px 3px rgba(0,0,0,.6);
+  }
+  #page-boiler .syn-solar-grid::before { top:calc(var(--v) * 6); }
+  #page-boiler .syn-solar-grid::after  { bottom:calc(var(--v) * 6); }
+  /* Cover glass: sky reflection, then a sweep while the loop charges. */
+  #page-boiler .syn-solar-glass {
+    position:absolute;
+    inset:calc(var(--v) * 8);
+    border-radius:calc(var(--v) * 3);
+    overflow:hidden;
+    z-index:3;
+    background:linear-gradient(140deg,
+      rgba(255,255,255,.42) 0 12%,
+      rgba(255,255,255,.10) 12% 24%,
+      rgba(255,255,255,.02) 24% 56%,
+      rgba(255,255,255,.16) 56% 63%,
+      rgba(255,255,255,.03) 63% 100%);
+  }
+  #page-boiler .syn-solar-glass::before {
+    content:"";
+    position:absolute;
+    inset:0;
+    background:linear-gradient(215deg, rgba(186,230,253,.34), transparent 46%);
+    transition:background .6s ease;
+  }
+  #page-boiler .syn-solar-panel.active .syn-solar-glass::before {
+    background:
+      linear-gradient(215deg, rgba(254,215,170,.42), transparent 48%),
+      radial-gradient(62% 42% at 28% 20%, rgba(251,191,36,.38), transparent 72%);
+  }
+  #page-boiler .syn-solar-glass::after {
+    content:"";
+    position:absolute;
+    top:-60%; bottom:-60%;
+    width:26%;
+    left:-40%;
+    background:linear-gradient(90deg, transparent, rgba(255,255,255,.48), transparent);
+    opacity:0;
+  }
+  #page-boiler .syn-solar-panel.active .syn-solar-glass::after {
+    opacity:1;
+    animation:dmStSweep 5s ease-in-out infinite;
+  }
+  @keyframes dmStSweep {
+    0%,66%  { left:-40%; }
+    100%    { left:116%; }
+  }
+
+  /* Collector readout: lifted out of the panel so the isometric skew never
+     reaches the digits. Backlit LCD, upright, floating above the roof plane. */
+  #page-boiler .syn-solar-content {
+    position:absolute;
+    left:calc(var(--v) * -72);
+    top:calc(var(--v) * -142);
+    width:max(112px, calc(var(--v) * 144));
+    z-index:6;
+    padding:calc(var(--v) * 8) calc(var(--v) * 10) calc(var(--v) * 9);
+    border-radius:calc(var(--v) * 8);
+    display:grid;
+    grid-template-columns:auto 1fr;
+    grid-template-areas:"icon label" "icon value";
+    align-items:center;
+    column-gap:calc(var(--v) * 9);
+    text-align:left;
+    background:var(--st-lcd);
+    border:1px solid var(--st-lcd-line);
+    box-shadow:0 calc(var(--v) * 7) calc(var(--v) * 14) rgba(0,0,0,.42), inset 0 1px 0 rgba(255,255,255,.16);
+  }
+  /* Leader line down to the panel. */
+  #page-boiler .syn-solar-content::after {
+    content:"";
+    position:absolute;
+    left:50%; top:100%;
+    width:1px;
+    height:calc(var(--v) * 22);
+    background:linear-gradient(180deg, var(--st-lcd-line), transparent);
+  }
+  #page-boiler .sun-icon {
+    grid-area:icon;
+    font-size:max(17px, calc(var(--v) * 22));
+    line-height:1;
+    margin:0;
+  }
+  #page-boiler .syn-lbl {
+    grid-area:label;
+    margin:0;
+    font-size:max(7px, calc(var(--v) * 8));
+    letter-spacing:calc(var(--v) * 1.2);
+    color:#94a3b8;
+    text-align:left;
+  }
+  #page-boiler .syn-val {
+    grid-area:value;
+    font-family:'Oswald', sans-serif;
+    font-size:max(16px, calc(var(--v) * 21));
+    font-weight:700;
+    line-height:1.1;
+    letter-spacing:calc(var(--v) * .9);
+    text-shadow:0 0 calc(var(--v) * 11) rgba(245,158,11,.55);
+  }
+
+  /* ───────── storage cylinder standing on the floor ───────── */
+  #page-boiler .syn-tank {
+    position:absolute;
+    left:calc(var(--v) * -62);
+    top:calc(var(--v) * -110);
+    width:calc(var(--v) * 124);
+    height:calc(var(--v) * 220);
+    padding:calc(var(--v) * 42) 0;
+    border:none;
+    /* Elliptical caps turn the rectangle into a cylinder on the iso plane. */
+    border-radius:calc(var(--v) * 62) / calc(var(--v) * 22);
+    background:linear-gradient(90deg, #8593a8, #dfe6ee 22%, #cfd9e4 52%, #9fb0c4 78%, #667287 100%);
+    box-shadow:
+      0 calc(var(--v) * 22) calc(var(--v) * 30) rgba(15,23,42,.32),
+      inset 0 calc(var(--v) * -8) calc(var(--v) * 14) rgba(15,23,42,.26);
+  }
+  html[data-theme="dark"] #page-boiler .syn-tank {
+    background:linear-gradient(90deg, #131b2c, #46536b 22%, #3b4760 52%, #26314a 78%, #101827 100%);
+    box-shadow:
+      0 calc(var(--v) * 22) calc(var(--v) * 30) rgba(0,0,0,.55),
+      inset 0 calc(var(--v) * -8) calc(var(--v) * 14) rgba(0,0,0,.45);
+  }
+  /* Top face of the cylinder, plus the lower shadow band. */
+  #page-boiler .syn-tank::before,
+  #page-boiler .syn-tank::after {
+    content:"";
+    position:absolute;
+    left:0; right:0;
+    z-index:5;
+    pointer-events:none;
+  }
+  #page-boiler .syn-tank::before {
+    top:0;
+    height:calc(var(--v) * 42);
+    border-radius:50% / 50%;
+    background:radial-gradient(60% 120% at 36% 24%, #ffffff, #cdd8e5 52%, #8d9db2 100%);
+    box-shadow:inset 0 -1px 2px rgba(15,23,42,.30);
+  }
+  html[data-theme="dark"] #page-boiler .syn-tank::before {
+    background:radial-gradient(60% 120% at 36% 24%, #7f8ea6, #46536b 52%, #202a3f 100%);
+  }
+  #page-boiler .syn-tank::after {
+    bottom:0;
+    height:calc(var(--v) * 34);
+    border-radius:50% / 50%;
+    background:linear-gradient(180deg, rgba(15,23,42,0), rgba(15,23,42,.34));
+  }
+  /* Cylindrical shading with the cutaway left clear in the middle. */
+  #page-boiler .tank-glass {
+    z-index:4;
+    background:
+      linear-gradient(90deg,
+        rgba(30,41,59,.70) 0%,
+        rgba(203,213,225,.88) 7%,
+        rgba(255,255,255,.92) 13%,
+        rgba(203,213,225,.58) 20%,
+        rgba(203,213,225,0) 27%,
+        rgba(203,213,225,0) 74%,
+        rgba(148,163,184,.42) 83%,
+        rgba(71,85,105,.70) 93%,
+        rgba(15,23,42,.60) 100%),
+      repeating-linear-gradient(180deg, rgba(255,255,255,.09) 0 1px, transparent 1px calc(var(--v) * 22)),
+      linear-gradient(112deg, rgba(255,255,255,.30) 0 14%, rgba(255,255,255,.04) 32%, transparent 58%, rgba(15,23,42,.16) 100%);
+  }
+  /* Brushed steel reflects far less light in a dark room. */
+  html[data-theme="dark"] #page-boiler .tank-glass {
+    background:
+      linear-gradient(90deg,
+        rgba(2,6,16,.78) 0%,
+        rgba(100,116,139,.70) 7%,
+        rgba(148,163,184,.76) 13%,
+        rgba(100,116,139,.46) 20%,
+        rgba(100,116,139,0) 27%,
+        rgba(100,116,139,0) 74%,
+        rgba(51,65,85,.52) 83%,
+        rgba(15,23,42,.78) 93%,
+        rgba(2,6,16,.72) 100%),
+      repeating-linear-gradient(180deg, rgba(148,163,184,.10) 0 1px, transparent 1px calc(var(--v) * 22)),
+      linear-gradient(112deg, rgba(226,232,240,.14) 0 14%, rgba(226,232,240,.03) 32%, transparent 58%, rgba(0,0,0,.28) 100%);
+  }
+  /* Copper heat exchanger, seen through the cutaway. */
+  #page-boiler .dm-st-coil {
+    position:absolute;
+    left:50%; top:50%;
+    transform:translate(-50%, -50%);
+    width:calc(var(--v) * 60);
+    height:calc(var(--v) * 84);
+    z-index:2;
+    pointer-events:none;
+    opacity:.7;
+  }
+  #page-boiler .dm-st-coil i {
+    position:absolute;
+    left:0; right:0;
+    height:calc(var(--v) * 16);
+    border-radius:50%;
+    border:calc(var(--v) * 1.6) solid rgba(146,64,14,.78);
+    border-top-color:rgba(251,191,36,.88);
+    border-bottom-color:rgba(120,53,15,.8);
+  }
+  #page-boiler .dm-st-coil i:nth-child(1) { top:0; }
+  #page-boiler .dm-st-coil i:nth-child(2) { top:calc(var(--v) * 11); }
+  #page-boiler .dm-st-coil i:nth-child(3) { top:calc(var(--v) * 22); }
+  #page-boiler .dm-st-coil i:nth-child(4) { top:calc(var(--v) * 33); }
+  #page-boiler .dm-st-coil i:nth-child(5) { top:calc(var(--v) * 44); }
+  #page-boiler .dm-st-coil i:nth-child(6) { top:calc(var(--v) * 55); }
+  #page-boiler .dm-st-coil i:nth-child(7) { top:calc(var(--v) * 66); }
+
+  /* Sensor readouts: lifted out of the cylinder so they read as mounted
+     displays beside it rather than stickers on the shell. */
+  /* Left of the shell: the right flank carries the recirculation loop. */
+  #page-boiler .tank-probes {
+    position:absolute;
+    right:calc(var(--v) * 100);
+    top:calc(var(--v) * -92);
+    height:calc(var(--v) * 176);
+    padding:0;
+    align-items:flex-end;
+    z-index:6;
+  }
+  #page-boiler .probe {
+    position:relative;
+    min-width:max(80px, calc(var(--v) * 92));
+    padding:calc(var(--v) * 6) calc(var(--v) * 11) calc(var(--v) * 7);
+    border-radius:calc(var(--v) * 7);
+    display:flex;
+    flex-direction:column;
+    align-items:flex-start;
+    gap:0;
+    background:var(--st-lcd);
+    border:1px solid var(--st-lcd-line);
+    box-shadow:0 calc(var(--v) * 6) calc(var(--v) * 12) rgba(0,0,0,.42), inset 0 1px 0 rgba(255,255,255,.14);
+    backdrop-filter:none;
+  }
+  /* Leader across to the shell. */
+  #page-boiler .probe::after {
+    content:"";
+    position:absolute;
+    left:100%; top:50%;
+    width:calc(var(--v) * 44);
+    height:1px;
+    background:linear-gradient(90deg, var(--st-lcd-line), transparent);
+  }
+  #page-boiler .dm-st-probe-tag {
+    font-size:max(7px, calc(var(--v) * 7.5));
+    font-weight:900;
+    letter-spacing:calc(var(--v) * 1.3);
+    text-transform:uppercase;
+    display:flex;
+    align-items:center;
+    gap:calc(var(--v) * 4);
+  }
+  #page-boiler .dm-st-probe-tag::before {
+    content:"";
+    width:calc(var(--v) * 5);
+    height:calc(var(--v) * 5);
+    border-radius:50%;
+    background:currentColor;
+    box-shadow:0 0 calc(var(--v) * 6) currentColor;
+  }
+  /* The runtime already paints the live temperature colours into these two
+     variables for the tank gradient; the captions reuse them for free. */
+  #page-boiler .probe:first-child .dm-st-probe-tag { color:var(--tank-top); }
+  #page-boiler .probe:last-child  .dm-st-probe-tag { color:var(--tank-bottom); }
+  #page-boiler .probe-val {
+    font-size:max(15px, calc(var(--v) * 19));
+    line-height:1.15;
+    letter-spacing:calc(var(--v) * .9);
+    color:#f1f5f9;
+    text-shadow:0 0 calc(var(--v) * 9) rgba(226,232,240,.35);
+  }
+
+  /* Safety relief valve, tucked onto the cylinder's shoulder. */
+  #page-boiler .sv-wrap {
+    left:calc(var(--v) * 40);
+    top:calc(var(--v) * -104);
+    transform:scale(calc(var(--v) / 1.076));
+    transform-origin:0 0;
+  }
+
+  /* ───────── wet-rotor circulators, upright cans on the pipe run ───────── */
+  #page-boiler .syn-pump .icon {
+    position:relative;
+    width:calc(var(--v) * 62);
+    height:calc(var(--v) * 66);
+    padding-top:calc(var(--v) * 12);
+    border:none;
+    border-radius:calc(var(--v) * 31) / calc(var(--v) * 13);
+    overflow:visible;
+    background:
+      repeating-radial-gradient(circle at 50% 50%, rgba(15,23,42,.08) 0 1px, transparent 1px calc(var(--v) * 4)),
+      linear-gradient(90deg, #7d8ca1, #ffffff 28%, #cfd9e4 58%, #7f8ea6 100%);
+    box-shadow:
+      0 calc(var(--v) * 12) calc(var(--v) * 18) rgba(15,23,42,.34),
+      inset 0 calc(var(--v) * -6) calc(var(--v) * 10) rgba(15,23,42,.28);
+  }
+  html[data-theme="dark"] #page-boiler .syn-pump .icon {
+    background:
+      repeating-radial-gradient(circle at 50% 50%, rgba(0,0,0,.20) 0 1px, transparent 1px calc(var(--v) * 4)),
+      linear-gradient(90deg, #131b2c, #7f8ea6 28%, #46536b 58%, #161f2f 100%);
+    box-shadow:
+      0 calc(var(--v) * 12) calc(var(--v) * 18) rgba(0,0,0,.5),
+      inset 0 calc(var(--v) * -6) calc(var(--v) * 10) rgba(0,0,0,.45);
+  }
+  /* Top face of the can. */
+  #page-boiler .syn-pump .icon::before {
+    content:"";
+    position:absolute;
+    left:0; right:0; top:0;
+    height:calc(var(--v) * 26);
+    border-radius:50% / 50%;
+    background:radial-gradient(60% 120% at 36% 26%, #ffffff, #ccd7e4 54%, #90a0b5 100%);
+    box-shadow:inset 0 -1px 2px rgba(15,23,42,.28);
+    z-index:1;
+  }
+  html[data-theme="dark"] #page-boiler .syn-pump .icon::before {
+    background:radial-gradient(60% 120% at 36% 26%, #7f8ea6, #46536b 54%, #1f2a3d 100%);
+  }
+  /* Both circulators sit on vertical risers, so their flanges face up and down. */
+  #page-boiler .dm-st-flange { position:absolute; inset:0; pointer-events:none; z-index:3; }
+  #page-boiler .dm-st-flange::before,
+  #page-boiler .dm-st-flange::after {
+    content:"";
+    position:absolute;
+    left:50%;
+    transform:translateX(-50%);
+    width:calc(var(--v) * 30);
+    height:calc(var(--v) * 11);
+    border-radius:calc(var(--v) * 2);
+    background:linear-gradient(90deg, #8ea0b6, #f4f7fb 34%, #9fb0c4 100%);
+    box-shadow:0 2px 4px rgba(15,23,42,.4);
+  }
+  #page-boiler .dm-st-flange::before { top:calc(var(--v) * -7); }
+  #page-boiler .dm-st-flange::after  { bottom:calc(var(--v) * -7); }
+  html[data-theme="dark"] #page-boiler .dm-st-flange::before,
+  html[data-theme="dark"] #page-boiler .dm-st-flange::after {
+    background:linear-gradient(90deg, #2c3648, #7f8ea6 34%, #3b4760 100%);
+  }
+  /* Terminal box with the run indicator. */
+  #page-boiler .dm-st-box {
+    position:absolute;
+    top:calc(var(--v) * -13);
+    left:50%;
+    transform:translateX(-50%);
+    z-index:4;
+    width:calc(var(--v) * 30);
+    height:calc(var(--v) * 17);
+    border-radius:calc(var(--v) * 4) calc(var(--v) * 4) calc(var(--v) * 2) calc(var(--v) * 2);
+    background:linear-gradient(180deg, #f8fafc, #cbd5e1 58%, #8ea0b6);
+    box-shadow:0 2px 5px rgba(15,23,42,.4), inset 0 1px 0 rgba(255,255,255,.95);
+  }
+  html[data-theme="dark"] #page-boiler .dm-st-box {
+    background:linear-gradient(180deg, #7d8ca1, #46536b 58%, #232d42);
+  }
+  #page-boiler .dm-st-box::after {
+    content:"";
+    position:absolute;
+    left:50%; top:calc(var(--v) * 5);
+    transform:translateX(-50%);
+    width:calc(var(--v) * 6);
+    height:calc(var(--v) * 6);
+    border-radius:50%;
+    background:#94a3b8;
+    box-shadow:inset 0 1px 2px rgba(0,0,0,.45);
+    transition:background .3s ease, box-shadow .3s ease;
+  }
+  #page-boiler .syn-pump.active .dm-st-box::after {
+    background:#22c55e;
+    box-shadow:0 0 calc(var(--v) * 8) rgba(34,197,94,.95);
+  }
+  /* Impeller on the front face; the legacy rule spins .anim-icon on .active. */
+  #page-boiler .dm-st-rotor {
+    position:relative;
+    z-index:2;
+    width:calc(var(--v) * 28);
+    height:calc(var(--v) * 28);
+    border-radius:50%;
+    background:conic-gradient(from 0deg,
+      var(--st-rotor) 0 9%, transparent 9% 25%,
+      var(--st-rotor) 25% 34%, transparent 34% 50%,
+      var(--st-rotor) 50% 59%, transparent 59% 75%,
+      var(--st-rotor) 75% 84%, transparent 84% 100%);
+    -webkit-mask:radial-gradient(circle, transparent 0 22%, #000 24%);
+    mask:radial-gradient(circle, transparent 0 22%, #000 24%);
+    filter:drop-shadow(0 1px 1px rgba(15,23,42,.45));
+    transition:background .4s ease;
+  }
+  /* A running circulator stays a metal can: the state is carried by the rim
+     light, the LED, the aura and the spinning impeller, not by a colour swap. */
+  #page-boiler .syn-pump.active .icon {
+    background:
+      radial-gradient(90% 60% at 50% 120%, rgba(249,115,22,.34), transparent 64%),
+      repeating-radial-gradient(circle at 50% 50%, rgba(15,23,42,.08) 0 1px, transparent 1px calc(var(--v) * 4)),
+      linear-gradient(90deg, #7d8ca1, #ffffff 28%, #cfd9e4 58%, #7f8ea6 100%);
+    box-shadow:
+      0 calc(var(--v) * 12) calc(var(--v) * 20) rgba(194,65,12,.40),
+      0 0 calc(var(--v) * 18) rgba(234,88,12,.30),
+      inset 0 calc(var(--v) * -6) calc(var(--v) * 10) rgba(124,45,18,.28);
+  }
+  #page-boiler .syn-pump.active .dm-st-rotor { background:conic-gradient(from 0deg,
+      #9a3412 0 9%, transparent 9% 25%,
+      #9a3412 25% 34%, transparent 34% 50%,
+      #9a3412 50% 59%, transparent 59% 75%,
+      #9a3412 75% 84%, transparent 84% 100%); }
+  #page-boiler .syn-pump.active .icon::after {
+    content:"";
+    position:absolute;
+    left:50%; bottom:calc(var(--v) * -6);
+    transform:translateX(-50%);
+    width:calc(var(--v) * 74);
+    height:calc(var(--v) * 30);
+    border-radius:50%;
+    border:1px solid rgba(234,88,12,.45);
+    animation:dmStPulse 1.9s ease-out infinite;
+    pointer-events:none;
+  }
+  @keyframes dmStPulse {
+    0%   { transform:translateX(-50%) scale(.82); opacity:.85; }
+    100% { transform:translateX(-50%) scale(1.24); opacity:0; }
+  }
+  #page-boiler .syn-pump .lbl,
+  #page-boiler .syn-valve .lbl {
+    margin-top:calc(var(--v) * 14);
+    padding:calc(var(--v) * 5) calc(var(--v) * 11);
+    border-radius:999px;
+    font-size:max(8px, calc(var(--v) * 9));
+    letter-spacing:calc(var(--v) * 1.1);
+    color:var(--st-ink-dim);
+    background:var(--st-glass);
+    border:1px solid var(--st-glass-line);
+    box-shadow:0 calc(var(--v) * 5) calc(var(--v) * 11) rgba(15,23,42,.10);
+    white-space:nowrap;
+  }
+  #page-boiler .syn-pump.active .lbl {
+    color:#c2410c;
+    border-color:rgba(234,88,12,.28);
+    background:rgba(255,247,237,.96);
+  }
+  /* Recirculation keeps its own violet identity. */
+  #page-boiler #syn-p-ricircolo.active .icon {
+    background:
+      radial-gradient(90% 60% at 50% 120%, rgba(139,92,246,.34), transparent 64%),
+      repeating-radial-gradient(circle at 50% 50%, rgba(15,23,42,.08) 0 1px, transparent 1px calc(var(--v) * 4)),
+      linear-gradient(90deg, #7d8ca1, #ffffff 28%, #cfd9e4 58%, #7f8ea6 100%);
+    box-shadow:
+      0 calc(var(--v) * 12) calc(var(--v) * 20) rgba(109,40,217,.38),
+      0 0 calc(var(--v) * 18) rgba(124,58,237,.30),
+      inset 0 calc(var(--v) * -6) calc(var(--v) * 10) rgba(76,29,149,.26);
+  }
+  #page-boiler #syn-p-ricircolo.active .dm-st-rotor { background:conic-gradient(from 0deg,
+      #5b21b6 0 9%, transparent 9% 25%,
+      #5b21b6 25% 34%, transparent 34% 50%,
+      #5b21b6 50% 59%, transparent 59% 75%,
+      #5b21b6 75% 84%, transparent 84% 100%); }
+  #page-boiler #syn-p-ricircolo.active .icon::after { border-color:rgba(124,58,237,.45); }
+  #page-boiler #syn-p-ricircolo.active .lbl {
+    color:#6d28d9;
+    border-color:rgba(124,58,237,.28);
+    background:rgba(245,243,255,.96);
+  }
+
+  /* ───────── butterfly valve: the legacy open/closed rules use !important on
+     an id selector, so the housing restyle has to answer in kind ───────── */
+  #page-boiler .syn-valve .icon { position:relative; }
+  #page-boiler #syn-v-chiave .icon {
+    width:calc(var(--v) * 54) !important;
+    height:calc(var(--v) * 54) !important;
+    border:none !important;
+    background:
+      repeating-radial-gradient(circle at 50% 50%, rgba(15,23,42,.07) 0 1px, transparent 1px calc(var(--v) * 5)),
+      radial-gradient(circle at 34% 27%, #ffffff, #dde5ee 38%, #9fb0c4 74%, #5f6d82 100%) !important;
+    box-shadow:
+      0 calc(var(--v) * 12) calc(var(--v) * 18) rgba(15,23,42,.34),
+      inset 0 0 0 calc(var(--v) * 3) rgba(255,255,255,.45) !important;
+  }
+  html[data-theme="dark"] #page-boiler #syn-v-chiave .icon {
+    background:
+      repeating-radial-gradient(circle at 50% 50%, rgba(0,0,0,.20) 0 1px, transparent 1px calc(var(--v) * 5)),
+      radial-gradient(circle at 34% 27%, #7f8ea6, #4c5972 38%, #2c3648 74%, #161f2f 100%) !important;
+  }
+  #page-boiler #syn-v-chiave.active .icon {
+    box-shadow:
+      0 calc(var(--v) * 12) calc(var(--v) * 20) rgba(5,150,105,.40),
+      0 0 0 2px rgba(16,185,129,.5),
+      inset 0 0 0 calc(var(--v) * 3) rgba(255,255,255,.45) !important;
+  }
+  #page-boiler #syn-v-chiave:not(.active) .icon {
+    box-shadow:
+      0 calc(var(--v) * 12) calc(var(--v) * 20) rgba(190,18,60,.34),
+      0 0 0 2px rgba(239,68,68,.45),
+      inset 0 0 0 calc(var(--v) * 3) rgba(255,255,255,.45) !important;
+  }
+  #page-boiler #syn-v-chiave .valve-svg { width:70%; height:70%; }
+  #page-boiler #syn-v-chiave.active .lbl {
+    color:#047857;
+    border-color:rgba(16,185,129,.30);
+    background:rgba(240,253,244,.96);
+  }
+  /* Hand-lever stem, so the valve reads as a body rather than a badge. */
+  #page-boiler #syn-v-chiave .icon::after {
+    content:"";
+    position:absolute;
+    top:calc(var(--v) * -12);
+    left:50%;
+    transform:translateX(-50%);
+    width:calc(var(--v) * 8);
+    height:calc(var(--v) * 15);
+    border-radius:calc(var(--v) * 3) calc(var(--v) * 3) 0 0;
+    background:linear-gradient(180deg, #eef3f9, #94a3b8 60%, #5f6d82);
+    box-shadow:0 2px 4px rgba(15,23,42,.4);
+  }
+
+  /* ───────── safety banner ───────── */
+  #page-boiler .syn-safety-alert {
+    top:16px;
+    left:auto;
+    right:16px;
+    padding:9px 18px;
+    border-radius:999px;
+    border:1px solid #fca5a5;
+    background:linear-gradient(135deg, #fff1f2, #fee2e2);
+    color:#b91c1c;
+    font-size:11px;
+    letter-spacing:1.4px;
+    box-shadow:0 14px 30px rgba(220,38,38,.22);
+    z-index:12;
+  }
+  /* Own keyframes: the legacy pulseAlert animates transform, which would fight
+     any positioning this banner needs. */
+  #page-boiler .syn-safety-alert.active {
+    animation:dmStAlert 1.8s ease-in-out infinite;
+  }
+  @keyframes dmStAlert {
+    0%,100% { box-shadow:0 14px 30px rgba(220,38,38,.22); }
+    50%     { box-shadow:0 14px 34px rgba(220,38,38,.46); }
+  }
+
+  /* ───────── statistics ───────── */
+  #page-boiler .boiler-stats-row {
+    display:grid;
+    grid-template-columns:repeat(3, 1fr);
+    gap:14px;
+    margin:0 22px 16px;
+  }
+  #page-boiler .b-stat-card {
+    position:relative;
+    overflow:hidden;
+    padding:19px 17px 16px;
+    border-radius:22px;
+    align-items:flex-start;
+    text-align:left;
+    gap:9px;
+    background:var(--st-panel);
+    border:1px solid var(--st-line);
+    box-shadow:0 12px 30px rgba(15,23,42,.06);
+  }
+  #page-boiler .b-stat-card::before {
+    content:"";
+    position:absolute;
+    inset:0 0 auto 0;
+    height:4px;
+    background:linear-gradient(90deg, var(--st-accent), transparent 88%);
+  }
+  #page-boiler .b-stat-card:nth-child(1) { --st-accent:#059669; }
+  #page-boiler .b-stat-card:nth-child(2) { --st-accent:#0284c7; }
+  #page-boiler .b-stat-card:nth-child(3) { --st-accent:#ea580c; }
+  #page-boiler .b-stat-card::after {
+    content:"";
+    position:absolute;
+    right:-40px; bottom:-52px;
+    width:104px; height:104px;
+    border-radius:50%;
+    background:radial-gradient(circle, var(--st-accent), transparent 66%);
+    opacity:.07;
+    pointer-events:none;
+  }
+  #page-boiler .b-stat-card .lbl {
+    display:flex;
+    align-items:center;
+    gap:7px;
+    font-size:10.5px;
+    letter-spacing:1.2px;
+  }
+  #page-boiler .b-stat-card .lbl::before { font-size:13px; line-height:1; }
+  #page-boiler .b-stat-card:nth-child(1) .lbl::before { content:"🌡️"; }
+  #page-boiler .b-stat-card:nth-child(2) .lbl::before { content:"💧"; }
+  #page-boiler .b-stat-card:nth-child(3) .lbl::before { content:"⚡"; }
+  #page-boiler .b-stat-card .val {
+    font-size:clamp(23px, 2.7vw, 31px);
+    line-height:1.05;
+    letter-spacing:.5px;
+  }
+  #page-boiler .b-stat-card:hover { box-shadow:0 20px 40px rgba(15,23,42,.10); }
+
+  /* ───────── control tiles ─────────
+     Nine controls, laid out so no row is ever left with a single orphan tile:
+     9 across when the card is wide, then 5+4, then 3+3+3. */
+  #page-boiler .b-controls-grid {
+    grid-template-columns:repeat(9, 1fr);
+    gap:12px;
+    margin:0 22px 24px;
+  }
+  @media (max-width:1080px) {
+    #page-boiler .b-controls-grid { grid-template-columns:repeat(5, 1fr); }
+  }
+  #page-boiler .b-btn {
+    position:relative;
+    overflow:hidden;
+    padding:16px 8px 14px;
+    border-radius:22px;
+    gap:9px;
+    background:var(--st-panel);
+    border:1px solid var(--st-line);
+    box-shadow:0 10px 24px rgba(15,23,42,.05);
+  }
+  #page-boiler .b-btn .icon {
+    width:46px; height:46px;
+    display:grid;
+    place-items:center;
+    border-radius:16px;
+    font-size:23px;
+    background:var(--st-chip);
+    filter:grayscale(1) opacity(.5);
+    transition:.35s cubic-bezier(.165,.84,.44,1);
+  }
+  #page-boiler .b-btn .lbl {
+    font-size:9.5px;
+    letter-spacing:.5px;
+    color:var(--st-ink-dim);
+  }
+  #page-boiler .b-btn .state {
+    padding:5px 10px;
+    border-radius:999px;
+    font-size:9px;
+    letter-spacing:.9px;
+    color:var(--st-ink-dim);
+    background:var(--st-chip);
+    border:1px solid var(--st-line);
+  }
+  #page-boiler .b-btn.active {
+    transform:translateY(-4px);
+    border-color:rgba(var(--c-rgb), .50);
+    background:linear-gradient(168deg, rgba(var(--c-rgb), .11), rgba(var(--c-rgb), .03));
+    box-shadow:0 18px 34px rgba(var(--c-rgb), .22);
+  }
+  #page-boiler .b-btn.active .icon {
+    filter:none;
+    transform:scale(1.04);
+    background:rgba(var(--c-rgb), .16);
+    box-shadow:0 8px 18px rgba(var(--c-rgb), .28);
+  }
+  #page-boiler .b-btn.active .lbl { color:rgb(var(--c-rgb)); }
+  #page-boiler .b-btn.active .state {
+    color:rgb(var(--c-rgb));
+    background:rgba(var(--c-rgb), .13);
+    border-color:rgba(var(--c-rgb), .30);
+  }
+  #page-boiler .b-btn.active::after {
+    content:"";
+    position:absolute;
+    top:12px; right:12px;
+    width:7px; height:7px;
+    border-radius:50%;
+    background:rgb(var(--c-rgb));
+    box-shadow:0 0 0 3px rgba(var(--c-rgb), .18);
+  }
+  #page-boiler .b-btn:active { transform:scale(.97); }
+  /* The markup ships .spin-active/.blink-active hooks that nothing animated. */
+  #page-boiler .b-btn.active .spin-active {
+    display:inline-block;
+    animation:spinAnim 1.6s linear infinite;
+  }
+  #page-boiler .b-btn.active .blink-active {
+    display:inline-block;
+    animation:dmStBlink 1.25s ease-in-out infinite;
+  }
+  @keyframes dmStBlink {
+    0%,100% { opacity:1; }
+    50%     { opacity:.35; }
+  }
+
+  /* ───────── compact layout ───────── */
+  @media (max-width:768px) {
+    #page-boiler .boiler-dashboard { border-radius:24px; }
+    #page-boiler .boiler-header { padding:20px 18px 18px; }
+    #page-boiler .boiler-header::before { top:-74px; right:-58px; width:180px; height:180px; }
+    #page-boiler .synoptic-stage {
+      --st-u:calc(1vw - .68px);
+      margin:16px 14px 12px;
+      border-radius:20px;
+    }
+    #page-boiler .syn-safety-alert { top:11px; right:11px; padding:7px 13px; font-size:9.5px; }
+    #page-boiler .boiler-stats-row { gap:9px; margin:0 14px 12px; }
+    #page-boiler .b-stat-card { padding:14px 12px 12px; border-radius:18px; gap:6px; }
+    #page-boiler .b-stat-card .lbl { font-size:9px; letter-spacing:.6px; gap:5px; }
+    #page-boiler .b-stat-card .lbl::before { font-size:11px; }
+    #page-boiler .b-stat-card .val { font-size:19px; }
+    #page-boiler .b-controls-grid {
+      grid-template-columns:repeat(3, 1fr);
+      gap:9px;
+      margin:0 14px 18px;
+    }
+    #page-boiler .b-btn { padding:13px 6px 11px; border-radius:18px; gap:7px; }
+    #page-boiler .b-btn .icon { width:38px; height:38px; border-radius:13px; font-size:19px; }
+    #page-boiler .b-btn .lbl { font-size:8.5px; letter-spacing:.2px; }
+    #page-boiler .b-btn .state { font-size:8px; padding:4px 8px; }
+    #page-boiler .b-btn.active::after { top:9px; right:9px; width:6px; height:6px; }
+  }
+  @media (max-width:420px) {
+    #page-boiler .dm-st-sub { font-size:9.5px; letter-spacing:1px; }
+    #page-boiler .dm-st-live { margin-top:11px; font-size:9.5px; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    #page-boiler .syn-solar-panel.active .syn-solar-glass::after,
+    #page-boiler .syn-pump.active .icon::after,
+    #page-boiler .syn-safety-alert.active,
+    #page-boiler .b-btn.active .spin-active,
+    #page-boiler .b-btn.active .blink-active { animation:none; }
+  }
+  `;
+}
+
+function element(tag, className, text) {
+  const node = doc.createElement(tag);
+  if (className) node.className = className;
+  if (text) node.textContent = text;
+  return node;
+}
+
+/** Mark the two anchor nodes so the layout never depends on sibling order. */
+function markNodes() {
+  const panel = doc.querySelector("#page-boiler .syn-solar-panel");
+  const tank = doc.querySelector("#page-boiler .syn-tank");
+  panel?.closest(".syn-node-boiler")?.classList.add("dm-st-node-collector");
+  tank?.closest(".syn-node-boiler")?.classList.add("dm-st-node-tank");
+}
+
+/** Give the two empty `.syn-pump` divs a circulator body and a nameplate. */
+function buildPumps() {
+  for (const [id, label] of PUMP_LABELS) {
+    const pump = doc.getElementById(id);
+    if (!pump || pump.querySelector(".icon")) continue;
+    const icon = element("div", "icon");
+    icon.append(
+      element("span", "dm-st-flange"),
+      element("span", "anim-icon dm-st-rotor"),
+      element("span", "dm-st-box"),
+    );
+    pump.append(icon, element("div", "lbl", label()));
+  }
+}
+
+/** The valve ships an icon but no nameplate. */
+function nameValve() {
+  const valve = doc.getElementById("syn-v-chiave");
+  if (!valve || valve.querySelector(".lbl")) return;
+  valve.append(element("div", "lbl", t("Chiave Solare", "Solar Valve")));
+}
+
+/** Copper heat exchanger, visible through the cylinder cutaway. */
+function buildCoil() {
+  const tank = doc.querySelector("#page-boiler .syn-tank");
+  if (!tank || tank.querySelector(".dm-st-coil")) return;
+  const coil = element("div", "dm-st-coil");
+  for (let turn = 0; turn < COIL_TURNS; turn += 1) coil.append(element("i"));
+  tank.prepend(coil);
+}
+
+/**
+ * Lift the two readouts out of the bodies they were painted on. The collector
+ * carries an isometric skew that would shear its own digits, and the cylinder
+ * clips its overflow, so both readouts live on the anchor node instead.
+ */
+function liftReadouts() {
+  const collector = doc.querySelector("#page-boiler .dm-st-node-collector");
+  const readout = doc.querySelector("#page-boiler .syn-solar-content");
+  if (collector && readout && readout.parentElement !== collector) collector.append(readout);
+
+  const tankNode = doc.querySelector("#page-boiler .dm-st-node-tank");
+  const probes = doc.querySelector("#page-boiler .tank-probes");
+  if (tankNode && probes && probes.parentElement !== tankNode) tankNode.append(probes);
+}
+
+/** Caption the two tank probes, which only ever showed a bare temperature. */
+function captionProbes() {
+  const probes = doc.querySelectorAll("#page-boiler .tank-probes .probe");
+  if (probes.length !== 2) return;
+  const captions = [t("Alto", "Top"), t("Basso", "Bottom")];
+  probes.forEach((probe, index) => {
+    if (probe.querySelector(".dm-st-probe-tag")) return;
+    probe.prepend(element("span", "dm-st-probe-tag", captions[index]));
+  });
+}
+
+/**
+ * Route the pipework on isometric axes and keep the three coaxial strokes of
+ * each run in sync. The runtime only toggles `active` on the flow paths by id,
+ * so their geometry belongs to this module.
+ */
+function routePipes(portrait) {
+  const stage = doc.querySelector("#page-boiler .synoptic-stage");
+  const svg = doc.querySelector("#page-boiler .syn-svg");
+  if (!stage || !svg) return;
+  const layout = portrait ? PORTRAIT : LANDSCAPE;
+
+  stage.classList.toggle("dm-st-portrait", portrait);
+  if (svg.getAttribute("viewBox") !== layout.viewBox) {
+    svg.setAttribute("viewBox", layout.viewBox);
+  }
+
+  for (const [id, route] of Object.entries(layout.routes)) {
+    const flow = doc.getElementById(id);
+    if (!flow) continue;
+    const run = [flow];
+    let sibling = flow.previousElementSibling;
+    while (
+      sibling &&
+      (sibling.classList.contains("syn-pipe-inner") ||
+        sibling.classList.contains("syn-pipe-bg") ||
+        sibling.classList.contains("dm-st-pipe-hi"))
+    ) {
+      run.push(sibling);
+      sibling = sibling.previousElementSibling;
+    }
+    for (const path of run) {
+      if (path.getAttribute("d") !== route) path.setAttribute("d", route);
+    }
+  }
+}
+
+/** Specular line along each pipe, drawn between the body and the flow comet. */
+function highlightPipes() {
+  for (const body of doc.querySelectorAll("#page-boiler .syn-pipe-inner")) {
+    const route = body.getAttribute("d") || "";
+    let highlight = body.nextElementSibling;
+    if (!highlight?.classList?.contains("dm-st-pipe-hi")) {
+      highlight = doc.createElementNS(SVG_NS, "path");
+      highlight.setAttribute("class", "dm-st-pipe-hi");
+      body.after(highlight);
+    }
+    if (highlight.getAttribute("d") !== route) highlight.setAttribute("d", route);
+  }
+}
+
+/** Two control tiles ship an icon and a state but no name. */
+function nameButtons() {
+  for (const [id, label] of BUTTON_LABELS) {
+    const button = doc.getElementById(id);
+    if (!button || button.querySelector(".lbl")) continue;
+    const stateNode = button.querySelector(".state");
+    const node = element("div", "lbl", label());
+    if (stateNode) button.insertBefore(node, stateNode);
+    else button.append(node);
+  }
+}
+
+/** Subtitle and the CSS-driven status pill for the hero header. */
+function buildHeader() {
+  const header = doc.querySelector("#page-boiler .boiler-header");
+  if (!header || header.querySelector(".dm-st-sub")) return;
+  header.append(
+    element(
+      "div",
+      "dm-st-sub",
+      t(
+        "Circuito primario · Boiler · Ricircolo sanitario",
+        "Primary loop · Tank · DHW recirculation",
+      ),
+    ),
+    element("div", "dm-st-live"),
+  );
+}
+
+function decorate() {
+  if (!doc?.getElementById("page-boiler")) return false;
+  buildHeader();
+  markNodes();
+  buildPumps();
+  nameValve();
+  buildCoil();
+  liftReadouts();
+  captionProbes();
+  routePipes(Boolean(state.query?.matches));
+  highlightPipes();
+  nameButtons();
+  return true;
+}
+
+function schedule() {
+  if (state.frame) return;
+  state.frame = root.requestAnimationFrame?.(() => {
+    state.frame = 0;
+    decorate();
+  }) || 0;
+  if (!state.frame) decorate();
+}
+
+export function installSolarThermalDesignSection() {
+  installStyle(STYLE_ID, stylesheet());
+  state.query ||= root.matchMedia?.(PORTRAIT_QUERY) || null;
+  decorate();
+  if (state.installed) return true;
+  state.installed = true;
+  // The portrait scene swaps in on a media-query event, never on a timer.
+  state.query?.addEventListener?.("change", schedule);
+  // The legacy runtime only writes text and classes into this page, so the
+  // added hardware survives; re-running after a render keeps it in place if a
+  // future legacy repaint ever replaces the markup.
+  for (const name of ["render", "renderBoiler", "renderSolarThermal"]) {
+    wrapFunction(name, `__dmSolarThermalDesign_${name}`, schedule);
+  }
+  return true;
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/subload-popup-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/subload-popup-section.js
@@ -90,7 +90,7 @@ function element(tag, className = "", text = "") {
  * either. A token printed as text would show "mdi:stove" where the circle
  * shows the glyph. */
 function iconInto(target, icon) {
-  writeIconGlyph(target, icon, { size: 24 });
+  writeIconGlyph(target, icon, { size: 24, kind: "load" });
   return target;
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/temperature-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/temperature-section.js
@@ -10,6 +10,7 @@ import {
   installStyle,
   root,
   section,
+  temperatureCardLabels,
 } from "./shared.js";
 
 root.__DM_20260815C__ = true;
@@ -144,8 +145,9 @@ function createTemperatureCard(room) {
   body.className = "cp-body temp-card-body";
   const current = doc.createElement("div");
   current.className = "cp-temp-current-wrap";
+  const labels = temperatureCardLabels(room);
   current.append(
-    makeText("cp-temp-current-lbl", english() ? "Temperature" : "Temperatura"),
+    makeText("cp-temp-current-lbl", labels.temperature),
     makeText("cp-temp-current temp-value", "—"),
   );
   current.lastElementChild.id = `tv_${tid}`;
@@ -153,7 +155,7 @@ function createTemperatureCard(room) {
   const humidityBox = doc.createElement("div");
   humidityBox.className = "cp-temp-target";
   humidityBox.append(
-    makeText("lbl", `💧 ${english() ? "Humidity" : "Umidità"}`),
+    makeText("lbl", `💧 ${labels.humidity}`),
     makeText("val temp-hum-val", "—%"),
   );
   humidityBox.lastElementChild.id = `hv_${hid}`;

--- a/custom_components/dashboardmodern/frontend/tests/beta30-energy-flow-dynamic.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta30-energy-flow-dynamic.test.js
@@ -330,7 +330,7 @@ test("an mdi icon is drawn through the icon engine, not as an empty ha-icon box"
     });
 
     const icon = bubbles(views.instant)[0].querySelector(".node-icon");
-    assert.deepEqual(asked[0], ["action", "mdi:car-electric", 28]);
+    assert.deepEqual(asked[0], ["load", "mdi:car-electric", 28]);
     assert.match(icon.innerHTML, /🚘/);
     assert.equal(icon.textContent, "", "the token is never printed as text");
   } finally {

--- a/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
@@ -7,5 +7,5 @@ const manifest = JSON.parse(
 );
 
 test("the release manifest is versioned correctly", () => {
-  assert.equal(manifest.version, "1.0.0-beta.30.6");
+  assert.equal(manifest.version, "1.0.0-beta.30.7");
 });

--- a/custom_components/dashboardmodern/frontend/tests/climate-thermal-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/climate-thermal-section.test.js
@@ -1,0 +1,161 @@
+// DM-FIX-20260817D
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(
+  new URL("../src/sections/climate-thermal-section.js", import.meta.url),
+  "utf8",
+);
+
+async function loadSection() {
+  return import(`../src/sections/climate-thermal-section.js?fix=${Date.now()}`);
+}
+
+test("a unit lands in the heating zone only when its type says so", async () => {
+  const { climateZone } = await loadSection();
+  assert.equal(climateZone({ type: "clima" }), "freddo");
+  assert.equal(climateZone({ type: "termo" }), "caldo");
+  assert.equal(climateZone({ type: "Termostato" }), "caldo");
+  assert.equal(climateZone({ type: "heat" }), "caldo");
+  assert.equal(climateZone({}), "freddo");
+});
+
+test("configured units are read through the legacy list and keep the legacy card ids", async () => {
+  const { climateUnits } = await loadSection();
+  const previous = globalThis.getClimaUnits;
+  try {
+    globalThis.getClimaUnits = () => [
+      { entity: "climate.salone", name: "Salone", room: "Salone", type: "clima" },
+      { entity: "climate.bagno", name: "Bagno", type: "termo" },
+      { name: "senza entità" },
+    ];
+    const units = climateUnits();
+    assert.equal(units.length, 2);
+    // The legacy runtime and every caller look the card up by this id.
+    assert.equal(units[0].cardId, "card-climate-salone");
+    assert.equal(units[0].zone, "freddo");
+    assert.equal(units[1].cardId, "card-climate-bagno");
+    assert.equal(units[1].zone, "caldo");
+  } finally {
+    if (previous === undefined) delete globalThis.getClimaUnits;
+    else globalThis.getClimaUnits = previous;
+  }
+});
+
+test("a unit counts as running unless Home Assistant reports it off or unreachable", async () => {
+  const { climateReading } = await loadSection();
+  const states = {
+    "climate.a": { state: "cool", attributes: { temperature: 24, current_temperature: 26.4 } },
+    "climate.b": { state: "off", attributes: { temperature: 25 } },
+    "climate.c": { state: "unavailable", attributes: {} },
+    "climate.d": { state: "fan_only", attributes: { fan_mode: "medium" } },
+  };
+  assert.equal(climateReading("climate.a", states).on, true);
+  assert.equal(climateReading("climate.a", states).target, 24);
+  assert.equal(climateReading("climate.a", states).ambient, 26.4);
+  assert.equal(climateReading("climate.b", states).on, false);
+  assert.equal(climateReading("climate.c", states).on, false);
+  assert.equal(climateReading("climate.d", states).fan, "medium");
+  // An entity Home Assistant never sent is not "off", it is unknown: the bulk
+  // switch must skip it instead of firing a service call into the void.
+  assert.equal(climateReading("climate.missing", states).known, false);
+});
+
+test("a missing temperature never becomes a number on the rail", async () => {
+  const { climateReading } = await loadSection();
+  const reading = climateReading("climate.x", {
+    "climate.x": { state: "heat", attributes: { current_temperature: "n/a" } },
+  });
+  assert.equal(reading.target, null);
+  assert.equal(reading.ambient, null);
+});
+
+test("the sparkline needs real history before it draws anything", async () => {
+  const { sparklinePath } = await loadSection();
+  assert.equal(sparklinePath([]), null);
+  assert.equal(sparklinePath([21.4, 21.5]), null);
+  const path = sparklinePath([21, 21.6, 22.2, 22]);
+  assert.ok(path.line.startsWith("M"));
+  assert.ok(path.area.endsWith("Z"));
+  // A flat series must not divide by a zero span.
+  const flat = sparklinePath([20, 20, 20, 20]);
+  assert.ok(Number.isFinite(flat.end[1]));
+});
+
+test("the page keeps every hook the legacy climate runtime writes into", () => {
+  for (const hook of [
+    'id="clima-grid-freddo"',
+    'id="clima-grid-caldo"',
+    'id="clima-page-mode-${cold ? "freddo" : "caldo"}"',
+    "clima-page-mode-switch",
+    "clima-page-mode-btn",
+    "clima-zone clima-zone-freddo show",
+    "clima-zone clima-zone-caldo",
+    "card-${entity.replaceAll",
+  ])
+    assert.ok(source.includes(hook), hook);
+  // Zone switching, the service calls and the HVAC/fan popup stay legacy.
+  assert.match(source, /setClimaPageMode\('\$\{zone\}'\)/);
+  assert.match(source, /setTemp\('\$\{entity\}', 'down'\)/);
+  assert.match(source, /setTemp\('\$\{entity\}', 'up'\)/);
+  assert.match(source, /toggleClima\('\$\{entity\}'\)/);
+  // The card itself keeps an onclick carrying the entity, which is what
+  // cdAutoHide() reads to hide units the user never mapped.
+  assert.match(source, /onclick="apriClimaPopup\('\$\{entity\}', event\)"/);
+});
+
+test("HVAC and fan modes are one click away from the card", () => {
+  // The request that drove this redesign: a visible control that opens the
+  // HVAC/fan panel instead of hiding it behind a tap on the card body.
+  assert.match(source, /class="dm-cl-modes"/);
+  assert.match(source, /event\.stopPropagation\(\); apriClimaPopup\('\$\{entity\}'\)/);
+  // The button reads the active mode, so it says "Freddo · Auto" and not just "Modalità".
+  assert.match(source, /data-dm-cl-mode-cap/);
+  assert.match(source, /function modeCaption/);
+});
+
+test("plus and minus move by a whole degree, in the popup too", async () => {
+  const { wholeDegreeDelta } = await loadSection();
+  // The card already steps by one through setTemp(); the legacy popup markup
+  // still asks for half a degree, so the delta is corrected on the way in.
+  assert.equal(24 + wholeDegreeDelta(24, 0.5), 25);
+  assert.equal(24 + wholeDegreeDelta(24, -0.5), 23);
+  // A unit parked on a half degree walks to the next whole one, not past it.
+  assert.equal(23.5 + wholeDegreeDelta(23.5, 0.5), 24);
+  assert.equal(23.5 + wholeDegreeDelta(23.5, -0.5), 23);
+  // Nothing readable on screen still moves by one.
+  assert.equal(wholeDegreeDelta(NaN, -0.5), -1);
+  assert.equal(wholeDegreeDelta(undefined, 0.5), 1);
+  assert.match(source, /root\.cpSetTemp = cpSetTempThermal/);
+});
+
+test("the redesigned card drops the legacy class names the old layers fight over", () => {
+  // Beta 4, Beta 7, Beta 16 and personalization all ship !important corrections
+  // for these names. The new markup must not carry them, otherwise the page is
+  // back to five stylesheets arguing about one card.
+  const markup = source.slice(source.indexOf("function cardMarkup"), source.indexOf("function floorOf"));
+  for (const legacy of ["cp-card", "cp-header", "cp-body", "cp-controls", "cp-btn", "clima-premium-grid"])
+    assert.ok(!markup.includes(legacy), legacy);
+});
+
+test("the back arrow stays at the top of the page after a rebuild", () => {
+  assert.match(source, /:scope > \.back-home-btn/);
+  assert.match(source, /host\.insertBefore\(backButton, host\.firstChild\)/);
+});
+
+test("the section owns presentation only and adds no polling", () => {
+  const body = source.slice(source.indexOf("import {"));
+  assert.doesNotMatch(body, /setInterval\s*\(/);
+  assert.doesNotMatch(body, /MutationObserver/);
+  // No service call is rebuilt here: the websocket stays behind the legacy API.
+  assert.doesNotMatch(body, /call_service/);
+  assert.doesNotMatch(body, /new\s+WebSocket/);
+});
+
+test("bulk power acts on the visible zone only and skips units already in that state", () => {
+  assert.match(source, /function bulkSwitch/);
+  assert.match(source, /if \(unit\.zone !== zone\) continue;/);
+  assert.match(source, /if \(!reading\.known \|\| reading\.on === wantsOn\) continue;/);
+  assert.match(source, /root\.toggleClima\(unit\.entity\)/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/energy-loads-editor-panel.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energy-loads-editor-panel.test.js
@@ -370,7 +370,7 @@ test("an mdi icon is drawn as a glyph, in the preview and in the picker button",
     const card = cards()[0];
     const bubble = card.querySelector(".dm-loads-preview-bubble");
     const pick = card.querySelector("[data-dm-load-icon-pick]");
-    assert.deepEqual(asked[0], ["action", "mdi:car-electric", 24]);
+    assert.deepEqual(asked[0], ["load", "mdi:car-electric", 24]);
     assert.match(bubble.innerHTML, /🚘/);
     assert.match(pick.innerHTML, /🚘/);
     assert.equal(bubble.textContent, "", "the token is never printed as text");

--- a/custom_components/dashboardmodern/frontend/tests/entity-search-index.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/entity-search-index.test.js
@@ -1,0 +1,216 @@
+/* The picker's search: what it finds, what it proposes, and what it costs.
+ *
+ * The cost assertions are deliberately about work done, not milliseconds: how
+ * many records a keystroke scans and how many rows it ranks are properties of
+ * the algorithm, while a timing threshold only measures the machine running the
+ * suite. */
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildEntityIndex,
+  createSearchSession,
+  fieldHints,
+  foldText,
+  prepareHints,
+  queryScore,
+  rankMatches,
+  searchEntityIndex,
+} from "../src/core/entity-search-index.js";
+
+const HOUSE = [
+  { id: "sensor.cucina_temperatura", name: "Cucina Temperatura", dc: "temperature", unit: "°C", area: "Cucina", state: "21.4" },
+  { id: "sensor.cucina_umidita", name: "Cucina Umidità", dc: "humidity", unit: "%", area: "Cucina", state: "48" },
+  { id: "sensor.salotto_temperatura", name: "Salotto Temperatura", dc: "temperature", unit: "°C", area: "Salotto", state: "22.8" },
+  { id: "sensor.citta_meteo", name: "Città Meteo", state: "sole" },
+  { id: "sensor.consumo_totale", name: "Consumo Totale", dc: "energy", unit: "kWh", sc: "total_increasing", state: "4210" },
+  { id: "light.cucina_faretti", name: "Faretti Cucina", area: "Cucina", state: "on" },
+  { id: "switch.forno", name: "Forno", state: "off" },
+  { id: "climate.salotto", name: "Clima Salotto", area: "Salotto", state: "heat" },
+  { id: "automation.risveglio", name: "Risveglio", state: "on" },
+  { id: "sensor.bagno_temperatura", name: "Bagno Temperatura", dc: "temperature", unit: "°C", area: "Bagno", state: "unavailable" },
+];
+
+const ids = (result) => result.rows.map((row) => row.record.id);
+
+function syntheticHouse(count) {
+  const domains = ["sensor", "binary_sensor", "switch", "light", "cover", "climate"];
+  const words = ["cucina", "salotto", "bagno", "temperatura", "potenza", "presa", "tapparella", "giardino"];
+  const list = [];
+  for (let position = 0; position < count; position += 1) {
+    const domain = domains[position % domains.length];
+    const first = words[position % words.length];
+    const second = words[(position * 7) % words.length];
+    list.push({
+      id: `${domain}.${first}_${second}_${position}`,
+      name: `${first} ${second} ${position}`,
+      state: "on",
+    });
+  }
+  return list;
+}
+
+test("folding makes accents and case irrelevant to a search", () => {
+  assert.equal(foldText("Città"), "citta");
+  assert.equal(foldText("Umidità Salotto"), "umidita salotto");
+  const index = buildEntityIndex(HOUSE);
+  assert.deepEqual(ids(searchEntityIndex(index, "città")), ["sensor.citta_meteo"]);
+  assert.deepEqual(ids(searchEntityIndex(index, "UMIDITA")), ["sensor.cucina_umidita"]);
+});
+
+test("every term must match, and the closest match ranks first", () => {
+  const index = buildEntityIndex(HOUSE);
+  assert.deepEqual(ids(searchEntityIndex(index, "cucina temperatura")), ["sensor.cucina_temperatura"]);
+  assert.equal(searchEntityIndex(index, "cucina inesistente").matched, 0);
+  const cucina = ids(searchEntityIndex(index, "cucina"));
+  assert.deepEqual(cucina.slice().sort(), [
+    "light.cucina_faretti",
+    "sensor.cucina_temperatura",
+    "sensor.cucina_umidita",
+  ]);
+  // A whole-id prefix beats a match that only appears inside the name.
+  assert.equal(ids(searchEntityIndex(index, "switch.forno"))[0], "switch.forno");
+});
+
+test("an unavailable entity is ranked below an equally good live one", () => {
+  const index = buildEntityIndex(HOUSE);
+  const rows = ids(searchEntityIndex(index, "temperatura"));
+  assert.equal(rows.length, 3);
+  // Same name shape, same device class, shortest id of the three — last only
+  // because Home Assistant is not reporting a value for it.
+  assert.equal(rows[rows.length - 1], "sensor.bagno_temperatura");
+});
+
+test("the field describes itself, and the search proposes accordingly", () => {
+  const hints = fieldHints({
+    ref: "sensor.temperatura_cucina",
+    placeholder: "sensor.temperatura (°C)",
+    label: "🌡️ Temperatura stanza",
+  });
+  assert.ok(hints.domains.has("sensor"));
+  assert.ok(hints.deviceClasses.has("temperature"));
+  assert.ok(hints.units.has("°C"));
+  assert.ok(hints.keywords.includes("temperatura"));
+
+  const index = buildEntityIndex(HOUSE);
+  const proposed = searchEntityIndex(index, "", { hints });
+  // With no query at all, the two temperature sensors of the house come first
+  // and are marked, instead of the alphabetically first entity.
+  assert.deepEqual(ids(proposed).slice(0, 2), ["sensor.cucina_temperatura", "sensor.salotto_temperatura"]);
+  assert.ok(proposed.rows[0].hinted);
+  assert.ok(proposed.hinted >= 2);
+  assert.equal(proposed.rows.find((row) => row.record.id === "automation.risveglio")?.hinted, false);
+});
+
+test("a light field proposes lights and an energy field proposes meters", () => {
+  const index = buildEntityIndex(HOUSE);
+  const light = fieldHints({ ref: "light.cucina", label: "Luce principale" });
+  assert.equal(ids(searchEntityIndex(index, "", { hints: light }))[0], "light.cucina_faretti");
+  const energy = fieldHints({ id: "ed-en-tot", label: "Energia totale casa (kWh)" });
+  assert.ok(energy.units.has("kWh"));
+  assert.equal(ids(searchEntityIndex(index, "", { hints: energy }))[0], "sensor.consumo_totale");
+});
+
+test("the hint table is computed once per field and reused across keystrokes", () => {
+  const index = buildEntityIndex(HOUSE);
+  const hints = fieldHints({ ref: "sensor.temperatura_cucina" });
+  const first = prepareHints(index, hints);
+  assert.equal(prepareHints(index, hints), first);
+  assert.equal(first.scores.length, index.size);
+  // The query score never carries the hint bonus, which is what lets the table
+  // stay valid while the query changes.
+  const record = index.records.find((entry) => entry.id === "sensor.cucina_temperatura");
+  assert.equal(queryScore(record, { folded: "", terms: [], empty: true }), record.penalty);
+});
+
+test("extending a query rescans only the previous matches", () => {
+  const index = buildEntityIndex(syntheticHouse(1200));
+  const session = createSearchSession();
+  const first = searchEntityIndex(index, "cuc", { session });
+  assert.equal(first.scanned, 1200);
+  const second = searchEntityIndex(index, "cucina", { session });
+  assert.equal(second.scanned, first.matched);
+  assert.ok(second.scanned < 1200);
+  const third = searchEntityIndex(index, "cucina bagno", { session });
+  assert.equal(third.scanned, second.matched);
+
+  // Narrowing must not lose rows: the same query from a cold session finds the
+  // same set.
+  const cold = searchEntityIndex(index, "cucina bagno", { session: createSearchSession() });
+  assert.equal(third.matched, cold.matched);
+  assert.deepEqual(ids(third), ids(cold));
+
+  // Shortening the query is not a narrowing, so it rescans everything.
+  const back = searchEntityIndex(index, "cuc", { session });
+  assert.equal(back.scanned, 1200);
+  assert.equal(back.matched, first.matched);
+});
+
+test("only one page is ranked, and paging continues it without gaps", () => {
+  const index = buildEntityIndex(syntheticHouse(900));
+  const session = createSearchSession();
+  const result = searchEntityIndex(index, "cucina", { session, limit: 60 });
+  assert.equal(result.rows.length, 60);
+  assert.ok(result.matched > 60);
+  assert.equal(result.truncated, true);
+
+  const second = rankMatches(index, session, { offset: 60, limit: 60, query: "cucina" });
+  const seen = new Set([...ids(result), ...second.map((row) => row.record.id)]);
+  assert.equal(seen.size, result.rows.length + second.length);
+});
+
+test("domain counts describe the whole match set, not the visible page", () => {
+  const index = buildEntityIndex(HOUSE);
+  const result = searchEntityIndex(index, "", { withDomains: true, limit: 2 });
+  assert.equal(result.rows.length, 2);
+  assert.equal(result.domains.get("sensor"), 6);
+  assert.equal(result.domains.get("light"), 1);
+  const filtered = searchEntityIndex(index, "", { domain: "light" });
+  assert.deepEqual(ids(filtered), ["light.cucina_faretti"]);
+  assert.equal(filtered.filtered, 1);
+  assert.equal(filtered.matched, HOUSE.length);
+});
+
+test("the suggested filter narrows the view without narrowing the search", () => {
+  const index = buildEntityIndex(HOUSE);
+  const hints = fieldHints({ ref: "sensor.temperatura_cucina", label: "Temperatura" });
+  const suggested = searchEntityIndex(index, "", { hints, hintedOnly: true });
+  const shown = ids(suggested);
+  assert.deepEqual(shown.slice(0, 3), [
+    "sensor.cucina_temperatura",
+    "sensor.salotto_temperatura",
+    "sensor.bagno_temperatura",
+  ]);
+  // The field asks for a sensor, so a light whose name carries the same room
+  // word is not proposed for it.
+  assert.ok(shown.every((id) => id.startsWith("sensor.")));
+  assert.equal(suggested.filtered, shown.length);
+  // The match set behind it is still the whole house, so the next keystroke
+  // narrows from everything and clearing the filter costs nothing.
+  assert.equal(suggested.matched, HOUSE.length);
+  assert.equal(suggested.hinted, shown.length);
+  const paged = rankMatches(index, createSearchSession(), { offset: 0, limit: 5, hints, hintedOnly: true });
+  assert.equal(paged.length, 0, "paging uses the session's own match set");
+});
+
+test("index building tolerates both metadata and raw Home Assistant states", () => {
+  const index = buildEntityIndex([
+    { entity_id: "sensor.raw", state: "12", attributes: { friendly_name: "Raw", device_class: "power", unit_of_measurement: "W" } },
+    { id: "sensor.meta", name: "Meta", dc: "power", unit: "W", state: "8" },
+    { id: "not-an-entity" },
+    null,
+  ]);
+  assert.equal(index.size, 2);
+  const raw = index.records[0];
+  assert.equal(raw.name, "Raw");
+  assert.equal(raw.dc, "power");
+  assert.equal(raw.unit, "W");
+  const power = fieldHints({ label: "Potenza istantanea (W)" });
+  assert.equal(searchEntityIndex(index, "", { hints: power }).hinted, 2);
+});
+
+test("the same list is indexed once", () => {
+  const entries = syntheticHouse(200);
+  const first = buildEntityIndex(entries);
+  assert.equal(buildEntityIndex(entries), first);
+  assert.notEqual(buildEntityIndex(entries, { version: "changed" }), first);
+});

--- a/custom_components/dashboardmodern/frontend/tests/ev-showcase-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/ev-showcase-section.test.js
@@ -1,0 +1,131 @@
+// DM-FIX-20260817D
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("../src/sections/ev-showcase-section.js", import.meta.url), "utf8");
+
+async function loadSection() {
+  return import(`../src/sections/ev-showcase-section.js?fix=${Date.now()}`);
+}
+
+function fakeDocument({ activeMode = "", battWidth = "" } = {}) {
+  const buttons = ["off", "pv", "minpv", "now"].map((mode) => ({
+    id: `m-btn-${mode}`,
+    mode,
+  }));
+  return {
+    querySelector(selector) {
+      if (selector !== ".evcc-mode-btn.active") return null;
+      return buttons.find((button) => button.mode === activeMode) || null;
+    },
+    getElementById(id) {
+      if (id !== "ev-mod-batt-fill") return null;
+      return { style: { width: battWidth } };
+    },
+  };
+}
+
+test("the active EVCC mode is read from the button the legacy runtime marks", async () => {
+  const { evActiveMode } = await loadSection();
+  assert.equal(evActiveMode(fakeDocument({ activeMode: "pv" })), "pv");
+  assert.equal(evActiveMode(fakeDocument({ activeMode: "minpv" })), "minpv");
+  assert.equal(evActiveMode(fakeDocument({ activeMode: "now" })), "now");
+  assert.equal(evActiveMode(fakeDocument({ activeMode: "off" })), "off");
+  // No mode marked yet: the page stays on the neutral colour.
+  assert.equal(evActiveMode(fakeDocument()), "");
+});
+
+test("an unknown button id never becomes a mode", async () => {
+  const { evActiveMode } = await loadSection();
+  const scope = { querySelector: () => ({ id: "m-btn-turbo" }) };
+  assert.equal(evActiveMode(scope), "");
+});
+
+test("the ring reads the state of charge from the bar the render loop writes", async () => {
+  const { batteryLevel } = await loadSection();
+  assert.equal(batteryLevel(fakeDocument({ battWidth: "68%" })), 68);
+  assert.equal(batteryLevel(fakeDocument({ battWidth: "0%" })), 0);
+  assert.equal(batteryLevel(fakeDocument({ battWidth: "12.5%" })), 12.5);
+  // Out of range values are clamped rather than drawn past the ring.
+  assert.equal(batteryLevel(fakeDocument({ battWidth: "140%" })), 100);
+  assert.equal(batteryLevel(fakeDocument({ battWidth: "-3%" })), 0);
+  // Before the first render there is no width to read.
+  assert.equal(batteryLevel(fakeDocument()), null);
+  assert.equal(batteryLevel({ getElementById: () => null }), null);
+});
+
+test("the arc length matches the percentage it has to draw", async () => {
+  const { arcDash } = await loadSection();
+  const [drawn, gap] = arcDash(50, 100).split(" ").map(Number);
+  assert.equal(drawn, 50);
+  assert.equal(gap, 50);
+  assert.equal(arcDash(0, 100), "0.0 100.0");
+  assert.equal(arcDash(100, 100), "100.0 0.0");
+  // A missing reading draws an empty ring instead of a full one.
+  assert.equal(arcDash(null, 100), "0.0 100.0");
+  assert.equal(arcDash(Number.NaN, 100), "0.0 100.0");
+});
+
+test("the redesigned page keeps every legacy runtime hook", () => {
+  // The legacy render loop drives these: it writes the width, --batt-col and
+  // the low/mid classes on the battery bar, fills the badge ids per EVSE state
+  // and marks the active .evcc-mode-btn. Losing any of them freezes the page.
+  for (const hook of [
+    "ev-mod-batt-fill",
+    "lm-hero-card",
+    "lm-charge-badge",
+    "ev-mod-car-img",
+    "evcc-mode-btn",
+    "m-btn-",
+    "--batt-col",
+  ])
+    assert.ok(source.includes(hook), hook);
+  // The rows next to the ring carry legacy value classes, so the render loop
+  // fills them through querySelectorAll instead of this module computing them.
+  for (const valueClass of ["v-ev-pow", "v-ev-remain", "v-auto-limite"])
+    assert.match(source, new RegExp(`class="dm-evv-row-val ${valueClass}"`), valueClass);
+});
+
+test("the section owns presentation only and never recomputes EV values", () => {
+  // The header documents the legacy owners by name; the code below it must stay
+  // clear of the engine.
+  const body = source.slice(source.indexOf("\nimport {"));
+  for (const owned of [
+    "setEVMode",
+    "cdEvApplyCar",
+    "renderVehicleSelector",
+    "apriStorico\\(",
+    "dm\\.ev_target_soc",
+    "localStorage",
+  ])
+    assert.doesNotMatch(body, new RegExp(owned), owned);
+  // Event-driven only: no polling, no observer.
+  assert.doesNotMatch(body, /setInterval\s*\(/);
+  assert.doesNotMatch(body, /MutationObserver/);
+});
+
+test("the battery block is moved into the ring, never duplicated", () => {
+  const mount = source.slice(source.indexOf("function mountPower"), source.indexOf("function mountStatIcons"));
+  // append() moves the node; cloneNode would leave two owners of the same bar.
+  assert.match(mount, /\.append\(battery\)/);
+  assert.doesNotMatch(mount, /cloneNode/);
+  // Mounting twice must not build a second card.
+  assert.match(mount, /if \(power\) return power/);
+});
+
+test("the target card and the mode buttons carry the configured EVCC colours", () => {
+  for (const colour of ["#e11d48", "#059669", "#d97706", "#0284c7"])
+    assert.ok(source.includes(colour), colour);
+  // The buttons keep their own inline --btn-col instead of a forked palette.
+  assert.match(source, /background:var\(--btn-col\)!important/);
+  // The target card follows the mirrored mode attribute.
+  assert.match(source, /#page-ev\.dm-evv \.lm-target-card\{[\s\S]*?--evv-mode/);
+  assert.match(source, /page\.dataset\.dmEvMode = mode/);
+});
+
+test("each mode button gets its own animation and reduced motion stops them all", () => {
+  for (const keyframe of ["dmEvvOffRing", "dmEvvSpin", "dmEvvCloud", "dmEvvZoom"])
+    assert.match(source, new RegExp(`@keyframes ${keyframe}`), keyframe);
+  assert.match(source, /prefers-reduced-motion:reduce[\s\S]*?animation:none!important/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/load-icon-catalog.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/load-icon-catalog.test.js
@@ -1,0 +1,117 @@
+// DM-FIX-20260817E
+/* The icon catalogue offered when configuring a load.
+ *
+ * The picker used to offer the action catalogue: a list built around what a
+ * dashboard button *does* — a scene, a script, an alert, the alarm, a camera —
+ * which is the wrong question for a circle that measures consumption, and which
+ * carried none of the areas of a house. */
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import {
+  LOAD_ICON_CATALOG,
+  loadCatalogMatch,
+  loadGlyph,
+} from "../src/core/personalization-catalog.js";
+
+const frontend = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sections = path.join(frontend, "src", "sections");
+
+const italian = (name) => LOAD_ICON_CATALOG.find((item) => item.it === name);
+
+test("the areas of a house are offered: a circle is as often a room as an appliance", () => {
+  for (const room of ["Cucina", "Salone", "Garage", "Bagno", "Camera", "Giardino", "Cantina"]) {
+    const entry = italian(room);
+    assert.ok(entry, `${room} is missing from the load catalogue`);
+    assert.equal(entry.group, "room");
+  }
+});
+
+test("what actually draws power is offered, well past the five the action list had", () => {
+  for (const appliance of [
+    "Forno",
+    "Lavatrice",
+    "Asciugatrice",
+    "Lavastoviglie",
+    "Frigorifero",
+    "Boiler",
+    "Pompa di calore",
+    "Condizionatore",
+    "Auto elettrica",
+    "Fotovoltaico",
+    "Irrigazione",
+    "Server / NAS",
+  ]) {
+    const entry = italian(appliance);
+    assert.ok(entry, `${appliance} is missing from the load catalogue`);
+    assert.equal(entry.group, "appliance");
+  }
+  assert.ok(
+    LOAD_ICON_CATALOG.filter((item) => item.group === "appliance").length >= 30,
+    "the appliance half is meant to cover a whole house",
+  );
+});
+
+test("what can never be a load is not offered", () => {
+  // Security and cameras were in the action list and made no sense on a circle
+  // that reads a meter.
+  const tokens = LOAD_ICON_CATALOG.map((item) => item.mdi);
+  for (const excluded of [
+    "mdi:shield-home",
+    "mdi:cctv",
+    "mdi:movie-open",
+    "mdi:script-text-play",
+    "mdi:bell",
+    "mdi:star",
+    "mdi:toggle-switch-outline",
+  ])
+    assert.equal(tokens.includes(excluded), false, `${excluded} is not a load`);
+});
+
+test("no icon is offered twice, so the same tile never appears in both groups", () => {
+  const tokens = LOAD_ICON_CATALOG.map((item) => item.mdi);
+  const ids = LOAD_ICON_CATALOG.map((item) => item.id);
+  assert.equal(new Set(tokens).size, tokens.length, "duplicate mdi token");
+  assert.equal(new Set(ids).size, ids.length, "duplicate id");
+  // The laundry room is the case this guards: its icon *is* the washing machine.
+  assert.equal(italian("Lavanderia"), undefined);
+  assert.ok(italian("Lavatrice"));
+});
+
+test("every entry carries a glyph that can actually be drawn", () => {
+  for (const item of LOAD_ICON_CATALOG) {
+    assert.ok(item.glyph, `${item.id} has no glyph`);
+    assert.doesNotMatch(item.glyph, /^mdi:/, `${item.id} would print its token`);
+    assert.match(item.mdi, /^mdi:/);
+    assert.ok(item.it && item.en, `${item.id} is not labelled in both languages`);
+  }
+});
+
+test("a token resolves to its own glyph, and an unknown one to a plug rather than a star", () => {
+  assert.equal(loadGlyph("mdi:stove"), "🍳");
+  assert.equal(loadGlyph("mdi:washing-machine"), "🧺");
+  assert.equal(loadGlyph("mdi:car-electric"), "🚗");
+  assert.equal(loadGlyph("mdi:garage"), "🚗");
+  // An emoji already chosen goes straight through.
+  assert.equal(loadGlyph("🔥"), "🔥");
+  // A load that never matches must not fall back to the action list's star.
+  assert.equal(loadGlyph("mdi:not-a-real-icon"), "🔌");
+  assert.equal(loadGlyph(""), "🔌");
+  // A token saved before this catalogue existed still resolves.
+  assert.equal(loadGlyph("mdi:water"), "🚰");
+  assert.equal(loadCatalogMatch("mdi:toaster-oven")?.it, "Forno");
+});
+
+test("the loads editor asks for the load catalogue, under a heading that says so", async () => {
+  const engine = await readFile(path.join(sections, "icon-engine-section.js"), "utf8");
+  const editor = await readFile(path.join(sections, "energy-loads-editor-section.js"), "utf8");
+  assert.match(editor, /openIconPicker\(icon, "load"\)/);
+  assert.match(engine, /Scegli icona del carico/);
+  assert.match(engine, /Choose load icon/);
+  // The two halves are labelled, because one flat grid of this length buries
+  // what is being looked for.
+  assert.match(engine, /Aree della casa/);
+  assert.match(engine, /Apparecchi e impianti/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -163,7 +163,12 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // legacy markup left empty and reads no Home Assistant state, so the page keeps
   // the legacy runtime as its single behavioural owner. It adds no polling, and
   // its only listener is a media query that swaps the portrait scene in.
-  assert.ok(relative.length <= 90, `production graph unexpectedly grew to ${relative.length} modules`);
+  // The Security redesign adds exactly one owner: the section renderer that
+  // repaints the alarm console and the camera grid. It is event-driven
+  // (state-changed + legacy render loop), adds no polling and no observer, and
+  // keeps the camera engine — apriCamera, the streaming strategies and
+  // toggleFullScreenCam — in the legacy runtime instead of forking it.
+  assert.ok(relative.length <= 91, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -157,6 +157,14 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // replaces both legacy paint functions. Beta11's stylesheet block and the
   // Beta12/14/16 pool correctives stood down into it, so the two pages have one
   // renderer and one stylesheet instead of five competing layers.
+  // The Tapparelle redesign adds exactly one owner: the scene section that
+  // replaces the legacy paint function so the page can carry a summary header,
+  // per-room headings and a position track. It renders per structural
+  // signature rather than per tick, keeps commands on the legacy cdTappCmd
+  // handler, and adds no polling and no observer. The window skin stays in the
+  // existing shutter section, which is still the single owner of the
+  // first-paint geometry, so the two modules split structure from paint rather
+  // than competing over the same declarations.
   // All facade/cycle/orphan/polling/global-observer checks stay active.
   // The Solar Thermal redesign adds exactly one owner: a style-and-labels module
   // for #page-boiler. It installs one stylesheet, fills the decorative labels the
@@ -168,7 +176,7 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // (state-changed + legacy render loop), adds no polling and no observer, and
   // keeps the camera engine — apriCamera, the streaming strategies and
   // toggleFullScreenCam — in the legacy runtime instead of forking it.
-  assert.ok(relative.length <= 91, `production graph unexpectedly grew to ${relative.length} modules`);
+  assert.ok(relative.length <= 92, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -181,7 +181,13 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // as an attribute and restyles the picker that ev-section.js keeps building.
   // It reads no Home Assistant state — the ring reads #ev-mod-batt-fill, the
   // rows carry legacy value classes — and adds no polling and no observer.
-  assert.ok(relative.length <= 93, `production graph unexpectedly grew to ${relative.length} modules`);
+  // The fast entity search adds exactly two: the pure search index (folding,
+  // ranking and field auto-detection) and the section that installs it over the
+  // vendored `cdEpFilter`. No new picker is introduced — the canonical dialog
+  // stays the only one — and the section is event-driven, with no polling and
+  // no observer.
+  // All facade/cycle/orphan/polling/global-observer checks stay active.
+  assert.ok(relative.length <= 95, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -158,7 +158,12 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // Beta12/14/16 pool correctives stood down into it, so the two pages have one
   // renderer and one stylesheet instead of five competing layers.
   // All facade/cycle/orphan/polling/global-observer checks stay active.
-  assert.ok(relative.length <= 89, `production graph unexpectedly grew to ${relative.length} modules`);
+  // The Solar Thermal redesign adds exactly one owner: a style-and-labels module
+  // for #page-boiler. It installs one stylesheet, fills the decorative labels the
+  // legacy markup left empty and reads no Home Assistant state, so the page keeps
+  // the legacy runtime as its single behavioural owner. It adds no polling, and
+  // its only listener is a media query that swaps the portrait scene in.
+  assert.ok(relative.length <= 90, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -176,7 +176,12 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // (state-changed + legacy render loop), adds no polling and no observer, and
   // keeps the camera engine — apriCamera, the streaming strategies and
   // toggleFullScreenCam — in the legacy runtime instead of forking it.
-  assert.ok(relative.length <= 92, `production graph unexpectedly grew to ${relative.length} modules`);
+  // The EV redesign adds exactly one owner: the skin for #page-ev. It moves the
+  // battery block into a charge ring, mirrors the active EVCC mode onto the page
+  // as an attribute and restyles the picker that ev-section.js keeps building.
+  // It reads no Home Assistant state — the ring reads #ev-mod-batt-fill, the
+  // rows carry legacy value classes — and adds no polling and no observer.
+  assert.ok(relative.length <= 93, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -186,8 +186,15 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // vendored `cdEpFilter`. No new picker is introduced — the canonical dialog
   // stays the only one — and the section is event-driven, with no polling and
   // no observer.
+  // The Climate redesign adds exactly one owner: the section renderer for
+  // #page-clima. It replaces buildClimaCards/updateClimaCards instead of adding
+  // a layer on top, so the Beta 4 / Beta 7 / Beta 16 / personalization
+  // corrections for the old .cp-card markup stop matching and the page keeps one
+  // renderer and one stylesheet. It is event-driven (state-changed + the legacy
+  // render loop) and leaves every service call — setTemp, toggleClima and the
+  // HVAC/fan popup — in the legacy runtime.
   // All facade/cycle/orphan/polling/global-observer checks stay active.
-  assert.ok(relative.length <= 95, `production graph unexpectedly grew to ${relative.length} modules`);
+  assert.ok(relative.length <= 96, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 

--- a/custom_components/dashboardmodern/frontend/tests/security-showcase-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/security-showcase-section.test.js
@@ -1,0 +1,114 @@
+// DM-FIX-20260817C
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(
+  new URL("../src/sections/security-showcase-section.js", import.meta.url),
+  "utf8",
+);
+
+async function loadSection() {
+  return import(`../src/sections/security-showcase-section.js?fix=${Date.now()}`);
+}
+
+test("camera slugs match the legacy ids the camera engine writes into", async () => {
+  const { cameraSlug } = await loadSection();
+  assert.equal(cameraSlug({ entity: "camera.giardino" }, 0), "cam-giardino");
+  assert.equal(cameraSlug({ camera_entity: "camera.retro_casa" }, 2), "cam-retro_casa");
+  assert.equal(cameraSlug({}, 4), "cam-x4");
+});
+
+test("a camera counts as offline only when Home Assistant has no usable state", async () => {
+  const { cameraOffline } = await loadSection();
+  const states = {
+    "camera.a": { state: "streaming" },
+    "camera.b": { state: "idle" },
+    "camera.c": { state: "unavailable" },
+    "camera.d": { state: "unknown" },
+    "camera.e": { state: "" },
+  };
+  assert.equal(cameraOffline("camera.a", states), false);
+  assert.equal(cameraOffline("camera.b", states), false);
+  assert.equal(cameraOffline("camera.c", states), true);
+  assert.equal(cameraOffline("camera.d", states), true);
+  assert.equal(cameraOffline("camera.e", states), true);
+  assert.equal(cameraOffline("camera.missing", states), true);
+});
+
+test("configured cameras are read through the legacy normalizer when it exists", async () => {
+  const { securityCameras } = await loadSection();
+  const previous = globalThis.getCameras;
+  try {
+    globalThis.getCameras = () => [{ entity: "camera.garage", name: "Garage" }];
+    assert.deepEqual(securityCameras(), [{ entity: "camera.garage", name: "Garage" }]);
+    globalThis.getCameras = () => {
+      throw new Error("legacy runtime not booted");
+    };
+    assert.deepEqual(securityCameras(), []);
+  } finally {
+    if (previous === undefined) delete globalThis.getCameras;
+    else globalThis.getCameras = previous;
+  }
+});
+
+test("the redesigned alarm panel keeps every legacy runtime hook", () => {
+  // The legacy render loop drives this card: it toggles .armed/.triggered on
+  // #alarm-stage, writes --al-col/--al-rgb, fills the three ids below and marks
+  // the active .alarm-mode-btn[data-mode]. Losing any of them silently freezes
+  // the alarm panel on "CARICAMENTO".
+  for (const hook of [
+    'id="alarm-stage"',
+    'id="alarm-icon-new"',
+    'id="alarm-state-text-new"',
+    'id="alarm-state-timer"',
+    'data-mode="away"',
+    'data-mode="night"',
+    'data-mode="disarm"',
+  ])
+    assert.ok(source.includes(hook), hook);
+  for (const service of ["alarm_arm_away", "alarm_arm_night", "alarm_disarm"])
+    assert.match(source, new RegExp(`promptPinAndSet\\('\\$\\{service\\}'\\)|${service}`));
+  assert.match(source, /promptPinAndSet/);
+  // The timer element is hidden/shown through the legacy `.show` class.
+  assert.match(source, /\.dm-sec-timer\.show/);
+  // "Protetto / Intrusione" is derived from the legacy classes, not recomputed.
+  assert.match(source, /\.dm-sec-alarm\.armed \.dm-sec-chip::after/);
+  assert.match(source, /\.dm-sec-alarm\.triggered \.dm-sec-chip::after/);
+});
+
+test("camera cards keep the contracts the camera engine and the clock rely on", () => {
+  assert.match(source, /class="cam-card dm-cam"/);
+  assert.match(source, /<img id="\$\{esc\(model\.slug\)\}"/);
+  assert.match(source, /class="dm-cam-time cam-time" id="time-/);
+  assert.match(source, /root\.apriCamera\(slug, clean\(card\.dataset\.dmTitle\)\)/);
+  assert.match(source, /id="cam-grid"/);
+});
+
+test("the section owns presentation only and never forks the streaming engine", () => {
+  // The file header documents the legacy owners by name; only the code below it
+  // has to stay free of them.
+  const body = source.slice(source.indexOf("\nimport {"));
+  for (const owned of [
+    "dmCamOpen",
+    "dmCamWebRTC",
+    "dmCamHLS",
+    "dmCamMJPEG",
+    "dmCamPolling",
+    "toggleFullScreenCam",
+    "isPseudoFullscreen",
+    "camera/stream",
+  ])
+    assert.doesNotMatch(body, new RegExp(owned), owned);
+  // Event-driven only: no polling, no observer.
+  assert.doesNotMatch(body, /setInterval\s*\(/);
+  assert.doesNotMatch(body, /MutationObserver/);
+});
+
+test("the camera wall is only rebuilt when the configured cameras change", () => {
+  // A blind repaint would drop every <img> already holding a live frame.
+  const sync = source.slice(source.indexOf("function syncCards"), source.indexOf("export function renderSecurity"));
+  assert.match(sync, /grid\._sig === signature/);
+  assert.match(sync, /grid\._sig = signature/);
+  assert.match(sync, /cam-card:not\(\.dm-cam\)/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/shutter-page-skin.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/shutter-page-skin.test.js
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+const shutter = await read("../src/sections/shutter-section.js");
+const beta9 = await read("../src/sections/beta9-real-device-polish-section.js");
+
+/**
+ * The skin is one template literal handed to installStyle. A stray backtick
+ * inside it silently splits the literal into a comparison expression instead of
+ * failing to parse, so the stylesheet is read back the same way a browser would
+ * see it and every assertion below runs against that text.
+ */
+function skin(source) {
+  const call = source.indexOf('installStyle("dm-shutter-section-style", `');
+  assert.notEqual(call, -1, "shutter section must install its stylesheet");
+  const open = source.indexOf("`", call);
+  const close = source.indexOf("`", open + 1);
+  const css = source.slice(open + 1, close);
+  assert.match(css, /page-tapparelle/, "stylesheet is truncated by a stray backtick");
+  return css;
+}
+
+const css = skin(shutter);
+
+test("the shutter page paints a real window behind the slats", () => {
+  assert.match(css, /--tapp-sky:linear-gradient/);
+  assert.match(css, /--tapp-sun:radial-gradient/);
+  assert.match(css, /--tapp-hill-a:radial-gradient/);
+  assert.match(css, /--tapp-hill-b:radial-gradient/);
+  assert.match(css, /--tapp-mullion:linear-gradient/);
+  assert.match(css, /\.tapp-win\{[^}]*background:var\(--tapp-mullion\),var\(--tapp-clouds\),var\(--tapp-stars\),var\(--tapp-sun\),var\(--tapp-trees\),var\(--tapp-hill-a\),var\(--tapp-hill-b\),var\(--tapp-sky\)!important/);
+  assert.match(css, /\.tapp-win::before\{[^}]*background:var\(--tapp-box\)!important/);
+  assert.match(css, /\.tapp-win::after\{[^}]*background:var\(--tapp-guides\)!important/);
+});
+
+test("the shutter panel carries its own slat texture so a closed shutter is opaque", () => {
+  // The groove stop of --tapp-slat is translucent, so every layer that paints
+  // the texture also names the opaque base colour behind it. Without it the sky
+  // shows through one pixel of every slat on a fully closed shutter.
+  assert.match(css, /--tapp-slat-base:#[0-9a-f]{6}/);
+  assert.match(css, /\.tapp-shutter\{[^}]*var\(--tapp-slat\) left bottom\/100% 12px repeat-y var\(--tapp-slat-base\)!important/);
+  assert.match(css, /\.tapp-shutter::before\{[^}]*var\(--tapp-slat\) left bottom\/100% 12px repeat-y var\(--tapp-slat-base\)/);
+  assert.match(css, /\.tapp-shutter i\{[^}]*background:none!important;border:0!important/);
+});
+
+test("the slats travel while the shutter is moving", () => {
+  // Beta9 pins animation:none on the panel itself, and an inline declaration
+  // cannot reach a pseudo-element — that is why the travelling texture lives on
+  // ::before. An !important declaration outranks a CSS animation, so every
+  // property the keyframes drive has to stay normal-weight.
+  assert.match(css, /\.tapp-shutter\.closing::before\{animation:dmTappRoll [^}]*infinite!important\}/);
+  assert.match(css, /\.tapp-shutter\.opening::before\{animation:dmTappRoll [^}]*infinite reverse!important\}/);
+  assert.match(css, /@keyframes dmTappRoll\{from\{background-position-y:100%\}to\{background-position-y:calc\(100% \+ 12px\)\}\}/);
+  for (const rule of [
+    css.match(/\.tapp-shutter::before\{[^}]*\}/)[0],
+    css.match(/\.tapp-card::before\{[^}]*\}/)[0],
+  ]) {
+    assert.doesNotMatch(rule, /background(-position|-size|-repeat)?:[^;}]*!important/);
+  }
+});
+
+test("the page skin keeps the Beta9 first-paint geometry", () => {
+  assert.match(css, /First paint is already the final Beta9 geometry/);
+  assert.match(css, /#tapp-grid\{display:grid!important;grid-template-columns:repeat\(auto-fit,minmax\(280px,360px\)\)!important/);
+  assert.match(css, /\.tapp-card\{box-sizing:border-box!important;width:100%!important;max-width:360px!important/);
+  assert.match(css, /\.tapp-win\{box-sizing:border-box!important;height:132px!important;min-height:132px!important;max-height:132px!important/);
+  assert.match(css, /\.tapp-shutter\{animation:none!important;filter:none!important;transition:height \.55s/);
+});
+
+test("the skin themes itself instead of hard-coding one palette", () => {
+  assert.match(css, /html\[data-theme="dark"\] body #page-tapparelle#page-tapparelle,html body\.dark-theme #page-tapparelle#page-tapparelle\{/);
+  assert.match(css, /--tapp-stars:none/);
+  assert.match(css, /--tapp-stars:radial-gradient/);
+  assert.match(css, /@media\(prefers-reduced-motion:reduce\)/);
+});
+
+test("card controls and the open/close-everything bar have one owner", () => {
+  assert.match(css, /\.tapp-btn\[data-svc="open_cover"\]\{background:var\(--tapp-up-bg\)/);
+  assert.match(css, /\.tapp-btn\[data-svc="stop_cover"\]\{background:var\(--tapp-stop-bg\)/);
+  assert.match(css, /\.tapp-btn\[data-svc="close_cover"\]\{background:var\(--tapp-down-bg\)/);
+  assert.match(css, /\.tapp-btn\[data-all\]\{[^}]*height:46px!important/);
+  assert.doesNotMatch(beta9, /\.tapp-btn/);
+});
+
+test("the page skin stays static CSS and never walks the grid", () => {
+  const page = shutter.slice(shutter.indexOf("Tapparelle page"));
+  assert.doesNotMatch(page, /querySelector|MutationObserver|setInterval/);
+  assert.doesNotMatch(shutter, /wrapFunction\([^\n]*renderTapparelle/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/shutter-scene.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/shutter-scene.test.js
@@ -70,6 +70,23 @@ test("only a cover that reports SET_POSITION becomes draggable", () => {
   assert.match(scene, /if \(!view\.settable\) return `<div class="dm-tapp-track" data-dm-static/);
 });
 
+test("the page keeps the same way back home as every other section", () => {
+  // Same class, same label and the same inline handler the legacy runtime uses,
+  // so it looks and behaves like the button on Clima or Temperature.
+  assert.match(scene, /class="back-home-btn dm-tapp-back"/);
+  assert.match(scene, /<span class="bh-icon">←<\/span>/);
+  assert.match(scene, /onclick="document\.querySelector\('\[data-tab=&quot;home&quot;\]'\)\.click\(\); if\(navigator\.vibrate\)navigator\.vibrate\(5\);"/);
+  // Rendered inside the grid, so it lines up with the header and the cards
+  // instead of sitting against the viewport edge where the runtime puts it.
+  assert.match(scene, /let markup = backHomeMarkup\(\) \+ heroMarkup\(\)/);
+  assert.match(scene, /grid\.innerHTML = `\$\{backHomeMarkup\(\)\}<div class="ed-empty/);
+  assert.match(scene, /\.back-home-btn\.dm-tapp-back\{grid-column:1\/-1!important;justify-self:start!important/);
+  // And the runtime's own copy is dropped, so the page never shows two.
+  assert.match(scene, /function dropLegacyBackHome\(\)/);
+  assert.match(scene, /querySelectorAll\(":scope > \.back-home-btn"\)/);
+  assert.match(scene, /dropLegacyBackHome\(\);\n {2}const views = coverList\(\);/);
+});
+
 test("a position the user asked for survives the next legacy repaint", () => {
   // Home Assistant keeps reporting the old position until the motor arrives.
   assert.match(scene, /const GRAB_MS = \d+/);

--- a/custom_components/dashboardmodern/frontend/tests/shutter-scene.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/shutter-scene.test.js
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+const scene = await read("../src/sections/shutter-scene-section.js");
+const runtime = await read("../src/sections/section-runtime.js");
+const legacyCss = await read("../legacy/dashboard-runtime-it.css");
+
+test("the Tapparelle page has exactly one render owner, installed once", () => {
+  assert.match(scene, /root\.renderTapparelle = owned/);
+  assert.match(scene, /owned\[MARKER\] = true/);
+  assert.match(scene, /if \(typeof current === "function" && current\[MARKER\]\) return/);
+  // Replacing the legacy painter, not decorating it: a wrapper would paint the
+  // legacy markup first and this module's markup over it on every tick.
+  assert.doesNotMatch(scene, /wrapFunction/);
+  assert.equal((runtime.match(/shutter-scene-section\.js/g) || []).length, 1);
+  assert.equal((runtime.match(/installShutterSceneSection\(\)/g) || []).length, 1);
+});
+
+test("markup is rebuilt per structural signature, not per repaint", () => {
+  // The legacy loop calls renderTapparelle every 2s. Rewriting innerHTML each
+  // time would drop the position track the user is holding.
+  assert.match(scene, /if \(state\.signature !== current \|\| !grid\.querySelector\("\[data-dm-shutter-card\]"\)\)/);
+  assert.match(scene, /function syncCard\(card, view\)/);
+  assert.doesNotMatch(scene, /setInterval\s*\(/);
+  assert.doesNotMatch(scene, /MutationObserver/);
+});
+
+test("the cards keep every legacy class the skin and the device contracts use", () => {
+  for (const className of [
+    "tapp-card",
+    "tapp-head",
+    "tapp-name",
+    "tapp-state",
+    "tapp-win",
+    "tapp-glass",
+    "tapp-shutter",
+    "tapp-pos",
+    "tapp-ctl",
+    "tapp-btn",
+  ]) {
+    assert.match(scene, new RegExp(`class="[^"]*\\b${className}\\b`), `missing ${className}`);
+  }
+  assert.match(scene, /const SLAT_COUNT = 8/);
+  assert.match(scene, /`<i><\/i>`\.repeat\(SLAT_COUNT\)/);
+});
+
+test("markup avoids the tags the legacy stylesheet claims globally", () => {
+  // dashboard-runtime.css styles bare `header` and `h1,h2,h3`, so a <header>
+  // here would inherit a card background and a 30px margin.
+  assert.match(legacyCss, /^header \{/m);
+  assert.match(legacyCss, /^h1, h2, h3 \{/m);
+  assert.doesNotMatch(scene, /<(?:header|h1|h2|h3)[ >]/);
+  assert.match(scene, /role="heading" aria-level="2"/);
+  assert.match(scene, /role="heading" aria-level="3"/);
+});
+
+test("commands stay on the legacy handler and positions go through the service", () => {
+  assert.equal((scene.match(/onclick="cdTappCmd\(this\)"/g) || []).length, 5);
+  assert.match(scene, /data-svc="open_cover"/);
+  assert.match(scene, /data-svc="stop_cover"/);
+  assert.match(scene, /data-svc="close_cover"/);
+  assert.match(scene, /dmCallHaService\?\.\("cover", "set_cover_position"/);
+});
+
+test("only a cover that reports SET_POSITION becomes draggable", () => {
+  assert.match(scene, /const SUPPORT_SET_POSITION = 4/);
+  assert.match(scene, /settable: Boolean\(features & SUPPORT_SET_POSITION\)/);
+  assert.match(scene, /if \(!view\.settable\) return `<div class="dm-tapp-track" data-dm-static/);
+});
+
+test("a position the user asked for survives the next legacy repaint", () => {
+  // Home Assistant keeps reporting the old position until the motor arrives.
+  assert.match(scene, /const GRAB_MS = \d+/);
+  assert.match(scene, /range !== doc\.activeElement && !state\.grabbed\.has\(view\.entity\)/);
+  assert.match(scene, /const grab = state\.grabbed\.get\(entity\)/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/subload-popup-render.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/subload-popup-render.test.js
@@ -207,7 +207,7 @@ test("where the icon engine is installed, it is what resolves an mdi token", () 
     popup.renderSubloadPopup("cucina");
 
     const icon = title.querySelector(".dm-subload-title-icon");
-    assert.deepEqual(asked[0], ["action", "mdi:car-electric", 24]);
+    assert.deepEqual(asked[0], ["load", "mdi:car-electric", 24]);
     assert.match(icon.innerHTML, /🚘/);
     assert.doesNotMatch(icon.innerHTML, /data-icon=/, "the legacy markup is not used");
   } finally {

--- a/custom_components/dashboardmodern/frontend/tests/temperature-labels-regression.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/temperature-labels-regression.test.js
@@ -25,11 +25,56 @@ test("Temperature editor exposes and persists custom display names for both enti
 });
 
 test("custom Temperature entity names are projected onto live dashboard labels", async () => {
-  const source = await readFile(guardUrl, "utf8");
-  assert.match(source, /function repairTemperatureDashboardLabels\(\)/);
-  assert.match(source, /\.cp-temp-current-lbl/);
-  assert.match(source, /\.cp-temp-target \.lbl/);
-  assert.match(source, /dmBeta20TemperatureEntityLabels/);
+  const { temperatureCardLabels } = await import("../src/sections/shared.js");
+  const room = {
+    temp_name: "Temperatura Camera",
+    hum_name: "Umidità Camera",
+  };
+
+  // The first association carries the room's custom names.
+  assert.deepEqual(temperatureCardLabels(room), {
+    temperature: "Temperatura Camera",
+    humidity: "Umidità Camera",
+  });
+  assert.deepEqual(temperatureCardLabels(room, { id: "primary" }), {
+    temperature: "Temperatura Camera",
+    humidity: "Umidità Camera",
+  });
+
+  // An extra probe carries its own name, never the room's — that is what used
+  // to make the label flip between the two on every repaint.
+  assert.deepEqual(
+    temperatureCardLabels(room, { id: "temperature-extra-1", name: "Seconda sonda" }),
+    {
+      temperature: "Seconda sonda",
+      humidity: "Umidità",
+    },
+  );
+  assert.deepEqual(temperatureCardLabels(room, { id: "temperature-extra-1" }), {
+    temperature: "Temperatura",
+    humidity: "Umidità",
+  });
+  assert.deepEqual(temperatureCardLabels({}), {
+    temperature: "Temperatura",
+    humidity: "Umidità",
+  });
+});
+
+test("the label above the reading has a single owner", async () => {
+  const guard = await readFile(guardUrl, "utf8");
+  for (const name of [
+    "temperature-section.js",
+    "beta25-real-device-fixes-section.js",
+    "beta26-real-device-stability-section.js",
+  ]) {
+    const source = await readFile(new URL(`../src/sections/${name}`, import.meta.url), "utf8");
+    assert.match(source, /temperatureCardLabels\(/, name);
+    // No renderer may hard-code the generic word beside the reading any more.
+    assert.doesNotMatch(source, /"cp-temp-current-lbl", english\(\)/, name);
+  }
+  // The Beta 17 pass keeps its editor repairs and no longer writes card labels.
+  assert.doesNotMatch(guard, /repairTemperatureDashboardLabels/);
+  assert.match(guard, /function repairTemperatureEditor\(\)/);
 });
 
 test("Beta20 label hardening reuses an existing scoped owner and keeps the layout shim passive", async () => {
@@ -47,8 +92,7 @@ test("the comfort pill carries a short unavailable label and keeps the full word
   // long enough to paint out of it and over the room name beside it.
   assert.equal(comfortBadgeText("Non disponibile"), "N/D");
   assert.equal(comfortBadgeText("Unavailable"), "N/D");
-  for (const label of ["Caldo", "Comfort", "Freddo"])
-    assert.equal(comfortBadgeText(label), label);
+  for (const label of ["Caldo", "Comfort", "Freddo"]) assert.equal(comfortBadgeText(label), label);
 
   // Every renderer of the pill shows the short form while `title`, `aria-label`
   // and `data-comfort` keep the full label the badge colours key off.

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.30.6"
+  "version": "1.0.0-beta.30.7"
 }


### PR DESCRIPTION
La stessa scheda di **Temperature** mostrava `TEMPERATURA` e un istante dopo il nome dato al sensore in configurazione. Nelle schermate dell'utente si vedono i due fotogrammi a un minuto di distanza, stessa pagina, stessi sensori.

## Causa

Il testo sopra il numero aveva **tre proprietari**, ognuno con la propria regola:

- i renderer (`beta25` e la sezione canonica) scrivevano la parola generica alla creazione della scheda;
- la passata di rifinitura `beta17` la riscriveva a ogni frame con il nome della stanza, su **tutte** le schede di quella stanza, seconda sonda compresa;
- il livello `beta27` la scriveva per associazione.

Su un impianto vero i sensori aggiornano di continuo: ogni aggiornamento ridisegna la griglia e fa ripartire il giro, quindi l'etichetta ballava tra i tre valori. Campionandola per due secondi con i ridisegni che un impianto vero produce, i tre stati si vedono tutti:

```
"Temperatura | Temperatura"          ← i renderer, alla creazione
"Cameretta | Cameretta | Pippo"      ← beta17, ogni frame, ignorando l'associazione
"Cameretta | Temperatura | Pippo"    ← beta27, per associazione
```

Dentro c'era anche un errore di merito: `beta17` scriveva il nome della stanza anche sulla scheda di una sonda aggiuntiva, che quel nome non ce l'ha.

## Correzione

La regola vive ora in un punto solo — `temperatureCardLabels()` in `sections/shared.js` — e la usano tutti e tre i disegnatori:

- la prima associazione porta il nome dato alla temperatura della stanza;
- una sonda aggiuntiva porta il proprio nome;
- senza nome resta la parola generica.

L'umidità segue la stessa regola. La passata `beta17` conserva le riparazioni dell'editor e non tocca più le schede.

## Verifiche

| Verifica | Esito |
|---|---|
| Test frontend | 611 passati |
| E2E completa desktop | 105 passati |
| E2E completa mobile | 104 passati |
| `format:check` | pulito |

Copertura nuova: un e2e campiona ogni associazione cento volte forzando i ridisegni e pretende **un solo** valore per scheda —

```
room-cameretta::primary             → ["Cameretta"]
room-cameretta::temperature-extra-1 → ["Seconda sonda"]
room-matrimoniale::primary          → ["Pippo"]
```

Il gate che pinnava `beta17` come proprietario delle etichette diventa un test di comportamento sulla nuova funzione più una guardia sul singolo proprietario.

Una nota: durante il lavoro l'e2e `beta5-root-causes` è fallito due volte sotto carico con la suite intera in parallelo. È instabile di suo, non una regressione — fallisce anche su `main` senza queste modifiche e passa in tre esecuzioni singole di fila: attende al massimo 5 secondi che l'editor si assesti.

Versione: `1.0.0-beta.30.7`.

---

## Sicurezza ridisegnata

Terzo commit, aggiunto qui su richiesta: nuova veste grafica per la pagina **Sicurezza**, senza toccare il motore video.

Nuovo owner `sections/security-showcase-section.js`, che ridisegna la pagina come una postazione di controllo:

- il titolo di pagina diventa un'intestazione leggera invece dell'ennesima scheda bianca, con la pillola **TVCC attivo / offline** calcolata sullo stato reale delle telecamere;
- console antifurto con cresta di stato sul bordo superiore che scorre quando il sistema è inserito, trama a punti sullo sfondo e **orbita radar** attorno all'icona, che ruota da armato e accelera in allarme;
- riga di stato con targhetta **Protetto / Non protetto / Intrusione** e tempo di inserimento; su schermo largo lo stato sta a sinistra e il tastierino a destra, così il pannello non è più una fascia mezza vuota;
- pulsanti modalità con icona, etichetta e sotto-etichetta (*Inserimento totale*, *Perimetro attivo*, *Disinserisci*);
- intestazione telecamere con **REC**, numero di canali, quanti sono attivi e orologio di sistema;
- schede telecamera con badge LIVE, numero canale e mirini sul fotogramma, nome e orario nel piede; una telecamera irraggiungibile diventa bianco e nero con reticolo diagonale e **Nessun segnale**, con il nome sempre leggibile;
- stato vuoto dedicato con scorciatoia alla Configurazione, tema scuro completo, mobile a colonna singola e animazioni disattivate con `prefers-reduced-motion`.

### Contratti tenuti fermi

Il comportamento resta dove è sempre stato — questo modulo è solo presentazione:

- le schede chiamano `apriCamera()`, quindi WebRTC → HLS → MJPEG → polling, pannello audio e `toggleFullScreenCam()` non cambiano di una riga;
- la console è ancora `#alarm-stage` con `#alarm-icon-new`, `#alarm-state-text-new`, `#alarm-state-timer` e `.alarm-mode-btn[data-mode]`, così il ciclo di render legacy continua a scrivere `--al-col` / `--al-rgb` e le classi `.armed` / `.triggered`. "Protetto / Intrusione" è derivato da quelle classi in CSS puro invece di duplicare la logica dell'allarme;
- i pulsanti chiamano ancora `promptPinAndSet()`: il tastierino del PIN è invariato;
- le immagini restano `<img>` dentro `#cam-grid` e gli orologi restano `.cam-time`, quindi il refresh dei fotogrammi (legacy e `live-ui`) funziona come prima.

La griglia viene ricostruita solo quando cambia la firma delle telecamere, così i fotogrammi già caricati non lampeggiano a ogni evento di stato. Nessun polling e nessun observer aggiunti, nessuna modifica ai file legacy vendorizzati.

### Verifiche di questa parte

| Verifica | Esito |
|---|---|
| Test frontend (intera suite, inclusi 7 nuovi) | 618 passati |
| `format:check` | pulito |
| `check:inline-syntax` | pulito |
| Render della pagina in Chromium | 4 schede, 1 offline riconosciuta, id immagini e `.cam-time` intatti, nessun errore in console |

L'E2E non è stata rieseguita per questa parte: i numeri desktop/mobile in tabella sopra sono quelli dei primi due commit.

---

## EV ridisegnata

Ultimo commit, aggiunto qui su richiesta: nuova veste grafica per la pagina **EV**, costruita attorno alla foto del veicolo. Nuovo owner `sections/ev-showcase-section.js`; comportamento, entità e calcoli restano dove sono sempre stati.

La direzione è stata scelta su mockup interattive: fondo chiaro, schede flottanti, angoli morbidi, densità comoda, movimento contenuto.

- **La foto diventa una vetrina**: cornice ad angoli morbidi con ombra propria e velatura leggera, al posto del riquadro scuro a tutta altezza con il gradiente pesante sopra. Senza foto configurata la cornice si abbassa e mostra un segnaposto discreto invece di una lastra vuota — lo stato lo dà già `data-ev-image` che `ev-section.js` scrive sull'hero.
- **La batteria esce dalla foto** ed entra in un **anello di carica**, con accanto potenza, tempo stimato e autonomia al target. Il numero della percentuale sta al centro dell'anello.
- **Schede flottanti** su superficie chiara per KPI, sessione, statistiche, target e console, con la stessa famiglia di ombre e raggi.
- **Icone a tratto** al posto delle emoji su statistiche e tasti modalità, associate all'entità che la scheda apre nello storico.
- **Selettore veicoli rivestito**: logo del marchio, modello, percentuale di carica e spunta sul profilo attivo, con scorrimento orizzontale quando le schede non ci stanno. Resta invisibile con un solo veicolo, come già faceva.

### I colori EVCC comandano la pagina

La modalità attiva viene rispecchiata su `#page-ev` come `data-dm-ev-mode`, leggendo quale `.evcc-mode-btn` porta la classe `.active` che il runtime già assegna da `dm.ev_modalita_ricarica_evcc`. Da lì, in CSS puro, la **barra target** e i **tasti** prendono i quattro colori già configurati nel markup — `#e11d48`, `#059669`, `#d97706`, `#0284c7` — e ogni tasto attivo porta la propria animazione:

| Modalità | Colore | Animazione |
|---|---|---|
| Spento | `#e11d48` | anello che si allarga e si spegne, 3,4 s |
| Solar | `#059669` | raggi che ruotano dietro il sole, un giro in 11 s |
| Min+Sol | `#d97706` | una nuvola attraversa il tasto e copre il sole, 6,5 s |
| Fast | `#0284c7` | due scie di velocità ogni 1,5 s |

Il resto della pagina — anello, icone, accenti — resta verde fisso. Con `prefers-reduced-motion` le animazioni restano tutte ferme.

### Contratti tenuti fermi

- la foto resta `#ev-mod-car-img` dentro `#lm-hero-card`: il risolutore immagini di `ev-section.js` e lo scambio idle/plugged non cambiano;
- `#ev-mod-batt-fill` conserva larghezza, `--batt-col` e classi `low` / `mid`. L'anello **legge** quell'elemento invece di ricalcolare lo stato di carica, così il valore della batteria ha un solo proprietario;
- `#lm-charge-badge` resta dentro l'hero con `#lm-dot` e `#lm-stato-txt`, quindi i colori inline che il ciclo di render scrive per stato EVSE (grigio / arancio / ciano / rosso) continuano ad arrivare, e `.lm-charging` sull'hero significa quello che significava;
- le righe accanto all'anello portano le classi legacy `v-ev-pow`, `v-ev-remain` e `v-auto-limite`, che il ciclo di render riempie via `querySelectorAll`: nessun valore viene calcolato qui. Al montaggio vengono inizializzate dal valore già a schermo, così non lampeggiano su `—`;
- i tasti chiamano ancora `setEVMode()` e il selettore veicoli resta di `renderVehicleSelector()` e `applyEvAppearance()`: questo modulo ne cambia solo il foglio di stile.

Il blocco batteria viene **spostato, mai duplicato**, e il montaggio è idempotente. Nessun polling, nessun observer, nessuna modifica ai file legacy vendorizzati.

### Verifiche di questa parte

| Verifica | Esito |
|---|---|
| Test frontend (intera suite, inclusi 9 nuovi) | 649 passati |
| E2E `ev-showcase` desktop | 4 passati |
| E2E `ev-showcase` mobile | 4 passati |
| `format:check` | pulito |
| `check:inline-syntax` | pulito |
| Render della pagina in Chromium (1440 e 390 px) | tutte le schede presenti, anello al 68%, colore target che segue le quattro modalità, nessuno scorrimento orizzontale, nessun errore in console |

L'E2E completa non è stata rieseguita per questa parte: i numeri desktop/mobile nella prima tabella sono quelli dei primi due commit.