### PR TITLE
Nel job di release, pip e ruff vanno chiamati tramite l'interprete

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,13 +48,19 @@ jobs:
           cache: npm
       - name: Install test dependencies
         run: |
+          # `python -m pip`, not `pip`: the container has no pip on PATH, only
+          # the module. On a bare runner setup-python leaves both, which is why
+          # this only broke once the job moved into the image.
           python -m pip install --upgrade pip
-          pip install -r requirements_test.txt ruff
+          python -m pip install -r requirements_test.txt ruff
           npm ci
       - name: Lint
         run: |
-          ruff check .
-          ruff format --check .
+          # Through the interpreter for the same reason as the install above:
+          # nothing in this job should depend on a console script being on the
+          # container's PATH.
+          python -m ruff check .
+          python -m ruff format --check .
       - name: Test
         run: |
           python scripts/generate_build_info.py --expected-commit "$GITHUB_SHA"


### PR DESCRIPTION
Seguito della #153. Ho lanciato il Release su `main` dopo il merge e **è fallito in 40 secondi** — una regressione mia, non un problema preesistente.

## Cosa è successo

Run [`32101974467`](https://github.com/danigio15/dashboardmodern-v2/actions/runs/32101974467), step *Install test dependencies*:

```
python -m pip install --upgrade pip     ← ok, "Requirement already satisfied: pip ... (26.2.1)"
pip install -r requirements_test.txt ruff
/__w/_temp/….sh: 2: pip: not found
##[error]Process completed with exit code 127
```

Spostando il job dentro l'immagine Playwright è cambiato cosa c'è su `PATH`. Su un runner nudo `setup-python` lascia sia `python` sia lo script `pip`; dentro il container c'è solo l'interprete. Per questo la prima riga è passata e la seconda no: usavano due strade diverse per la stessa cosa.

Il gate non è mai arrivato alla suite browser, quindi **la 30.7 non è ancora pubblicata**.

## La correzione

Entrambe le installazioni passano ora da `python -m pip`, che è esattamente la forma che funzionava già una riga sopra.

Il **lint** passa a `python -m ruff` per lo stesso motivo: in questo job niente deve dipendere dall'esistenza di uno script eseguibile sul `PATH` del container. `ruff` verrebbe installato da pip nella stessa cartella dell'interprete e quindi con ogni probabilità si troverebbe — ma è la stessa classe di guasto che ha appena bruciato un giro, e un giro di release costa venti minuti più un merge.

## Il lato buono

Il resto della #153 ha fatto il suo lavoro: il job è fallito **in 40 secondi con un errore leggibile**, invece di restare appeso 2h40m come il run #106. Container e timeout funzionano; questi due comandi erano l'ultimo pezzo da adattare.

## Verifiche

Le Actions non sono eseguibili da qui, ma ho verificato quello che si può verificare, su questo albero:

| Verifica | Esito |
|---|---|
| `python -m ruff --version` | `ruff 0.16.3` — la forma è valida |
| `python -m ruff check .` | `All checks passed!` |
| `python -m ruff format --check .` | `32 files already formatted` |
| YAML del workflow | valido, step nell'ordine atteso |

Il resto lo prova solo il run vero. Appena questa è unita rilancio il Release e ti dico come va.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7zhot9vAJwXsUCpSE16nE)_