### PR TITLE
Il gate di release non si pianta più sull'installazione dei browser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,25 @@ jobs:
   verify:
     name: Verify before releasing
     runs-on: ubuntu-latest
+    # Same image the Browser E2E workflow uses, which already carries the
+    # browsers the gate needs. Installing them here instead is what hung run
+    # #106 for hours on `playwright install --with-deps`, so the release never
+    # published; the previous release needed a second attempt at the same step.
+    container:
+      image: mcr.microsoft.com/playwright:v1.54.1-noble
+    # Without this a stuck step sits until GitHub's six-hour cap. The whole job
+    # takes about twenty minutes when it is healthy.
+    timeout-minutes: 45
     outputs:
       release_tag: ${{ steps.version.outputs.release_tag }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+      # The workspace belongs to another user inside the container, so git
+      # refuses to read it until it is marked safe. Both the build-info script
+      # and the tag check below shell out to git.
+      - name: Trust the workspace checkout
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -48,8 +62,6 @@ jobs:
           npm run check:inline-syntax
           npm run format:check
           npm run test:frontend
-      - name: Install Playwright browsers used by the suite
-        run: npx playwright install --with-deps chromium webkit
       - name: Browser E2E release gate
         run: npm run test:e2e
       - name: Resolve and verify release version
@@ -73,6 +85,7 @@ jobs:
     name: Publish release
     needs: verify
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v6


### PR DESCRIPTION
La **1.0.0-beta.30.7 non è stata pubblicata**: il tag `v1.0.0-beta.30.7` e la release non esistono, l'ultima è la 30.6.

## Cosa è successo

Il run **Release #106** (`32087443300`) sul commit di merge `4c84c12` è rimasto appeso **2h40m** nel job *Verify before releasing*, allo step:

```
npx playwright install --with-deps chromium webkit
```

partito alle 01:15:10 e mai concluso. Tutto ciò che viene prima — lint, `pytest`, `check:inline-syntax`, `format:check`, test frontend — era passato. Il job **non ha un timeout**, quindi sarebbe rimasto lì fino al tetto di sei ore di GitHub e poi sarebbe morto rosso senza pubblicare. L'ho cancellato.

Non è un caso isolato: anche la **30.6 è uscita solo al secondo tentativo**, dallo stesso step.

## Perché è assurdo che si pianti lì

Sullo **stesso commit**, minuti prima, il workflow **Browser E2E** (`32087443212`) era **verde**. I due eseguono la stessa suite, ma per strade diverse:

| | `e2e.yml` (verde) | `release.yml` (piantato) |
|---|---|---|
| Browser | container `mcr.microsoft.com/playwright:v1.54.1-noble`, già presenti | `playwright install --with-deps` su runner nudo |
| Timeout | `timeout-minutes: 20` | nessuno |
| Esecuzione | 3 progetti in parallelo | tutto in serie |

Il gate rieseguiva una suite già passata sullo stesso SHA, per la strada più lenta e più fragile: `--with-deps` fa `apt-get`, ed è lì che si è bloccato.

## La correzione

Il job `verify` usa ora **la stessa immagine** del workflow E2E, dove i browser ci sono già, e lo step di installazione sparisce.

- **Il gate resta**: una release deve ancora passare `npm run test:e2e` con tutti e tre i progetti, webkit compreso. Non è stato indebolito, solo reso affidabile.
- **Entrambi i job hanno un timeout** (45 min il verify, che ne impiega ~20 quando è sano; 15 min la pubblicazione), così uno step bloccato fallisce in minuti invece che in ore.
- **`safe.directory` sul workspace**: dentro un container la cartella appartiene a un altro utente e git si rifiuta di leggerla. Servono `scripts/generate_build_info.py` e il controllo del tag con `git ls-remote`. È esattamente quello che `e2e.yml` fa già.

L'immagine è agganciata a `v1.54.1-noble`, che corrisponde a `@playwright/test` pinnato in `package.json`, ed è la stessa tag già in uso in `e2e.yml`.

## Verifiche

Il file è YAML valido e la sequenza degli step è quella attesa. Il resto lo può dimostrare solo un run vero: le Actions non sono eseguibili da qui, quindi la prova è il prossimo Release.

Una volta unita questa, il Release non riparte da solo — si attiva su push a `main` che tocchino `manifest.json`, che qui non cambia. Va lanciato a mano con **Run workflow** su `main`: il manifest dice già `1.0.0-beta.30.7` e quel tag non esiste, quindi pubblicherà la 30.7. Posso lanciarlo io appena questa è unita, se preferisci.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7zhot9vAJwXsUCpSE16nE)_