### PR TITLE
Correzioni post-152: lente solo sui campi entità, via la trama sul video, foto EV e configurazione veicolo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,22 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
 ### Corretto
 
+- Su PC, con tutte le sezioni accese, le ultime voci della barra in basso non
+  si potevano raggiungere. La barra è larga quanto il suo contenuto ed è fissa e
+  centrata sullo schermo: quando le tredici sezioni superano la larghezza della
+  finestra, le voci di testa e di coda finiscono oltre i bordi, e lo scorrimento
+  della pagina non le sposta perché la barra non scorre con essa. Ora le voci
+  stanno in una loro pista scorrevole, la barra non supera mai la larghezza
+  della finestra e la si scorre in quattro modi: la rotella verticale del mouse
+  sopra la barra, il trascinamento con il tasto sinistro, le due frecce tonde
+  che compaiono ai lati solo quando serve scorrere, e i tasti freccia
+  sinistra/destra. Le frecce si spengono quando da quel lato si è arrivati in
+  fondo, e la sezione aperta viene riportata sotto gli occhi quando la barra
+  ricompare. L'effetto dock — la voce puntata che si ingrandisce — resta
+  intatto, e quando le sezioni ci stanno tutte la barra è identica a prima:
+  niente frecce, larghezza sul contenuto. Su smartphone e tablet non cambia
+  nulla, la barra continua a scorrere da sé come ha sempre fatto.
+
 - Sul desktop i flussi non si animavano: se nel sistema e' attivo **"riduci
   movimento"** — impostazione comune su Windows e macOS e quasi mai su un
   telefono, il che spiega perche' il moto si vedeva solo li' — ogni linea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,19 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
 ### Corretto
 
+- Sul desktop i flussi non si animavano: se nel sistema e' attivo **"riduci
+  movimento"** — impostazione comune su Windows e macOS e quasi mai su un
+  telefono, il che spiega perche' il moto si vedeva solo li' — ogni linea
+  restava ferma, comprese quelle principali di solare, rete e batteria. Il
+  motore dei flussi introdotto con la Beta 30 rispetta quella preferenza, ma la
+  rispettava azzerando l'animazione e lasciando il tratteggio: una linea
+  tratteggiata e immobile e' pero' indistinguibile da una spenta, e il moto era
+  l'unico segnale che l'energia stesse passando. Ora, con la preferenza attiva,
+  la linea di un flusso attivo viene disegnata **piena, colorata e a piena
+  intensita'**, mentre quella inattiva resta tratteggiata e sbiadita: lo stato
+  si legge lo stesso, senza movimento. Con la preferenza disattivata il
+  tratteggio scorre come prima.
+
 - In **Temperature** l'etichetta sopra il numero cambiava da sola: la stessa
   scheda mostrava "TEMPERATURA" e un istante dopo il nome dato al sensore. Quel
   testo aveva tre proprietari che non erano d'accordo — i renderer scrivevano la

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,20 +101,18 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   intatto, e quando le sezioni ci stanno tutte la barra è identica a prima:
   niente frecce, larghezza sul contenuto. Su smartphone e tablet non cambia
   nulla, la barra continua a scorrere da sé come ha sempre fatto.
-
-- Sul desktop i flussi non si animavano: se nel sistema e' attivo **"riduci
-  movimento"** — impostazione comune su Windows e macOS e quasi mai su un
-  telefono, il che spiega perche' il moto si vedeva solo li' — ogni linea
-  restava ferma, comprese quelle principali di solare, rete e batteria. Il
-  motore dei flussi introdotto con la Beta 30 rispetta quella preferenza, ma la
-  rispettava azzerando l'animazione e lasciando il tratteggio: una linea
-  tratteggiata e immobile e' pero' indistinguibile da una spenta, e il moto era
-  l'unico segnale che l'energia stesse passando. Ora, con la preferenza attiva,
-  la linea di un flusso attivo viene disegnata **piena, colorata e a piena
-  intensita'**, mentre quella inattiva resta tratteggiata e sbiadita: lo stato
-  si legge lo stesso, senza movimento. Con la preferenza disattivata il
-  tratteggio scorre come prima.
-
+- **Sul desktop i flussi non si animavano.** Se nel sistema è attiva
+  l'impostazione **"riduci movimento"** — spesso attiva su un computer e quasi
+  mai su un telefono, il che spiega perché il moto si vedeva solo lì — ogni
+  linea restava ferma, comprese quelle principali di solare, rete e batteria.
+  Il motore dei flussi introdotto con la Beta 30 rispettava quella preferenza,
+  cosa che per un'animazione decorativa sarebbe giusta; qui però il tratteggio
+  che scorre non è una decorazione, è l'unico segnale che l'energia sta
+  passando, e la stessa plancia finiva per raccontare due cose diverse a
+  seconda dello schermo. Ora le linee dei flussi scorrono su ogni schermo,
+  indipendentemente da quell'impostazione: il desktop mostra esattamente quello
+  che mostra il telefono. Le altre sezioni continuano a rispettarla, perché lì
+  il movimento è effettivamente decorativo.
 - In **Temperature** l'etichetta sopra il numero cambiava da sola: la stessa
   scheda mostrava "TEMPERATURA" e un istante dopo il nome dato al sensore. Quel
   testo aveva tre proprietari che non erano d'accordo — i renderer scrivevano la

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,14 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   entità che Home Assistant riporta come non disponibili. Ogni riga mostra ora
   anche il valore attuale e la stanza dell'entità, e la lista si comanda da
   tastiera con ↑ ↓ e Invio.
+- **Temperature** ha ora un pannello **Andamento** sotto le schede, che segue i
+  tab delle stanze: scelta una stanza disegna le sue sonde, su "Tutte" mette una
+  linea per stanza per confrontarle. Il grafico mostra la fascia comfort dove
+  rientra nell'inquadratura, le ore notturne in ombra, il valore corrente in
+  fondo a ogni linea e, sotto, una pastiglia per serie con valore attuale e
+  minimo/massimo del periodo; si passa fra 24 ore e 7 giorni. I dati sono lo
+  stesso storico che la plancia chiede già toccando una scheda, disegnato in SVG
+  senza librerie di grafici.
 - Ogni scheda di **Temperature** porta ora in fondo la scala del comfort, dal
   freddo al caldo, con una tacca nel punto della lettura: si vede quanto una
   stanza è fuori dal comfort, non solo se lo è. Sotto la percentuale di umidità

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.0.0-beta.30.8 — 2026-08-18
+
+### Aggiunto
+
+- **Le luci RGB si comandano dalla dashboard.** Il popup Gestione luci aveva un
+  solo gesto — tocca la scheda, la luce si accende o si spegne — e non importava
+  se dietro c'era una lampadina on/off, un dimmer o una striscia RGB. Ora ogni
+  luce riceve i comandi che l'entità dichiara di avere: il pulsante dei
+  controlli apre il pannello della singola luce con luminosità (e i valori
+  rapidi 1 / 25 / 50 / 75 / 100 %), colore con dodici colori pronti, i cursori
+  di tinta e saturazione e il selettore del colore esatto, bianco regolabile in
+  kelvin ed elenco degli effetti. Una luce che non ha una di queste cose non ne
+  vede il comando: non compare un cursore che Home Assistant rifiuterebbe.
+- **Le luci dimmerabili hanno il cursore sulla scheda.** "Un po' meno luce" è la
+  richiesta più frequente e ora non richiede di aprire nulla. Il valore appena
+  impostato resta sullo schermo finché Home Assistant continua a riportare il
+  precedente, quindi il cursore non torna indietro sotto il dito durante la
+  dissolvenza.
+- **Una luce può essere uno `switch.`**, non solo una `light.`. Una lampada
+  dietro un relè si aggiunge esattamente come una lampadina smart: viene
+  comandata con `switch.turn_on` / `switch.turn_off` e non riceve mai luminosità
+  o colore. L'editor accetta anche le entità `input_boolean.`, `fan.` e `group.`
+  che le versioni precedenti hanno sempre scritto in configurazione: prima la
+  finestra di modifica le rifiutava e una luce già configurata non si poteva più
+  modificare. Il selettore di entità propone ora anche gli `switch.` quando il
+  campo chiede una luce.
+- Nella scheda **Luci** dell'editor ogni luce dice cosa sa fare — RGB, bianco
+  regolabile, dimmer oppure solo acceso/spento — letto dall'entità stessa, e le
+  pastiglie si aggiornano mentre punti la luce su un'altra entità. Dalla stessa
+  finestra il pulsante **Prova i controlli** apre il pannello della luce.
+
+### Modificato
+
+- **Il popup Gestione luci è stato ridisegnato.** Ogni scheda si illumina del
+  colore che la lampada sta davvero emettendo — il bordo, il bagliore, il LED e
+  la sfera — invece dell'ambra fissa di prima; una luce in bianco regolabile
+  prende il colore della sua temperatura. Lo stato dice anche la percentuale
+  ("ACCESA · 45%") e le luci non disponibili restano visibili, in grigio, invece
+  di sparire dall'elenco come se fossero state cancellate.
+- Ogni stanza ha ora il proprio conteggio ("2/3") e il proprio comando accendi /
+  spegni, accanto a "Spegni tutte" che resta in cima. Il raggruppamento per
+  stanza e per piano è quello di prima.
+- Il popup si ridisegna solo quando cambia la sua forma — una luce nuova, un
+  nome, un cambio di stanza, una lampada che inizia a dichiarare il colore —
+  mentre acceso/spento, luminosità e colore vengono scritti nelle schede già
+  presenti. Il ciclo del runtime ridisegna ogni due secondi e prima quella
+  ricostruzione avrebbe strappato via il cursore sotto il dito.
+- Durante il trascinamento la lampada riceve un comando ogni 320 ms e il valore
+  esatto al rilascio, invece di una chiamata per pixel.
+
 ## 1.0.0-beta.30.7 — 2026-08-17
 
 ### Aggiunto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,12 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   entità che Home Assistant riporta come non disponibili. Ogni riga mostra ora
   anche il valore attuale e la stanza dell'entità, e la lista si comanda da
   tastiera con ↑ ↓ e Invio.
+- Ogni scheda di **Temperature** porta ora in fondo la scala del comfort, dal
+  freddo al caldo, con una tacca nel punto della lettura: si vede quanto una
+  stanza è fuori dal comfort, non solo se lo è. Sotto la percentuale di umidità
+  c'è una barra che si riempie fino al valore. Nessun renderer è cresciuto di
+  markup: gli aggiornatori passano la lettura a un'unica funzione che la scrive
+  sulla scheda, e il foglio di stile disegna scala e barra da lì.
 
 ### Corretto
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,44 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   i titoli di piano e stanza hanno la loro riga con la linea che sfuma.
 - Tutta la pagina segue il tema chiaro e scuro, si adatta al telefono e chi ha
   attivato "riduci animazioni" vede la scena ferma.
+- **L'autorilevamento della Configurazione è stato rifatto.** Il pulsante 🪄
+  *Avvia autorilevamento* interrogava Home Assistant e poi controllava ogni
+  mezzo secondo se la risposta fosse arrivata, fino a venti secondi; poi
+  confrontava ogni entità della casa con ognuno dei 96 campi, riscrivendo ogni
+  volta le stesse parole, e nel frattempo la pagina restava bloccata. Ora
+  l'elenco viene letto una volta e ogni campo guarda solo le entità che hanno
+  una parola in comune con lui: su un impianto da 5000 entità il rilevamento
+  passa da circa 230 ms a 11 ms, e mentre lavora si vede a che punto è.
+- **Adesso prima ti fa vedere cosa ha trovato.** Al posto del salvataggio
+  immediato seguito dal ricaricamento, compare il riepilogo — quante luci,
+  stanze, unità clima, telecamere e collegamenti — con l'elenco dei campi
+  collegati e il pulsante per applicare. Finché non lo premi non viene scritto
+  niente. I campi in cui due entità sono altrettanto probabili non vengono più
+  riempiti a caso: te li dice, e li lasci come vuoi tu nelle altre schede.
+- **Le stanze arrivano dalle aree di Home Assistant**, come era previsto dalla
+  versione 0.9: il rilevamento chiedeva i registri di aree, dispositivi ed
+  entità, ma chiudeva la connessione appena arrivavano gli stati, cioè prima
+  che i registri rispondessero. Il risultato è che le aree non erano mai
+  disponibili e le stanze venivano indovinate dai nomi dei sensori. Ora i
+  registri vengono letti prima di decidere: una stanza per area, con il suo
+  sensore di temperatura e quello di umidità della stessa area, e i nomi delle
+  aree usati anche per luci, unità clima e telecamere.
+- **I collegamenti dell'Energia adesso restano.** Erano scritti tra gli
+  "override" delle entità, ma dalla versione 4 della configurazione la sezione
+  Energia è la proprietaria di quei campi e riscriveva sopra, cancellandoli: un
+  autorilevamento poteva quindi sembrare riuscito e lasciare l'Energia vuota.
+  Ora vengono scritti nel modello Energia, che è ciò che li tiene.
+- Le righe dei campi entità nell'editor venivano riscritte in forma leggibile
+  solo se la scheda era già stata disegnata prima che i moduli finissero di
+  caricare: `editorSwitch` veniva agganciato dentro un evento che, per i moduli
+  caricati su richiesta, era già passato. Ora l'aggancio avviene comunque, così
+  le righe si aggiornano a ogni cambio scheda.
+- Il rilevamento legge l'unità di misura scritta nell'etichetta del campo come
+  un vincolo e non come un suggerimento: un campo in kWh non prende più un
+  sensore in watt, un campo "oggi" non prende un contatore mensile, e un campo
+  che chiede uno `script` o un `select` guarda solo quel dominio. Quando due
+  campi si contendono la stessa entità, la prende quello che la descrive
+  meglio, non quello che compare prima nell'elenco.
 - **La ricerca delle entità nella configurazione è diventata istantanea.** Il
   selettore (la lente 🔍 accanto a ogni campo entità) rileggeva tutte le entità
   della casa a ogni lettera digitata e ridisegnava trecento righe ogni volta: su

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ La UI è disponibile in **italiano e inglese**, supporta più istanze della plan
 | 🔌 **Wallbox** | potenza e dati di ricarica tramite le entità disponibili in Home Assistant |
 | 🌡️ **Temperatura** | temperatura e umidità associate alle stanze canoniche |
 | 🔥❄️ **Clima** | gestione separata delle unità **Caldo** e **Freddo** |
-| 💡 **Luci** | luci per stanza, stato e controllo |
+| 💡 **Luci** | luci per stanza, entità `light.*` o `switch.*`, dimmer, colore RGB, bianco regolabile ed effetti |
 | 🪟 **Tapparelle** | apertura, chiusura, stop e posizione quando supportata |
 | 🛡️ **Sicurezza** | allarme, sensori e telecamere configurate |
 | 🏊 **Piscina** | temperatura, stato e comandi configurabili |
@@ -279,10 +279,33 @@ Configura l'entità `climate.*` e la stanza corretta. Il runtime usa gli stati e
 
 Per ogni luce puoi configurare:
 
-- entità `light.*`;
+- entità `light.*` **oppure** `switch.*` — una lampada dietro un relè si aggiunge
+  esattamente come una lampadina smart; sono accettate anche le entità
+  `input_boolean.*`, `fan.*` e `group.*` scritte dalle versioni precedenti;
 - nome visualizzato;
 - stanza;
 - ordine.
+
+Nella scheda **Luci** dell'editor ogni luce mostra cosa sa fare — RGB, bianco
+regolabile, dimmer oppure solo acceso/spento — letto dall'entità stessa.
+
+Il popup **Gestione luci** presenta le luci raggruppate per stanza, con il
+conteggio e il comando accendi/spegni di ogni stanza. Ogni scheda si accende del
+colore che la lampada sta davvero emettendo e, se la luce è dimmerabile, porta
+il cursore della luminosità sulla scheda. Il pulsante dei controlli apre il
+pannello della singola luce, che offre soltanto quello che l'entità dichiara:
+
+- accensione e spegnimento;
+- luminosità, con i valori rapidi 1 / 25 / 50 / 75 / 100 %;
+- colore, con dodici colori pronti, i cursori di tinta e saturazione e il
+  selettore del colore esatto;
+- bianco regolabile in kelvin, entro i limiti dichiarati dalla lampada;
+- effetti, quando l'entità ne espone un elenco.
+
+Una luce collegata a uno switch mostra solo acceso/spento: la dashboard non le
+invia mai luminosità o colore. Il valore appena impostato resta sullo schermo
+finché Home Assistant continua a riportare il precedente, così il cursore non
+torna indietro sotto il dito.
 
 La dashboard mantiene il controllo tramite i servizi Home Assistant e presenta le luci organizzate secondo la configurazione della plancia.
 

--- a/custom_components/dashboardmodern/frontend/e2e/editor-slots.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-slots.spec.js
@@ -1,0 +1,142 @@
+// DM-FIX-20260817E
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [{ id: "ev-b10", name: "B10", brand: "Leapmotor", model: "B10", icon: "mdi:car-electric" }],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  visibility: { home: true, energy: true, ev: true },
+};
+
+function evBody(page) {
+  return page
+    .locator("#ed-body .ed-acc-body")
+    .filter({ has: page.locator('.ed-slot-in[data-ref^="dm.ev_"]') })
+    .first();
+}
+
+async function openEvEditor(page) {
+  await page.evaluate(() => {
+    window._RAW_STATES = Object.assign(window._RAW_STATES || {}, {
+      "sensor.b10_soc": { state: "68", attributes: { friendly_name: "B10 Stato di carica" } },
+    });
+    if (!document.getElementById("editor-modal")?.classList.contains("show")) apriConfigEntita();
+    editorSwitch("sez2");
+    const accordion = [...document.querySelectorAll("#ed-body details.ed-acc")].find((node) =>
+      node.querySelector('.ed-slot-in[data-ref^="dm.ev_"]'),
+    );
+    if (accordion) accordion.open = true;
+  });
+  await expect(page.locator("#editor-modal")).toBeVisible();
+  // The rows are decorated on the frame after the editor prints them.
+  await expect(evBody(page).locator(".dm-slot").first()).toBeVisible();
+}
+
+test.describe("editor entity rows", () => {
+  test("each slot becomes one readable row, with the raw field kept behind a switch", async ({
+    page,
+  }, testInfo) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+    await openEvEditor(page);
+
+    const row = evBody(page).locator(".dm-slot").first();
+    await expect(row.locator(".dm-slot-chip")).toBeVisible();
+    // The field the editor saves through is still there, just not on screen.
+    await expect(row.locator(".ed-slot-in")).toHaveCount(1);
+    await expect(row.locator(".ed-slot-in")).toBeHidden();
+
+    const body = evBody(page);
+    await body.locator(".dm-slots-manual").click();
+    await expect(body.locator(".ed-slot-in").first()).toBeVisible();
+    await body.locator(".dm-slots-manual").click();
+    await expect(body.locator(".ed-slot-in").first()).toBeHidden();
+  });
+
+  test("choosing an entity repaints the row without touching the save path", async ({
+    page,
+  }, testInfo) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+    await openEvEditor(page);
+
+    // What cdEpChoose() does once the picker closes: write the value and fire
+    // change, which is the event edSetSlot listens to.
+    const result = await page.evaluate(() => {
+      const body = [...document.querySelectorAll("#ed-body .ed-acc-body")].find((node) =>
+        node.querySelector('.ed-slot-in[data-ref^="dm.ev_"]'),
+      );
+      const row = body.querySelector(".dm-slot");
+      const input = row.querySelector(".ed-slot-in");
+      input.value = "sensor.b10_soc";
+      input.dispatchEvent(new Event("change"));
+      return {
+        state: row.dataset.dmSlot,
+        chip: row.querySelector(".dm-slot-chip").innerText,
+        saved: input.value,
+      };
+    });
+    expect(result.state).toBe("mapped");
+    expect(result.chip).toContain("B10 Stato di carica");
+    expect(result.chip).toContain("sensor.b10_soc");
+    expect(result.saved).toBe("sensor.b10_soc");
+  });
+
+  test("brand and model sit inside the vehicle section, above its entities", async ({
+    page,
+  }, testInfo) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+    await openEvEditor(page);
+
+    // The editor repaints while the tab settles; the panel lands in its section
+    // as soon as the accordion exists.
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const body = [...document.querySelectorAll("#ed-body .ed-acc-body")].find((node) =>
+            node.querySelector('.ed-slot-in[data-ref^="dm.ev_"]'),
+          );
+          const panel = document.querySelector("[data-ev-appearance]");
+          return Boolean(body && panel && body.contains(panel));
+        }),
+      )
+      .toBe(true);
+
+    const inside = await page.evaluate(() => {
+      const body = [...document.querySelectorAll("#ed-body .ed-acc-body")].find((node) =>
+        node.querySelector('.ed-slot-in[data-ref^="dm.ev_"]'),
+      );
+      const panel = document.querySelector("[data-ev-appearance]");
+      return {
+        inAccordion: Boolean(body && panel && body.contains(panel)),
+        beforeSlots: Boolean(
+          panel &&
+          panel.compareDocumentPosition(body.querySelector(".dm-slot")) &
+            Node.DOCUMENT_POSITION_FOLLOWING,
+        ),
+        hasBrand: Boolean(panel?.querySelector("select[data-brand]")),
+        hasModel: Boolean(panel?.querySelector("select[data-model]")),
+      };
+    });
+    expect(inside).toEqual({
+      inAccordion: true,
+      beforeSlots: true,
+      hasBrand: true,
+      hasModel: true,
+    });
+  });
+});

--- a/custom_components/dashboardmodern/frontend/e2e/energy-flow-motion.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/energy-flow-motion.spec.js
@@ -137,24 +137,30 @@ test("il connettore di un carico acceso scorre davvero", async ({ page }, testIn
   expect(new Set(offsets).size).toBeGreaterThan(1);
 });
 
-test("con 'riduci movimento' la linea attiva resta leggibile invece di sparire", async ({
+test("le linee scorrono anche con 'riduci movimento': stessa lettura su ogni schermo", async ({
   page,
 }, testInfo) => {
   await page.emulateMedia({ reducedMotion: "reduce" });
   await boot(page, testInfo);
 
-  const active = await readArc(page, "boiler");
-  await page.waitForTimeout(300);
-  const later = await readArc(page, "boiler");
-  // Nessun movimento: la preferenza di sistema va rispettata.
-  expect(later.offset).toBe(active.offset);
-  // Ma il tratteggio congelato sarebbe identico a una linea spenta: la linea
-  // attiva diventa piena e a piena intensita', quella spenta resta tratteggiata
-  // e sbiadita, cosi' "sta passando energia" si legge lo stesso.
-  expect(active.dash).toBe("none");
-  expect(active.opacity).toBe(1);
+  /* La preferenza di sistema e' spesso attiva su un computer e quasi mai su un
+   * telefono: rispettarla qui lasciava il desktop immobile mentre il telefono
+   * scorreva, cioe' la stessa plancia raccontava due cose diverse. Il
+   * tratteggio in movimento non e' una decorazione, e' l'unico segnale che
+   * l'energia sta passando. */
+  const first = await readArc(page, "boiler");
+  expect(first.animations).toBeGreaterThan(0);
+  expect(first.opacity).toBe(1);
+  expect(first.dash).not.toBe("none");
 
+  const offsets = [first.offset];
+  for (let index = 0; index < 4; index += 1) {
+    await page.waitForTimeout(130);
+    offsets.push((await readArc(page, "boiler")).offset);
+  }
+  expect(new Set(offsets).size).toBeGreaterThan(1);
+
+  // Il carico spento resta comunque distinguibile: sbiadito e senza moto.
   const idle = await readArc(page, "wallbox");
-  expect(idle.dash).not.toBe("none");
   expect(idle.opacity).toBeLessThan(1);
 });

--- a/custom_components/dashboardmodern/frontend/e2e/energy-flow-motion.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/energy-flow-motion.spec.js
@@ -1,0 +1,160 @@
+// DM-FIX-20260817F
+/* Il moto dei flussi, misurato nel browser invece che dedotto dal CSS.
+ *
+ * Il tratteggio che scorre e' l'unico segnale che l'energia sta passando, e
+ * "animation-name e' impostato" non prova che si muova: qui si campiona
+ * stroke-dashoffset a distanza di tempo. Il secondo caso e' quello che sul
+ * desktop lasciava la plancia immobile: con "riduci movimento" attivo tutte le
+ * linee si fermavano, e una linea tratteggiata ferma e' indistinguibile da una
+ * spenta. */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { clickBottomTab } from "./helpers/navigation.js";
+
+const states = [
+  {
+    entity_id: "sensor.boiler_power",
+    state: "2100",
+    attributes: { unit_of_measurement: "W", device_class: "power" },
+  },
+  {
+    entity_id: "sensor.wb_power",
+    state: "0",
+    attributes: { unit_of_measurement: "W", device_class: "power" },
+  },
+  {
+    entity_id: "sensor.casa_power",
+    state: "2100",
+    attributes: { unit_of_measurement: "W", device_class: "power" },
+  },
+];
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    lights: [],
+    appliances: [],
+    climate: [],
+    ev: [],
+    loads: [
+      {
+        id: "boiler",
+        name: "Boiler",
+        icon: "mdi:water-boiler",
+        order: 0,
+        power_entity: "sensor.boiler_power",
+      },
+      {
+        id: "wallbox",
+        name: "Wallbox",
+        icon: "mdi:ev-station",
+        order: 1,
+        power_entity: "sensor.wb_power",
+      },
+    ],
+    energy: { home: { power: "sensor.casa_power" } },
+  },
+  visibility: { home: true, energy: true },
+};
+
+async function boot(page, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript((haStates) => {
+    class MockBridgeSocket extends EventTarget {
+      static OPEN = 1;
+      readyState = 1;
+      constructor() {
+        super();
+        queueMicrotask(() => {
+          this.onopen?.({});
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+        });
+      }
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") return;
+        const result =
+          message.type === "get_states"
+            ? haStates
+            : message.type === "frontend/get_user_data"
+              ? { value: null }
+              : null;
+        queueMicrotask(() =>
+          this.onmessage?.({
+            data: JSON.stringify({ id: message.id, type: "result", success: true, result }),
+          }),
+        );
+      }
+      close() {
+        this.readyState = 3;
+        this.onclose?.({});
+      }
+    }
+    window.__DASHBOARDMODERN_BRIDGE_WS__ = MockBridgeSocket;
+    window.WebSocket = MockBridgeSocket;
+  }, states);
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+  await clickBottomTab(page, "energy", testInfo);
+  await expect(page.locator("#page-energy.active")).toBeVisible();
+  // Un connettore per riquadro: quello desktop e quello mobile, uno solo mostrato.
+  await expect(page.locator('#view-ist [data-dm-flow-arc="boiler"]')).toHaveCount(2);
+}
+
+/* Il connettore del carico acceso, nel riquadro effettivamente mostrato a
+ * questa larghezza: desktop e mobile hanno due SVG e uno dei due e' nascosto. */
+function readArc(page, arc) {
+  return page.evaluate((id) => {
+    const paths = [...document.querySelectorAll(`#view-ist [data-dm-flow-arc="${id}"]`)];
+    const path =
+      paths.find(
+        (node) => node.getBoundingClientRect().width > 0 || node.getBoundingClientRect().height > 0,
+      ) || paths[0];
+    const style = getComputedStyle(path);
+    return {
+      offset: style.strokeDashoffset,
+      dash: style.strokeDasharray,
+      opacity: Number(style.opacity),
+      animations: path.getAnimations ? path.getAnimations().length : 0,
+    };
+  }, arc);
+}
+
+test("il connettore di un carico acceso scorre davvero", async ({ page }, testInfo) => {
+  await boot(page, testInfo);
+  const first = await readArc(page, "boiler");
+  expect(first.animations).toBeGreaterThan(0);
+  expect(first.opacity).toBe(1);
+
+  /* Campioni ravvicinati invece di due soli: il ciclo dura 0,8 s, e due letture
+   * distanti quanto il ciclo tornerebbero lo stesso offset anche mentre la
+   * linea scorre. */
+  const offsets = [first.offset];
+  for (let index = 0; index < 4; index += 1) {
+    await page.waitForTimeout(130);
+    offsets.push((await readArc(page, "boiler")).offset);
+  }
+  expect(new Set(offsets).size).toBeGreaterThan(1);
+});
+
+test("con 'riduci movimento' la linea attiva resta leggibile invece di sparire", async ({
+  page,
+}, testInfo) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await boot(page, testInfo);
+
+  const active = await readArc(page, "boiler");
+  await page.waitForTimeout(300);
+  const later = await readArc(page, "boiler");
+  // Nessun movimento: la preferenza di sistema va rispettata.
+  expect(later.offset).toBe(active.offset);
+  // Ma il tratteggio congelato sarebbe identico a una linea spenta: la linea
+  // attiva diventa piena e a piena intensita', quella spenta resta tratteggiata
+  // e sbiadita, cosi' "sta passando energia" si legge lo stesso.
+  expect(active.dash).toBe("none");
+  expect(active.opacity).toBe(1);
+
+  const idle = await readArc(page, "wallbox");
+  expect(idle.dash).not.toBe("none");
+  expect(idle.opacity).toBeLessThan(1);
+});

--- a/custom_components/dashboardmodern/frontend/e2e/entity-autodetect.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/entity-autodetect.spec.js
@@ -1,0 +1,228 @@
+/* The 🪄 button in Config, driven end to end: it must read the instance, show
+ * what it found before writing anything, and write exactly the keys the runtime
+ * has always written once the proposal is accepted. */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const STATES = [
+  {
+    entity_id: "sensor.cucina_temperatura",
+    state: "21.5",
+    attributes: {
+      friendly_name: "Temperatura cucina",
+      unit_of_measurement: "°C",
+      device_class: "temperature",
+    },
+  },
+  {
+    entity_id: "sensor.cucina_umidita",
+    state: "48",
+    attributes: {
+      friendly_name: "Umidità cucina",
+      unit_of_measurement: "%",
+      device_class: "humidity",
+    },
+  },
+  {
+    entity_id: "sensor.salotto_temperatura",
+    state: "22.4",
+    attributes: {
+      friendly_name: "Temperatura salotto",
+      unit_of_measurement: "°C",
+      device_class: "temperature",
+    },
+  },
+  {
+    entity_id: "sensor.solaredge_produzione_oggi",
+    state: "12.4",
+    attributes: {
+      friendly_name: "Produzione solare oggi",
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "total_increasing",
+    },
+  },
+  {
+    entity_id: "sensor.solaredge_produzione_mese",
+    state: "240",
+    attributes: {
+      friendly_name: "Produzione solare mese",
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "total_increasing",
+    },
+  },
+  {
+    entity_id: "sensor.fotovoltaico_potenza",
+    state: "1830",
+    attributes: {
+      friendly_name: "Potenza fotovoltaico",
+      unit_of_measurement: "W",
+      device_class: "power",
+    },
+  },
+  {
+    entity_id: "sensor.batteria_soc",
+    state: "76",
+    attributes: {
+      friendly_name: "Stato carica batteria",
+      unit_of_measurement: "%",
+      device_class: "battery",
+    },
+  },
+  { entity_id: "light.cucina", state: "on", attributes: { friendly_name: "Luce cucina" } },
+  { entity_id: "light.salotto", state: "off", attributes: { friendly_name: "Luce salotto" } },
+  { entity_id: "climate.salotto", state: "cool", attributes: { friendly_name: "Clima salotto" } },
+  { entity_id: "camera.ingresso", state: "idle", attributes: { friendly_name: "Camera ingresso" } },
+  { entity_id: "weather.casa", state: "sunny", attributes: { friendly_name: "Meteo casa" } },
+];
+
+// Two of the temperature sensors live in a Home Assistant area. The rooms the
+// detector proposes must come from those areas, not from their names.
+const AREAS = [
+  { area_id: "area_cucina", name: "Cucina", floor_id: "piano_terra" },
+  { area_id: "area_salotto", name: "Salotto", floor_id: "piano_terra" },
+];
+const DEVICES = [{ id: "dev_multisensore", area_id: "area_cucina" }];
+const ENTITIES = [
+  { entity_id: "sensor.cucina_temperatura", device_id: "dev_multisensore", area_id: null },
+  { entity_id: "sensor.cucina_umidita", device_id: "dev_multisensore", area_id: null },
+  { entity_id: "sensor.salotto_temperatura", device_id: null, area_id: "area_salotto" },
+  { entity_id: "light.cucina", device_id: null, area_id: "area_cucina" },
+];
+
+const seed = { schema_version: 4, sections: { rooms: [] }, visibility: {} };
+
+for (const variant of ["dashboard.html", "dashboard-en.html"]) {
+  test(`${variant}: the Config auto-detection shows what it found before writing it`, async ({
+    page,
+  }, testInfo) => {
+    // The flow waits on two Home Assistant reads and ends in a real reload, so
+    // it is slower than a render test by design.
+    test.slow();
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await page.addInitScript(
+      ({ states, areas, devices, entities }) => {
+        window.WebSocket = class extends EventTarget {
+          static OPEN = 1;
+          readyState = 1;
+          constructor() {
+            super();
+            queueMicrotask(() =>
+              this.onmessage?.({ data: JSON.stringify({ type: "auth_required" }) }),
+            );
+          }
+          send(raw) {
+            const message = JSON.parse(raw);
+            if (message.type === "auth") {
+              this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+              return;
+            }
+            const byType = {
+              get_states: states,
+              "config/area_registry/list": areas,
+              "config/device_registry/list": devices,
+              "config/entity_registry/list": entities,
+            };
+            this.onmessage?.({
+              data: JSON.stringify({
+                id: message.id,
+                type: "result",
+                success: true,
+                result: byType[message.type] || [],
+              }),
+            });
+          }
+          close() {}
+        };
+      },
+      { states: STATES, areas: AREAS, devices: DEVICES, entities: ENTITIES },
+    );
+    await bootNamespacedDashboard(page, variant, testInfo, seed);
+    await page
+      .locator("#setup-wizard")
+      .evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+    await page.evaluate((haStates) => {
+      haStates.forEach((state) => {
+        _RAW_STATES[state.entity_id] = state;
+        STATES[state.entity_id] = state;
+      });
+      apriConfigEntita();
+      editorSwitch("visib");
+    }, STATES);
+
+    // The flow ends in a real reload, so the marker below is how the test knows
+    // the page it is reading is the one that came back.
+    await page.evaluate(() => {
+      window.__dmBeforeReload = true;
+    });
+
+    /* The override replaces the runtime's own `edAutoRileva`, so a click landing
+     * before the modules finish loading legitimately gets the vendored flow.
+     * Waiting for the owner to exist keeps this test about the new behaviour
+     * rather than about how fast the machine served the modules. */
+    await page.waitForFunction(
+      () => window.__DASHBOARDMODERN_ENTITY_AUTODETECT__?.installed === true,
+    );
+    const button = page
+      .locator("#ed-body button", { hasText: /autorilevamento|auto-?detect/i })
+      .first();
+    await expect(button).toBeVisible();
+    await button.click();
+
+    const summary = page.locator("#ed-rileva-out .dm-ad-summary");
+    // The flow's own ceiling is the two Home Assistant reads; the rest of this
+    // budget is for a machine running several dashboards at once.
+    await expect(summary).toBeVisible({ timeout: 30_000 });
+    // Nothing is written until the proposal is accepted.
+    expect(
+      await page.evaluate(() => JSON.parse(localStorage.getItem("cd_stanze") || "[]")),
+    ).toEqual([]);
+
+    const rows = await summary
+      .locator(".dm-ad-row")
+      .evaluateAll((nodes) => nodes.map((node) => node.textContent.trim()));
+    expect(rows.join(" | ")).toMatch(/2/); // two rooms, two lights, one camera…
+    await expect(summary.locator(".dm-ad-link").first()).toContainText("sensor.");
+
+    await summary.locator(".dm-ad-apply").click();
+    await page.waitForFunction(
+      () => window.__dmBeforeReload === undefined && window.__DASHBOARDMODERN_LEGACY_READY__,
+      undefined,
+      { timeout: 30_000 },
+    );
+
+    const written = await page.evaluate(() => ({
+      rooms: DashboardModernModules.store.getSection("rooms"),
+      lights: JSON.parse(localStorage.getItem("cd_luci") || "{}"),
+      cameras: JSON.parse(localStorage.getItem("cd_cameras") || "[]"),
+      climate: JSON.parse(localStorage.getItem("cd_clima_units") || "[]"),
+      overrides: JSON.parse(localStorage.getItem("cd_entity_overrides") || "{}"),
+      energy: DashboardModernModules.store.getSection("energy"),
+    }));
+
+    // Rooms carry the Home Assistant area names, with the humidity twin of the
+    // area attached — the registry path the runtime could never reach in time.
+    const detected = written.rooms.filter((room) => room.temp);
+    expect(detected.map((room) => room.name).sort()).toEqual(["Cucina", "Salotto"]);
+    const kitchen = detected.find((room) => room.name === "Cucina");
+    expect(kitchen.temp).toBe("sensor.cucina_temperatura");
+    expect(kitchen.hum).toBe("sensor.cucina_umidita");
+    expect(Object.keys(written.lights).sort()).toEqual(["light.cucina", "light.salotto"]);
+    expect(written.cameras[0].entity).toBe("camera.ingresso");
+    expect(written.climate[0].entity).toBe("climate.salotto");
+
+    // Energy links land in the canonical Energy model, which is what owns those
+    // slots in schema 4 — writing them as plain overrides would be undone by the
+    // store's own projection on the next save.
+    expect(written.energy.solar.daily_energy).toBe("sensor.solaredge_produzione_oggi");
+    expect(written.energy.solar.monthly_energy).toBe("sensor.solaredge_produzione_mese");
+    expect(written.energy.battery.soc).toBe("sensor.batteria_soc");
+    // And they come back out as the legacy slots the runtime reads.
+    expect(written.overrides["dm.energy_produzione_solare_oggi"]).toBe(
+      "sensor.solaredge_produzione_oggi",
+    );
+    // Everything outside Energy stays an override, as it always was.
+    expect(written.overrides["dm.home_meteo"]).toBe("weather.casa");
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/entity-search-picker.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/entity-search-picker.spec.js
@@ -50,6 +50,9 @@ const seed = {
 };
 
 async function openTemperaturePicker(page) {
+  // The fast filter replaces the runtime's own; opening the dialog before the
+  // modules load legitimately paints the vendored list instead.
+  await page.waitForFunction(() => window.__DASHBOARDMODERN_ENTITY_SEARCH__?.installed === true);
   await page.locator('.dm-entity-picker[data-entity-target="ed-pl-temp"]').click();
   await expect(page.locator("#cd-entpick")).toBeVisible();
   await expect(page.locator("#cd-ep-list .dm-ep-row").first()).toBeVisible();

--- a/custom_components/dashboardmodern/frontend/e2e/lights-popup.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/lights-popup.spec.js
@@ -1,0 +1,225 @@
+/* The Gestione Luci popup on a real page, with a real Home Assistant socket
+ * behind it: what each light offers, and what Home Assistant is actually asked
+ * to do when the user touches it. */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [
+      { id: "room-salone", name: "Salone", icon: "mdi:sofa" },
+      { id: "room-garage", name: "Garage", icon: "mdi:garage" },
+    ],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  visibility: { home: true },
+};
+
+async function boot(page, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript(() => {
+    class MockBridgeSocket extends EventTarget {
+      static OPEN = 1;
+      readyState = 1;
+      onopen = null;
+      onmessage = null;
+      onclose = null;
+      constructor() {
+        super();
+        queueMicrotask(() => {
+          this.onopen?.({});
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+        });
+      }
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") return;
+        let result = null;
+        if (message.type === "get_states") result = [];
+        if (message.type === "frontend/get_user_data") result = { value: null };
+        globalThis.__DM_SERVICE_CALLS__ ||= [];
+        if (message.type === "call_service") globalThis.__DM_SERVICE_CALLS__.push(message);
+        queueMicrotask(() =>
+          this.onmessage?.({
+            data: JSON.stringify({ id: message.id, type: "result", success: true, result }),
+          }),
+        );
+      }
+      close() {}
+    }
+    window.WebSocket = MockBridgeSocket;
+  });
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+}
+
+async function openLights(page) {
+  await page.evaluate(() => {
+    localStorage.setItem(
+      "cd_luci",
+      JSON.stringify({
+        "light.strip": "Strip TV",
+        "light.faretti": "Faretti",
+        "switch.garage": "Lampada garage",
+      }),
+    );
+    localStorage.setItem(
+      "cd_luci_rooms",
+      JSON.stringify({
+        "light.strip": "room-salone",
+        "light.faretti": "room-salone",
+        "switch.garage": "room-garage",
+      }),
+    );
+    window.eval(`
+      _RAW_STATES['light.strip'] = { state: 'on', attributes: {
+        friendly_name: 'Strip TV', supported_color_modes: ['hs','color_temp'], color_mode: 'hs',
+        brightness: 128, rgb_color: [255, 0, 0],
+        min_color_temp_kelvin: 2202, max_color_temp_kelvin: 6535,
+        effect_list: ['Arcobaleno','Fuoco'], effect: 'Fuoco' } };
+      _RAW_STATES['light.faretti'] = { state: 'on', attributes: {
+        friendly_name: 'Faretti', supported_color_modes: ['brightness'], brightness: 255 } };
+      _RAW_STATES['switch.garage'] = { state: 'off', attributes: { friendly_name: 'Lampada garage' } };
+      Object.assign(STATES, _RAW_STATES);
+    `);
+    globalThis.__DM_SERVICE_CALLS__ = [];
+    window.apriGestioneLuci(true);
+  });
+  await expect(page.locator('#details-list [data-dm-light="light.strip"]')).toBeVisible();
+}
+
+const calls = (page) => page.evaluate(() => globalThis.__DM_SERVICE_CALLS__ || []);
+
+test("every light in the popup gets the controls its entity declares", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
+  await boot(page, testInfo);
+  await openLights(page);
+
+  const strip = page.locator('#details-list [data-dm-light="light.strip"]');
+  const spots = page.locator('#details-list [data-dm-light="light.faretti"]');
+  const relay = page.locator('#details-list [data-dm-light="switch.garage"]');
+
+  // The card is painted with the colour the lamp is emitting, not with the
+  // dashboard's amber.
+  await expect(strip).toHaveAttribute("style", /--dm-light-color:#ff0000/);
+  await expect(strip.locator(".lgx-state")).toHaveText("ACCESA · 50%");
+  await expect(strip.locator('.dm-lightx-badge[data-kind="rgb"]')).toBeVisible();
+
+  // A dimmer gets its dimmer on the card; a relay gets neither a dimmer nor a
+  // controls button, because it has nothing to tune.
+  await expect(strip.locator("[data-dm-light-brightness]")).toHaveCount(1);
+  await expect(spots.locator("[data-dm-light-brightness]")).toHaveCount(1);
+  await expect(relay.locator("[data-dm-light-brightness]")).toHaveCount(0);
+  await expect(relay.locator("[data-dm-light-open]")).toHaveCount(0);
+  await expect(relay.locator('.dm-lightx-badge[data-kind="switch"]')).toBeVisible();
+  await expect(relay.locator(".lgx-state")).toHaveText("SPENTA");
+
+  // The room heading counts its own lights and can switch them as a group.
+  const salone = page.locator('#details-list [data-dm-light-group="Salone"]');
+  await expect(salone.locator(".dm-lightx-room-count")).toHaveText("2/2");
+  await expect(salone.locator("[data-dm-light-room]")).toHaveText("Spegni");
+});
+
+test("a switch configured as a light is switched, never dimmed", async ({ page }, testInfo) => {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
+  await boot(page, testInfo);
+  await openLights(page);
+
+  await page.locator('[data-dm-light="switch.garage"] [data-dm-light-toggle]').click();
+  await expect
+    .poll(async () => (await calls(page)).at(-1))
+    .toMatchObject({
+      domain: "switch",
+      service: "turn_on",
+      service_data: { entity_id: "switch.garage" },
+    });
+});
+
+test("the control sheet sends brightness, colour and white the lamp accepts", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
+  await boot(page, testInfo);
+  await openLights(page);
+
+  await page.locator('[data-dm-light="light.strip"] [data-dm-light-open]').click();
+  const sheet = page.locator("#dm-light-control-modal");
+  await expect(sheet).toBeVisible();
+  await expect(sheet.locator('[data-block="brightness"]')).toBeVisible();
+  await expect(sheet.locator('[data-block="color"]')).toBeVisible();
+  await expect(sheet.locator('[data-block="white"]')).toBeVisible();
+  await expect(sheet.locator('[data-block="effect"] select')).toHaveValue("Fuoco");
+
+  await sheet.locator('[data-dm-light-color="#2f7bff"]').click();
+  await expect
+    .poll(async () => (await calls(page)).at(-1))
+    .toMatchObject({
+      domain: "light",
+      service: "turn_on",
+      service_data: { entity_id: "light.strip", rgb_color: [47, 123, 255] },
+    });
+
+  await sheet.locator("[data-dm-light-brightness-preset='25']").click();
+  await expect
+    .poll(async () => (await calls(page)).at(-1))
+    .toMatchObject({
+      domain: "light",
+      service: "turn_on",
+      service_data: { entity_id: "light.strip", brightness_pct: 25 },
+    });
+  // The value the user just asked for stays on screen while Home Assistant
+  // still reports the old one.
+  await expect(sheet.locator("[data-dm-light-level]")).toHaveText("25%");
+
+  await sheet.locator("[data-dm-light-kelvin-preset='2700']").click();
+  await expect
+    .poll(async () => (await calls(page)).at(-1))
+    .toMatchObject({
+      domain: "light",
+      service: "turn_on",
+      service_data: { entity_id: "light.strip", color_temp_kelvin: 2700 },
+    });
+
+  await sheet.locator("[data-close]").click();
+  await expect(page.locator("#dm-light-control-modal")).toHaveCount(0);
+});
+
+test("the popup keeps the slider the user is holding while the runtime ticks", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
+  await boot(page, testInfo);
+  await openLights(page);
+
+  const range = page.locator('[data-dm-light="light.strip"] [data-dm-light-brightness]');
+  await range.evaluate((node) => {
+    node.value = "12";
+    node.dispatchEvent(new Event("input", { bubbles: true }));
+    node.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  await expect
+    .poll(async () => (await calls(page)).at(-1))
+    .toMatchObject({
+      domain: "light",
+      service: "turn_on",
+      service_data: { entity_id: "light.strip", brightness_pct: 12 },
+    });
+
+  // Home Assistant is still reporting 50%: the repaint must not drag the
+  // handle back under the finger.
+  await page.evaluate(() => window.updateGestioneLuci());
+  await expect(range).toHaveValue("12");
+  await expect(page.locator('[data-dm-light="light.strip"] .lgx-state')).toHaveText("ACCESA · 12%");
+});

--- a/custom_components/dashboardmodern/frontend/e2e/navbar-desktop-scroll.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/navbar-desktop-scroll.spec.js
@@ -1,0 +1,155 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { revealBottomNavigation, waitForStableBox } from "./helpers/navigation.js";
+
+// Screenshot-proven regression: with every section enabled the desktop dock is
+// wider than the screen. It is fixed and centered, so the page scroll never
+// moves it and the last sections stayed off screen with no way to reach them.
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  visibility: { home: true },
+};
+
+const SECTION_KEYS = [
+  "home",
+  "energy",
+  "appliances",
+  "ev",
+  "boiler",
+  "clima",
+  "temp",
+  "security",
+  "server",
+  "tapparelle",
+  "irrigazione",
+  "piscina",
+];
+
+async function bootWithEverySectionVisible(page, testInfo, viewport) {
+  await page.setViewportSize(viewport);
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+  await page.locator("#setup-wizard").evaluateAll((nodes) => nodes.forEach((n) => n.remove()));
+  await page.evaluate((keys) => {
+    localStorage.setItem(
+      "cd_sections",
+      JSON.stringify(Object.fromEntries(keys.map((key) => [key, true]))),
+    );
+    window.cdApplyNavVis?.();
+    document.querySelectorAll(".tab[data-tab]").forEach((tab) => {
+      tab.style.removeProperty("display");
+    });
+  }, SECTION_KEYS);
+  // The scroll port belongs to the modular runtime, which boots after the
+  // legacy bar is already on screen.
+  await expect(page.locator("nav.tabs.bottom-nav-bar .dm-nav-scroll")).toBeAttached();
+}
+
+const portMetrics = (page) =>
+  page.evaluate(() => {
+    const nav = document.querySelector("nav.tabs.bottom-nav-bar");
+    const port = nav.querySelector(".dm-nav-scroll");
+    const tabs = [...nav.querySelectorAll(".tab")].filter(
+      (tab) => getComputedStyle(tab).display !== "none",
+    );
+    const last = tabs.at(-1).getBoundingClientRect();
+    const box = port.getBoundingClientRect();
+    return {
+      display: getComputedStyle(port).display,
+      canScroll: nav.classList.contains("dm-nav-can-scroll"),
+      scrollLeft: Math.round(port.scrollLeft),
+      overflow: port.scrollWidth - port.clientWidth,
+      lastTab: tabs.at(-1).dataset.tab,
+      lastTabVisible: last.left >= box.left - 2 && last.right <= box.right + 2,
+    };
+  });
+
+// The dock slides in and out on hover, and a bar that is mid-transition is not
+// a stable click target. The shipped "barra fissa" mode pins it open, which is
+// the same layout with the animation out of the way.
+async function pinDock(page) {
+  const nav = page.locator("nav.tabs.bottom-nav-bar");
+  await page.evaluate(() => document.body.classList.add("cd-nav-fixed"));
+  await waitForStableBox(nav);
+  await expect
+    .poll(async () => {
+      const box = await nav.boundingBox();
+      return Math.round((await page.evaluate(() => window.innerHeight)) - box.y - box.height);
+    })
+    .toBe(18);
+  return nav;
+}
+
+test("the desktop dock scrolls to the sections that do not fit", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "desktop", "the scroll port is the fine-pointer layout");
+  test.setTimeout(80_000);
+  await bootWithEverySectionVisible(page, testInfo, { width: 1180, height: 800 });
+  const nav = await pinDock(page);
+
+  const start = await portMetrics(page);
+  expect(start.display).toBe("flex");
+  expect(start.canScroll).toBe(true);
+  expect(start.overflow).toBeGreaterThan(0);
+  expect(start.lastTabVisible).toBe(false);
+
+  const previous = page.locator(".dm-nav-arrow-prev");
+  const next = page.locator(".dm-nav-arrow-next");
+  await expect(previous).toBeDisabled();
+  await expect(next).toBeEnabled();
+
+  await next.click();
+  await expect.poll(async () => (await portMetrics(page)).lastTabVisible).toBe(true);
+  await expect(previous).toBeEnabled();
+
+  // The vertical wheel of a plain mouse is the only scroll gesture a desktop
+  // always has, so over the dock it has to move it sideways.
+  const box = await nav.boundingBox();
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.wheel(0, -1200);
+  await expect.poll(async () => (await portMetrics(page)).scrollLeft).toBe(0);
+  await expect(previous).toBeDisabled();
+
+  // Dragging the bar scrolls it and must not land on the tab under the pointer.
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width / 2 - 220, box.y + box.height / 2, { steps: 12 });
+  await page.mouse.up();
+  await expect.poll(async () => (await portMetrics(page)).scrollLeft).toBeGreaterThan(0);
+  await expect(page.locator("#page-home")).toHaveClass(/active/);
+
+  // Scrolling must not cost a click: the tabs still switch page.
+  const tab = page.locator('.tab[data-tab="clima"]');
+  await tab.click();
+  await expect(page.locator("#page-clima")).toHaveClass(/active/);
+});
+
+test("the touch bar keeps the scrolling it already had", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "desktop", "covers the coarse-pointer layout");
+  test.setTimeout(120_000);
+  await bootWithEverySectionVisible(page, testInfo, { width: 390, height: 844 });
+  await revealBottomNavigation(page);
+
+  const metrics = await portMetrics(page);
+  expect(metrics.display).toBe("contents");
+  expect(metrics.canScroll).toBe(false);
+  await expect(page.locator(".dm-nav-arrow-next")).toBeHidden();
+  const navOverflow = await page.evaluate(() => {
+    const nav = document.querySelector("nav.tabs.bottom-nav-bar");
+    return nav.scrollWidth - nav.clientWidth;
+  });
+  expect(navOverflow).toBeGreaterThan(0);
+});

--- a/custom_components/dashboardmodern/frontend/e2e/temperature-trend-panel.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/temperature-trend-panel.spec.js
@@ -1,0 +1,108 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+/* The Temperature page says how a room is now; the panel under the cards says
+ * how it has been. It reads the room selection from the tab strip — the single
+ * owner of that state — so picking a room draws that room's probes, and "all"
+ * compares the rooms. The history comes from the same
+ * history/history_during_period the card popup already uses. */
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [
+      {
+        id: "r1",
+        name: "Cameretta",
+        icon: "🛏️",
+        temp: "sensor.a_temperature",
+        hum: "sensor.a_humidity",
+        temp_name: "Cameretta",
+        metadata: {
+          temperature_entries: [
+            {
+              id: "temperature-extra-1",
+              name: "Seconda sonda",
+              temp: "sensor.b_temperature",
+              hum: "sensor.b_humidity",
+            },
+          ],
+        },
+      },
+      {
+        id: "r2",
+        name: "Matrimoniale",
+        icon: "🛏️",
+        temp: "sensor.c_temperature",
+        hum: "sensor.c_humidity",
+        temp_name: "Pippo",
+      },
+    ],
+  },
+  visibility: { temp: true },
+};
+const states = [
+  { entity_id: "sensor.a_temperature", state: "31.4", attributes: { unit_of_measurement: "°C" } },
+  { entity_id: "sensor.a_humidity", state: "54", attributes: { unit_of_measurement: "%" } },
+  { entity_id: "sensor.c_temperature", state: "30.8", attributes: { unit_of_measurement: "°C" } },
+];
+test("the trend panel follows the room tabs", async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 900 });
+  await page.route("https://**", (r) => r.fulfill({ status: 200, body: "" }));
+  await page.addInitScript((haStates) => {
+    window.WebSocket = class extends EventTarget {
+      static OPEN = 1;
+      readyState = 1;
+      constructor() {
+        super();
+        queueMicrotask(() => this.onmessage?.({ data: JSON.stringify({ type: "auth_required" }) }));
+      }
+      send(raw) {
+        const m = JSON.parse(raw);
+        if (m.type === "auth") {
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+          return;
+        }
+        let result = [];
+        if (m.type === "get_states") result = haStates;
+        if (m.type === "history/history_during_period") {
+          const entity = m.entity_ids?.[0];
+          const end = Date.now();
+          const rows = [];
+          for (let i = 96; i >= 0; i -= 1)
+            rows.push({
+              s: (24 + Math.sin(i / 8) * 4).toFixed(1),
+              lu: (end - i * 15 * 60 * 1000) / 1000,
+            });
+          result = { [entity]: rows };
+        }
+        this.onmessage?.({
+          data: JSON.stringify({ id: m.id, type: "result", success: true, result }),
+        });
+      }
+      close() {}
+    };
+  }, states);
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+  await page.locator("#setup-wizard").evaluateAll((n) => n.forEach((x) => x.remove()));
+  await page.evaluate((haStates) => {
+    haStates.forEach((s) => {
+      _RAW_STATES[s.entity_id] = s;
+      STATES[s.entity_id] = s;
+    });
+    document.querySelectorAll(".page").forEach((n) => n.classList.remove("active"));
+    document.getElementById("page-temp")?.classList.add("active");
+    window.render?.();
+    window.buildTempCards?.();
+  }, states);
+  const panel = page.locator("#dm-temperature-trend");
+  await expect(panel).toHaveAttribute("data-state", "ready", { timeout: 8000 });
+  await expect(panel.locator(".dm-trend-title")).toHaveText("Tutte le stanze");
+  expect(await panel.locator(".dm-trend-series").count()).toBe(2);
+  await page.locator('#dm-beta16-temperature-tabs button[data-room-filter="r1"]').click();
+  await expect(panel.locator(".dm-trend-title")).toHaveText("Cameretta");
+  await expect.poll(() => panel.locator(".dm-trend-series").count()).toBe(2);
+  await expect
+    .poll(() => panel.locator(".dm-trend-chip-name").allTextContents())
+    .toEqual(["Cameretta", "Seconda sonda"]);
+});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.7","dashboardVersion":"1.0.0-beta.30.7","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T09:17:16+00:00","commit":"01c15ed97f058ada25bc5d391c5a1f9c7de9f962","assetHash":"3ec0b59360afae15"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.8","dashboardVersion":"1.0.0-beta.30.8","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T09:19:10+00:00","commit":"b15ec4159ffc45ddf4ab60ff5ff7852d3f4a826a","assetHash":"981c78b9164021b1"});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.7","dashboardVersion":"1.0.0-beta.30.7","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T08:13:34+00:00","commit":"c56a521e1c66327306defc11b83efd303b1668ce","assetHash":"c05f717b5b91b0e8"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.7","dashboardVersion":"1.0.0-beta.30.7","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T08:37:34+00:00","commit":"9921128e35962ee1b1f0268713220c07374661d7","assetHash":"884e9e66bd72face"});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.8","dashboardVersion":"1.0.0-beta.30.8","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T09:19:10+00:00","commit":"b15ec4159ffc45ddf4ab60ff5ff7852d3f4a826a","assetHash":"981c78b9164021b1"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.8","dashboardVersion":"1.0.0-beta.30.8","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T09:27:11+00:00","commit":"1fbf366326e90603aa8541e360560c94cee3283f","assetHash":"6d79b590334f69e8"});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.7","dashboardVersion":"1.0.0-beta.30.7","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T07:47:00+00:00","commit":"89d6cdb808549337e76498dad6a89c191ee83fe8","assetHash":"d30644a0bc1a59b2"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.7","dashboardVersion":"1.0.0-beta.30.7","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T08:13:34+00:00","commit":"c56a521e1c66327306defc11b83efd303b1668ce","assetHash":"c05f717b5b91b0e8"});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.7","dashboardVersion":"1.0.0-beta.30.7","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T08:37:34+00:00","commit":"9921128e35962ee1b1f0268713220c07374661d7","assetHash":"884e9e66bd72face"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.7","dashboardVersion":"1.0.0-beta.30.7","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T09:17:16+00:00","commit":"01c15ed97f058ada25bc5d391c5a1f9c7de9f962","assetHash":"3ec0b59360afae15"});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.7","dashboardVersion":"1.0.0-beta.30.7","moduleVersion":14,"schemaVersion":4,"date":"2026-08-17T21:53:28+00:00","commit":"869d9875795375940a5ebcf52f79c0bfc1aa80ab","assetHash":"d2d5f1c3c66bac16"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.7","dashboardVersion":"1.0.0-beta.30.7","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T07:47:00+00:00","commit":"89d6cdb808549337e76498dad6a89c191ee83fe8","assetHash":"d30644a0bc1a59b2"});

--- a/custom_components/dashboardmodern/frontend/src/core/entity-autodetect.js
+++ b/custom_components/dashboardmodern/frontend/src/core/entity-autodetect.js
@@ -1,0 +1,712 @@
+/* Auto-detection: what the 🪄 button behind Config actually decides.
+ *
+ * The vendored `wzAutoDetect` walks every entity of the instance once per slot,
+ * and inside that loop it lowercases the id and the name and splits both with a
+ * regular expression. With 96 slots and a few thousand entities that is a few
+ * hundred thousand string splits on the main thread, which is why the button
+ * freezes the page before the reload. It is also the reason it cannot afford to
+ * be any smarter than it is.
+ *
+ * This module inverts the problem. The entity index (`entity-search-index.js`)
+ * already folded and tokenized everything once, so here we add a posting list —
+ * token to entities — and a slot only ever looks at the entities that share a
+ * word with it. A slot label is parsed once into what it is actually asking
+ * for: the unit in its parentheses, the device class the unit implies, the
+ * domain a word like "Script" or "Interruttore" implies, and the period
+ * ("oggi", "mese", "anno") it belongs to. That turns most of the matching into
+ * constraints instead of guesses.
+ *
+ * The other change is how the winners are chosen. The old loop walked slots in
+ * declaration order and let each one take the best entity still free, so an
+ * early slot with a weak claim could take the entity a later slot matched
+ * perfectly. Here every (slot, entity) pair is scored first and the assignment
+ * runs over all of them by confidence, so the strongest claim wins wherever it
+ * sits in the list — and a slot whose best two candidates are equally plausible
+ * is reported as undecided instead of being filled with a coin flip.
+ *
+ * Pure: no DOM, no storage, no globals. The section around it owns the
+ * fetching, the progress and the writing.
+ */
+import { entityTokens, foldText, tokenize } from "./entity-search-index.js";
+
+/* ── Slot labels ──────────────────────────────────────────────────────────── */
+
+/* The parenthesis at the end of a slot label is the most reliable thing about
+ * it: "Produzione solare oggi (kWh)" states the unit, "Modalità ricarica EVCC
+ * (select)" states the domain. The old detector only read units, and only
+ * through a handful of regular expressions over the whole label. */
+const TYPE_HINTS = Object.freeze([
+  { match: /^kwh$/i, units: ["kWh", "Wh", "MWh"], dc: ["energy"], domains: ["sensor"] },
+  { match: /^w$/i, units: ["W", "kW"], dc: ["power"], domains: ["sensor"] },
+  { match: /^%$/, units: ["%"], dc: [], domains: ["sensor"] },
+  { match: /^°c$/i, units: ["°C", "°F"], dc: ["temperature"], domains: ["sensor"] },
+  { match: /^v$/i, units: ["V"], dc: ["voltage"], domains: ["sensor"] },
+  { match: /^a$/i, units: ["A"], dc: ["current"], domains: ["sensor"] },
+  { match: /^bar$/i, units: ["bar", "hPa", "psi"], dc: ["pressure"], domains: ["sensor"] },
+  { match: /^km$/i, units: ["km", "mi"], dc: ["distance"], domains: ["sensor"] },
+  { match: /^ms$/i, units: ["ms"], dc: [], domains: ["sensor"] },
+  {
+    match: /^mbit\/s$/i,
+    units: ["Mbit/s", "Mbps", "MB/s"],
+    dc: ["data_rate"],
+    domains: ["sensor"],
+  },
+  { match: /^select$/i, units: [], dc: [], domains: ["select", "input_select"] },
+  { match: /^switch/i, units: [], dc: [], domains: ["switch", "input_boolean"] },
+  { match: /^binary$/i, units: [], dc: [], domains: ["binary_sensor"] },
+  { match: /^cover$/i, units: [], dc: [], domains: ["cover"] },
+  { match: /^testo$|^text$/i, units: [], dc: [], domains: ["sensor", "input_text"] },
+  { match: /weather/i, units: [], dc: [], domains: ["weather"] },
+  { match: /alarm_control_panel/i, units: [], dc: [], domains: ["alarm_control_panel"] },
+  { match: /^on\/off-grid$/i, units: [], dc: [], domains: ["sensor", "binary_sensor"] },
+]);
+
+/* A leading word can be as strong as the parenthesis: every "Script …" slot
+ * wants a script, every "Interruttore …" slot wants something switchable. */
+const LEAD_HINTS = Object.freeze([
+  { match: /^script\b/i, domains: ["script", "scene", "automation"] },
+  { match: /^interruttore\b|^presa\b/i, domains: ["switch", "input_boolean"] },
+  { match: /^valvola\b/i, domains: ["cover", "valve", "switch"] },
+  { match: /^pompa\b/i, domains: ["switch", "input_boolean", "sensor", "binary_sensor"] },
+  { match: /^centrale\s+allarme|^allarme\b/i, domains: ["alarm_control_panel"] },
+  { match: /^meteo\b/i, domains: ["weather"] },
+]);
+
+const STOP = new Set([
+  "di",
+  "del",
+  "della",
+  "delle",
+  "dei",
+  "dal",
+  "dalla",
+  "con",
+  "per",
+  "nel",
+  "una",
+  "uno",
+  "il",
+  "lo",
+  "la",
+  "le",
+  "in",
+  "da",
+  "al",
+  "su",
+  "un",
+  "on",
+  "of",
+  "to",
+  "by",
+  "at",
+  "and",
+  "the",
+  "for",
+  "entita",
+  "entity",
+  "sensore",
+  "sensor",
+  "stato",
+  "valore",
+  "non",
+  "smart",
+  "che",
+  "solo",
+  "dispositivo",
+  "manuale",
+  "testo",
+  "select",
+  "switch",
+  "binary",
+  "cover",
+  "weather",
+  "text",
+]);
+
+/* Italian label, English entity names: without this table the detector only
+ * ever finds the entities of an Italian-speaking installation. Each key is a
+ * word that appears in a slot label; the values are what the same thing is
+ * called in an entity id. */
+const SYNONYMS = Object.freeze({
+  produzione: [
+    "production",
+    "yield",
+    "generated",
+    "generation",
+    "pv",
+    "solar",
+    "fotovoltaico",
+    "photovoltaic",
+  ],
+  solare: ["solar", "pv", "fotovoltaico", "photovoltaic"],
+  fotovoltaico: [
+    "pv",
+    "solar",
+    "photovoltaic",
+    "solarman",
+    "fronius",
+    "growatt",
+    "solaredge",
+    "huawei",
+    "goodwe",
+    "sungrow",
+    "enphase",
+    "sma",
+    "victron",
+  ],
+  consumo: ["consumption", "load", "used", "usage", "assorbimento"],
+  casa: ["house", "home"],
+  prelevata: ["import", "imported", "bought", "purchased", "from_grid", "grid_consumption"],
+  prelievo: ["import", "imported", "bought", "purchased", "from_grid"],
+  immessa: ["export", "exported", "sold", "returned", "feed_in", "to_grid", "injected"],
+  acquistata: ["bought", "import", "imported", "purchased"],
+  venduta: ["sold", "export", "exported", "feed_in"],
+  rete: ["grid", "mains", "net"],
+  scambio: ["grid", "exchange", "external", "net"],
+  batteria: [
+    "battery",
+    "batt",
+    "soc",
+    "accumulo",
+    "storage",
+    "bms",
+    "pylontech",
+    "powerwall",
+    "sonnen",
+  ],
+  caricata: ["charged", "charge", "charging"],
+  scaricata: ["discharged", "discharge"],
+  usata: ["discharge", "discharged", "used"],
+  carica: ["charge", "soc", "charging"],
+  potenza: ["power", "watt", "watts", "active_power"],
+  energia: ["energy", "kwh"],
+  somma: ["sum", "total", "totale"],
+  totale: ["total", "lifetime", "cumulative", "overall"],
+  temperatura: ["temperature", "temp"],
+  umidita: ["humidity", "hum"],
+  tensione: ["voltage", "volt"],
+  corrente: ["current", "amperage"],
+  pressione: ["pressure"],
+  inverter: ["inverter"],
+  ventola: ["fan", "cooling"],
+  boiler: ["boiler", "water_heater", "dhw", "acs", "scaldabagno", "termoaccumulo", "puffer"],
+  resistenza: ["resistance", "heater", "element", "heating_element"],
+  centralina: ["controller", "control", "regulator"],
+  pompa: ["pump", "circulator"],
+  sonda: ["probe", "ds18b20", "sonde"],
+  delta: ["delta", "diff", "difference"],
+  valvola: ["valve"],
+  sicurezza: ["safety", "security"],
+  clima: [
+    "climate",
+    "ac",
+    "air_conditioner",
+    "hvac",
+    "condizionatore",
+    "split",
+    "daikin",
+    "melcloud",
+    "sensibo",
+  ],
+  condizionatori: ["climate", "ac", "air_conditioner", "hvac", "condizionatore"],
+  cucina: ["kitchen"],
+  lavanderia: ["laundry"],
+  lavatrice: ["washing", "washer", "washing_machine"],
+  centrifuga: ["spin", "spin_speed"],
+  programma: ["program", "course", "cycle"],
+  fase: ["phase", "cycle", "status"],
+  rimanente: ["remaining", "left", "time_remaining"],
+  tempo: ["time", "remaining"],
+  avvio: ["start", "power", "run"],
+  ciclo: ["cycle", "wash"],
+  presa: ["plug", "socket", "outlet", "switch"],
+  auto: ["car", "vehicle", "ev"],
+  autonomia: ["range", "autonomy"],
+  odometro: ["odometer", "mileage"],
+  ricarica: ["charge", "charging", "charger"],
+  wallbox: [
+    "wallbox",
+    "charger",
+    "evse",
+    "evcc",
+    "ocpp",
+    "keba",
+    "wattpilot",
+    "easee",
+    "zappi",
+    "goe",
+  ],
+  evcc: ["evcc", "loadpoint"],
+  sessione: ["session", "charged", "charge_session"],
+  limite: ["limit", "target", "threshold"],
+  target: ["target", "setpoint", "limit"],
+  modalita: ["mode", "modo"],
+  percentuale: ["percentage", "percent", "pct"],
+  km: ["km", "distance", "range", "mileage"],
+  ultima: ["last", "latest"],
+  cpu: ["cpu", "processor", "processore"],
+  ram: ["ram", "memory", "mem"],
+  disco: ["disk", "storage", "ssd", "hdd", "use"],
+  uptime: ["uptime", "boot", "last_boot"],
+  minipc: ["minipc", "nas", "server", "raspberry", "rpi", "proxmox", "synology", "host", "system"],
+  server: ["server", "minipc", "nas", "raspberry", "rpi", "proxmox", "synology", "host", "system"],
+  raspberry: ["raspberry", "rpi", "pi"],
+  internet: ["internet", "wan", "online", "connectivity", "reachable", "ping"],
+  ping: ["ping", "latency"],
+  raggiungibilita: ["reachable", "reachability", "online", "ping"],
+  google: ["google", "dns", "8_8_8_8"],
+  speedtest: ["speedtest", "fast_com", "ookla"],
+  download: ["download", "down"],
+  upload: ["upload", "up"],
+  meteo: ["weather", "forecast"],
+  allarme: ["alarm", "antifurto", "alarmo", "alarm_control_panel"],
+  antifurto: ["alarm", "antifurto", "security"],
+  cancello: ["gate", "garage", "portone", "door_opener"],
+  apertura: ["open", "opening", "apri"],
+  telecamera: ["camera", "cam"],
+  luce: ["light", "lamp", "led"],
+  stanza: ["room", "area"],
+  giornaliera: ["daily", "today", "oggi"],
+  oggi: ["daily", "today", "giornalier"],
+  mese: ["month", "monthly", "mensile"],
+  anno: ["year", "annual", "yearly", "annuale"],
+  nodo: ["node", "circuit", "linea"],
+  carichi: ["load", "loads", "carico"],
+  rapido: ["quick", "rapid", "fast", "express"],
+  misto: ["mixed", "misto"],
+  colorati: ["color", "colour", "colorati"],
+});
+
+/* The table above is written Italian-first because the slot labels are, but the
+ * English build asks the same questions in English ("Photovoltaic power (W)").
+ * Reading it in both directions costs one pass at load and means one table
+ * instead of two that can disagree. */
+const EXPANSIONS = (() => {
+  const map = new Map();
+  const link = (word, group) => {
+    const current = map.get(word) || new Set([word]);
+    for (const other of group) current.add(other);
+    map.set(word, current);
+  };
+  for (const [key, aliases] of Object.entries(SYNONYMS)) {
+    const group = [key, ...aliases];
+    for (const word of group) link(word, group);
+  }
+  return new Map([...map.entries()].map(([word, group]) => [word, [...group].slice(0, 12)]));
+})();
+
+export function expandWord(word) {
+  return EXPANSIONS.get(word) || [word];
+}
+
+const PERIODS = Object.freeze({
+  d: ["oggi", "daily", "today", "giornalier", "giornaliera", "day"],
+  m: ["mese", "mensile", "month", "monthly"],
+  y: ["anno", "annuale", "annual", "year", "yearly"],
+});
+
+export function periodOf(text) {
+  const folded = foldText(text);
+  for (const [period, words] of Object.entries(PERIODS)) {
+    if (words.some((word) => folded.includes(word))) return period;
+  }
+  return "";
+}
+
+/** Read one slot label into the constraints it is really expressing. */
+export function parseSlotPlan(slot, section = "") {
+  const label = String(slot?.lbl || "");
+  /* Everything after an em dash is prose for the person configuring, not part
+   * of what the slot is asking for. */
+  const head = label.split("—")[0];
+  const units = new Set();
+  const deviceClasses = new Set();
+  const domains = new Set();
+
+  for (const raw of head.match(/\(([^)]*)\)/g) || []) {
+    const inner = raw.slice(1, -1).trim();
+    for (const hint of TYPE_HINTS) {
+      if (!hint.match.test(inner)) continue;
+      hint.units.forEach((unit) => units.add(unit));
+      hint.dc.forEach((dc) => deviceClasses.add(dc));
+      hint.domains.forEach((domain) => domains.add(domain));
+      break;
+    }
+  }
+  const bare = head.replace(/\([^)]*\)/g, " ").trim();
+  for (const hint of LEAD_HINTS) {
+    if (hint.match.test(bare)) {
+      hint.domains.forEach((domain) => domains.add(domain));
+      break;
+    }
+  }
+
+  /* Two letters and single digits stay: "Temperatura AC inverter" and
+   * "Temperatura DC inverter" are the same label without them, and "Sonda
+   * temperatura 1" is the same as 2 and 3. Dropping them is what made those
+   * slots indistinguishable, and therefore undecidable. */
+  const words = tokenize(foldText(bare)).filter(
+    (word) => !STOP.has(word) && (word.length >= 2 || /^[0-9]$/.test(word)),
+  );
+  const keys = words.map((word) => expandWord(word));
+
+  return {
+    ref: String(slot?.ref || ""),
+    label,
+    section,
+    keys,
+    units: [...units],
+    deviceClasses: [...deviceClasses],
+    domains: [...domains],
+    period: periodOf(bare),
+    cumulative: units.has("kWh") && /totale|total|lifetime|anno|annual/i.test(bare),
+  };
+}
+
+/* ── Posting lists ────────────────────────────────────────────────────────── */
+
+/**
+ * token → entities, plus a four-letter prefix bucket so "temperatur" still
+ * reaches "temperatura" and "temperature" without scanning the instance.
+ */
+export function buildPostings(records) {
+  const exact = new Map();
+  const prefix = new Map();
+  records.forEach((record, position) => {
+    const seen = new Set();
+    for (const token of entityTokens(record)) {
+      if (seen.has(token)) continue;
+      seen.add(token);
+      let list = exact.get(token);
+      if (!list) exact.set(token, (list = []));
+      list.push(position);
+      if (token.length < 4) continue;
+      const head = token.slice(0, 4);
+      let bucket = prefix.get(head);
+      if (!bucket) prefix.set(head, (bucket = []));
+      if (bucket[bucket.length - 1] !== position) bucket.push(position);
+    }
+  });
+  return { exact, prefix, size: records.length };
+}
+
+/* Candidates are gathered with a stamp array instead of a Set: the same list is
+ * rebuilt once per slot, and allocating a Set per slot is the kind of cost this
+ * module exists to remove. */
+function gatherCandidates(plan, postings, stamps, stamp, out) {
+  out.length = 0;
+  for (const aliases of plan.keys) {
+    for (const alias of aliases) {
+      const lists = [postings.exact.get(alias)];
+      if (alias.length >= 4) lists.push(postings.prefix.get(alias.slice(0, 4)));
+      for (const list of lists) {
+        if (!list) continue;
+        for (const position of list) {
+          if (stamps[position] === stamp) continue;
+          stamps[position] = stamp;
+          out.push(position);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/* ── Scoring ──────────────────────────────────────────────────────────────── */
+
+const UNAVAILABLE = new Set(["unavailable", "unknown", "none", ""]);
+
+function tokenMatches(tokens, alias) {
+  for (const token of tokens) {
+    if (token === alias || (alias.length >= 4 && token.startsWith(alias))) return true;
+  }
+  return false;
+}
+
+/**
+ * Score one entity against one slot. `-Infinity` means the entity cannot belong
+ * to the slot at all: a wrong domain, or a "mese" sensor under an "oggi" slot.
+ */
+export function scoreSlotCandidate(record, plan) {
+  if (plan.domains.length && !plan.domains.includes(record.domain)) return -Infinity;
+  if (plan.period) {
+    const entityPeriod = periodOf(record.hay);
+    if (entityPeriod && entityPeriod !== plan.period) return -Infinity;
+  }
+
+  let score = 0;
+  let covered = 0;
+  let idHits = 0;
+  for (const aliases of plan.keys) {
+    let hit = 0;
+    for (const alias of aliases) {
+      if (tokenMatches(record.idTokens, alias)) {
+        hit = 3.2;
+        idHits += 1;
+        break;
+      }
+      if (tokenMatches(record.nameTokens, alias)) hit = Math.max(hit, 2);
+      else if (record.areaFold && tokenMatches(record.areaTokens, alias)) hit = Math.max(hit, 1.4);
+    }
+    if (hit > 0) {
+      covered += 1;
+      score += hit;
+    }
+  }
+  const needed = Math.max(1, Math.ceil(plan.keys.length * 0.6) - (hasNarrowDomain(plan) ? 1 : 0));
+  if (covered < needed) return -Infinity;
+
+  if (plan.deviceClasses.length) {
+    if (record.dc && plan.deviceClasses.includes(record.dc)) score += 6;
+    else if (record.dc) score -= 2.5;
+  }
+  if (plan.units.length) {
+    if (record.unit && plan.units.includes(record.unit)) score += 5;
+    else if (record.unit) return -Infinity; /* a slot in kWh is never a sensor in °C */
+    else score -= 1.5;
+  }
+  if (plan.cumulative && (record.sc === "total" || record.sc === "total_increasing")) score += 2.5;
+  if (UNAVAILABLE.has(String(record.state).toLowerCase())) score -= 2;
+  score -= Math.min(record.id.length, 80) * 0.02;
+  return score + idHits * 0.2;
+}
+
+/* A stated domain that only a handful of entities in a house can satisfy —
+ * `weather`, `script`, `alarm_control_panel`, `select` — is evidence in itself,
+ * worth about one word of the label. Without it "Centrale allarme
+ * (alarm_control_panel)" rejects the only alarm panel there is, because the
+ * entity is called "Antifurto" and so matches one of the label's two words. */
+function hasNarrowDomain(plan) {
+  return plan.domains.length > 0 && !plan.domains.includes("sensor");
+}
+
+function minimumScore(plan) {
+  let base = plan.keys.length === 1 ? 3 : Math.max(5, plan.keys.length * 2);
+  /* A unit or a device class is evidence the words alone cannot give, so a slot
+   * that carries one can accept a slightly thinner word match. */
+  if (plan.units.length || plan.deviceClasses.length) base -= 1.5;
+  if (hasNarrowDomain(plan)) base -= 2.5;
+  /* The floor cannot sit above what a single friendly-name match is worth, or a
+   * one-word slot like "Meteo (entità weather)" rejects the only weather entity
+   * in the house for being called "Meteo casa" rather than "meteo". */
+  return Math.max(1.5, base);
+}
+
+/* ── Assignment ───────────────────────────────────────────────────────────── */
+
+const CANDIDATES_PER_SLOT = 4;
+
+/**
+ * Propose one entity per slot.
+ *
+ * Every slot's best few candidates are scored first, then the assignment walks
+ * all of them by confidence: the strongest claim on an entity wins no matter
+ * where its slot sits in the list. A slot whose two best candidates are within
+ * `margin` of each other is left undecided and reported, because filling it
+ * with the first of two equally good answers is how a configuration ends up
+ * quietly wrong.
+ */
+export function detectSlots(
+  records,
+  plans,
+  { taken = new Set(), postings = null, margin = 1.2 } = {},
+) {
+  const lists = postings || buildPostings(records);
+  const stamps = new Int32Array(records.length);
+  const buffer = [];
+  const pairs = [];
+  const runnerUp = new Map();
+  let stamp = 0;
+
+  for (const plan of plans) {
+    if (!plan.keys.length) continue;
+    stamp += 1;
+    const candidates = gatherCandidates(plan, lists, stamps, stamp, buffer);
+    const best = [];
+    const floor = minimumScore(plan);
+    for (const position of candidates) {
+      const record = records[position];
+      if (taken.has(record.id)) continue;
+      const score = scoreSlotCandidate(record, plan);
+      if (score === -Infinity || score < floor) continue;
+      best.push({ position, score });
+    }
+    if (!best.length) continue;
+    best.sort(
+      (left, right) =>
+        right.score - left.score ||
+        records[left.position].id.length - records[right.position].id.length,
+    );
+    runnerUp.set(plan.ref, best.length > 1 ? best[1].score : -Infinity);
+    for (const entry of best.slice(0, CANDIDATES_PER_SLOT)) {
+      pairs.push({ ref: plan.ref, plan, position: entry.position, score: entry.score });
+    }
+  }
+
+  pairs.sort(
+    (left, right) =>
+      right.score - left.score ||
+      records[left.position].id.length - records[right.position].id.length ||
+      (left.ref < right.ref ? -1 : left.ref > right.ref ? 1 : 0),
+  );
+
+  const assignments = [];
+  const undecided = [];
+  const assigned = new Set();
+  const used = new Set(taken);
+  const ambiguous = new Set();
+  for (const pair of pairs) {
+    if (assigned.has(pair.ref) || ambiguous.has(pair.ref)) continue;
+    const record = records[pair.position];
+    if (used.has(record.id)) continue;
+    const second = runnerUp.get(pair.ref);
+    if (Number.isFinite(second) && pair.score - second < margin) {
+      ambiguous.add(pair.ref);
+      undecided.push({
+        ref: pair.ref,
+        label: pair.plan.label,
+        reason: "ambiguous",
+        best: record.id,
+        score: pair.score,
+      });
+      continue;
+    }
+    assigned.add(pair.ref);
+    used.add(record.id);
+    assignments.push({
+      ref: pair.ref,
+      label: pair.plan.label,
+      section: pair.plan.section,
+      id: record.id,
+      name: record.name,
+      score: Math.round(pair.score * 10) / 10,
+    });
+  }
+  return { assignments, undecided, scanned: pairs.length };
+}
+
+/* ── Categories ───────────────────────────────────────────────────────────── */
+
+const TERMO = /termo|radiat|riscald|heat|valve|trv/i;
+const OPENING_CLASSES = new Set(["door", "window", "opening", "garage_door"]);
+
+function withArea(name, area) {
+  if (!area) return name;
+  return foldText(name).includes(foldText(area)) ? name : `${area} - ${name}`;
+}
+
+function isTemperature(record) {
+  return (
+    record.domain === "sensor" &&
+    (record.dc === "temperature" || /temperatur/.test(record.idFold)) &&
+    (record.unit.includes("°") || record.dc === "temperature")
+  );
+}
+
+function isHumidity(record) {
+  return (
+    record.domain === "sensor" &&
+    (record.dc === "humidity" || /umidit|humidity/.test(record.idFold))
+  );
+}
+
+/**
+ * The whole-section proposals: lights, rooms, climate units and cameras.
+ *
+ * Rooms come from the Home Assistant areas first — one room per area, with the
+ * temperature sensor that lives there and its humidity twin — and only fall
+ * back to reading names when an area has nothing or a sensor has no area. That
+ * order was already the intent of the vendored detector, but the registry it
+ * needed never arrived in time to be used (its socket closes on the states
+ * reply, before the area, device and entity registries come back), so in
+ * practice every installation went down the name-guessing path.
+ */
+export function detectCategories(
+  records,
+  { maxLights = 300, maxRooms = 24, maxFallbackRooms = 14 } = {},
+) {
+  const lights = {};
+  const climate = [];
+  const cameras = [];
+  const groups = { win: [], batt: [], luci: [], clima: [], risc: [] };
+  const climateNames = new Set();
+  const temperatures = [];
+  const humidities = [];
+
+  for (const record of records) {
+    switch (record.domain) {
+      case "light":
+        if (Object.keys(lights).length < maxLights)
+          lights[record.id] = withArea(record.name, record.area);
+        groups.luci.push(record.id);
+        break;
+      case "camera":
+        cameras.push({ name: withArea(record.name, record.area), entity: record.id });
+        break;
+      case "climate": {
+        const heating = TERMO.test(`${record.id} ${record.name}`);
+        const stripped = record.name
+          .replace(/termosifone|radiator|thermostat|condizionatore|clima/gi, "")
+          .trim();
+        /* The area is the name the house already uses, properly cased; the
+         * stripped entity name is only a fallback, and only it can tell two
+         * units in the same room apart. */
+        let name = record.area || stripped || record.name;
+        if (climateNames.has(foldText(name))) name = stripped || record.name;
+        climateNames.add(foldText(name));
+        climate.push({ name, entity: record.id, type: heating ? "termo" : "clima" });
+        groups[heating ? "risc" : "clima"].push(record.id);
+        break;
+      }
+      case "binary_sensor":
+        if (
+          (OPENING_CLASSES.has(record.dc) ||
+            /finestra|porta|window|door|contact/.test(record.hay)) &&
+          !/bypass/.test(record.hay)
+        ) {
+          groups.win.push(record.id);
+        }
+        break;
+      case "sensor":
+        if (record.dc === "battery" && record.unit === "%") groups.batt.push(record.id);
+        if (isTemperature(record)) temperatures.push(record);
+        else if (isHumidity(record)) humidities.push(record);
+        break;
+      default:
+        break;
+    }
+  }
+
+  const rooms = [];
+  const usedTemperature = new Set();
+  const byArea = new Map();
+  for (const record of temperatures) {
+    if (!record.area || byArea.has(record.area)) continue;
+    byArea.set(record.area, record);
+  }
+  for (const [area, record] of [...byArea.entries()].slice(0, maxRooms)) {
+    usedTemperature.add(record.id);
+    const twin = humidities.find((humidity) => humidity.area === area);
+    const room = { name: area, icon: "🌡️", temp: record.id };
+    if (twin) room.hum = twin.id;
+    rooms.push(room);
+  }
+
+  for (const record of temperatures) {
+    if (rooms.length >= Math.max(maxFallbackRooms, byArea.size)) break;
+    if (usedTemperature.has(record.id) || record.area) continue;
+    const base = record.id.replace(/_?temperatur[ae]?/i, "");
+    const twin = humidities.find(
+      (humidity) => humidity.id.replace(/_?(umidita|humidity)/i, "") === base,
+    );
+    const room = {
+      name: record.name.replace(/temperatura|temperature|sensore?/gi, "").trim() || record.name,
+      icon: "🌡️",
+      temp: record.id,
+    };
+    if (twin) room.hum = twin.id;
+    rooms.push(room);
+  }
+
+  return { lights, rooms, climate, cameras, groups };
+}

--- a/custom_components/dashboardmodern/frontend/src/core/entity-search-index.js
+++ b/custom_components/dashboardmodern/frontend/src/core/entity-search-index.js
@@ -251,10 +251,14 @@ const HINT_RULES = Object.freeze([
     domains: ["sensor"],
   },
   {
+    /* A light field accepts a relay too: a lamp behind a `switch.` is
+     * configured in the Luci tab exactly like a `light.`, so the picker has to
+     * propose both or the switch never gets suggested for the field that wants
+     * it. */
     words: ["luce", "luci", "light", "lampada", "lampadario", "faretti", "led"],
     dc: [],
     units: [],
-    domains: ["light"],
+    domains: ["light", "switch"],
   },
   {
     words: [

--- a/custom_components/dashboardmodern/frontend/src/core/entity-search-index.js
+++ b/custom_components/dashboardmodern/frontend/src/core/entity-search-index.js
@@ -45,6 +45,22 @@ export function tokenize(folded) {
     .filter((token) => token.length > 0);
 }
 
+/* Every word of an entity, id first: callers that only need "does any token
+ * start with this" walk the three lists rather than a merged copy, so the index
+ * never allocates a fourth array per entity. */
+export function* entityTokens(record) {
+  yield* record.idTokens;
+  yield* record.nameTokens;
+  yield* record.areaTokens;
+}
+
+function anyToken(record, test) {
+  for (const token of record.idTokens) if (test(token)) return true;
+  for (const token of record.nameTokens) if (test(token)) return true;
+  for (const token of record.areaTokens) if (test(token)) return true;
+  return false;
+}
+
 function initialsOf(tokens) {
   let initials = "";
   for (const token of tokens) initials += token[0];
@@ -68,7 +84,15 @@ export function normalizeEntry(raw) {
   const nameFold = foldText(name);
   const areaFold = area ? foldText(area) : "";
   const hay = `${idFold} ${nameFold} ${areaFold}`;
-  const tokens = tokenize(hay);
+  /* Kept apart as well as together: the search only needs one haystack, but the
+   * auto-detector weighs a word found in the id above the same word found in
+   * the friendly name, and cannot tell them apart once they are merged. */
+  /* The domain is not a word of the entity: counting `sensor.` as one makes
+   * every sensor in the house match a slot whose label mentions a sensor, and
+   * the domain is already a constraint of its own. */
+  const idTokens = tokenize(foldText(object));
+  const nameTokens = tokenize(nameFold);
+  const areaTokens = areaFold ? tokenize(areaFold) : [];
   const state = String(raw.state ?? "");
   /* Both parts of the constant penalty are query-independent: an entity that is
    * currently unavailable is rarely the one being configured, and between two
@@ -91,8 +115,10 @@ export function normalizeEntry(raw) {
     areaFold,
     unitFold: foldText(raw.unit || attributes.unit_of_measurement || ""),
     hay,
-    tokens,
-    initials: initialsOf(tokenize(nameFold)),
+    idTokens,
+    nameTokens,
+    areaTokens,
+    initials: initialsOf(nameTokens),
   };
 }
 
@@ -519,13 +545,15 @@ function hintDetail(record, hints) {
   let matched = 0;
   for (const keyword of hints.keywords) {
     if (matched >= 3) break;
-    for (const token of record.tokens) {
-      if (token === keyword || (keyword.length >= 4 && token.startsWith(keyword))) {
-        score += 28;
-        matched += 1;
-        strong = true;
-        break;
-      }
+    if (
+      anyToken(
+        record,
+        (token) => token === keyword || (keyword.length >= 4 && token.startsWith(keyword)),
+      )
+    ) {
+      score += 28;
+      matched += 1;
+      strong = true;
     }
   }
   /* A field that knows its domain cannot be satisfied by another one: a light
@@ -549,9 +577,7 @@ function termScore(record, term) {
   if (record.idFold.startsWith(term)) return 100;
   if (record.objectFold.startsWith(term)) return 92;
   if (record.nameFold.startsWith(term)) return 88;
-  for (const token of record.tokens) {
-    if (token.startsWith(term)) return 70;
-  }
+  if (anyToken(record, (token) => token.startsWith(term))) return 70;
   const inId = record.idFold.indexOf(term) >= 0;
   if (inId) return 40;
   if (record.nameFold.indexOf(term) >= 0) return 34;

--- a/custom_components/dashboardmodern/frontend/src/core/light-model.js
+++ b/custom_components/dashboardmodern/frontend/src/core/light-model.js
@@ -1,0 +1,366 @@
+/* What a configured light is, what it can do and what to ask Home Assistant.
+ *
+ * A "light" on this dashboard is not necessarily a `light.` entity: a lamp
+ * behind a relay is a `switch.`, and the user configures it in the Luci tab
+ * exactly like any other. Everything downstream — the popup, the cards, the
+ * alerts group — therefore has to reason about capabilities rather than about
+ * the domain: an on/off relay, a dimmer, a tunable white and an RGB strip are
+ * four different control surfaces, and only the entity itself knows which one
+ * it is.
+ *
+ * This module is the single place that answers those questions. It holds no
+ * DOM, no storage and no locale: it turns a Home Assistant state object into a
+ * view, and a requested change into the service call that performs it.
+ */
+
+/* Domains that may be configured as a light. `light` and `switch` are what a
+ * real installation uses — a lamp behind a relay is a switch — and the last
+ * three are the ones the legacy wizard has always written into `cd_luci`, so
+ * rejecting them here would make a light added years ago uneditable. Every one
+ * of them answers turn_on/turn_off/toggle. */
+export const LIGHT_DOMAINS = Object.freeze(["light", "switch", "input_boolean", "fan", "group"]);
+
+/** Colour modes that carry a full colour, as opposed to a white point. */
+const COLOR_MODES = new Set(["hs", "xy", "rgb", "rgbw", "rgbww"]);
+
+/** Colour modes that carry a brightness. `onoff` is the only one that cannot. */
+const DIMMABLE_MODES = new Set([
+  "brightness",
+  "color_temp",
+  "hs",
+  "xy",
+  "rgb",
+  "rgbw",
+  "rgbww",
+  "white",
+]);
+
+/* Pre-2021 integrations report no `supported_color_modes` at all, only the
+ * legacy feature bitmask. A real installation still has a few of them, and
+ * without this fallback their dimmer would be hidden. */
+const LEGACY_BRIGHTNESS = 1;
+const LEGACY_COLOR_TEMP = 2;
+const LEGACY_EFFECT = 4;
+const LEGACY_COLOR = 16;
+
+export const DEFAULT_MIN_KELVIN = 2000;
+export const DEFAULT_MAX_KELVIN = 6535;
+
+/* The white point a colour-only light is given when the user asks for white,
+ * and the fallback shown for a tunable light that is off and reports nothing. */
+export const NEUTRAL_KELVIN = 4000;
+
+const clean = (value) => String(value ?? "").trim();
+
+export const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+const numberOrNull = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+export function entityDomain(id) {
+  const value = clean(id);
+  const index = value.indexOf(".");
+  return index > 0 ? value.slice(0, index).toLowerCase() : "";
+}
+
+/** True for an entity id this dashboard accepts in the Luci tab. */
+export function isLightEntity(id) {
+  const value = clean(id);
+  return LIGHT_DOMAINS.some((domain) => new RegExp(`^${domain}\\.[a-z0-9_]+$`, "i").test(value));
+}
+
+function colorModes(attributes = {}) {
+  const raw = attributes.supported_color_modes;
+  return new Set(
+    (Array.isArray(raw) ? raw : []).map((mode) => clean(mode).toLowerCase()).filter(Boolean),
+  );
+}
+
+function kelvinRange(attributes = {}) {
+  const min =
+    numberOrNull(attributes.min_color_temp_kelvin) ??
+    (numberOrNull(attributes.max_mireds) ? Math.round(1e6 / Number(attributes.max_mireds)) : null);
+  const max =
+    numberOrNull(attributes.max_color_temp_kelvin) ??
+    (numberOrNull(attributes.min_mireds) ? Math.round(1e6 / Number(attributes.min_mireds)) : null);
+  const low = min ?? DEFAULT_MIN_KELVIN;
+  const high = max ?? DEFAULT_MAX_KELVIN;
+  return high > low
+    ? { min: low, max: high }
+    : { min: DEFAULT_MIN_KELVIN, max: DEFAULT_MAX_KELVIN };
+}
+
+/* 0-255 is what Home Assistant reports and 0-100 is what the user sets, so the
+ * conversion rounds up: a lamp reporting brightness 1 is on, and showing 0%
+ * next to a lit lamp reads as a bug. */
+export function brightnessToPercent(brightness) {
+  const value = numberOrNull(brightness);
+  if (value === null || value <= 0) return null;
+  return clamp(Math.round((value / 255) * 100) || 1, 1, 100);
+}
+
+/**
+ * Everything the controls need to know about one configured light.
+ *
+ * `state` is the Home Assistant state object, or nothing at all when the entity
+ * is not in the registry — a configured light whose integration is down still
+ * has to appear, marked unavailable, instead of silently vanishing.
+ */
+export function lightView(id, { name = "", state = null, room = "", floor = "" } = {}) {
+  const entity = clean(id);
+  const domain = entityDomain(entity);
+  const attributes = state?.attributes || {};
+  const status = clean(state?.state).toLowerCase();
+  const available = Boolean(state) && status !== "unavailable" && status !== "unknown";
+  const modes = colorModes(attributes);
+  const features = Number(attributes.supported_features) || 0;
+  const light = domain === "light";
+  const legacyOnly = light && modes.size === 0;
+
+  const dimmable =
+    light &&
+    ([...modes].some((mode) => DIMMABLE_MODES.has(mode)) ||
+      (legacyOnly && (Boolean(features & LEGACY_BRIGHTNESS) || attributes.brightness != null)));
+  const colorful =
+    light &&
+    ([...modes].some((mode) => COLOR_MODES.has(mode)) ||
+      (legacyOnly && (Boolean(features & LEGACY_COLOR) || Array.isArray(attributes.rgb_color))));
+  const tunable =
+    light &&
+    (modes.has("color_temp") ||
+      (legacyOnly &&
+        (Boolean(features & LEGACY_COLOR_TEMP) || attributes.color_temp_kelvin != null)));
+
+  const effects = Array.isArray(attributes.effect_list)
+    ? attributes.effect_list.map(clean).filter(Boolean)
+    : [];
+  const range = kelvinRange(attributes);
+  const kelvin =
+    numberOrNull(attributes.color_temp_kelvin) ??
+    (numberOrNull(attributes.color_temp) ? Math.round(1e6 / Number(attributes.color_temp)) : null);
+  const mode = clean(attributes.color_mode).toLowerCase();
+  const rgb = Array.isArray(attributes.rgb_color) ? attributes.rgb_color.slice(0, 3) : null;
+
+  return {
+    id: entity,
+    domain,
+    name: clean(name) || clean(attributes.friendly_name) || entity,
+    room: clean(room),
+    floor: clean(floor),
+    available,
+    on: status === "on",
+    dimmable: Boolean(dimmable),
+    colorful: Boolean(colorful),
+    tunable: Boolean(tunable),
+    effects: light && (effects.length || features & LEGACY_EFFECT) ? effects : [],
+    effect: clean(attributes.effect),
+    colorMode: mode,
+    brightness: dimmable ? brightnessToPercent(attributes.brightness) : null,
+    rgb: colorful ? rgb : null,
+    kelvin: tunable ? (kelvin === null ? null : clamp(kelvin, range.min, range.max)) : null,
+    minKelvin: range.min,
+    maxKelvin: range.max,
+  };
+}
+
+/**
+ * The colour the card and the orb are painted with: what the lamp is actually
+ * emitting when it says so, the white point when it is in tunable mode, and the
+ * dashboard's amber when the entity reports nothing — an on/off relay included.
+ */
+export function lightColorHex(view, fallback = "#f59e0b") {
+  if (!view?.on) return fallback;
+  if (view.colorMode === "color_temp" && view.kelvin) return kelvinToHex(view.kelvin);
+  if (Array.isArray(view.rgb) && view.rgb.length === 3) return rgbToHex(view.rgb);
+  if (view.kelvin) return kelvinToHex(view.kelvin);
+  return fallback;
+}
+
+/** Which control surface this light gets, in the order the popup shows them. */
+export function lightControls(view) {
+  const controls = ["power"];
+  if (view?.dimmable) controls.push("brightness");
+  if (view?.colorful) controls.push("color");
+  if (view?.tunable) controls.push("white");
+  if (view?.effects?.length) controls.push("effect");
+  return controls;
+}
+
+/* ── Colour maths ─────────────────────────────────────────────────────────── */
+
+const channel = (value) => clamp(Math.round(Number(value) || 0), 0, 255);
+
+export function rgbToHex(rgb) {
+  const values = Array.isArray(rgb) ? rgb : [];
+  if (values.length < 3) return "#ffffff";
+  return `#${values
+    .slice(0, 3)
+    .map((value) => channel(value).toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
+export function hexToRgb(hex) {
+  const value = clean(hex).replace(/^#/, "");
+  const full =
+    value.length === 3
+      ? value
+          .split("")
+          .map((part) => part + part)
+          .join("")
+      : value;
+  if (!/^[0-9a-f]{6}$/i.test(full)) return [255, 255, 255];
+  return [0, 2, 4].map((offset) => Number.parseInt(full.slice(offset, offset + 2), 16));
+}
+
+/** h in 0-360, s and v in 0-100. */
+export function hsvToRgb(h, s, v) {
+  const hue = (((Number(h) || 0) % 360) + 360) % 360;
+  const saturation = clamp(Number(s) || 0, 0, 100) / 100;
+  const value = clamp(Number(v) || 0, 0, 100) / 100;
+  const c = value * saturation;
+  const x = c * (1 - Math.abs(((hue / 60) % 2) - 1));
+  const m = value - c;
+  const sector = Math.floor(hue / 60) % 6;
+  const [r, g, b] = [
+    [c, x, 0],
+    [x, c, 0],
+    [0, c, x],
+    [0, x, c],
+    [x, 0, c],
+    [c, 0, x],
+  ][sector];
+  return [r, g, b].map((part) => channel((part + m) * 255));
+}
+
+export function rgbToHsv(rgb) {
+  const [r, g, b] = (Array.isArray(rgb) ? rgb : [0, 0, 0]).map((value) => channel(value) / 255);
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+  let hue = 0;
+  if (delta > 0) {
+    if (max === r) hue = 60 * (((g - b) / delta) % 6);
+    else if (max === g) hue = 60 * ((b - r) / delta + 2);
+    else hue = 60 * ((r - g) / delta + 4);
+  }
+  if (hue < 0) hue += 360;
+  return [Math.round(hue), Math.round(max === 0 ? 0 : (delta / max) * 100), Math.round(max * 100)];
+}
+
+/* Tanner Helland's black-body approximation, which is what makes a 2700K
+ * preview look like tungsten and a 6500K one look like daylight instead of both
+ * looking white. */
+export function kelvinToHex(kelvin) {
+  const temperature = clamp(Number(kelvin) || NEUTRAL_KELVIN, 1000, 40000) / 100;
+  let red;
+  let green;
+  let blue;
+  if (temperature <= 66) {
+    red = 255;
+    green = 99.4708025861 * Math.log(temperature) - 161.1195681661;
+    blue = temperature <= 19 ? 0 : 138.5177312231 * Math.log(temperature - 10) - 305.0447927307;
+  } else {
+    red = 329.698727446 * (temperature - 60) ** -0.1332047592;
+    green = 288.1221695283 * (temperature - 60) ** -0.0755148492;
+    blue = 255;
+  }
+  return rgbToHex([red, green, blue]);
+}
+
+/* Which of black or white stays readable on this colour.
+ *
+ * The controls paint themselves in the lamp's own colour — the power button,
+ * the glyph inside the orb — and a lamp can be deep blue as easily as pale
+ * amber, so the ink cannot be a constant. This is the WCAG relative luminance,
+ * with the usual 0.5 split. */
+export function readableInk(hex, dark = "#0f172a", light = "#ffffff") {
+  const channels = hexToRgb(hex).map((value) => {
+    const ratio = value / 255;
+    return ratio <= 0.04045 ? ratio / 12.92 : ((ratio + 0.055) / 1.055) ** 2.4;
+  });
+  const luminance = 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+  return luminance > 0.4 ? dark : light;
+}
+
+/* ── Commands ─────────────────────────────────────────────────────────────── */
+
+/**
+ * The single service call that performs one requested change.
+ *
+ * A switch only knows turn_on/turn_off/toggle, so every colour or brightness
+ * field is dropped for it rather than sent and rejected. A light takes the
+ * whole change in one `light.turn_on`: asking for a colour on a lamp that is
+ * off turns it on with that colour, which is what a user tapping a swatch
+ * expects to happen.
+ */
+export function lightCommand(view, change = {}) {
+  const entity = clean(view?.id);
+  const domain = view?.domain === "light" ? "light" : entityDomain(entity) || "homeassistant";
+  if (!entity) return null;
+
+  const power = change.power;
+  const wantsOff = power === false || change.brightnessPct === 0;
+  if (wantsOff) return { domain, service: "turn_off", data: { entity_id: entity } };
+  if (domain !== "light") {
+    return {
+      domain,
+      service: power === true ? "turn_on" : "toggle",
+      data: { entity_id: entity },
+    };
+  }
+
+  const data = { entity_id: entity };
+  if (view?.dimmable && change.brightnessPct != null) {
+    data.brightness_pct = clamp(Math.round(Number(change.brightnessPct) || 0), 1, 100);
+  }
+  if (view?.colorful && change.hex) data.rgb_color = hexToRgb(change.hex);
+  if (view?.tunable && change.kelvin != null) {
+    data.color_temp_kelvin = clamp(
+      Math.round(Number(change.kelvin) || NEUTRAL_KELVIN),
+      view.minKelvin || DEFAULT_MIN_KELVIN,
+      view.maxKelvin || DEFAULT_MAX_KELVIN,
+    );
+  }
+  if (view?.effects?.length && change.effect) data.effect = clean(change.effect);
+
+  const onlyEntity = Object.keys(data).length === 1;
+  if (onlyEntity && power !== true) return { domain, service: "toggle", data };
+  return { domain, service: "turn_on", data };
+}
+
+/** Header counters for a popup or a room heading. */
+export function lightSummary(views = []) {
+  const list = Array.isArray(views) ? views : [];
+  return {
+    total: list.length,
+    on: list.filter((view) => view.on).length,
+    unavailable: list.filter((view) => !view.available).length,
+    dimmable: list.filter((view) => view.dimmable).length,
+    colorful: list.filter((view) => view.colorful).length,
+  };
+}
+
+/**
+ * What changed in a way that changes the shape of the popup, as opposed to a
+ * value inside it. A lamp that starts reporting a colour, a new light, a rename
+ * or a room move rebuilds the markup; on/off, brightness and colour do not.
+ */
+export function lightsSignature(views = []) {
+  return (Array.isArray(views) ? views : [])
+    .map((view) =>
+      [
+        view.id,
+        view.name,
+        view.room,
+        view.floor,
+        view.dimmable ? "d" : "",
+        view.colorful ? "c" : "",
+        view.tunable ? "w" : "",
+        view.effects.length,
+        view.available ? "" : "x",
+      ].join("~"),
+    )
+    .join("|");
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/beta25-real-device-fixes-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta25-real-device-fixes-section.js
@@ -3,6 +3,7 @@ import { applianceArtwork, canonicalArtworkType } from "../core/appliance-artwor
 import { directEmoji, roomGlyph } from "../core/personalization-catalog.js";
 import {
   allStates,
+  applyTemperatureReading,
   clean,
   comfortBadgeText,
   dashboardStore,
@@ -220,6 +221,7 @@ function updateTemperatureCard(card, record) {
   const name = card.querySelector(".temp-room-name");
   if (value) value.textContent = temperature == null ? "—" : temperature.toFixed(1);
   if (hum) hum.textContent = humidity == null ? "—%" : `${humidity.toFixed(0)}%`;
+  applyTemperatureReading(card, temperature, humidity);
   if (comfort) {
     const label = comfortLabel(temperature);
     comfort.textContent = comfortBadgeText(label);

--- a/custom_components/dashboardmodern/frontend/src/sections/beta25-real-device-fixes-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta25-real-device-fixes-section.js
@@ -251,7 +251,13 @@ export function renderBeta25TemperatureCards() {
     return card;
   });
   grid.replaceChildren(...cards);
-  grid.dataset.dmTemperatureRenderer = "beta25-multi";
+  /* Both markers in the same render turn, as the stable Beta 26 owner already
+   * does. Stamping only "beta25-multi" and leaving the rename to the
+   * compatibility pass opened a window in which the grid claimed a renderer
+   * nobody owns: the pass is wired to a different trigger, so whichever ran
+   * last won, and on a slow boot that was this render. */
+  grid.dataset.beta25TemperatureRenderer = "multi";
+  grid.dataset.dmTemperatureRenderer = "canonical";
   return true;
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/beta26-real-device-stability-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta26-real-device-stability-section.js
@@ -9,6 +9,7 @@ import {
 } from "./beta25-real-device-fixes-section.js";
 import {
   allStates,
+  applyTemperatureReading,
   clean,
   comfortBadgeText,
   dashboardStore,
@@ -246,6 +247,7 @@ function updateStableTemperatureValues() {
       temperatureValue.textContent = value == null ? "—" : value.toFixed(1);
     if (humidityValue)
       humidityValue.textContent = humidity == null ? "—%" : `${humidity.toFixed(0)}%`;
+    applyTemperatureReading(card, value, humidity);
     if (comfort) {
       const label = comfortLabel(value);
       comfort.textContent = comfortBadgeText(label);

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-crud-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-crud-section.js
@@ -298,6 +298,17 @@ function installStyles() {
          to shrink, otherwise one long entity id expands the whole mobile modal. */
       #editor-modal .ed-shell,#editor-modal .ed-body,#editor-modal .ed-form,#editor-modal .ed-list,#editor-modal .ed-row,#editor-modal .ed-form-row{box-sizing:border-box!important;min-width:0!important;max-width:100%!important;width:100%!important}
       #editor-modal .ed-body{overflow-x:clip!important;overflow-y:visible!important}
+      /* The body of every editor tab is a vertical stack of full-width controls.
+         The entity-picker guard used to hand .dm-entity-picker-row — flex, with
+         min-width:0 children — to the parent of any field it decorated, and on
+         Tapparelle, Telecamere and Irrigazione that parent is this element, so
+         the whole editor laid out as a row of narrow columns with words broken
+         mid-syllable. The guard no longer flexes a container, and this pins the
+         outcome: block with no columns is what the correct rendering already
+         computes, so it changes nothing where the editor is right and makes
+         that failure unreachable for any other owner. */
+      #editor-modal .ed-body{display:block!important;columns:auto!important;column-count:auto!important}
+      #editor-modal .ed-body>*{float:none!important}
       #editor-modal .ed-body>*,#editor-modal .ed-form>*,#editor-modal .ed-list>*,#editor-modal .ed-row>*,#editor-modal .ed-form-row>*,#editor-modal .ed-form [style*="display:flex"]>*{box-sizing:border-box!important;min-width:0!important;max-width:100%!important}
       #editor-modal .ed-form>[style*="display:flex"],#editor-modal .ed-form-row{box-sizing:border-box!important;min-width:0!important;max-width:100%!important;width:100%!important}
       #editor-modal .ed-form-row>.ed-input,#editor-modal .ed-form>[style*="display:flex"]>.ed-input{width:0!important;min-width:0!important;max-width:100%!important;flex:1 1 0!important}

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
@@ -1,0 +1,225 @@
+// DM-FIX-20260817E
+/* Entity slots in the editor, made readable.
+ *
+ * Every section tab listed the same thing: a label, a bare text field asking
+ * for an entity id and a lens button next to it. Sixteen of those in a row —
+ * the EV tab — read as a form to fill in by hand, when the entity is really
+ * picked from a list.
+ *
+ * The row now shows what it is worth reading: whether the slot is mapped, the
+ * friendly name of the entity behind it and its id underneath. Tapping the row
+ * opens the picker the dashboard already has. The raw field stays in the DOM,
+ * hidden, and comes back with "Modifica manuale" for whoever wants to type an
+ * id straight in.
+ *
+ * Contracts preserved on purpose:
+ * - the input keeps its `.ed-slot-in[data-ref]` class and its `edSetSlot`
+ *   handler, so a value chosen here saves exactly like a typed one;
+ * - the picker is the legacy `wzPickEntity()`, called with the input element:
+ *   `cdEpChoose()` then writes the value and fires `change`, which is what the
+ *   editor listens to;
+ *   the legacy lens button is only hidden, never removed, so
+ *   `entity-picker-guard-section.js` keeps seeing the pair it reconciles;
+ * - `edSaveSezione()` still reads the same inputs from `.ed-acc-body`.
+ *
+ * Nothing here reads or writes Home Assistant state beyond the friendly name of
+ * an entity already in `_RAW_STATES`.
+ */
+import { clean, doc, root, installStyle, t, wrapFunction } from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_EDITOR_SLOTS__";
+const STYLE_ID = "dm-editor-slots-style";
+const state = (root[KEY] ||= { installed: false, frame: 0 });
+
+/** Friendly name Home Assistant knows for an entity, "" when it knows none. */
+export function entityLabel(entity, states = root._RAW_STATES || root.STATES || {}) {
+  const id = clean(entity);
+  if (!id) return "";
+  const name = clean(states?.[id]?.attributes?.friendly_name);
+  return name && name !== id ? name : "";
+}
+
+/** How many slots of a section are mapped, for the accordion header. */
+export function slotCounts(scope) {
+  const inputs = [...(scope?.querySelectorAll?.(".ed-slot-in[data-ref]") || [])];
+  const mapped = inputs.filter((input) => clean(input.value)).length;
+  return { total: inputs.length, mapped };
+}
+
+function isSlotRow(slot) {
+  // The loads editor reuses .ed-slot for its own form; it owns its layout.
+  if (slot.closest("[data-load-form]")) return false;
+  return Boolean(slot.querySelector(":scope .ed-slot-in[data-ref]"));
+}
+
+function chipMarkup() {
+  return `<span class="dm-slot-chip-copy"><b data-chip-name></b><small data-chip-id></small></span><span class="dm-slot-chip-go" aria-hidden="true">›</span>`;
+}
+
+function decorate(slot) {
+  if (!isSlotRow(slot)) return false;
+  const input = slot.querySelector(".ed-slot-in[data-ref]");
+  slot.classList.add("dm-slot");
+  let chip = slot.querySelector(":scope > .dm-slot-chip");
+  if (!chip) {
+    chip = doc.createElement("button");
+    chip.type = "button";
+    chip.className = "dm-slot-chip";
+    chip.innerHTML = chipMarkup();
+    // Appended at the end of the row: the lens stays the input's next sibling,
+    // which is the pair the entity picker guard reconciles.
+    slot.append(chip);
+    chip.addEventListener("click", (event) => {
+      event.preventDefault();
+      try {
+        root.wzPickEntity?.(input);
+      } catch (_error) {}
+    });
+    input.addEventListener("change", () => paint(slot));
+  }
+  paint(slot);
+  return true;
+}
+
+function paint(slot) {
+  const input = slot.querySelector(".ed-slot-in[data-ref]");
+  const chip = slot.querySelector(":scope > .dm-slot-chip");
+  if (!input || !chip) return;
+  const value = clean(input.value);
+  const label = entityLabel(value);
+  slot.dataset.dmSlot = value ? "mapped" : "empty";
+  const name = chip.querySelector("[data-chip-name]");
+  const id = chip.querySelector("[data-chip-id]");
+  const nameText = value ? label || value : t("Scegli entità", "Choose entity");
+  const idText = value && label ? value : "";
+  if (name.textContent !== nameText) name.textContent = nameText;
+  if (id.textContent !== idText) id.textContent = idText;
+  chip.setAttribute(
+    "aria-label",
+    `${clean(slot.querySelector(".ed-slot-lbl input")?.value) || clean(slot.querySelector(".ed-slot-lbl")?.textContent)}: ${nameText}`,
+  );
+}
+
+function decorateBody(body) {
+  let count = 0;
+  for (const slot of body.querySelectorAll(".ed-slot")) if (decorate(slot)) count += 1;
+  if (!count) return false;
+  body.classList.add("dm-slots");
+  if (!body.querySelector(":scope > .dm-slots-manual")) {
+    const toggle = doc.createElement("button");
+    toggle.type = "button";
+    toggle.className = "dm-slots-manual";
+    toggle.textContent = t("Modifica manuale", "Edit by hand");
+    toggle.setAttribute("aria-pressed", "false");
+    toggle.addEventListener("click", () => {
+      const on = body.classList.toggle("dm-slots-raw");
+      toggle.setAttribute("aria-pressed", String(on));
+    });
+    body.prepend(toggle);
+  }
+  const counts = slotCounts(body);
+  const badge = body.closest("details")?.querySelector(".ed-acc-n");
+  if (badge && counts.total) {
+    const text = t(`${counts.mapped} su ${counts.total} mappate`, `${counts.mapped} of ${counts.total} mapped`);
+    if (badge.textContent !== text) badge.textContent = text;
+  }
+  return true;
+}
+
+export function decorateEditorSlots(scope = doc?.getElementById("ed-body")) {
+  if (!scope) return 0;
+  let count = 0;
+  for (const body of scope.querySelectorAll(".ed-acc-body")) if (decorateBody(body)) count += 1;
+  return count;
+}
+
+function schedule() {
+  if (state.frame) return;
+  const run = () => {
+    state.frame = 0;
+    decorateEditorSlots();
+  };
+  state.frame = root.requestAnimationFrame?.(run) || root.setTimeout?.(run, 0);
+}
+
+function installStyles() {
+  installStyle(STYLE_ID, `
+.dm-slots{display:grid!important;gap:8px!important}
+.dm-slots-manual{
+  justify-self:end!important;margin:0 0 2px!important;padding:6px 12px!important;border:1px solid var(--divider-color,#dbe4ee)!important;
+  border-radius:999px!important;background:transparent!important;color:var(--secondary-text-color,#64748b)!important;
+  font-size:11.5px!important;font-weight:750!important;cursor:pointer!important
+}
+.dm-slots-manual[aria-pressed="true"]{
+  border-color:var(--primary-color,#0ea5e9)!important;color:var(--primary-color,#0ea5e9)!important;
+  background:color-mix(in srgb,var(--primary-color,#0ea5e9) 8%,transparent)!important
+}
+.dm-slots .dm-slot{
+  display:grid!important;grid-template-columns:minmax(0,1fr)!important;gap:6px!important;
+  margin:0!important;padding:11px 13px!important;border:1px solid var(--divider-color,#dbe4ee)!important;
+  border-radius:16px!important;background:var(--card-background-color,#fff)!important
+}
+.dm-slots .dm-slot[data-dm-slot="mapped"]{border-color:color-mix(in srgb,#16a34a 30%,var(--divider-color,#dbe4ee))!important}
+.dm-slots .dm-slot>.ed-slot-lbl{margin:0!important;display:flex!important;align-items:center!important;gap:8px!important}
+.dm-slots .dm-slot>.ed-slot-lbl::before{
+  content:"";width:7px;height:7px;border-radius:50%;flex:0 0 7px;
+  background:var(--divider-color,#cbd5e1)
+}
+.dm-slots .dm-slot[data-dm-slot="mapped"]>.ed-slot-lbl::before{background:#16a34a}
+.dm-slots .dm-slot .wz-lbl-edit{
+  border:0!important;background:transparent!important;padding:0!important;width:100%!important;
+  font-size:13px!important;font-weight:800!important;color:var(--text,#0f172a)!important
+}
+.dm-slots .dm-slot .wz-lbl-edit:focus{
+  outline:2px solid color-mix(in srgb,var(--primary-color,#0ea5e9) 45%,transparent)!important;
+  outline-offset:3px!important;border-radius:6px!important
+}
+/* the raw field and its lens stay in the DOM: hidden until "Modifica manuale" */
+.dm-slots:not(.dm-slots-raw) .dm-slot>div:has(>.ed-slot-in){display:none!important}
+.dm-slots.dm-slots-raw .dm-slot>.dm-slot-chip{display:none!important}
+.dm-slot-chip{
+  display:flex!important;align-items:center!important;gap:10px!important;width:100%!important;
+  padding:9px 11px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:12px!important;
+  background:var(--secondary-background-color,#f6f8fb)!important;color:var(--text,#0f172a)!important;
+  font:inherit!important;text-align:left!important;cursor:pointer!important;min-width:0!important
+}
+.dm-slot-chip:hover{border-color:var(--primary-color,#0ea5e9)!important}
+.dm-slot-chip:focus-visible{outline:2px solid var(--primary-color,#0ea5e9)!important;outline-offset:2px!important}
+.dm-slot-chip-copy{display:grid!important;gap:2px!important;min-width:0!important;flex:1 1 auto!important}
+.dm-slot-chip-copy b{font-size:13px!important;font-weight:750!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important}
+.dm-slot-chip-copy small{
+  font-size:10.5px!important;font-family:ui-monospace,Menlo,monospace!important;
+  color:var(--secondary-text-color,#64748b)!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important
+}
+.dm-slot[data-dm-slot="empty"] .dm-slot-chip-copy b{color:var(--secondary-text-color,#64748b)!important;font-weight:650!important}
+.dm-slot-chip-go{flex:0 0 auto!important;font-size:18px!important;color:var(--secondary-text-color,#94a3b8)!important;line-height:1!important}
+  `);
+}
+
+export function installEditorSlotsSection() {
+  if (!doc || state.installed) return;
+  state.installed = true;
+  installStyles();
+  for (const eventName of ["dashboardmodern:legacy-ready", "dashboardmodern:runtime-ready"]) {
+    root.addEventListener?.(eventName, () => {
+      wrapFunction("editorSwitch", "__dmEditorSlots_editorSwitch", schedule);
+      schedule();
+    });
+  }
+  doc.addEventListener(
+    "click",
+    (event) => {
+      if (event.target?.closest?.(".ed-tab,[data-tab],.ed-acc-head,.ed-save-btn,.ed-btn-add,.ed-del")) {
+        root.setTimeout?.(schedule, 0);
+      }
+    },
+    true,
+  );
+  schedule();
+}
+
+if (doc?.readyState === "loading") {
+  doc.addEventListener("DOMContentLoaded", installEditorSlotsSection, { once: true });
+} else {
+  installEditorSlotsSection();
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
@@ -196,15 +196,21 @@ function installStyles() {
   `);
 }
 
-/* The legacy entry points that print the editor. Wrapping is attempted as early
- * as this module loads and again whenever the runtime announces itself, because
- * `wrapFunction` is a no-op until the legacy global exists: whichever happens
- * first, opening the editor or switching tab always schedules a pass.
+/* The legacy entry points that print the editor.
  *
- * The wrap used to be attached only on `legacy-ready`/`runtime-ready`, so an
- * editor opened before that event carried undecorated rows until the event
- * finally landed — visible as raw entity fields for a beat, and long enough to
- * be missed entirely under load. */
+ * Attached when this module loads, and again on the ready events for the
+ * opposite order — `wrapFunction` is a no-op while the legacy global is still
+ * undefined, so trying twice costs nothing.
+ *
+ * Attaching only inside the ready handlers, as before, meant never attaching at
+ * all whenever the bundle finished loading after the runtime had already
+ * announced itself: the handler simply never ran. The editor then printed rows
+ * that nothing scheduled a pass for, and they stayed raw entity fields until
+ * the next click. `editorSwitch` carried the markers of a dozen other owners
+ * and none of this one, which is what gave it away.
+ *
+ * Opening the editor is wrapped too, not just the tab switch: it is the moment
+ * the rows appear, so it is the moment they need decorating. */
 function bindLegacyEntryPoints() {
   wrapFunction("editorSwitch", "__dmEditorSlots_editorSwitch", schedule);
   wrapFunction("apriConfigEntita", "__dmEditorSlots_apriConfigEntita", schedule);

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
@@ -196,13 +196,27 @@ function installStyles() {
   `);
 }
 
+/* The legacy entry points that print the editor. Wrapping is attempted as early
+ * as this module loads and again whenever the runtime announces itself, because
+ * `wrapFunction` is a no-op until the legacy global exists: whichever happens
+ * first, opening the editor or switching tab always schedules a pass.
+ *
+ * The wrap used to be attached only on `legacy-ready`/`runtime-ready`, so an
+ * editor opened before that event carried undecorated rows until the event
+ * finally landed — visible as raw entity fields for a beat, and long enough to
+ * be missed entirely under load. */
+function bindLegacyEntryPoints() {
+  wrapFunction("editorSwitch", "__dmEditorSlots_editorSwitch", schedule);
+  wrapFunction("apriConfigEntita", "__dmEditorSlots_apriConfigEntita", schedule);
+}
+
 export function installEditorSlotsSection() {
   if (!doc || state.installed) return;
   state.installed = true;
   installStyles();
   for (const eventName of ["dashboardmodern:legacy-ready", "dashboardmodern:runtime-ready"]) {
     root.addEventListener?.(eventName, () => {
-      wrapFunction("editorSwitch", "__dmEditorSlots_editorSwitch", schedule);
+      bindLegacyEntryPoints();
       schedule();
     });
   }
@@ -215,6 +229,7 @@ export function installEditorSlotsSection() {
     },
     true,
   );
+  bindLegacyEntryPoints();
   schedule();
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-flow-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-flow-section.js
@@ -495,11 +495,13 @@ function installStyles() {
     .dm-energy-flow-idle{opacity:.30!important;filter:none!important;transition:stroke .18s ease,fill .18s ease,opacity .18s ease!important}
     .flow-line.dm-energy-flow-active,path.dm-energy-flow-active,line.dm-energy-flow-active,polyline.dm-energy-flow-active{stroke:var(--dm-flow-color)!important;stroke-dasharray:12 9!important;stroke-linecap:round!important;animation-name:dmEnergyFlowDash!important;animation-duration:.8s!important;animation-timing-function:linear!important;animation-iteration-count:infinite!important;animation-play-state:running!important;will-change:stroke-dashoffset!important}
     @keyframes dmEnergyFlowDash{from{stroke-dashoffset:0}to{stroke-dashoffset:-42}}
-    /* Con "riduci movimento" attivo il tratteggio non scorre, ma una linea
-       tratteggiata e ferma e' indistinguibile da una spenta: il moto era
-       l'unico segnale che l'energia sta passando. La linea attiva resta quindi
-       piena, colorata e a piena intensita', cosi' lo stato si legge lo stesso. */
-    @media(prefers-reduced-motion:reduce){.flow-line.dm-energy-flow-active,path.dm-energy-flow-active,line.dm-energy-flow-active,polyline.dm-energy-flow-active{animation:none!important;stroke-dasharray:none!important}}
+    /* Nessuna eccezione per "riduci movimento": il tratteggio che scorre non e'
+       una decorazione ma l'unico segnale che l'energia sta passando, e la
+       plancia deve mostrare le stesse linee su ogni schermo. Quella preferenza
+       e' spesso attiva su un computer e quasi mai su un telefono, quindi
+       rispettarla qui rendeva il desktop immobile mentre il telefono scorreva:
+       stessa plancia, due letture diverse. Le altre sezioni continuano a
+       rispettarla, perche' li' il moto e' effettivamente decorativo. */
     /* An mdi icon resolved by the engine sits inside .node-icon, which already
        sizes the emoji of the hand-authored circles at every breakpoint: the
        glyph inherits it so a configured circle matches its neighbours. */

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-flow-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-flow-section.js
@@ -495,7 +495,11 @@ function installStyles() {
     .dm-energy-flow-idle{opacity:.30!important;filter:none!important;transition:stroke .18s ease,fill .18s ease,opacity .18s ease!important}
     .flow-line.dm-energy-flow-active,path.dm-energy-flow-active,line.dm-energy-flow-active,polyline.dm-energy-flow-active{stroke:var(--dm-flow-color)!important;stroke-dasharray:12 9!important;stroke-linecap:round!important;animation-name:dmEnergyFlowDash!important;animation-duration:.8s!important;animation-timing-function:linear!important;animation-iteration-count:infinite!important;animation-play-state:running!important;will-change:stroke-dashoffset!important}
     @keyframes dmEnergyFlowDash{from{stroke-dashoffset:0}to{stroke-dashoffset:-42}}
-    @media(prefers-reduced-motion:reduce){.flow-line.dm-energy-flow-active,path.dm-energy-flow-active,line.dm-energy-flow-active,polyline.dm-energy-flow-active{animation:none!important}}
+    /* Con "riduci movimento" attivo il tratteggio non scorre, ma una linea
+       tratteggiata e ferma e' indistinguibile da una spenta: il moto era
+       l'unico segnale che l'energia sta passando. La linea attiva resta quindi
+       piena, colorata e a piena intensita', cosi' lo stato si legge lo stesso. */
+    @media(prefers-reduced-motion:reduce){.flow-line.dm-energy-flow-active,path.dm-energy-flow-active,line.dm-energy-flow-active,polyline.dm-energy-flow-active{animation:none!important;stroke-dasharray:none!important}}
     /* An mdi icon resolved by the engine sits inside .node-icon, which already
        sizes the emoji of the hand-authored circles at every breakpoint: the
        glyph inherits it so a configured circle matches its neighbours. */

--- a/custom_components/dashboardmodern/frontend/src/sections/entity-autodetect-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/entity-autodetect-section.js
@@ -1,0 +1,572 @@
+/* The 🪄 button in Config: what it does while you wait, and what it decides.
+ *
+ * `edAutoRileva` in the vendored runtime opens a WebSocket, then polls every
+ * 500 ms — up to forty times — for the entity list to appear, then runs
+ * `wzAutoDetect` on the main thread, then writes and reloads. Three things go
+ * wrong with that on a real installation:
+ *
+ *   - the poll adds up to half a second of waiting after the data has already
+ *     arrived, and up to twenty seconds of nothing at all if it never does;
+ *   - the detection itself re-tokenizes every entity once per slot, so with
+ *     ninety-six slots and a few thousand entities the page simply stops
+ *     answering until it is over;
+ *   - the socket it opens asks for the states first and the area, device and
+ *     entity registries after, but closes on the first array that comes back —
+ *     which is the states. The registries therefore never arrive, and the
+ *     "one room per Home Assistant area" detection they were added for has
+ *     been falling back to guessing from names ever since.
+ *
+ * This section replaces that path. The entity universe is folded and tokenized
+ * once by the same index the picker uses, the registries are fetched through
+ * the runtime's own `cdRegEnrich` before detection instead of after it, and the
+ * matching runs in `core/entity-autodetect.js` over posting lists, so a slot
+ * only looks at the entities that share a word with it.
+ *
+ * The last difference is that it now shows its work: a progress line while it
+ * runs, then what it found — how many lights, rooms, climate units, cameras and
+ * links, and which slots it deliberately left alone because two candidates were
+ * equally plausible — and it writes nothing until that summary is accepted.
+ *
+ * What it writes is what the runtime has always written, key for key and with
+ * the same never-overwrite rule, followed by the same registry enrich and
+ * reload. The one deliberate exception is the Energy slots, which schema 4 owns
+ * through the canonical Energy model; `writeEnergyAssignments` explains why
+ * writing them the old way loses them. If any of this fails, the vendored
+ * `edAutoRileva` runs instead.
+ */
+import { ENERGY_SLOT_MAP } from "../core/energy-projection.js";
+import { buildEntityIndex } from "../core/entity-search-index.js";
+import { buildPostings, detectCategories, detectSlots, parseSlotPlan } from "../core/entity-autodetect.js";
+import { allStates, clean, dashboardStore, doc, installStyle, lexicalGlobal, readJson, root, t } from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_ENTITY_AUTODETECT__";
+const HOSTED_ENOUGH = 200;
+const WAIT_STEP = 80;
+const WAIT_LIMIT = 6000;
+
+const state = (root[KEY] ||= { installed: false, running: false, proposal: null });
+
+/* ── Progress and summary ─────────────────────────────────────────────────── */
+
+function outlet() {
+  return doc?.getElementById("ed-rileva-out") || null;
+}
+
+function progress(step, total, message) {
+  const target = outlet();
+  if (!target) return;
+  const percent = Math.max(4, Math.min(100, Math.round((step / total) * 100)));
+  target.innerHTML =
+    `<div class="dm-ad-progress"><div class="dm-ad-bar"><i style="width:${percent}%"></i></div>` +
+    `<div class="dm-ad-step"></div></div>`;
+  const line = target.querySelector(".dm-ad-step");
+  if (line) line.textContent = message;
+}
+
+function failure(message) {
+  const target = outlet();
+  if (target) target.innerHTML = `<div class="ed-intro dm-ad-error"></div>`;
+  const line = target?.querySelector(".dm-ad-error");
+  if (line) line.textContent = `❌ ${message}`;
+}
+
+function countRow(icon, label, value, note = "") {
+  const row = doc.createElement("div");
+  row.className = "dm-ad-row";
+  const left = doc.createElement("span");
+  left.className = "dm-ad-row-label";
+  left.textContent = `${icon} ${label}`;
+  const right = doc.createElement("span");
+  right.className = value ? "dm-ad-row-value" : "dm-ad-row-value is-empty";
+  right.textContent = note || String(value);
+  row.append(left, right);
+  return row;
+}
+
+function renderSummary(proposal) {
+  const target = outlet();
+  if (!target) return;
+  target.textContent = "";
+  const panel = doc.createElement("div");
+  panel.className = "dm-ad-summary";
+
+  const title = doc.createElement("div");
+  title.className = "dm-ad-title";
+  title.textContent = t("🪄 Ecco cosa ho trovato", "🪄 Here is what I found");
+  panel.append(title);
+
+  const intro = doc.createElement("div");
+  intro.className = "dm-ad-intro";
+  intro.textContent = t(
+    `${proposal.entities} entità analizzate in ${proposal.elapsed} ms. Niente è stato ancora salvato.`,
+    `${proposal.entities} entities analysed in ${proposal.elapsed} ms. Nothing has been saved yet.`,
+  );
+  panel.append(intro);
+
+  const kept = t("già configurato", "already configured");
+  panel.append(
+    countRow("🔗", t("Collegamenti alle entità", "Entity links"), proposal.assignments.length),
+    countRow("💡", t("Luci", "Lights"), proposal.lightCount, proposal.skipped.lights ? kept : ""),
+    countRow("🌡️", t("Stanze", "Rooms"), proposal.rooms.length, proposal.skipped.rooms ? kept : ""),
+    countRow("❄️", t("Unità clima", "Climate units"), proposal.climate.length, proposal.skipped.climate ? kept : ""),
+    countRow("📹", t("Telecamere", "Cameras"), proposal.cameras.length, proposal.skipped.cameras ? kept : ""),
+    countRow("🔔", t("Entità nei gruppi avvisi", "Entities in alert groups"), proposal.groupCount),
+  );
+
+  if (proposal.assignments.length) {
+    const list = doc.createElement("div");
+    list.className = "dm-ad-list";
+    for (const item of proposal.assignments.slice(0, 12)) {
+      const row = doc.createElement("div");
+      row.className = "dm-ad-link";
+      const label = doc.createElement("b");
+      label.textContent = item.label;
+      const id = doc.createElement("span");
+      id.className = "mono";
+      id.textContent = item.id;
+      row.append(label, id);
+      list.append(row);
+    }
+    if (proposal.assignments.length > 12) {
+      const more = doc.createElement("div");
+      more.className = "dm-ad-more";
+      more.textContent = t(
+        `… e altri ${proposal.assignments.length - 12} collegamenti.`,
+        `… and ${proposal.assignments.length - 12} more links.`,
+      );
+      list.append(more);
+    }
+    panel.append(list);
+  }
+
+  if (proposal.undecided.length) {
+    const note = doc.createElement("div");
+    note.className = "dm-ad-note";
+    /* Being told what was left alone is the difference between a configuration
+     * you can trust and one you have to re-read field by field. */
+    note.textContent = t(
+      `${proposal.undecided.length} campi hanno due candidati altrettanto probabili: li lascio a te, nelle altre schede.`,
+      `${proposal.undecided.length} fields have two equally likely candidates: those are left for you, in the other tabs.`,
+    );
+    panel.append(note);
+  }
+
+  const actions = doc.createElement("div");
+  actions.className = "dm-ad-actions";
+  const apply = doc.createElement("button");
+  apply.type = "button";
+  apply.className = "ed-btn-add dm-ad-apply";
+  apply.textContent = t("✅ Applica e ricarica", "✅ Apply and reload");
+  apply.addEventListener("click", () => applyProposal(proposal));
+  const cancel = doc.createElement("button");
+  cancel.type = "button";
+  cancel.className = "ed-btn-add dm-ad-cancel";
+  cancel.textContent = t("Annulla", "Cancel");
+  cancel.addEventListener("click", () => {
+    state.proposal = null;
+    const node = outlet();
+    if (node) node.textContent = "";
+  });
+  actions.append(apply, cancel);
+  panel.append(actions);
+  target.append(panel);
+}
+
+/* ── Home Assistant data ──────────────────────────────────────────────────── */
+
+/* `cdRegEnrich` already fetches the floor, area, entity and device registries
+ * through whichever transport the page has — the bridge when hosted, a token
+ * socket when standalone — and hands them to `cdRegApply`. Borrowing that call
+ * gives the detector real areas without a second implementation of the same
+ * fetch.
+ *
+ * What it must not do here is let `cdRegApply` run: applying it creates a room
+ * for every Home Assistant area, and the detector would then find the rooms
+ * already configured and propose none. The runtime applies the registries after
+ * detection, and so does this section — through the same `cdRegEnrich` call,
+ * once the proposal has been accepted. */
+function loadRegistries(callback) {
+  const apply = root.cdRegApply;
+  if (typeof root.cdRegEnrich !== "function" || typeof apply !== "function") {
+    callback(null);
+    return;
+  }
+  let captured = null;
+  let done = false;
+  const capture = function capturedRegApply(payload) {
+    captured = payload;
+    return null;
+  };
+  const finish = () => {
+    if (done) return;
+    done = true;
+    if (root.cdRegApply === capture) root.cdRegApply = apply;
+    callback(captured);
+  };
+  root.cdRegApply = capture;
+  try {
+    root.cdRegEnrich(finish);
+  } catch (_error) {
+    finish();
+  }
+  root.setTimeout?.(finish, WAIT_LIMIT);
+}
+
+export function areaLookup(registries) {
+  const areaName = new Map();
+  for (const area of registries?.areas || []) areaName.set(area.area_id, clean(area.name));
+  const deviceArea = new Map();
+  for (const device of registries?.devs || []) if (device.area_id) deviceArea.set(device.id, device.area_id);
+  const entityArea = new Map();
+  for (const entity of registries?.ents || []) {
+    const areaId = entity.area_id || deviceArea.get(entity.device_id);
+    const name = areaId ? areaName.get(areaId) : "";
+    if (name) entityArea.set(entity.entity_id, name);
+  }
+  /* The wizard may already hold the same three registries in its own shape. */
+  const wiz = lexicalGlobal("WIZ");
+  if (!entityArea.size && wiz?.entReg) {
+    for (const [id, registry] of Object.entries(wiz.entReg)) {
+      const areaId = registry?.a || (registry?.d && wiz.devArea?.[registry.d]) || "";
+      const name = areaId ? clean(wiz.areaNames?.[areaId]) : "";
+      if (name) entityArea.set(id, name);
+    }
+  }
+  return entityArea;
+}
+
+function waitForMeta(callback) {
+  const started = Date.now();
+  const tick = () => {
+    const meta = lexicalGlobal("WIZ")?.allMeta;
+    if (Array.isArray(meta) && meta.length) {
+      callback(meta);
+      return;
+    }
+    if (Date.now() - started >= WAIT_LIMIT) {
+      callback(null);
+      return;
+    }
+    root.setTimeout?.(tick, WAIT_STEP);
+  };
+  tick();
+}
+
+/* `wzLoadAllEntities` reads its connection details from the wizard's own state,
+ * which the runtime only fills when the wizard is opened. The vendored button
+ * opens it and throws the markup away for exactly this reason, so the override
+ * does the same rather than sending an unauthenticated socket. */
+function primeWizard() {
+  try {
+    root.apriSetupWizard?.();
+    doc?.getElementById("setup-wizard")?.remove();
+  } catch (_error) {}
+}
+
+/* Hosted in Home Assistant, the panel already holds every state with its
+ * attributes, so the detector can start without a round trip. Standalone, the
+ * runtime's own loader is asked for the full list and polled at a rate that
+ * notices it arriving, instead of every half second. */
+function loadEntities(callback) {
+  const live = allStates();
+  if (Object.keys(live).length >= HOSTED_ENOUGH) {
+    callback(live, null);
+    return;
+  }
+  const meta = lexicalGlobal("WIZ")?.allMeta;
+  if (Array.isArray(meta) && meta.length) {
+    callback(live, meta);
+    return;
+  }
+  primeWizard();
+  try {
+    root.wzLoadAllEntities?.();
+  } catch (_error) {}
+  waitForMeta((loaded) => callback(allStates(), loaded));
+}
+
+function buildIndex(live, meta, entityArea) {
+  const entries = [];
+  const seen = new Set();
+  for (const entry of meta || []) {
+    const id = clean(entry?.id);
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    entries.push(entry);
+  }
+  for (const [id, snapshot] of Object.entries(live || {})) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    entries.push({ id, ...snapshot, entity_id: id });
+  }
+  const enrich = (id, entry) => {
+    const current = live?.[id];
+    const area = entityArea.get(id) || entry?.area || "";
+    if (!current) return area ? { area } : null;
+    return {
+      dc: current.attributes?.device_class || entry?.dc || "",
+      unit: current.attributes?.unit_of_measurement || entry?.unit || "",
+      sc: current.attributes?.state_class || entry?.sc || "",
+      state: current.state,
+      area,
+    };
+  };
+  return buildEntityIndex(entries, { enrich, version: `autodetect|${entityArea.size}` });
+}
+
+/* ── Detection ────────────────────────────────────────────────────────────── */
+
+function slotPlans() {
+  const sections = lexicalGlobal("CD_SLOTS");
+  if (!sections || typeof sections !== "object") return [];
+  const plans = [];
+  for (const [key, section] of Object.entries(sections)) {
+    for (const slot of section?.slots || []) plans.push(parseSlotPlan(slot, key));
+  }
+  return plans;
+}
+
+function currentOverrides() {
+  const stored = readJson("cd_entity_overrides", {});
+  const lexical = lexicalGlobal("ENTITY_OVERRIDES");
+  return { ...(lexical && typeof lexical === "object" ? lexical : {}), ...(stored || {}) };
+}
+
+function buildProposal(index, elapsedStart) {
+  const overrides = currentOverrides();
+  const configured = new Set(Object.values(overrides).filter((value) => clean(value).includes(".")));
+  const plans = slotPlans().filter((plan) => !clean(overrides[plan.ref]));
+  const postings = buildPostings(index.records);
+  const slots = detectSlots(index.records, plans, { taken: configured, postings });
+  const categories = detectCategories(index.records);
+
+  const lights = readJson("cd_luci", {}) || {};
+  const rooms = readJson("cd_stanze", []) || [];
+  const climate = readJson("cd_clima_units", []) || [];
+  const cameras = readJson("cd_cameras", []) || [];
+  const skipped = {
+    lights: Object.keys(lights).length > 0,
+    rooms: Array.isArray(rooms) && rooms.length > 0,
+    climate: Array.isArray(climate) && climate.length > 0,
+    cameras: Array.isArray(cameras) && cameras.length > 0,
+  };
+
+  const groups = {};
+  const existingGroups = readJson("cd_gruppi_extra", {}) || {};
+  let groupCount = 0;
+  for (const [name, ids] of Object.entries(categories.groups)) {
+    if (Array.isArray(existingGroups[name]) && existingGroups[name].length) continue;
+    if (!ids.length) continue;
+    groups[name] = ids;
+    groupCount += ids.length;
+  }
+
+  return {
+    entities: index.size,
+    elapsed: Math.max(1, Math.round(Date.now() - elapsedStart)),
+    assignments: slots.assignments,
+    undecided: slots.undecided,
+    lights: skipped.lights ? {} : categories.lights,
+    lightCount: skipped.lights ? Object.keys(lights).length : Object.keys(categories.lights).length,
+    rooms: skipped.rooms ? [] : categories.rooms,
+    climate: skipped.climate ? [] : categories.climate,
+    cameras: skipped.cameras ? [] : categories.cameras,
+    groups,
+    groupCount,
+    skipped,
+  };
+}
+
+/* ── Applying ─────────────────────────────────────────────────────────────── */
+
+/* In schema 4 the Energy slots are not owned by `cd_entity_overrides` at all:
+ * the canonical `energy` section owns them, and the store projects it back over
+ * the overrides — deleting any `dm.energy_*` entry the model does not contain.
+ * Writing an Energy detection the way the runtime always did therefore lands a
+ * value that the next projection removes, which is why auto-detected Energy
+ * links did not survive. These go into the model instead, and the projection
+ * puts them back into the overrides itself. */
+const ENERGY_SLOT_PATHS = new Map(
+  Object.entries(ENERGY_SLOT_MAP).map(([path, slot]) => [slot, path.split(".")]),
+);
+
+async function writeEnergyAssignments(assignments) {
+  const energy = assignments.filter((item) => ENERGY_SLOT_PATHS.has(item.ref));
+  if (!energy.length) return assignments;
+  const store = dashboardStore();
+  const rest = assignments.filter((item) => !ENERGY_SLOT_PATHS.has(item.ref));
+  const model = store?.getSection ? { ...(store.getSection("energy") || {}) } : readJson("cd_energy_model", {}) || {};
+  for (const item of energy) {
+    const [group, key] = ENERGY_SLOT_PATHS.get(item.ref);
+    model[group] = { ...(model[group] || {}) };
+    if (!clean(model[group][key])) model[group][key] = item.id;
+  }
+  model.metadata = { ...(model.metadata || {}), semantics_version: 3 };
+  if (store?.replaceSection) await store.replaceSection("energy", model);
+  else writeJson("cd_energy_model", model);
+  return rest;
+}
+
+function writeJson(key, value) {
+  try {
+    root.localStorage?.setItem(key, JSON.stringify(value));
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+export async function applyProposal(proposal) {
+  const target = outlet();
+  if (target) {
+    target.innerHTML = '<div class="ed-intro dm-ad-saving"></div>';
+    const line = target.querySelector(".dm-ad-saving");
+    if (line) line.textContent = t("💾 Salvo e ricarico…", "💾 Saving and reloading…");
+  }
+  if (Object.keys(proposal.lights).length) writeJson("cd_luci", proposal.lights);
+  if (proposal.rooms.length) writeJson("cd_stanze", proposal.rooms);
+  if (proposal.climate.length) writeJson("cd_clima_units", proposal.climate);
+  if (proposal.cameras.length) writeJson("cd_cameras", proposal.cameras);
+  if (proposal.assignments.length) {
+    const rest = await writeEnergyAssignments(proposal.assignments);
+    if (rest.length) {
+      const overrides = readJson("cd_entity_overrides", {}) || {};
+      for (const item of rest) overrides[item.ref] = item.id;
+      writeJson("cd_entity_overrides", overrides);
+    }
+  }
+  if (Object.keys(proposal.groups).length) {
+    const groups = readJson("cd_gruppi_extra", {}) || {};
+    for (const [name, ids] of Object.entries(proposal.groups)) groups[name] = ids;
+    writeJson("cd_gruppi_extra", groups);
+  }
+  try {
+    root.cdMarkDirty?.();
+    root.cdSyncPush?.();
+  } catch (_error) {}
+  const reload = () => root.setTimeout?.(() => root.location?.reload?.(), 400);
+  try {
+    if (typeof root.cdRegEnrich === "function") root.cdRegEnrich(reload);
+    else reload();
+  } catch (_error) {
+    reload();
+  }
+}
+
+/* ── Entry point ──────────────────────────────────────────────────────────── */
+
+function run() {
+  if (state.running) return;
+  state.running = true;
+  const started = Date.now();
+  progress(1, 3, t("Leggo aree ed entità da Home Assistant…", "Reading areas and entities from Home Assistant…"));
+
+  /* The two reads are independent sockets and were waited on one after the
+   * other, so a slow answer to the first was paid on top of the second. */
+  let pending = 2;
+  let entityArea = new Map();
+  let live = null;
+  let meta = null;
+  const ready = () => {
+    if ((pending -= 1) > 0) return;
+    const index = buildIndex(live, meta, entityArea);
+    if (!index.size) {
+      state.running = false;
+      failure(
+        t(
+          "Non riesco a leggere le entità da Home Assistant. Controlla la connessione e riprova.",
+          "I cannot read the entities from Home Assistant. Check the connection and try again.",
+        ),
+      );
+      return;
+    }
+    progress(2, 3, t(`Analizzo ${index.size} entità…`, `Analysing ${index.size} entities…`));
+    /* One frame between the message and the work, so the progress the user is
+     * reading is the progress that is actually happening. */
+    root.setTimeout?.(() => {
+      try {
+        const proposal = buildProposal(index, started);
+        state.proposal = proposal;
+        progress(3, 3, t("Fatto", "Done"));
+        renderSummary(proposal);
+      } catch (error) {
+        failure(String(error?.message || error));
+      } finally {
+        state.running = false;
+      }
+    }, 0);
+  };
+
+  loadRegistries((registries) => {
+    entityArea = areaLookup(registries);
+    ready();
+  });
+  loadEntities((states, loaded) => {
+    live = states;
+    meta = loaded;
+    ready();
+  });
+}
+
+function installStyles() {
+  installStyle(
+    "dm-entity-autodetect-style",
+    `
+    #ed-rileva-out .dm-ad-progress{margin-top:10px}
+    #ed-rileva-out .dm-ad-bar{height:8px;border-radius:999px;background:rgba(148,163,184,.22);overflow:hidden}
+    #ed-rileva-out .dm-ad-bar>i{display:block;height:100%;border-radius:999px;background:linear-gradient(135deg,#38bdf8,#0369a1);transition:width .25s ease}
+    #ed-rileva-out .dm-ad-step{margin-top:6px;color:var(--text-dim,#64748b);font-size:12px;font-weight:700}
+    #ed-rileva-out .dm-ad-error{color:#b91c1c;font-weight:700}
+    #ed-rileva-out .dm-ad-summary{margin-top:12px;padding:14px;border:1px solid rgba(148,163,184,.24);border-radius:18px;background:rgba(248,250,252,.75)}
+    #ed-rileva-out .dm-ad-title{font-size:15px;font-weight:900;color:var(--text,#0f172a)}
+    #ed-rileva-out .dm-ad-intro{margin:4px 0 10px;color:var(--text-dim,#64748b);font-size:11.5px;font-weight:700}
+    #ed-rileva-out .dm-ad-row{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:7px 0;border-bottom:1px solid rgba(148,163,184,.16);font-size:13px}
+    #ed-rileva-out .dm-ad-row:last-of-type{border-bottom:0}
+    #ed-rileva-out .dm-ad-row-label{font-weight:700;color:var(--text,#0f172a)}
+    #ed-rileva-out .dm-ad-row-value{min-width:34px;padding:2px 10px;border-radius:999px;background:#e0f2fe;color:#0369a1;font-size:12px;font-weight:900;text-align:center}
+    #ed-rileva-out .dm-ad-row-value.is-empty{background:rgba(148,163,184,.16);color:var(--text-dim,#64748b)}
+    #ed-rileva-out .dm-ad-list{margin-top:10px;display:flex;flex-direction:column;gap:5px;max-height:220px;overflow:auto}
+    #ed-rileva-out .dm-ad-link{display:flex;flex-direction:column;gap:1px;padding:7px 10px;border-radius:11px;background:rgba(255,255,255,.85);font-size:12px}
+    #ed-rileva-out .dm-ad-link .mono{color:var(--text-dim,#64748b);font-family:monospace;font-size:10.5px}
+    #ed-rileva-out .dm-ad-more,#ed-rileva-out .dm-ad-note{margin-top:8px;color:var(--text-dim,#64748b);font-size:11.5px;font-weight:700}
+    #ed-rileva-out .dm-ad-actions{display:flex;gap:8px;margin-top:14px}
+    #ed-rileva-out .dm-ad-actions .ed-btn-add{flex:1}
+    #ed-rileva-out .dm-ad-cancel{background:rgba(148,163,184,.28)!important;color:var(--text,#0f172a)!important}
+  `,
+  );
+}
+
+function installOverride() {
+  const legacy = root.edAutoRileva;
+  if (typeof legacy === "function" && legacy.__dmFastAutodetect) return false;
+  const fast = function edAutoRileva() {
+    try {
+      installStyles();
+      run();
+      return;
+    } catch (_error) {}
+    try {
+      legacy?.call(this);
+    } catch (_ignore) {}
+  };
+  fast.__dmFastAutodetect = true;
+  fast.__dmPrevious = legacy;
+  root.edAutoRileva = fast;
+  return true;
+}
+
+export function installEntityAutodetectSection() {
+  if (!doc || state.installed) return false;
+  state.installed = true;
+  installStyles();
+  installOverride();
+  for (const event of ["dashboardmodern:legacy-ready", "dashboardmodern:runtime-ready"]) {
+    root.addEventListener?.(event, installOverride);
+  }
+  doc.addEventListener("click", (event) => {
+    if (event.target?.closest?.("#editor-modal,.ed-tab,#ed-body")) installOverride();
+  }, true);
+  return true;
+}
+
+installEntityAutodetectSection();

--- a/custom_components/dashboardmodern/frontend/src/sections/entity-picker-guard-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/entity-picker-guard-section.js
@@ -76,6 +76,22 @@ function choose(input) {
   }
 }
 
+// .dm-entity-picker-row is display:flex with min-width:0 children, so it must
+// only ever land on the little wrapper that holds the field and its button.
+// The Tapparelle, Telecamere and Irrigazione forms put fields directly inside
+// #ed-body, and flexing that laid the whole editor out as a row: the intro,
+// every configured row, the inputs and the add button each collapsed into a
+// column a few pixels wide, with the words broken one letter per line.
+const NEVER_A_PICKER_ROW = "#ed-body,.ed-body,.ed-shell,#editor-modal,#setup-wizard,.ed-list,.dm-section-dialog,body";
+
+function markPickerRow(parent) {
+  if (!parent || !["LABEL", "SPAN", "DIV"].includes(parent.tagName)) return;
+  if (parent.matches?.(NEVER_A_PICKER_ROW)) return;
+  // A wrapper that holds more than the one field is a container, not a row.
+  if (parent.querySelectorAll("input,select,textarea").length > 1) return;
+  parent.classList.add("dm-entity-picker-row");
+}
+
 function mountOne(input) {
   cleanupFalsePicker(input);
   if (!isEntityInput(input)) return false;
@@ -106,8 +122,7 @@ function mountOne(input) {
   button.type = "button";
   button.dataset.entityTarget = id;
   button.setAttribute("aria-label", button.getAttribute("aria-label") || `Seleziona entità per ${input.getAttribute("aria-label") || input.name || id}`);
-  const parent = input.parentElement;
-  if (parent && ["LABEL", "SPAN", "DIV"].includes(parent.tagName)) parent.classList.add("dm-entity-picker-row");
+  markPickerRow(input.parentElement);
   return true;
 }
 
@@ -115,6 +130,10 @@ export function reconcileEntityPickers(scope = doc) {
   if (!scope?.querySelectorAll) return 0;
   // Let the canonical renderer mount first. The guard only fills genuine gaps.
   try { root.DashboardModernModules?.render?.mountEntityPickers?.(scope); } catch (_error) {}
+  // Take the flex row back off any container an earlier release flexed.
+  for (const node of [scope, ...scope.querySelectorAll(NEVER_A_PICKER_ROW)]) {
+    node?.classList?.remove?.("dm-entity-picker-row");
+  }
   let count = 0;
   scope.querySelectorAll("input").forEach((input) => { if (mountOne(input)) count += 1; });
   return count;

--- a/custom_components/dashboardmodern/frontend/src/sections/entity-picker-guard-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/entity-picker-guard-section.js
@@ -3,15 +3,32 @@ import { clean, doc, installStyle, root, wrapFunction } from "./shared.js";
 const KEY = "__DASHBOARDMODERN_ENTITY_PICKER_GUARD__";
 const state = (root[KEY] ||= { installed: false, frame: 0, subscribed: false });
 const ENTITY_ID = /^[a-z_][a-z0-9_]*\.[a-z0-9_]+$/i;
-const ALERT_NON_ENTITY_IDS = new Set(["ed-avv-name", "ed-avv-val", "ed-avv-icon"]);
+// An entity_id can only be typed into a free-text field. Every other input type
+// in the editors holds a duration, a threshold, a time or a flag, so a lens
+// button next to it offers something the field cannot accept.
+const PICKABLE_TYPES = new Set(["text", "search", "url"]);
+// Editor ids that sit under an entity-shaped prefix but hold plain text: the
+// Alerts form reuses ed-avv-* for entity, display name, comparison value and
+// icon, and the camera / irrigation / shutter forms reuse their prefix for the
+// name the user gives the device and for the go2rtc stream name.
+const NON_ENTITY_IDS = new Set([
+  "ed-avv-name",
+  "ed-avv-val",
+  "ed-avv-icon",
+  "ed-cam-name",
+  "ed-cam-stream",
+  "ed-irr-name",
+  "ed-tp-name",
+]);
 
 function isEntityInput(input) {
-  if (!(input instanceof HTMLInputElement) || input.type === "hidden") return false;
+  if (!(input instanceof HTMLInputElement) || !PICKABLE_TYPES.has(input.type)) return false;
   const id = clean(input.id).toLowerCase();
-  // The Alerts form historically uses the same ed-avv-* prefix for entity,
-  // display name, comparison value and icon. Only ed-avv-ent is an entity_id.
-  // Check this before the generic data-entity marker because an older guard may
-  // already have decorated one of those text inputs during the current render.
+  // Check the exclusions before the generic data-entity marker because an older
+  // guard may already have decorated one of those text inputs during the
+  // current render.
+  if (NON_ENTITY_IDS.has(id)) return false;
+  // Of the whole ed-avv-* family only ed-avv-ent is an entity_id.
   if (id.startsWith("ed-avv-")) return id === "ed-avv-ent";
   if (input.dataset.entityInput === "true" || input.closest("[data-entity-field]")) return true;
   if (input.matches(".ed-slot-in[data-ref],input[data-domain]")) return true;
@@ -24,8 +41,10 @@ function isEntityInput(input) {
   return Boolean(input.nextElementSibling?.matches?.(".dm-entity-picker,button[onclick*='wzPickEntity']"));
 }
 
-function cleanupFalseAlertPicker(input) {
-  if (!(input instanceof HTMLInputElement) || !ALERT_NON_ENTITY_IDS.has(clean(input.id).toLowerCase())) return false;
+function cleanupFalsePicker(input) {
+  if (!(input instanceof HTMLInputElement)) return false;
+  const stale = NON_ENTITY_IDS.has(clean(input.id).toLowerCase()) || !PICKABLE_TYPES.has(input.type);
+  if (!stale) return false;
   const parent = input.parentElement;
   const generated = input.nextElementSibling?.matches?.(".dm-entity-picker[data-dm-persistent-picker='true']")
     ? input.nextElementSibling
@@ -58,7 +77,7 @@ function choose(input) {
 }
 
 function mountOne(input) {
-  cleanupFalseAlertPicker(input);
+  cleanupFalsePicker(input);
   if (!isEntityInput(input)) return false;
   const id = ensureId(input);
   input.dataset.entityInput = "true";

--- a/custom_components/dashboardmodern/frontend/src/sections/entity-search-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/entity-search-section.js
@@ -33,7 +33,7 @@ import {
   rankMatches,
   searchEntityIndex,
 } from "../core/entity-search-index.js";
-import { allStates, clean, doc, installStyle, root, t } from "./shared.js";
+import { allStates, clean, doc, installStyle, lexicalGlobal, root, t } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_ENTITY_SEARCH__";
 const PAGE = 60;
@@ -64,12 +64,18 @@ const entryId = (entry) => clean(entry?.id || entry?.entity_id);
 
 /* ── Entity sources ───────────────────────────────────────────────────────── */
 
-function areaOf(id) {
-  const wiz = root.WIZ;
-  const registry = wiz?.entReg?.[id];
-  if (!registry) return "";
-  const areaId = registry.a || (registry.d && wiz.devArea?.[registry.d]) || "";
-  return clean(areaId && wiz.areaNames?.[areaId]);
+/* Resolved once per index build, never per entity: reaching the runtime's
+ * script scope costs an `eval`, and paying that for every entity in the house
+ * is exactly the kind of per-item cost this index exists to remove. */
+function areaResolver() {
+  const wiz = lexicalGlobal("WIZ");
+  if (!wiz?.entReg) return () => "";
+  return (id) => {
+    const registry = wiz.entReg[id];
+    if (!registry) return "";
+    const areaId = registry.a || (registry.d && wiz.devArea?.[registry.d]) || "";
+    return clean(areaId && wiz.areaNames?.[areaId]);
+  };
 }
 
 /* The picker list and the live state map each know something the other does
@@ -105,6 +111,7 @@ function ensureIndex({ refresh = false } = {}) {
   const signature = `${entries.length}|${entryId(entries[0])}|${entryId(entries[entries.length - 1])}`;
   state.sourceRef = root._cdEpAll;
   if (state.index && state.signature === signature) return state.index;
+  const areaOf = areaResolver();
   const enrich = (id) => {
     const live = states[id];
     const area = areaOf(id);
@@ -434,9 +441,15 @@ function installFilter() {
   const legacy = root.cdEpFilter;
   if (typeof legacy === "function" && legacy.__dmFastEntitySearch) return false;
   const fast = function cdEpFilter(query) {
+    state.calls = (state.calls || 0) + 1;
     try {
       if (render(query)) return;
-    } catch (_error) {}
+      state.lastError = "empty-index";
+    } catch (error) {
+      /* Kept for support: a picker that quietly fell back to the vendored list
+       * should be able to say why it did. */
+      state.lastError = String(error?.message || error);
+    }
     /* Never leave the picker without a list: if anything above fails the
      * vendored filter still paints exactly what it always did. */
     try {
@@ -446,6 +459,15 @@ function installFilter() {
   fast.__dmFastEntitySearch = true;
   fast.__dmPrevious = legacy;
   root.cdEpFilter = fast;
+  /* On a slow first load the dialog can be open before this module is: the
+   * runtime painted its own list and will not call the filter again until the
+   * user types. Repainting the open picker here is what makes the fast list
+   * appear anyway, instead of waiting for it to be closed and reopened. */
+  const open = doc?.getElementById("cd-ep-list");
+  if (open && open.dataset.dmFastPicker !== "true") {
+    const search = doc.getElementById("cd-ep-search");
+    root.queueMicrotask?.(() => fast(search?.value || ""));
+  }
   return true;
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
@@ -13,6 +13,8 @@ const state = (root[KEY] ||= {
   selectorSignature: "",
 });
 const ENTITY_ID = /^[a-z_][a-z0-9_]*\.[a-z0-9_]+$/i;
+/* Paths Home Assistant already serves; anything else absolute lives under /local. */
+const HA_ROOTS = ["/local/", "/api/", "/media/", "/hacsfiles/", "/static/", "/frontend_latest/", "/auth/"];
 
 function integrationAssetRoot(base) {
   try {
@@ -40,7 +42,12 @@ export function resolveVehicleAsset(value, base = doc?.baseURI || root.location?
     const assetRoot = integrationAssetRoot(base);
     return assetRoot ? new URL(raw.slice(prefix.length), assetRoot).href : "";
   }
-  if (raw.startsWith("/")) return raw.replace(/^\/local\/\/+/, "/local/");
+  if (raw.startsWith("/")) {
+    const absolute = raw.replace(/^\/local\/\/+/, "/local/");
+    // Home Assistant serves /config/www as /local. A bare absolute path like
+    // "/ev/idle.png" is a www file missing that prefix, and 404s without it.
+    return HA_ROOTS.some((prefix) => absolute.startsWith(prefix)) ? absolute : `/local${absolute}`;
+  }
   try { return new URL(raw.replace(/^\.\//, ""), base).href; } catch (_error) { return ""; }
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/ev-showcase-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/ev-showcase-section.js
@@ -170,6 +170,25 @@ function mountModeButtons(page) {
   }
 }
 
+/**
+ * Mark the frame from the photo that actually loaded. `data-ev-image` only says
+ * whether a URL is configured, so a broken URL used to leave an empty slab.
+ */
+function syncPhoto(hero) {
+  const image = doc.getElementById("ev-mod-car-img");
+  if (!image) return;
+  if (!image.dataset.dmEvvWatched) {
+    image.dataset.dmEvvWatched = "true";
+    for (const eventName of ["load", "error"]) {
+      image.addEventListener(eventName, () => scheduleEvShowcase());
+    }
+  }
+  const broken = image.dataset.evFailed === "1" || Boolean(image.dataset.evImageError);
+  const loaded = Boolean(clean(image.getAttribute("src"))) && !broken && image.naturalWidth > 0;
+  const value = loaded ? "on" : "off";
+  if (hero.dataset.dmEvvPhoto !== value) hero.dataset.dmEvvPhoto = value;
+}
+
 /* ── render ───────────────────────────────────────────────────────────── */
 
 export function renderEvShowcase() {
@@ -184,6 +203,7 @@ export function renderEvShowcase() {
 
   const mode = evActiveMode(doc);
   if (page.dataset.dmEvMode !== mode) page.dataset.dmEvMode = mode;
+  syncPhoto(hero);
 
   const arc = power?.querySelector(".dm-evv-arc");
   if (arc) {
@@ -332,14 +352,14 @@ function evShowcaseCss() {
   font-size:11px!important;letter-spacing:.04em!important;backdrop-filter:blur(8px)!important;
   box-shadow:0 8px 20px rgba(6,14,22,.28)!important
 }
-/* no photo configured yet: a quiet placeholder instead of an empty slab */
-#page-ev.dm-evv .lm-hero[data-ev-image="missing"]{
+/* no photo on screen — missing or broken URL: a quiet placeholder, not a slab */
+#page-ev.dm-evv .lm-hero[data-dm-evv-photo="off"]{
   height:clamp(150px,30vw,196px)!important;
   background:
     radial-gradient(120% 90% at 50% 118%,rgba(var(--evv-green-rgb),.13) 0%,transparent 62%),
     linear-gradient(180deg,#fff,#eef4f9)!important
 }
-#page-ev.dm-evv .lm-hero[data-ev-image="missing"]::before{
+#page-ev.dm-evv .lm-hero[data-dm-evv-photo="off"]::before{
   content:"";position:absolute;inset:0;z-index:1;opacity:.16;
   background:no-repeat center/auto 42% url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%230c1420' stroke-width='1.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3 13.4 4.9 8.5A3 3 0 0 1 7.7 6.6h8.6a3 3 0 0 1 2.8 1.9l1.9 4.9M3 13.4h18M3 13.4V17h3.2v-3.6M20.8 13.4V17h-3.2v-3.6'/%3E%3C/svg%3E")
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/lights-alerts-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/lights-alerts-section.js
@@ -1,3 +1,4 @@
+import { LIGHT_DOMAINS, isLightEntity, lightView } from "../core/light-model.js";
 import {
   allStates,
   clean,
@@ -103,13 +104,42 @@ function roomOptions(selected) {
   ].join("");
 }
 
+/* What the Luci tab shows about an entity beyond its name: whether it is a
+ * lamp or a relay, and what Home Assistant says it can do. A light that only
+ * turns on and off, a dimmer and an RGB strip are configured identically here,
+ * so the badge is the only place the difference is visible before opening the
+ * controls. */
+function lightMeta(id) {
+  const view = lightView(id, { state: allStates()?.[id] });
+  const badges = [];
+  if (!view.available) badges.push({ kind: "off", label: t("NON DISPONIBILE", "UNAVAILABLE") });
+  if (view.colorful) badges.push({ kind: "rgb", label: "RGB" });
+  if (view.tunable) badges.push({ kind: "white", label: t("BIANCO", "WHITE") });
+  if (view.dimmable && !view.colorful && !view.tunable)
+    badges.push({ kind: "dim", label: t("DIMMER", "DIMMER") });
+  if (!view.dimmable && !view.colorful && !view.tunable)
+    badges.push({ kind: "onoff", label: t("ON/OFF", "ON/OFF") });
+  if (view.domain !== "light") badges.push({ kind: "domain", label: view.domain.toUpperCase() });
+  return {
+    view,
+    glyph: view.domain === "light" ? "💡" : "🔌",
+    badges: badges
+      .map(
+        (badge) =>
+          `<span class="dm-light-badge" data-kind="${badge.kind}">${esc(badge.label)}</span>`,
+      )
+      .join(""),
+  };
+}
+
 export function renderCanonicalLightsEditor() {
   const groups = configuredLightGroups();
   const assignments = readJson("cd_luci_rooms", {});
   const add = `<form class="ed-form dm-light-add-form" data-light-add-form onsubmit="event.preventDefault();cdLuceAdd()">
     <div class="ed-sec-title">＋ ${t("AGGIUNGI LUCE", "ADD LIGHT")}</div>
-    <div class="ed-form-row"><input id="luce-add-ent" class="ed-input mono" data-entity-input data-light-add-entity placeholder="light.salone"><button type="button" class="dm-entity-picker" data-entity-target="luce-add-ent" onclick="wzPickEntity(document.getElementById('luce-add-ent'))" aria-label="${t("Seleziona entità luce", "Select light entity")}">🔍</button></div>
+    <div class="ed-form-row"><input id="luce-add-ent" class="ed-input mono" data-entity-input data-light-add-entity data-domain="${LIGHT_DOMAINS.join(" ")}" placeholder="light.salone · switch.lampada"><button type="button" class="dm-entity-picker" data-entity-target="luce-add-ent" onclick="wzPickEntity(document.getElementById('luce-add-ent'))" aria-label="${t("Seleziona entità luce", "Select light entity")}">🔍</button></div>
     <input id="luce-add-name" class="ed-input" placeholder="${t("Nome luce", "Light name")}">
+    <div class="dm-light-add-hint">${t("Una luce può essere un'entità light.* oppure uno switch.*: una lampada dietro un relè si aggiunge esattamente allo stesso modo.", "A light can be a light.* entity or a switch.*: a lamp behind a relay is added in exactly the same way.")}</div>
     <button type="submit" class="ed-btn-add">＋ ${t("Aggiungi luce", "Add light")}</button>
   </form>`;
   if (!groups.length)
@@ -119,9 +149,10 @@ export function renderCanonicalLightsEditor() {
       const rows = group.entities
         .map((id, index) => {
           const name = group.lights[id] || allStates()?.[id]?.attributes?.friendly_name || id;
+          const meta = lightMeta(id);
           return `<article class="ed-row dm-light-row" data-light-entity="${esc(id)}">
             <span class="dm-light-order"><button type="button" class="ed-del" ${index === 0 ? "disabled" : ""} onclick="dmLightMove('${esc(id)}',-1)" aria-label="${t("Sposta su", "Move up")}">▲</button><button type="button" class="ed-del" ${index === group.entities.length - 1 ? "disabled" : ""} onclick="dmLightMove('${esc(id)}',1)" aria-label="${t("Sposta giù", "Move down")}">▼</button></span>
-            <div class="ed-row-main"><div class="ed-row-new">💡 ${esc(name)}</div><div class="ed-row-old mono">${esc(id)}</div></div>
+            <div class="ed-row-main"><div class="ed-row-new">${meta.glyph} ${esc(name)}</div><div class="ed-row-old mono">${esc(id)}</div><div class="dm-light-badges">${meta.badges}</div></div>
             <select class="ed-input dm-light-room" data-light-entity="${esc(id)}" onchange="dmLightSetRoom('${esc(id)}',this.value)">${roomOptions(assignments[id])}</select>
             <button type="button" class="ed-del dm-light-edit" onclick="dmOpenLightEditor('${esc(id)}')" aria-label="${t("Modifica luce", "Edit light")}">✏️</button>
             <button type="button" class="ed-del" onclick="cdLuceDel('${esc(id)}')" aria-label="${t("Elimina luce", "Delete light")}">🗑️</button>
@@ -131,7 +162,7 @@ export function renderCanonicalLightsEditor() {
       return `<section class="dm-light-group" data-light-room="${esc(group.room)}"><header class="ed-acc-head"><span>🏠 ${esc(group.room)} · ${group.entities.length}</span><span class="dm-light-room-order"><button type="button" class="ed-del" ${groupIndex === 0 ? "disabled" : ""} onclick="dmLightRoomMove('${esc(group.room)}',-1)">▲</button><button type="button" class="ed-del" ${groupIndex === groups.length - 1 ? "disabled" : ""} onclick="dmLightRoomMove('${esc(group.room)}',1)">▼</button></span></header><div class="ed-list">${rows}</div></section>`;
     })
     .join("");
-  return `<div class="ed-intro">${t("Sono mostrate solo le stanze che contengono almeno una luce. Modifica apre tutti i dati della luce, non una finestra del browser.", "Only rooms containing a light are shown. Edit opens all light fields, not a browser prompt.")}</div>${body}${add}`;
+  return `<div class="ed-intro">${t("Sono mostrate solo le stanze che contengono almeno una luce. Modifica apre tutti i dati della luce, non una finestra del browser. Le pastiglie dicono cosa sa fare ogni luce — RGB, bianco regolabile, dimmer o solo acceso/spento — ed è quello che comanda i controlli nel popup.", "Only rooms containing a light are shown. Edit opens all light fields, not a browser prompt. The pills say what each light can do — RGB, tunable white, dimmer or plain on/off — and that is what drives the controls in the popup.")}</div>${body}${add}`;
 }
 
 function persistLightOrder(groups, { sync = true } = {}) {
@@ -218,14 +249,16 @@ export function openLightEditor(entityId) {
   if (!oldId || !names[oldId]) return;
   doc?.getElementById("dm-light-editor-modal")?.remove();
   const assignments = readJson("cd_luci_rooms", {});
+  const meta = lightMeta(oldId);
   const modal = doc.createElement("div");
   modal.id = "dm-light-editor-modal";
   modal.className = "dm-section-modal";
   modal.innerHTML = `<section class="dm-section-dialog" role="dialog" aria-modal="true" aria-labelledby="dm-light-editor-title">
-    <header><strong id="dm-light-editor-title">💡 ${t("Modifica luce", "Edit light")}</strong><button type="button" data-close aria-label="${t("Chiudi", "Close")}">✕</button></header>
+    <header><strong id="dm-light-editor-title">${meta.glyph} ${t("Modifica luce", "Edit light")}</strong><button type="button" data-close aria-label="${t("Chiudi", "Close")}">✕</button></header>
     <form data-form>
       <label class="ed-slot"><span class="ed-slot-lbl">${t("Nome", "Name")}</span><input class="ed-input" name="name" value="${esc(names[oldId])}" required></label>
-      <label class="ed-slot"><span class="ed-slot-lbl">${t("Entità Home Assistant", "Home Assistant entity")}</span><span class="ed-form-row"><input class="ed-input mono" name="entity" value="${esc(oldId)}" required><button type="button" class="dm-entity-picker" data-pick>🔍</button></span></label>
+      <label class="ed-slot"><span class="ed-slot-lbl">${t("Entità Home Assistant", "Home Assistant entity")}</span><span class="ed-form-row"><input class="ed-input mono" name="entity" value="${esc(oldId)}" required data-domain="${LIGHT_DOMAINS.join(" ")}"><button type="button" class="dm-entity-picker" data-pick>🔍</button></span></label>
+      <div class="ed-slot"><span class="dm-light-caps-lbl">${t("Cosa sa fare", "What it can do")}</span><div class="dm-light-caps"><div class="dm-light-badges" data-capabilities>${meta.badges}</div><button type="button" class="dm-light-caps-try" data-controls>${t("Prova i controlli", "Try the controls")}</button></div><small class="dm-light-caps-note">${t("Letto da Home Assistant. Una luce dietro uno switch accende e spegne soltanto; luminosità e colore compaiono nel popup solo se l'entità li dichiara.", "Read from Home Assistant. A light behind a switch only turns on and off; brightness and colour appear in the popup only when the entity declares them.")}</small></div>
       <label class="ed-slot"><span class="ed-slot-lbl">${t("Stanza", "Room")}</span><select class="ed-input" name="room">${roomOptions(assignments[oldId])}</select></label>
       <output data-error></output>
       <footer><button type="button" class="ed-btn-add" data-cancel>${t("Annulla", "Cancel")}</button><button type="submit" class="ed-save-btn">💾 ${t("Salva modifiche", "Save changes")}</button></footer>
@@ -237,6 +270,18 @@ export function openLightEditor(entityId) {
   const close = () => modal.remove();
   modal.querySelectorAll("[data-close],[data-cancel]").forEach((button) => button.addEventListener("click", close));
   modal.querySelector("[data-pick]").addEventListener("click", () => root.wzPickEntity?.(entityInput));
+  /* The badges describe the entity in the field, not the one the modal opened
+   * with: pointing a light at another entity changes what it can do, and the
+   * controls the popup will offer change with it. */
+  const capabilities = modal.querySelector("[data-capabilities]");
+  const describe = () => {
+    if (capabilities) capabilities.innerHTML = lightMeta(clean(entityInput.value)).badges;
+  };
+  entityInput.addEventListener("input", describe);
+  entityInput.addEventListener("change", describe);
+  modal
+    .querySelector("[data-controls]")
+    .addEventListener("click", () => root.dmOpenLightControl?.(clean(entityInput.value)));
   modal.addEventListener("click", (event) => {
     if (event.target === modal) close();
   });
@@ -246,8 +291,11 @@ export function openLightEditor(entityId) {
     const name = clean(form.elements.name.value);
     const roomId = clean(form.elements.room.value);
     const error = form.querySelector("[data-error]");
-    if (!/^light\.[a-z0-9_]+$/i.test(entity) || !name) {
-      error.textContent = t("Inserisci un nome e un'entità light.* valida.", "Enter a name and a valid light.* entity.");
+    if (!isLightEntity(entity) || !name) {
+      error.textContent = t(
+        `Inserisci un nome e un'entità valida (${LIGHT_DOMAINS.map((domain) => `${domain}.*`).join(", ")}).`,
+        `Enter a name and a valid entity (${LIGHT_DOMAINS.map((domain) => `${domain}.*`).join(", ")}).`,
+      );
       return;
     }
     const existing = readJson("cd_luci", {});
@@ -406,6 +454,21 @@ function installStyles() {
       .dm-light-row{display:grid!important;grid-template-columns:auto minmax(140px,1fr) minmax(150px,260px) 42px 42px!important;align-items:center!important;gap:10px!important;min-width:0!important}
       .dm-light-order{display:grid!important;gap:3px!important}.dm-light-room-order{display:inline-flex!important;gap:4px!important}
       .dm-light-row .dm-light-room{width:100%!important;min-width:0!important}
+      .dm-light-badges{display:flex!important;flex-wrap:wrap!important;gap:5px!important;margin-top:5px!important}
+      .dm-light-badge{padding:2px 7px!important;border-radius:999px!important;border:1px solid color-mix(in srgb,var(--dm-light-badge,#0ea5e9) 30%,transparent)!important;background:color-mix(in srgb,var(--dm-light-badge,#0ea5e9) 13%,transparent)!important;color:color-mix(in srgb,var(--dm-light-badge,#0ea5e9) 62%,var(--text,#0f172a))!important;font-size:8.5px!important;font-weight:900!important;letter-spacing:.7px!important}
+      .dm-light-badge[data-kind="rgb"]{--dm-light-badge:#a855f7}
+      .dm-light-badge[data-kind="white"]{--dm-light-badge:#f59e0b}
+      .dm-light-badge[data-kind="dim"]{--dm-light-badge:#0ea5e9}
+      .dm-light-badge[data-kind="onoff"]{--dm-light-badge:#64748b}
+      .dm-light-badge[data-kind="domain"]{--dm-light-badge:#475569}
+      .dm-light-badge[data-kind="off"]{--dm-light-badge:#ef4444}
+      /* Not an .ed-slot-lbl: the legacy stylesheet appends a pencil to that
+         class, and this row is read from Home Assistant, not edited here. */
+      .dm-light-caps-lbl{font-size:12px!important;font-weight:800!important;color:var(--secondary-text-color,#64748b)!important}
+      .dm-light-caps{display:flex!important;align-items:center!important;flex-wrap:wrap!important;gap:8px!important}
+      .dm-light-caps .dm-light-badges{margin-top:0!important}
+      .dm-light-caps-try{margin-left:auto!important;min-height:36px!important;padding:8px 14px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:12px!important;background:var(--secondary-background-color,#f8fafc)!important;color:inherit!important;font-size:11.5px!important;font-weight:900!important;cursor:pointer!important}
+      .dm-light-add-hint,.dm-light-caps-note{display:block!important;color:var(--secondary-text-color,#64748b)!important;font-size:11px!important;font-weight:600!important;line-height:1.45!important}
       @media(max-width:720px){
         .dm-light-row{grid-template-columns:auto minmax(0,1fr) 42px 42px!important}.dm-light-row .dm-light-room{grid-column:1/-1!important;grid-row:2!important}
         .dm-light-picker-row{grid-template-columns:auto minmax(0,1fr) 36px 36px!important;padding:10px!important}

--- a/custom_components/dashboardmodern/frontend/src/sections/lights-scene-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/lights-scene-section.js
@@ -1,0 +1,941 @@
+import {
+  hexToRgb,
+  hsvToRgb,
+  kelvinToHex,
+  lightColorHex,
+  lightCommand,
+  lightSummary,
+  lightView,
+  lightsSignature,
+  readableInk,
+  rgbToHex,
+  rgbToHsv,
+} from "../core/light-model.js";
+import { configuredLightGroups } from "./lights-alerts-section.js";
+import { allStates, clean, doc, esc, installStyle, readJson, root, t } from "./shared.js";
+
+/* Single paint owner for the Gestione Luci popup and for the controls of one
+ * light.
+ *
+ * The legacy popup could do exactly one thing: tap a card, the light toggles.
+ * A dimmer had no dimmer, an RGB strip had no colour, a tunable white had no
+ * white, and every card was painted the same amber whatever the lamp was
+ * actually emitting. This module keeps the popup's bookkeeping in the legacy
+ * runtime — `apriGestioneLuci` still owns `currentPopupType`, which is a
+ * lexical binding this module cannot reach, and the tick still calls
+ * `updateGestioneLuci` through it — and takes over the two things that are
+ * about the lights themselves: what the list looks like, and what a light can
+ * be asked to do.
+ *
+ * What each light can be asked to do is decided by the entity, never by the
+ * domain: a lamp behind a relay is configured as a `switch.` and gets a power
+ * button, a dimmer gets a brightness track on the card, and a colour lamp gets
+ * the swatches, the hue/saturation pair and the white-point track in the
+ * control sheet. `core/light-model.js` is the single place that reads those
+ * capabilities and builds the service call.
+ *
+ * The list is rebuilt only when its shape changes — a new light, a rename, a
+ * room move, a lamp that starts reporting a colour. On/off, brightness and
+ * colour are written into the existing cards, because the legacy tick repaints
+ * every two seconds and rewriting innerHTML would drop the slider under the
+ * user's finger.
+ */
+
+const KEY = "__DASHBOARDMODERN_LIGHTS_SCENE_SECTION__";
+const MARKER = "__dmLightsSceneOwner";
+const STYLE_ID = "dm-lights-scene-style";
+const CONTROL_ID = "dm-light-control-modal";
+const LIST_ID = "details-list";
+
+/* How long a value the user just set wins over what Home Assistant reports.
+ * A lamp keeps reporting its previous brightness until the transition ends, so
+ * without this the slider would snap back under the finger on the next tick. */
+const HOLD_MS = 6000;
+
+/* A drag emits an event per pixel. The lamp gets one call every so often while
+ * the finger moves, and the exact value on release. */
+const LIVE_MS = 320;
+
+const state = (root[KEY] ||= {
+  installed: false,
+  listeners: false,
+  signature: "",
+  holds: new Map(),
+  live: 0,
+  liveAt: 0,
+});
+
+const SWATCHES = Object.freeze([
+  { hex: "#ff2d2d", it: "Rosso", en: "Red" },
+  { hex: "#ff6b1a", it: "Arancione", en: "Orange" },
+  { hex: "#ffb300", it: "Ambra", en: "Amber" },
+  { hex: "#ffe066", it: "Giallo", en: "Yellow" },
+  { hex: "#7bd94a", it: "Verde", en: "Green" },
+  { hex: "#18c39a", it: "Verde acqua", en: "Teal" },
+  { hex: "#25d3ee", it: "Ciano", en: "Cyan" },
+  { hex: "#2f7bff", it: "Blu", en: "Blue" },
+  { hex: "#6d4bff", it: "Indaco", en: "Indigo" },
+  { hex: "#b64bff", it: "Viola", en: "Violet" },
+  { hex: "#ff4bd8", it: "Magenta", en: "Magenta" },
+  { hex: "#ffd9c2", it: "Bianco caldo", en: "Warm white" },
+]);
+
+const KELVIN_PRESETS = Object.freeze([
+  { kelvin: 2200, it: "Candela", en: "Candle" },
+  { kelvin: 2700, it: "Caldo", en: "Warm" },
+  { kelvin: 4000, it: "Neutro", en: "Neutral" },
+  { kelvin: 5500, it: "Freddo", en: "Cool" },
+  { kelvin: 6500, it: "Luce diurna", en: "Daylight" },
+]);
+
+const BRIGHTNESS_PRESETS = Object.freeze([1, 25, 50, 75, 100]);
+
+/* ──────────────────────────────── model ─────────────────────────────────── */
+
+function popupFilter() {
+  const filter = root._luciPopupFilter;
+  return Array.isArray(filter) && filter.length ? new Set(filter.map(clean)) : null;
+}
+
+function heldValue(id, field) {
+  const hold = state.holds.get(`${id}:${field}`);
+  if (!hold) return null;
+  if (hold.expires <= Date.now()) {
+    state.holds.delete(`${id}:${field}`);
+    return null;
+  }
+  return hold.value;
+}
+
+function holdValue(id, field, value) {
+  state.holds.set(`${id}:${field}`, { value, expires: Date.now() + HOLD_MS });
+}
+
+function releaseHolds(id) {
+  for (const key of [...state.holds.keys()]) {
+    if (key.startsWith(`${id}:`)) state.holds.delete(key);
+  }
+}
+
+/**
+ * Every configured light, in the order the Luci tab put it, plus the lights the
+ * legacy runtime monitors without them being configured. A light whose entity
+ * is missing is kept and marked unavailable: dropping it would make a broken
+ * integration look like a deleted light.
+ */
+function lightViews() {
+  const names = readJson("cd_luci", {});
+  const states = allStates();
+  const allowed = popupFilter();
+  const seen = new Set();
+  const entries = [];
+  for (const group of configuredLightGroups()) {
+    for (const id of group.entities) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+      entries.push({ id, room: group.room });
+    }
+  }
+  const monitored = root.cdLightList?.();
+  for (const id of Array.isArray(monitored) ? monitored.map(clean) : []) {
+    if (!id.includes(".") || seen.has(id)) continue;
+    seen.add(id);
+    entries.push({ id, room: t("Altre zone", "Other areas") });
+  }
+  return entries
+    .filter(({ id }) => !allowed || allowed.has(id))
+    .map(({ id, room }) =>
+      lightView(id, {
+        name: names[id],
+        state: states[id],
+        room,
+        floor: clean(root.cdRoomFloorOf?.(room)),
+      }),
+    );
+}
+
+/**
+ * The legacy grouping, kept as it was: a room with two or more lights gets its
+ * own heading, a room with one is merged into the closing group where the card
+ * carries the room as its title. Rooms follow the floor order the user set.
+ */
+function lightGroups(views) {
+  const floors = root.cdFloorNames?.();
+  const order = Array.isArray(floors) ? floors : [];
+  const rank = (floor) => {
+    const index = order.indexOf(floor);
+    return index < 0 ? Number.MAX_SAFE_INTEGER : index;
+  };
+  const others = t("Altre zone", "Other areas");
+  const rooms = new Map();
+  for (const view of views) {
+    const room = view.room || others;
+    if (!rooms.has(room)) rooms.set(room, []);
+    rooms.get(room).push(view);
+  }
+  const groups = [];
+  const singles = [];
+  for (const [room, members] of rooms) {
+    if (room !== others && members.length === 1) {
+      singles.push(members[0]);
+      continue;
+    }
+    if (room === others) {
+      singles.push(...members);
+      continue;
+    }
+    groups.push({ room, floor: members[0].floor, views: members, merged: false });
+  }
+  groups.sort((left, right) => rank(left.floor) - rank(right.floor));
+  if (singles.length) groups.push({ room: others, floor: "", views: singles, merged: true });
+  return groups;
+}
+
+function cardColor(view) {
+  const hex = heldValue(view.id, "hex");
+  if (hex && view.on) return hex;
+  const kelvin = heldValue(view.id, "kelvin");
+  if (kelvin && view.on) return kelvinToHex(kelvin);
+  return lightColorHex(view);
+}
+
+function cardLevel(view) {
+  if (!view.on) return 0;
+  const held = heldValue(view.id, "brightness");
+  if (held != null) return held;
+  return view.brightness == null ? 100 : view.brightness;
+}
+
+function stateText(view) {
+  if (!view.available) return t("NON DISPONIBILE", "UNAVAILABLE");
+  if (!view.on) return t("SPENTA", "OFF");
+  const level = cardLevel(view);
+  return view.dimmable ? `${t("ACCESA", "ON")} · ${level}%` : t("ACCESA", "ON");
+}
+
+/* One badge, not a list of them: on a card two lines of pills push the status
+ * LED off the row, and what the user needs at a glance is the strongest thing
+ * this light can do. The full set stays in the Luci tab, where there is room
+ * for it. */
+function capabilityBadges(view) {
+  if (view.domain !== "light") return [{ kind: "switch", label: "SWITCH" }];
+  if (view.colorful) return [{ kind: "rgb", label: "RGB" }];
+  if (view.tunable) return [{ kind: "white", label: t("BIANCO", "WHITE") }];
+  if (view.dimmable) return [{ kind: "dim", label: t("DIMMER", "DIMMER") }];
+  return [];
+}
+
+/* ──────────────────────────────── markup ────────────────────────────────── */
+
+const BULB = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.7c.6.5 1 1.3 1 2.1h6c0-.8.4-1.6 1-2.1A7 7 0 0 0 12 2Z"/></svg>`;
+const PLUG = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2v6M15 2v6M6 8h12v3a6 6 0 0 1-6 6 6 6 0 0 1-6-6V8ZM12 17v5"/></svg>`;
+/* The controls button carries a drawn slider rather than an emoji: the control
+ * knobs glyph renders as a grey box on the platforms this dashboard runs on. */
+const SLIDERS = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M4 7h10M18 7h2M4 17h4M12 17h8"/><circle cx="16" cy="7" r="2.2"/><circle cx="10" cy="17" r="2.2"/></svg>`;
+
+function cardMarkup(view, showRoom) {
+  const title = showRoom && view.room ? view.room : view.name;
+  const subtitle = showRoom && view.room && view.room !== view.name ? view.name : "";
+  const badges = capabilityBadges(view)
+    .map((badge) => `<span class="dm-lightx-badge" data-kind="${badge.kind}">${badge.label}</span>`)
+    .join("");
+  const level = cardLevel(view);
+  const dimmer = view.dimmable
+    ? `<label class="dm-lightx-dim"><span class="dm-lightx-dim-lbl">${t("Luminosità", "Brightness")}</span><input class="dm-lightx-range" type="range" min="0" max="100" step="1" value="${level}" data-dm-light-brightness aria-label="${t("Luminosità", "Brightness")} ${esc(view.name)}"></label>`
+    : "";
+  const tools =
+    view.dimmable || view.colorful || view.tunable || view.effects.length
+      ? `<button type="button" class="dm-lightx-tune" data-dm-light-open aria-label="${t("Controlli di", "Controls for")} ${esc(view.name)}">${SLIDERS}</button>`
+      : "";
+  return `<article class="lgx-card dm-lightx-card ${view.on ? "is-on" : ""}" data-luce="${esc(view.id)}" data-dm-light="${esc(view.id)}" data-dm-light-available="${view.available}" style="--dm-light-color:${esc(cardColor(view))};--dm-light-ink:${readableInk(cardColor(view))};--dm-light-level:${view.on ? Math.max(12, level) : 0}%">
+    <div class="lgx-glow"></div>
+    <button type="button" class="dm-lightx-main" data-dm-light-toggle aria-pressed="${view.on}">
+      <span class="lgx-row-top">
+        <span class="lgx-orb dm-lightx-orb">${view.domain === "light" ? BULB : PLUG}</span>
+        <span class="dm-lightx-badges">${badges}</span>
+        <span class="lgx-led ${view.on ? "on" : ""}"></span>
+      </span>
+      <span class="lgx-name">${esc(title)}</span>
+      ${subtitle ? `<span class="lgx-sub">${esc(subtitle)}</span>` : ""}
+      <span class="lgx-state" data-dm-light-state>${stateText(view)}</span>
+    </button>
+    ${dimmer || tools ? `<div class="dm-lightx-tools">${dimmer}${tools}</div>` : ""}
+  </article>`;
+}
+
+function groupMarkup(group, previousFloor) {
+  const summary = lightSummary(group.views);
+  const floorHeading =
+    group.floor && group.floor !== previousFloor
+      ? `<div class="lgx-zona dm-lightx-floor">🏢 ${esc(group.floor.toUpperCase())}</div>`
+      : "";
+  const action = summary.on ? "off" : "on";
+  const label = summary.on ? t("Spegni", "All off") : t("Accendi", "All on");
+  return `${floorHeading}<div class="dm-lightx-room" data-dm-light-group="${esc(group.room)}">
+      <span class="lgx-zona dm-lightx-room-name">${esc(group.room.toUpperCase())}</span>
+      <span class="dm-lightx-room-count">${summary.on}/${summary.total}</span>
+      <button type="button" class="dm-lightx-room-btn" data-dm-light-room="${action}" data-dm-light-room-name="${esc(group.room)}">${label}</button>
+    </div>
+    <div class="lgx-grid">${group.views.map((view) => cardMarkup(view, group.merged)).join("")}</div>`;
+}
+
+/** The whole popup list for a set of views. Exported so the shape of the list
+ * — which light gets a dimmer, which gets the controls button, what the empty
+ * state says — can be asserted without a browser. */
+export function renderLightsPopupMarkup(views) {
+  const summary = lightSummary(views);
+  const counter = summary.on
+    ? `<b>${summary.on}</b><span>${summary.on === 1 ? t("accesa", "on") : t("accese", "on")}</span>`
+    : `<span>${t("Tutte spente", "All off")}</span>`;
+  const bar = `<div class="lgx-bar dm-lightx-bar">
+      <div class="lgx-bar-l"><span class="lgx-dot ${summary.on ? "active" : ""}"></span>${counter}</div>
+      ${summary.on ? `<div class="lgx-alloff" data-dm-light-all="off">${t("Spegni tutte", "Turn all off")}</div>` : ""}
+    </div>`;
+  if (!views.length)
+    return `${bar}<div class="dm-lightx-empty">${t("Nessuna luce configurata. Aggiungile dalla scheda Luci dell'editor: accetta sia entità light.* sia switch.*.", "No configured lights. Add them from the editor's Lights tab: both light.* and switch.* entities are accepted.")}</div>`;
+  let floor = "";
+  const body = lightGroups(views)
+    .map((group) => {
+      const markup = groupMarkup(group, floor);
+      if (group.floor) floor = group.floor;
+      return markup;
+    })
+    .join("");
+  return `${bar}${body}`;
+}
+
+/* ─────────────────────────────── painting ───────────────────────────────── */
+
+function listNode() {
+  return doc?.getElementById(LIST_ID) || null;
+}
+
+function paint() {
+  const list = listNode();
+  if (!list) return false;
+  const views = lightViews();
+  const scrollTop = list.scrollTop;
+  list.innerHTML = renderLightsPopupMarkup(views);
+  list.scrollTop = scrollTop;
+  state.signature = lightsSignature(views);
+  return true;
+}
+
+function syncCard(card, view) {
+  card.classList.toggle("is-on", view.on);
+  card.dataset.dmLightAvailable = String(view.available);
+  const color = cardColor(view);
+  card.style.setProperty("--dm-light-color", color);
+  card.style.setProperty("--dm-light-ink", readableInk(color));
+  const level = cardLevel(view);
+  card.style.setProperty("--dm-light-level", view.on ? `${Math.max(12, level)}%` : "0%");
+  card.querySelector(".lgx-led")?.classList.toggle("on", view.on);
+  card.querySelector("[data-dm-light-toggle]")?.setAttribute("aria-pressed", String(view.on));
+  const label = card.querySelector("[data-dm-light-state]");
+  const text = stateText(view);
+  if (label && label.textContent !== text) label.textContent = text;
+  const range = card.querySelector("[data-dm-light-brightness]");
+  if (range && doc.activeElement !== range) range.value = String(level);
+}
+
+function popupShowing() {
+  return Boolean(doc?.getElementById("details-modal")?.classList?.contains("show"));
+}
+
+function sync() {
+  const list = listNode();
+  if (!list) return false;
+  const views = lightViews();
+  const painted = Boolean(list.querySelector("[data-dm-light]"));
+  /* The list is shared with the other popups of the runtime. Repainting it
+   * without our own cards in it is only ever right while this popup is the one
+   * on screen; the sheet opened from the editor keeps updating either way. */
+  if (!painted && !popupShowing()) {
+    syncControl();
+    return false;
+  }
+  if (!painted || lightsSignature(views) !== state.signature) return paint();
+  const byId = new Map(views.map((view) => [view.id, view]));
+  for (const card of list.querySelectorAll("[data-dm-light]")) {
+    const view = byId.get(card.dataset.dmLight);
+    if (view) syncCard(card, view);
+  }
+  const groups = new Map(lightGroups(views).map((group) => [group.room, group.views]));
+  for (const heading of list.querySelectorAll("[data-dm-light-group]")) {
+    const summary = lightSummary(groups.get(heading.dataset.dmLightGroup) || []);
+    const count = heading.querySelector(".dm-lightx-room-count");
+    const text = `${summary.on}/${summary.total}`;
+    if (count && count.textContent !== text) count.textContent = text;
+    const button = heading.querySelector("[data-dm-light-room]");
+    if (button) {
+      button.dataset.dmLightRoom = summary.on ? "off" : "on";
+      const label = summary.on ? t("Spegni", "All off") : t("Accendi", "All on");
+      if (button.textContent !== label) button.textContent = label;
+    }
+  }
+  const summary = lightSummary(views);
+  const bar = list.querySelector(".dm-lightx-bar");
+  if (bar) {
+    const counter = summary.on
+      ? `<b>${summary.on}</b><span>${summary.on === 1 ? t("accesa", "on") : t("accese", "on")}</span>`
+      : `<span>${t("Tutte spente", "All off")}</span>`;
+    const markup = `<div class="lgx-bar-l"><span class="lgx-dot ${summary.on ? "active" : ""}"></span>${counter}</div>${summary.on ? `<div class="lgx-alloff" data-dm-light-all="off">${t("Spegni tutte", "Turn all off")}</div>` : ""}`;
+    if (bar.innerHTML !== markup) bar.innerHTML = markup;
+  }
+  syncControl();
+  return true;
+}
+
+/* ─────────────────────────────── commands ───────────────────────────────── */
+
+function viewOf(id) {
+  const entity = clean(id);
+  if (!entity) return null;
+  const names = readJson("cd_luci", {});
+  return lightView(entity, { name: names[entity], state: allStates()[entity] });
+}
+
+function send(view, change) {
+  const command = lightCommand(view, change);
+  if (!command) return;
+  try {
+    if (typeof root.dmCallHaService === "function") {
+      const result = root.dmCallHaService(command.domain, command.service, command.data);
+      result?.catch?.(() => {});
+      return;
+    }
+    if (command.service === "toggle") root.toggle?.(view.id);
+  } catch (_error) {}
+}
+
+function feedback(pattern = 10) {
+  try {
+    root.navigator?.vibrate?.(pattern);
+  } catch (_error) {}
+}
+
+/**
+ * Paint one requested value without rebuilding anything.
+ *
+ * A drag emits an event per pixel: recomputing every light on each of them
+ * would read storage and the whole state registry dozens of times per second,
+ * so only the card and the sheet of this one light are written.
+ */
+function applyLive(view, field, value) {
+  const color = field === "hex" ? value : field === "kelvin" ? kelvinToHex(value) : cardColor(view);
+  const level = field === "brightness" ? value : cardLevel(view);
+  /* Any of these changes lights the lamp: asking an unlit strip for a colour
+   * turns it on with that colour, so the card lights up with it instead of
+   * waiting for the state to come back. */
+  const on = field !== "brightness" || value > 0;
+  const card = listNode()?.querySelector(`[data-dm-light="${view.id}"]`) || null;
+  const dialog = controlNode()?.querySelector(".dm-lightctl-dialog") || null;
+  for (const node of [card, dialog]) {
+    if (!node) continue;
+    node.style.setProperty("--dm-light-color", color);
+    node.style.setProperty("--dm-light-ink", readableInk(color));
+    node.style.setProperty("--dm-light-level", on ? `${Math.max(12, level)}%` : "0%");
+  }
+  if (card) {
+    card.classList.toggle("is-on", on);
+    card.querySelector(".lgx-led")?.classList.toggle("on", on);
+    const label = card.querySelector("[data-dm-light-state]");
+    if (label) label.textContent = view.dimmable ? `${t("ACCESA", "ON")} · ${level}%` : t("ACCESA", "ON");
+  }
+  const modal = controlNode();
+  if (!modal) return;
+  const hero = modal.querySelector("[data-dm-light-hero-state]");
+  if (hero) hero.textContent = view.dimmable ? `${t("ACCESA", "ON")} · ${level}%` : t("ACCESA", "ON");
+  const percent = modal.querySelector("[data-dm-light-level]");
+  if (percent) percent.textContent = `${level}%`;
+  const kelvin = modal.querySelector("[data-dm-light-kelvin-value]");
+  if (kelvin && field === "kelvin") kelvin.textContent = `${value} K`;
+  const preview = modal.querySelector("[data-dm-light-hex]");
+  if (preview && field === "hex" && doc.activeElement !== preview) preview.value = value;
+}
+
+/**
+ * A change the user is still making. The value is applied at once so the slider
+ * tracks the finger, held so the next tick does not undo it, and sent to Home
+ * Assistant at most every LIVE_MS until the drag ends.
+ */
+function live(view, change, field, value, { commit = false } = {}) {
+  holdValue(view.id, field, value);
+  applyLive(view, field, value);
+  const now = Date.now();
+  if (state.live) {
+    root.clearTimeout?.(state.live);
+    state.live = 0;
+  }
+  if (commit || now - state.liveAt >= LIVE_MS) {
+    state.liveAt = now;
+    send(view, change);
+  } else {
+    state.live = root.setTimeout?.(() => {
+      state.live = 0;
+      state.liveAt = Date.now();
+      send(view, change);
+    }, LIVE_MS);
+  }
+}
+
+function toggleLight(id) {
+  const view = viewOf(id);
+  if (!view) return;
+  feedback();
+  releaseHolds(view.id);
+  send(view, { power: !view.on });
+  sync();
+}
+
+function setRoomPower(room, on) {
+  feedback(15);
+  const group = lightGroups(lightViews()).find((item) => item.room === room);
+  for (const view of group?.views || []) {
+    if (view.on === on) continue;
+    releaseHolds(view.id);
+    send(view, { power: on });
+  }
+  sync();
+}
+
+function allOff() {
+  feedback(15);
+  for (const view of lightViews()) {
+    if (!view.on) continue;
+    releaseHolds(view.id);
+    send(view, { power: false });
+  }
+  sync();
+}
+
+/* ───────────────────────── control sheet for one light ──────────────────── */
+
+function controlNode() {
+  return doc?.getElementById(CONTROL_ID) || null;
+}
+
+function hueFrom(view) {
+  const hex = heldValue(view.id, "hex") || (view.rgb ? rgbToHex(view.rgb) : "");
+  return hex ? rgbToHsv(hexToRgb(hex)) : [40, 60, 100];
+}
+
+/** The control sheet for one light, built from what that light declares. */
+export function renderLightControlMarkup(view) {
+  const level = cardLevel(view);
+  const [hue, saturation] = hueFrom(view);
+  const color = cardColor(view);
+  const kelvin = heldValue(view.id, "kelvin") || view.kelvin || Math.round((view.minKelvin + view.maxKelvin) / 2);
+  const brightness = view.dimmable
+    ? `<section class="dm-lightctl-block" data-block="brightness">
+        <div class="dm-lightctl-block-head"><span>${t("Luminosità", "Brightness")}</span><b data-dm-light-level>${level}%</b></div>
+        <input class="dm-lightctl-range dm-lightctl-dim" type="range" min="0" max="100" step="1" value="${level}" data-dm-light-brightness aria-label="${t("Luminosità", "Brightness")}">
+        <div class="dm-lightctl-presets">${BRIGHTNESS_PRESETS.map((value) => `<button type="button" data-dm-light-brightness-preset="${value}">${value}%</button>`).join("")}</div>
+      </section>`
+    : "";
+  const colorBlock = view.colorful
+    ? `<section class="dm-lightctl-block" data-block="color">
+        <div class="dm-lightctl-block-head"><span>${t("Colore", "Colour")}</span><span class="dm-lightctl-preview" data-dm-light-preview></span></div>
+        <div class="dm-lightctl-swatches">${SWATCHES.map((swatch) => `<button type="button" class="dm-lightctl-swatch" data-dm-light-color="${swatch.hex}" style="--dm-swatch:${swatch.hex}" title="${t(swatch.it, swatch.en)}" aria-label="${t(swatch.it, swatch.en)}"></button>`).join("")}</div>
+        <label class="dm-lightctl-slot"><span>${t("Tinta", "Hue")}</span><input class="dm-lightctl-range dm-lightctl-hue" type="range" min="0" max="360" step="1" value="${hue}" data-dm-light-hue aria-label="${t("Tinta", "Hue")}"></label>
+        <label class="dm-lightctl-slot"><span>${t("Saturazione", "Saturation")}</span><input class="dm-lightctl-range dm-lightctl-sat" type="range" min="0" max="100" step="1" value="${saturation}" data-dm-light-saturation aria-label="${t("Saturazione", "Saturation")}"></label>
+        <label class="dm-lightctl-exact"><span>${t("Colore esatto", "Exact colour")}</span><input type="color" value="${esc(color)}" data-dm-light-hex aria-label="${t("Colore esatto", "Exact colour")}"></label>
+      </section>`
+    : "";
+  const whiteBlock = view.tunable
+    ? `<section class="dm-lightctl-block" data-block="white">
+        <div class="dm-lightctl-block-head"><span>${t("Bianco", "White")}</span><b data-dm-light-kelvin-value>${kelvin} K</b></div>
+        <input class="dm-lightctl-range dm-lightctl-kelvin" type="range" min="${view.minKelvin}" max="${view.maxKelvin}" step="50" value="${kelvin}" data-dm-light-kelvin aria-label="${t("Temperatura colore", "Colour temperature")}">
+        <div class="dm-lightctl-presets">${KELVIN_PRESETS.filter((preset) => preset.kelvin >= view.minKelvin && preset.kelvin <= view.maxKelvin)
+          .map(
+            (preset) =>
+              `<button type="button" data-dm-light-kelvin-preset="${preset.kelvin}" style="--dm-swatch:${kelvinToHex(preset.kelvin)}">${t(preset.it, preset.en)}</button>`,
+          )
+          .join("")}</div>
+      </section>`
+    : "";
+  const effectBlock = view.effects.length
+    ? `<section class="dm-lightctl-block" data-block="effect">
+        <div class="dm-lightctl-block-head"><span>${t("Effetto", "Effect")}</span></div>
+        <select class="dm-lightctl-select" data-dm-light-effect aria-label="${t("Effetto", "Effect")}">${view.effects
+          .map(
+            (effect) =>
+              `<option value="${esc(effect)}" ${effect === view.effect ? "selected" : ""}>${esc(effect)}</option>`,
+          )
+          .join("")}</select>
+      </section>`
+    : "";
+  const plain =
+    !view.dimmable && !view.colorful && !view.tunable && !view.effects.length
+      ? `<p class="dm-lightctl-note">${
+          view.domain === "light"
+            ? t(
+                "Questa luce dichiara solo acceso e spento: Home Assistant non espone né luminosità né colore.",
+                "This light only reports on and off: Home Assistant exposes neither brightness nor colour.",
+              )
+            : t(
+                "Questa luce è collegata a uno switch: accende e spegne soltanto.",
+                "This light is wired to a switch: it only turns on and off.",
+              )
+        }</p>`
+      : "";
+  return `<section class="dm-section-dialog dm-lightctl-dialog" role="dialog" aria-modal="true" aria-labelledby="dm-lightctl-title" style="--dm-light-color:${esc(color)};--dm-light-ink:${readableInk(color)};--dm-light-level:${view.on ? Math.max(12, level) : 0}%">
+    <header><strong id="dm-lightctl-title">${view.domain === "light" ? "💡" : "🔌"} ${esc(view.name)}</strong><button type="button" data-close aria-label="${t("Chiudi", "Close")}">✕</button></header>
+    <div class="dm-lightctl-body">
+      <div class="dm-lightctl-hero">
+        <span class="dm-lightctl-orb">${view.domain === "light" ? BULB : PLUG}</span>
+        <span class="dm-lightctl-hero-text">
+          <b data-dm-light-hero-state>${stateText(view)}</b>
+          <small class="mono">${esc(view.id)}</small>
+          ${view.room ? `<small>${esc(view.room)}</small>` : ""}
+        </span>
+        <button type="button" class="dm-lightctl-power" data-dm-light-power aria-pressed="${view.on}">${view.on ? t("Spegni", "Turn off") : t("Accendi", "Turn on")}</button>
+      </div>
+      ${view.available ? "" : `<p class="dm-lightctl-note">${t("Entità non disponibile in Home Assistant.", "Entity unavailable in Home Assistant.")}</p>`}
+      ${brightness}${colorBlock}${whiteBlock}${effectBlock}${plain}
+    </div>
+  </section>`;
+}
+
+function bindControl(modal, id) {
+  const current = () => viewOf(id);
+  const close = () => modal.remove();
+  modal.querySelector("[data-close]")?.addEventListener("click", close);
+  modal.addEventListener("click", (event) => {
+    if (event.target === modal) {
+      close();
+      return;
+    }
+    const swatch = event.target?.closest?.("[data-dm-light-color]");
+    if (swatch) {
+      const view = current();
+      if (view) live(view, { hex: swatch.dataset.dmLightColor }, "hex", swatch.dataset.dmLightColor, { commit: true });
+      return;
+    }
+    const brightnessPreset = event.target?.closest?.("[data-dm-light-brightness-preset]");
+    if (brightnessPreset) {
+      const view = current();
+      const value = Number(brightnessPreset.dataset.dmLightBrightnessPreset);
+      if (view) live(view, { brightnessPct: value }, "brightness", value, { commit: true });
+      return;
+    }
+    const kelvinPreset = event.target?.closest?.("[data-dm-light-kelvin-preset]");
+    if (kelvinPreset) {
+      const view = current();
+      const value = Number(kelvinPreset.dataset.dmLightKelvinPreset);
+      if (view) live(view, { kelvin: value }, "kelvin", value, { commit: true });
+      return;
+    }
+    if (event.target?.closest?.("[data-dm-light-power]")) {
+      toggleLight(id);
+      syncControl();
+    }
+  });
+  const slide = (event, commit) => {
+    const view = current();
+    if (!view) return;
+    const target = event.target;
+    if (target?.matches?.("[data-dm-light-brightness]")) {
+      const value = Number(target.value);
+      if (value === 0) {
+        releaseHolds(view.id);
+        send(view, { power: false });
+        sync();
+        return;
+      }
+      live(view, { brightnessPct: value }, "brightness", value, { commit });
+      return;
+    }
+    if (target?.matches?.("[data-dm-light-hue],[data-dm-light-saturation]")) {
+      const hue = Number(modal.querySelector("[data-dm-light-hue]")?.value) || 0;
+      const saturation = Number(modal.querySelector("[data-dm-light-saturation]")?.value) || 0;
+      const hex = rgbToHex(hsvToRgb(hue, saturation, 100));
+      live(view, { hex }, "hex", hex, { commit });
+      return;
+    }
+    if (target?.matches?.("[data-dm-light-kelvin]")) {
+      const value = Number(target.value);
+      live(view, { kelvin: value }, "kelvin", value, { commit });
+      return;
+    }
+    if (target?.matches?.("[data-dm-light-hex]")) {
+      live(view, { hex: target.value }, "hex", target.value, { commit });
+      return;
+    }
+    if (target?.matches?.("[data-dm-light-effect]")) {
+      send(view, { effect: target.value, power: true });
+    }
+  };
+  modal.addEventListener("input", (event) => slide(event, false));
+  modal.addEventListener("change", (event) => slide(event, true));
+  modal.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") close();
+  });
+}
+
+export function openLightControl(id) {
+  if (!doc) return false;
+  const view = lightViews().find((item) => item.id === clean(id)) || viewOf(id);
+  if (!view) return false;
+  controlNode()?.remove();
+  const modal = doc.createElement("div");
+  modal.id = CONTROL_ID;
+  modal.className = "dm-section-modal dm-lightctl";
+  modal.dataset.dmLightControl = view.id;
+  modal.innerHTML = renderLightControlMarkup(view);
+  doc.body.append(modal);
+  bindControl(modal, view.id);
+  syncControl();
+  modal.querySelector("[data-close]")?.focus?.();
+  return true;
+}
+
+/** Values only: the sheet keeps its markup so a slider is never rebuilt mid-drag. */
+function syncControl() {
+  const modal = controlNode();
+  if (!modal) return false;
+  const view = viewOf(modal.dataset.dmLightControl);
+  if (!view) return false;
+  const dialog = modal.querySelector(".dm-lightctl-dialog");
+  const level = cardLevel(view);
+  const color = cardColor(view);
+  dialog?.style?.setProperty("--dm-light-color", color);
+  dialog?.style?.setProperty("--dm-light-ink", readableInk(color));
+  dialog?.style?.setProperty("--dm-light-level", view.on ? `${Math.max(12, level)}%` : "0%");
+  const hero = modal.querySelector("[data-dm-light-hero-state]");
+  const text = stateText(view);
+  if (hero && hero.textContent !== text) hero.textContent = text;
+  const power = modal.querySelector("[data-dm-light-power]");
+  if (power) {
+    power.setAttribute("aria-pressed", String(view.on));
+    const label = view.on ? t("Spegni", "Turn off") : t("Accendi", "Turn on");
+    if (power.textContent !== label) power.textContent = label;
+  }
+  const write = (selector, value) => {
+    const node = modal.querySelector(selector);
+    if (node && doc.activeElement !== node) node.value = String(value);
+  };
+  write("[data-dm-light-brightness]", level);
+  const percent = modal.querySelector("[data-dm-light-level]");
+  if (percent) percent.textContent = `${level}%`;
+  if (view.colorful) {
+    const [hue, saturation] = hueFrom(view);
+    write("[data-dm-light-hue]", hue);
+    write("[data-dm-light-saturation]", saturation);
+    write("[data-dm-light-hex]", color);
+  }
+  if (view.tunable) {
+    const kelvin = heldValue(view.id, "kelvin") || view.kelvin;
+    if (kelvin) {
+      write("[data-dm-light-kelvin]", kelvin);
+      const readout = modal.querySelector("[data-dm-light-kelvin-value]");
+      if (readout) readout.textContent = `${kelvin} K`;
+    }
+  }
+  return true;
+}
+
+/* ─────────────────────────────── listeners ──────────────────────────────── */
+
+function installListeners() {
+  const list = listNode();
+  if (!list || list.dataset.dmLightsBound === "true") return false;
+  list.dataset.dmLightsBound = "true";
+  list.addEventListener("click", (event) => {
+    const card = event.target?.closest?.("[data-dm-light]");
+    if (event.target?.closest?.("[data-dm-light-all]")) {
+      allOff();
+      return;
+    }
+    const room = event.target?.closest?.("[data-dm-light-room]");
+    if (room) {
+      setRoomPower(room.dataset.dmLightRoomName, room.dataset.dmLightRoom === "on");
+      return;
+    }
+    if (!card) return;
+    if (event.target?.closest?.("[data-dm-light-open]")) {
+      openLightControl(card.dataset.dmLight);
+      return;
+    }
+    if (event.target?.closest?.("[data-dm-light-toggle]")) toggleLight(card.dataset.dmLight);
+  });
+  const slide = (event, commit) => {
+    const card = event.target?.closest?.("[data-dm-light]");
+    if (!card || !event.target?.matches?.("[data-dm-light-brightness]")) return;
+    const view = viewOf(card.dataset.dmLight);
+    if (!view) return;
+    const value = Number(event.target.value);
+    if (value === 0) {
+      releaseHolds(view.id);
+      send(view, { power: false });
+      sync();
+      return;
+    }
+    live(view, { brightnessPct: value }, "brightness", value, { commit });
+  };
+  list.addEventListener("input", (event) => slide(event, false));
+  list.addEventListener("change", (event) => slide(event, true));
+  return true;
+}
+
+function installOwners() {
+  /* `apriGestioneLuci` keeps the bookkeeping — it is the only writer of the
+   * runtime's lexical `currentPopupType`, which is what makes the tick call
+   * `updateGestioneLuci` at all — and this module repaints the list it just
+   * filled, in the same task, so the legacy markup is never shown. */
+  const open = root.apriGestioneLuci;
+  if (typeof open === "function" && !open[MARKER]) {
+    function ownedOpen(...args) {
+      const result = open.apply(this, args);
+      installListeners();
+      paint();
+      return result;
+    }
+    ownedOpen[MARKER] = true;
+    ownedOpen.__dmPrevious = open;
+    root.apriGestioneLuci = ownedOpen;
+  }
+  const update = root.updateGestioneLuci;
+  if (typeof update !== "function" || !update[MARKER]) {
+    function ownedUpdate() {
+      installListeners();
+      return sync();
+    }
+    ownedUpdate[MARKER] = true;
+    if (typeof update === "function") ownedUpdate.__dmPrevious = update;
+    root.updateGestioneLuci = ownedUpdate;
+  }
+  root.dmOpenLightControl = openLightControl;
+  return true;
+}
+
+/* ──────────────────────────────── styles ────────────────────────────────── */
+
+function installStyles() {
+  installStyle(
+    STYLE_ID,
+    `
+    /* The popup cards keep every legacy .lgx- class, so the base skin still
+       paints them; what changes here is that the colour is the lamp's own
+       instead of a fixed amber, and that a dimmer has a track. */
+    #details-list .dm-lightx-bar{display:flex!important;align-items:center!important;justify-content:space-between!important;gap:12px!important;flex-wrap:wrap!important}
+    #details-list .dm-lightx-room{display:flex!important;align-items:center!important;gap:9px!important;margin:14px 4px 8px!important}
+    #details-list .dm-lightx-room:first-of-type{margin-top:2px!important}
+    #details-list .dm-lightx-room .lgx-zona{margin:0!important;flex:0 1 auto!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important}
+    #details-list .dm-lightx-room-count{flex:0 0 auto!important;padding:2px 9px!important;border:1px solid var(--card-border,rgba(148,163,184,.32))!important;border-radius:999px!important;font-size:10px!important;font-weight:800!important;letter-spacing:.6px!important;color:var(--text-dim,#94a3b8)!important}
+    #details-list .dm-lightx-room-btn{margin-left:auto!important;flex:0 0 auto!important;padding:6px 13px!important;border:1px solid var(--card-border,rgba(148,163,184,.32))!important;border-radius:999px!important;background:transparent!important;color:var(--text-dim,#94a3b8)!important;font-size:10px!important;font-weight:800!important;letter-spacing:.7px!important;text-transform:uppercase!important;cursor:pointer!important}
+    #details-list .dm-lightx-room-btn:active{transform:scale(.96)!important}
+    #details-list .dm-lightx-floor{opacity:.7!important;font-size:12px!important;letter-spacing:1.2px!important}
+    #details-list .dm-lightx-empty{padding:18px 4px!important;color:var(--text-dim,#94a3b8)!important;font-size:12.5px!important;font-weight:600!important;line-height:1.5!important}
+
+    #details-list .dm-lightx-card{display:grid!important;gap:8px!important;padding:0!important;cursor:default!important}
+    #details-list .dm-lightx-card:hover{transform:none!important}
+    #details-list .dm-lightx-card:active{transform:none!important}
+    #details-list .dm-lightx-card[data-dm-light-available="false"]{opacity:.55!important}
+    /* The glow, the border and the LED all read the lamp's own colour. */
+    #details-list .dm-lightx-card.is-on{border-color:color-mix(in srgb,var(--dm-light-color,#f59e0b) 55%,transparent)!important;box-shadow:0 6px 22px color-mix(in srgb,var(--dm-light-color,#f59e0b) 22%,transparent)!important}
+    #details-list .dm-lightx-card.is-on .lgx-glow{background:radial-gradient(circle at 22% 20%,color-mix(in srgb,var(--dm-light-color,#f59e0b) 30%,transparent) 0%,transparent 64%)!important}
+    #details-list .dm-lightx-card.is-on .lgx-led{background:var(--dm-light-color,#f59e0b)!important;box-shadow:0 0 10px color-mix(in srgb,var(--dm-light-color,#f59e0b) 70%,transparent)!important}
+    #details-list .dm-lightx-card.is-on .dm-lightx-orb{background:radial-gradient(circle at 38% 32%,color-mix(in srgb,var(--dm-light-color,#f59e0b) 25%,#fff),var(--dm-light-color,#f59e0b))!important;color:var(--dm-light-ink,#0f172a)!important;box-shadow:0 3px 12px color-mix(in srgb,var(--dm-light-color,#f59e0b) 45%,transparent)!important}
+    #details-list .dm-lightx-card.is-on .lgx-state{color:color-mix(in srgb,var(--dm-light-color,#f59e0b) 60%,var(--text,#0f172a))!important}
+
+    #details-list .dm-lightx-main{display:grid!important;gap:1px!important;box-sizing:border-box!important;width:100%!important;margin:0!important;padding:12px 12px 4px!important;border:0!important;border-radius:18px 18px 0 0!important;background:transparent!important;color:inherit!important;font:inherit!important;text-align:left!important;cursor:pointer!important;-webkit-tap-highlight-color:transparent!important}
+    #details-list .dm-lightx-main:active{transform:scale(.985)!important}
+    #details-list .dm-lightx-main .lgx-row-top{display:flex!important;align-items:center!important;gap:8px!important;margin-bottom:10px!important}
+    #details-list .dm-lightx-main .lgx-orb{display:flex!important;align-items:center!important;justify-content:center!important}
+    #details-list .dm-lightx-badges{display:flex!important;flex-wrap:wrap!important;gap:4px!important;margin-left:auto!important}
+    #details-list .dm-lightx-badge{padding:2px 6px!important;border-radius:999px!important;font-size:8.5px!important;font-weight:900!important;letter-spacing:.6px!important;background:color-mix(in srgb,var(--dm-light-color,#f59e0b) 16%,transparent)!important;color:color-mix(in srgb,var(--dm-light-color,#f59e0b) 55%,var(--text,#0f172a))!important;border:1px solid color-mix(in srgb,var(--dm-light-color,#f59e0b) 26%,transparent)!important}
+    #details-list .dm-lightx-badge[data-kind="switch"]{background:rgba(148,163,184,.14)!important;color:var(--text-dim,#64748b)!important;border-color:rgba(148,163,184,.3)!important}
+
+    #details-list .dm-lightx-tools{display:flex!important;align-items:center!important;gap:8px!important;padding:0 12px 11px!important}
+    #details-list .dm-lightx-dim{display:grid!important;flex:1 1 auto!important;min-width:0!important;gap:2px!important}
+    #details-list .dm-lightx-dim-lbl{font-size:8.5px!important;font-weight:800!important;letter-spacing:.7px!important;text-transform:uppercase!important;color:var(--text-dim,#94a3b8)!important}
+    #details-list .dm-lightx-tune{display:grid!important;place-items:center!important;flex:0 0 auto!important;width:36px!important;height:36px!important;padding:0!important;border:1px solid var(--card-border,rgba(148,163,184,.3))!important;border-radius:12px!important;background:transparent!important;color:var(--text-dim,#94a3b8)!important;cursor:pointer!important}
+    #details-list .dm-lightx-card.is-on .dm-lightx-tune{border-color:color-mix(in srgb,var(--dm-light-color,#f59e0b) 40%,transparent)!important;color:color-mix(in srgb,var(--dm-light-color,#f59e0b) 60%,var(--text,#0f172a))!important}
+    #details-list .dm-lightx-tune svg{width:19px!important;height:19px!important}
+    #details-list .dm-lightx-tune:active{transform:scale(.94)!important}
+
+    /* One track shape for the card dimmer and for every slider in the sheet:
+       the filled part is the light's colour, the rest is the empty groove. */
+    #details-list .dm-lightx-range,.dm-lightctl .dm-lightctl-range{box-sizing:border-box!important;width:100%!important;height:26px!important;margin:0!important;padding:0!important;border:0!important;appearance:none!important;-webkit-appearance:none!important;background:transparent!important;cursor:pointer!important;touch-action:pan-y!important}
+    #details-list .dm-lightx-range::-webkit-slider-runnable-track,.dm-lightctl .dm-lightctl-range::-webkit-slider-runnable-track{height:12px;border-radius:999px;background:linear-gradient(90deg,var(--dm-light-color,#f59e0b) 0 var(--dm-light-level,0%),rgba(148,163,184,.24) var(--dm-light-level,0%) 100%)}
+    #details-list .dm-lightx-range::-moz-range-track,.dm-lightctl .dm-lightctl-range::-moz-range-track{height:12px;border-radius:999px;background:linear-gradient(90deg,var(--dm-light-color,#f59e0b) 0 var(--dm-light-level,0%),rgba(148,163,184,.24) var(--dm-light-level,0%) 100%)}
+    #details-list .dm-lightx-range::-webkit-slider-thumb,.dm-lightctl .dm-lightctl-range::-webkit-slider-thumb{-webkit-appearance:none;width:20px;height:20px;margin-top:-4px;border-radius:50%;border:2px solid #fff;background:var(--dm-light-color,#f59e0b);box-shadow:0 2px 6px rgba(15,23,42,.32)}
+    #details-list .dm-lightx-range::-moz-range-thumb,.dm-lightctl .dm-lightctl-range::-moz-range-thumb{width:20px;height:20px;border-radius:50%;border:2px solid #fff;background:var(--dm-light-color,#f59e0b);box-shadow:0 2px 6px rgba(15,23,42,.32)}
+
+    /* The control sheet reuses the canonical modal shell owned by
+       editor-contracts-section.js; only its own height and inner blocks are
+       declared here, so the two do not compete over the same rules. */
+    .dm-lightctl .dm-lightctl-dialog{height:auto!important;max-height:min(760px,calc(100dvh - 32px))!important;grid-template-rows:auto minmax(0,1fr)!important}
+    .dm-lightctl .dm-lightctl-body{min-height:0!important;overflow:auto!important;display:grid!important;align-content:start!important;gap:14px!important;padding:18px 20px 22px!important}
+    .dm-lightctl .dm-lightctl-hero{display:flex!important;align-items:center!important;gap:14px!important;padding:14px!important;border:1px solid color-mix(in srgb,var(--dm-light-color,#f59e0b) 30%,var(--divider-color,#e2e8f0))!important;border-radius:20px!important;background:radial-gradient(120% 100% at 0% 0%,color-mix(in srgb,var(--dm-light-color,#f59e0b) 14%,transparent),transparent 70%)!important}
+    .dm-lightctl .dm-lightctl-orb{display:grid!important;place-items:center!important;flex:0 0 auto!important;width:52px!important;height:52px!important;border-radius:50%!important;background:radial-gradient(circle at 38% 32%,color-mix(in srgb,var(--dm-light-color,#f59e0b) 25%,#fff),var(--dm-light-color,#f59e0b))!important;color:var(--dm-light-ink,#0f172a)!important;box-shadow:0 6px 18px color-mix(in srgb,var(--dm-light-color,#f59e0b) 40%,transparent)!important}
+    .dm-lightctl .dm-lightctl-orb svg{width:26px!important;height:26px!important}
+    .dm-lightctl .dm-lightctl-hero-text{display:grid!important;gap:2px!important;flex:1 1 auto!important;min-width:0!important}
+    .dm-lightctl .dm-lightctl-hero-text b{font-size:14px!important;font-weight:900!important;letter-spacing:.6px!important}
+    .dm-lightctl .dm-lightctl-hero-text small{font-size:11px!important;color:var(--secondary-text-color,#64748b)!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important}
+    .dm-lightctl .dm-lightctl-power{flex:0 0 auto!important;padding:11px 18px!important;border:0!important;border-radius:14px!important;background:var(--dm-light-color,#f59e0b)!important;color:var(--dm-light-ink,#0f172a)!important;font-size:12px!important;font-weight:900!important;letter-spacing:.6px!important;text-transform:uppercase!important;cursor:pointer!important}
+    .dm-lightctl .dm-lightctl-power[aria-pressed="false"]{background:var(--secondary-background-color,#f1f5f9)!important;color:var(--secondary-text-color,#64748b)!important}
+    .dm-lightctl .dm-lightctl-block{display:grid!important;gap:10px!important;padding:14px!important;border:1px solid var(--divider-color,#e2e8f0)!important;border-radius:18px!important}
+    .dm-lightctl .dm-lightctl-block-head{display:flex!important;align-items:center!important;justify-content:space-between!important;gap:10px!important;font-size:11px!important;font-weight:900!important;letter-spacing:.9px!important;text-transform:uppercase!important;color:var(--secondary-text-color,#64748b)!important}
+    .dm-lightctl .dm-lightctl-block-head b{font-size:14px!important;color:var(--text,#0f172a)!important}
+    .dm-lightctl .dm-lightctl-preview{width:26px!important;height:26px!important;border-radius:50%!important;border:2px solid #fff!important;background:var(--dm-light-color,#f59e0b)!important;box-shadow:0 2px 8px rgba(15,23,42,.24)!important}
+    .dm-lightctl .dm-lightctl-presets{display:flex!important;flex-wrap:wrap!important;gap:8px!important}
+    .dm-lightctl .dm-lightctl-presets button{flex:1 1 auto!important;min-height:38px!important;padding:8px 12px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:12px!important;background:var(--secondary-background-color,#f8fafc)!important;color:inherit!important;font-size:11.5px!important;font-weight:800!important;cursor:pointer!important}
+    .dm-lightctl .dm-lightctl-presets button[data-dm-light-kelvin-preset]{border-left:6px solid var(--dm-swatch,#fff)!important}
+    .dm-lightctl .dm-lightctl-swatches{display:grid!important;grid-template-columns:repeat(6,minmax(0,1fr))!important;gap:8px!important}
+    .dm-lightctl .dm-lightctl-swatch{aspect-ratio:1!important;min-height:34px!important;padding:0!important;border:2px solid #fff!important;border-radius:50%!important;background:var(--dm-swatch,#fff)!important;box-shadow:0 2px 8px rgba(15,23,42,.2)!important;cursor:pointer!important}
+    .dm-lightctl .dm-lightctl-swatch:active{transform:scale(.92)!important}
+    .dm-lightctl .dm-lightctl-slot{display:grid!important;gap:2px!important}
+    .dm-lightctl .dm-lightctl-slot>span{font-size:10.5px!important;font-weight:800!important;letter-spacing:.6px!important;text-transform:uppercase!important;color:var(--secondary-text-color,#64748b)!important}
+    .dm-lightctl .dm-lightctl-hue::-webkit-slider-runnable-track{background:linear-gradient(90deg,#ff0000,#ffff00,#00ff00,#00ffff,#0000ff,#ff00ff,#ff0000)!important}
+    .dm-lightctl .dm-lightctl-hue::-moz-range-track{background:linear-gradient(90deg,#ff0000,#ffff00,#00ff00,#00ffff,#0000ff,#ff00ff,#ff0000)!important}
+    .dm-lightctl .dm-lightctl-sat::-webkit-slider-runnable-track{background:linear-gradient(90deg,#ffffff,var(--dm-light-color,#f59e0b))!important}
+    .dm-lightctl .dm-lightctl-sat::-moz-range-track{background:linear-gradient(90deg,#ffffff,var(--dm-light-color,#f59e0b))!important}
+    .dm-lightctl .dm-lightctl-kelvin::-webkit-slider-runnable-track{background:linear-gradient(90deg,#ffb46b,#ffd7ae,#fff6ec,#f2f6ff,#cfe0ff)!important}
+    .dm-lightctl .dm-lightctl-kelvin::-moz-range-track{background:linear-gradient(90deg,#ffb46b,#ffd7ae,#fff6ec,#f2f6ff,#cfe0ff)!important}
+    .dm-lightctl .dm-lightctl-exact{display:flex!important;align-items:center!important;justify-content:space-between!important;gap:12px!important;font-size:10.5px!important;font-weight:800!important;letter-spacing:.6px!important;text-transform:uppercase!important;color:var(--secondary-text-color,#64748b)!important}
+    .dm-lightctl .dm-lightctl-exact input{width:56px!important;height:38px!important;padding:2px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:12px!important;background:transparent!important;cursor:pointer!important}
+    .dm-lightctl .dm-lightctl-select{box-sizing:border-box!important;width:100%!important;min-height:44px!important;padding:10px 12px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:13px!important;background:var(--ha-card-background,var(--card-bg,#fff))!important;color:inherit!important}
+    .dm-lightctl .dm-lightctl-note{margin:0!important;color:var(--secondary-text-color,#64748b)!important;font-size:12px!important;font-weight:600!important;line-height:1.5!important}
+
+    @media(max-width:560px){
+      #details-list .dm-lightx-main{padding:11px 11px 4px!important}
+      #details-list .dm-lightx-tools{padding:0 11px 10px!important}
+      .dm-lightctl .dm-lightctl-hero{flex-wrap:wrap!important}
+      .dm-lightctl .dm-lightctl-power{flex:1 1 100%!important}
+      .dm-lightctl .dm-lightctl-swatches{grid-template-columns:repeat(6,minmax(0,1fr))!important}
+    }
+  `,
+  );
+}
+
+export function installLightsSceneSection() {
+  if (!doc) return;
+  installStyles();
+  installOwners();
+  installListeners();
+  if (!state.listeners) {
+    state.listeners = true;
+    for (const eventName of [
+      "dashboardmodern:legacy-ready",
+      "dashboardmodern:runtime-ready",
+      "dashboardmodern:persistence-restored",
+    ]) {
+      root.addEventListener?.(eventName, () => {
+        installOwners();
+        installListeners();
+      });
+    }
+    root.addEventListener?.("dashboardmodern:state-changed", () => {
+      if (controlNode() || (popupShowing() && listNode()?.querySelector("[data-dm-light]"))) sync();
+    });
+  }
+  state.installed = true;
+}
+
+if (doc?.readyState === "loading") {
+  doc.addEventListener("DOMContentLoaded", installLightsSceneSection, { once: true });
+} else {
+  installLightsSceneSection();
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/navigation-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/navigation-section.js
@@ -1,7 +1,19 @@
-import { doc, installStyle, root } from "./shared.js";
+import { doc, installStyle, root, t } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_NAVIGATION_SECTION__";
-const state = (root[KEY] ||= { installed: false });
+const state = (root[KEY] ||= { installed: false, scroller: null });
+
+/* The dock is sized on its content (`width:max-content`), so with every section
+ * enabled the thirteen tabs are wider than the screen and the ones past the
+ * viewport edge were simply unreachable: the bar is centered and fixed, so the
+ * page scroll never moves it. The tabs now live in their own scroll port with
+ * wheel, drag, arrows and keyboard, and the port is capped to the viewport. */
+const SCROLLER_CLASS = "dm-nav-scroll";
+const ARROW_CLASS = "dm-nav-arrow";
+const CAN_SCROLL_CLASS = "dm-nav-can-scroll";
+const DRAGGING_CLASS = "dm-nav-dragging";
+const DRAG_THRESHOLD = 6;
+const EDGE = 2;
 
 function installStyles() {
   installStyle(
@@ -19,14 +31,273 @@ function installStyles() {
       html[data-theme="dark"] .bottom-nav-bar .tab.active,html.dark .bottom-nav-bar .tab.active,body[data-theme="dark"] .bottom-nav-bar .tab.active,body.dark .bottom-nav-bar .tab.active,.dark .bottom-nav-bar .tab.active{background:#25324b!important;color:#fff!important;border-color:#52627f!important;box-shadow:0 8px 20px rgba(0,0,0,.28)!important}
       html[data-theme="dark"] .bottom-nav-bar .tab.active .text,html.dark .bottom-nav-bar .tab.active .text,body[data-theme="dark"] .bottom-nav-bar .tab.active .text,body.dark .bottom-nav-bar .tab.active .text,.dark .bottom-nav-bar .tab.active .text{color:#fff!important;opacity:1!important}
       @media(max-width:640px){.bottom-nav-bar .tab .text{font-weight:800!important}.bottom-nav-bar .tab{min-width:54px!important}}
+
+      /* Il contenitore è trasparente al layout finché non serve scorrere: su
+       * mobile la barra scorre già da sé e resta esattamente com'era. */
+      .bottom-nav-bar .${SCROLLER_CLASS}{display:contents}
+      .bottom-nav-bar .${ARROW_CLASS}{display:none}
+      @media(min-width:769px) and (hover:hover) and (pointer:fine){
+        nav.tabs.bottom-nav-bar{width:max-content!important;min-width:0!important;max-width:calc(100% - 48px)!important}
+        nav.tabs.bottom-nav-bar:has(:focus-visible){bottom:20px!important;opacity:1!important}
+        nav.tabs.bottom-nav-bar .${SCROLLER_CLASS}{display:flex!important;align-items:center!important;justify-content:flex-start!important;gap:12px!important;flex:0 1 auto!important;min-width:0!important;overflow-x:auto!important;overflow-y:hidden!important;overscroll-behavior-x:contain!important;scrollbar-width:none!important;-ms-overflow-style:none!important;scroll-padding-inline:28px!important}
+        /* Il padding fa spazio alla gobba del dock dentro il riquadro che
+         * ritaglia lo scroll; i margini negativi lo tolgono dal layout, così
+         * la pillola resta alta come prima. */
+        nav.tabs.bottom-nav-bar .${SCROLLER_CLASS}{padding:34px 12px 26px!important;margin:-34px -12px -26px!important}
+        nav.tabs.bottom-nav-bar .${SCROLLER_CLASS}::-webkit-scrollbar{width:0!important;height:0!important;display:none!important}
+        nav.tabs.bottom-nav-bar .${SCROLLER_CLASS} .tab{flex:0 0 auto!important}
+        nav.tabs.bottom-nav-bar .${SCROLLER_CLASS} .tab .text{white-space:nowrap!important}
+        nav.tabs.bottom-nav-bar.${DRAGGING_CLASS} .${SCROLLER_CLASS}{cursor:grabbing!important;user-select:none!important}
+        nav.tabs.bottom-nav-bar.${DRAGGING_CLASS} .tab{pointer-events:none!important}
+        nav.tabs.bottom-nav-bar.${CAN_SCROLL_CLASS} .${ARROW_CLASS}{display:flex!important;align-items:center!important;justify-content:center!important;align-self:center!important;flex:0 0 auto!important;width:34px!important;height:34px!important;padding:0!important;margin:0!important;border-radius:50%!important;border:1px solid rgba(15,23,42,.10)!important;background:rgba(255,255,255,.78)!important;color:#0f172a!important;cursor:pointer!important;box-shadow:0 4px 12px rgba(15,23,42,.14)!important;transition:opacity .2s ease,transform .2s ease,background .2s ease!important}
+        nav.tabs.bottom-nav-bar.${CAN_SCROLL_CLASS} .${ARROW_CLASS}:hover:not([disabled]){background:#fff!important;transform:scale(1.08)!important}
+        nav.tabs.bottom-nav-bar.${CAN_SCROLL_CLASS} .${ARROW_CLASS}[disabled]{opacity:.2!important;cursor:default!important;box-shadow:none!important}
+        nav.tabs.bottom-nav-bar .${ARROW_CLASS}::before{content:''!important;width:9px!important;height:9px!important;border-right:2px solid currentColor!important;border-bottom:2px solid currentColor!important}
+        nav.tabs.bottom-nav-bar .${ARROW_CLASS}-prev::before{transform:rotate(135deg)!important;margin-left:3px!important}
+        nav.tabs.bottom-nav-bar .${ARROW_CLASS}-next::before{transform:rotate(-45deg)!important;margin-right:3px!important}
+        html[data-theme="dark"] nav.tabs.bottom-nav-bar .${ARROW_CLASS},html.dark nav.tabs.bottom-nav-bar .${ARROW_CLASS},body[data-theme="dark"] nav.tabs.bottom-nav-bar .${ARROW_CLASS},body.dark nav.tabs.bottom-nav-bar .${ARROW_CLASS},.dark nav.tabs.bottom-nav-bar .${ARROW_CLASS}{background:#25324b!important;border-color:#52627f!important;color:#cbd5e1!important;box-shadow:0 6px 16px rgba(0,0,0,.32)!important}
+        html[data-theme="dark"] nav.tabs.bottom-nav-bar .${ARROW_CLASS}:hover:not([disabled]),html.dark nav.tabs.bottom-nav-bar .${ARROW_CLASS}:hover:not([disabled]),body[data-theme="dark"] nav.tabs.bottom-nav-bar .${ARROW_CLASS}:hover:not([disabled]),body.dark nav.tabs.bottom-nav-bar .${ARROW_CLASS}:hover:not([disabled]),.dark nav.tabs.bottom-nav-bar .${ARROW_CLASS}:hover:not([disabled]){background:#31415f!important;color:#fff!important}
+      }
     `,
   );
+}
+
+/* Pure geometry, so the scroll rules are testable without a browser. */
+export function navScrollState({ scrollLeft = 0, scrollWidth = 0, clientWidth = 0 } = {}) {
+  const max = Math.max(0, Math.round(scrollWidth - clientWidth));
+  const scrollable = max > EDGE;
+  const position = Math.max(0, Math.min(scrollLeft, max));
+  return Object.freeze({
+    max,
+    scrollable,
+    atStart: !scrollable || position <= EDGE,
+    atEnd: !scrollable || position >= max - EDGE,
+  });
+}
+
+export function navPageStep(clientWidth = 0) {
+  return Math.max(120, Math.round(clientWidth * 0.72));
+}
+
+export function navWheelDelta(event = {}) {
+  const horizontal = Math.abs(event.deltaX || 0) > Math.abs(event.deltaY || 0);
+  const raw = horizontal ? event.deltaX : event.deltaY;
+  const unit = event.deltaMode === 1 ? 18 : event.deltaMode === 2 ? 320 : 1;
+  return Number.isFinite(raw) ? raw * unit : 0;
+}
+
+export function navCenterTarget({
+  scrollLeft = 0,
+  portLeft = 0,
+  portWidth = 0,
+  tabLeft = 0,
+  tabWidth = 0,
+  max = 0,
+} = {}) {
+  const target = scrollLeft + (tabLeft - portLeft) - (portWidth - tabWidth) / 2;
+  return Math.max(0, Math.min(Math.round(target), Math.max(0, max)));
+}
+
+export function navTabIsVisible({ portLeft = 0, portRight = 0, tabLeft = 0, tabRight = 0 } = {}) {
+  return tabLeft >= portLeft - EDGE && tabRight <= portRight + EDGE;
+}
+
+function navigationBar() {
+  return doc?.querySelector("nav.tabs.bottom-nav-bar") || null;
+}
+
+/* The tabs are the only children the vendored markup puts in the bar, and the
+ * legacy reorder appends into `.tab`'s parent, so moving them into the port
+ * keeps both the DOM order and that reorder working. */
+function buildScroller(nav) {
+  const existing = nav.querySelector(`.${SCROLLER_CLASS}`);
+  if (existing) return existing;
+  const tabs = [...nav.querySelectorAll(".tab")];
+  if (!tabs.length) return null;
+  const scroller = doc.createElement("div");
+  scroller.className = SCROLLER_CLASS;
+  nav.insertBefore(scroller, tabs[0]);
+  for (const tab of tabs) scroller.append(tab);
+  return scroller;
+}
+
+function buildArrow(direction) {
+  const button = doc.createElement("button");
+  button.type = "button";
+  button.className = `${ARROW_CLASS} ${ARROW_CLASS}-${direction}`;
+  button.setAttribute(
+    "aria-label",
+    direction === "prev"
+      ? t("Sezioni precedenti", "Previous sections")
+      : t("Sezioni successive", "Next sections"),
+  );
+  return button;
+}
+
+function installScroller() {
+  const nav = navigationBar();
+  if (!nav || state.scroller) return Boolean(state.scroller);
+  const scroller = buildScroller(nav);
+  if (!scroller) return false;
+  state.scroller = scroller;
+
+  const previous = buildArrow("prev");
+  const next = buildArrow("next");
+  nav.insertBefore(previous, scroller);
+  nav.append(next);
+
+  const reduced = Boolean(root.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches);
+  const behavior = reduced ? "auto" : "smooth";
+
+  const sync = () => {
+    const status = navScrollState(scroller);
+    nav.classList.toggle(CAN_SCROLL_CLASS, status.scrollable);
+    previous.disabled = status.atStart;
+    next.disabled = status.atEnd;
+    return status;
+  };
+
+  const stepBy = (direction) => {
+    scroller.scrollBy({ left: direction * navPageStep(scroller.clientWidth), behavior });
+  };
+
+  /* Ogni volta che il dock ricompare la sezione aperta deve essere sotto gli
+   * occhi, ma senza rimbalzare via da dove l'utente aveva scorso. */
+  const revealActive = () => {
+    const status = sync();
+    if (!status.scrollable) return;
+    const active = scroller.querySelector(".tab.active");
+    if (!active) return;
+    const port = scroller.getBoundingClientRect();
+    const box = active.getBoundingClientRect();
+    if (
+      navTabIsVisible({
+        portLeft: port.left,
+        portRight: port.right,
+        tabLeft: box.left,
+        tabRight: box.right,
+      })
+    ) {
+      return;
+    }
+    scroller.scrollTo({
+      left: navCenterTarget({
+        scrollLeft: scroller.scrollLeft,
+        portLeft: port.left,
+        portWidth: scroller.clientWidth,
+        tabLeft: box.left,
+        tabWidth: box.width,
+        max: status.max,
+      }),
+      behavior,
+    });
+  };
+
+  previous.addEventListener("click", () => stepBy(-1));
+  next.addEventListener("click", () => stepBy(1));
+  scroller.addEventListener("scroll", sync, { passive: true });
+  /* Accendere o spegnere una sezione cambia la larghezza della barra: è il
+   * segnale che dice quando le frecce servono, senza nessun giro a vuoto. */
+  if (typeof root.ResizeObserver === "function") new root.ResizeObserver(sync).observe(scroller);
+  nav.addEventListener("pointerenter", revealActive);
+  nav.addEventListener("focusin", revealActive);
+  root.addEventListener?.("resize", sync);
+  root.addEventListener?.("dashboardmodern:legacy-ready", revealActive);
+
+  nav.addEventListener("keydown", (event) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    if (!navScrollState(scroller).scrollable) return;
+    stepBy(event.key === "ArrowLeft" ? -1 : 1);
+    event.preventDefault();
+  });
+
+  /* La rotella verticale del mouse è l'unico gesto di scorrimento che un PC
+   * fisso ha sempre: sopra il dock diventa orizzontale. */
+  nav.addEventListener(
+    "wheel",
+    (event) => {
+      const status = navScrollState(scroller);
+      if (!status.scrollable) return;
+      const delta = navWheelDelta(event);
+      if (!delta) return;
+      const target = Math.max(0, Math.min(scroller.scrollLeft + delta, status.max));
+      if (target === scroller.scrollLeft) return;
+      scroller.scrollLeft = target;
+      event.preventDefault();
+      sync();
+    },
+    { passive: false },
+  );
+
+  /* Trascinare la barra come si trascina il dock: il puntatore viene catturato
+   * solo dopo la soglia, così un click fermo su una scheda resta un click. */
+  let drag = null;
+  let swallowClick = false;
+
+  const dragMove = (event) => {
+    if (!drag) return;
+    const dx = event.clientX - drag.x;
+    if (!drag.moved) {
+      if (Math.abs(dx) < DRAG_THRESHOLD) return;
+      drag.moved = true;
+      nav.classList.add(DRAGGING_CLASS);
+      scroller.setPointerCapture?.(drag.pointerId);
+    }
+    scroller.scrollLeft = drag.left - dx;
+  };
+
+  const dragEnd = () => {
+    if (!drag) return;
+    const { pointerId, moved } = drag;
+    drag = null;
+    swallowClick = moved;
+    nav.classList.remove(DRAGGING_CLASS);
+    if (moved) scroller.releasePointerCapture?.(pointerId);
+    root.removeEventListener?.("pointermove", dragMove);
+    root.removeEventListener?.("pointerup", dragEnd);
+    root.removeEventListener?.("pointercancel", dragEnd);
+    sync();
+  };
+
+  scroller.addEventListener("pointerdown", (event) => {
+    swallowClick = false;
+    if (drag || event.button !== 0 || event.pointerType === "touch") return;
+    if (!navScrollState(scroller).scrollable) return;
+    drag = {
+      pointerId: event.pointerId,
+      x: event.clientX,
+      left: scroller.scrollLeft,
+      moved: false,
+    };
+    root.addEventListener?.("pointermove", dragMove);
+    root.addEventListener?.("pointerup", dragEnd);
+    root.addEventListener?.("pointercancel", dragEnd);
+  });
+
+  /* Trascinare finisce sempre con un click: quello che chiude il trascinamento
+   * non deve cambiare sezione. */
+  scroller.addEventListener(
+    "click",
+    (event) => {
+      if (!swallowClick) return;
+      swallowClick = false;
+      event.preventDefault();
+      event.stopPropagation();
+    },
+    true,
+  );
+
+  sync();
+  return true;
 }
 
 export function installNavigationSection() {
   if (!doc || state.installed) return;
   state.installed = true;
   installStyles();
+  if (!installScroller()) {
+    doc.addEventListener("DOMContentLoaded", () => installScroller(), { once: true });
+  }
 }
 
 if (doc?.readyState === "loading") {

--- a/custom_components/dashboardmodern/frontend/src/sections/personalization-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/personalization-section.js
@@ -3,7 +3,7 @@ import { clean, doc, esc, installStyle, readJson, root, t, writeJsonIfChanged, w
 
 globalThis.__DM_20260815C__ = true;
 const KEY = "__DASHBOARDMODERN_PERSONALIZATION_SECTION__";
-const state = (root[KEY] ||= { installed: false, frame: 0, actionEditIndex: -1, subscribed: false });
+const state = (root[KEY] ||= { installed: false, frame: 0, actionEditIndex: -1, subscribed: false, evHomeAttempts: 0 });
 
 // Model families sold in Europe with a battery-electric, full-hybrid,
 // range-extender or plug-in-hybrid powertrain. The selector also preserves an
@@ -433,7 +433,26 @@ function ensureEvAppearanceEditor() {
     body.querySelectorAll("[data-ev-appearance]").forEach((node) => node.remove());
     return;
   }
-  if (body.querySelector("[data-ev-appearance]")) return;
+  const evAccordionBody = () =>
+    [...body.querySelectorAll(".ed-acc-body")].find((node) =>
+      node.querySelector('.ed-slot-in[data-ref^="dm.ev_"]'),
+    );
+  const existing = body.querySelector("[data-ev-appearance]");
+  if (existing) {
+    // The editor repaints #ed-body while the tab settles, so the vehicle
+    // accordion can appear after the panel was built. Bring the panel home as
+    // soon as its own section exists, retrying a bounded number of times rather
+    // than polling for a section that may simply not be configured.
+    const home = evAccordionBody();
+    if (home) {
+      if (existing.parentElement !== home) home.prepend(existing);
+      state.evHomeAttempts = 0;
+    } else if ((state.evHomeAttempts || 0) < 5) {
+      state.evHomeAttempts = (state.evHomeAttempts || 0) + 1;
+      root.setTimeout?.(schedule, 120);
+    }
+    return;
+  }
   const { current, fallback } = evVisual();
   const visual = current || fallback || {};
   const panel = doc.createElement("section");
@@ -442,9 +461,23 @@ function ensureEvAppearanceEditor() {
   const brand = effectiveBrand(visual) || clean(visual.brand) || "Leapmotor";
   const model = effectiveModel(visual);
   panel.innerHTML = `<div class="ed-sec-title">🚘 ${t("Brand e modello auto", "Vehicle brand and model")}</div><div class="ed-intro">${t("Il logo viene associato automaticamente al marchio. Il modello sostituisce la vecchia icona auto generica.", "The logo is automatically associated with the brand. The model replaces the old generic car icon.")}</div><div class="dm-ev-appearance-grid"><button type="button" class="dm-brand-preview dm-visual-trigger" data-brand-preview aria-label="${t("Scegli brand auto", "Choose car brand")}">${carBrandVisual(brand, 56)}<span class="dm-ev-brand-copy"><b>${esc(brand)}</b>${model ? `<small>${esc(model)}</small>` : ""}</span></button><label class="dm-ev-appearance-field"><span>${t("Marchio", "Brand")}</span><select class="ed-input" data-brand>${CAR_BRANDS.map((item) => `<option value="${esc(item.name)}" ${item.name === brand ? "selected" : ""}>${esc(item.name)}</option>`).join("")}</select></label><label class="dm-ev-appearance-field"><span>${t("Modello elettrico / ibrido", "Electric / hybrid model")}</span><select class="ed-input" data-model>${modelOptions(brand, model)}</select></label></div><button type="button" class="ed-save-btn" data-save>💾 ${t("Salva brand e modello", "Save brand and model")}</button>`;
-  const visibleEvBlock = [...body.querySelectorAll("details,.ed-acc,.ed-form")].find((node) => node !== panel && /auto elettric|electric car|profilo auto|car profile|vettur|vehicle/i.test(clean(node.textContent)));
-  if (visibleEvBlock?.parentElement) visibleEvBlock.insertAdjacentElement("afterend", panel);
-  else body.prepend(panel);
+  // Brand and model belong to the vehicle, so they live inside the vehicle
+  // accordion, above the entities of the same car — not floating at the top of
+  // the tab. The accordion is found by its own EV slots rather than by its
+  // wording, so a renamed section still gets the panel.
+  const home = evAccordionBody();
+  if (home) home.prepend(panel);
+  else if (!body.querySelector(".ed-acc-body")) {
+    // The editor has not printed its accordions yet. Park the panel where it
+    // has always been and come back for it on the next pass, so it ends up in
+    // the vehicle section instead of staying at the top of the tab.
+    body.prepend(panel);
+    root.setTimeout?.(schedule, 0);
+  } else {
+    const visibleEvBlock = [...body.querySelectorAll("details,.ed-acc,.ed-form")].find((node) => node !== panel && /auto elettric|electric car|profilo auto|car profile|vettur|vehicle/i.test(clean(node.textContent)));
+    if (visibleEvBlock?.parentElement) visibleEvBlock.insertAdjacentElement("afterend", panel);
+    else body.prepend(panel);
+  }
   const brandSelect = panel.querySelector("[data-brand]");
   const modelSelect = panel.querySelector("[data-model]");
   const refreshPreview = () => {

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -17,6 +17,7 @@ import { installEnergyAnalysisSection } from "./energy-analysis-section.js";
 import { installHistorySection } from "./history-section.js";
 import { installTemperatureSection } from "./temperature-section.js";
 import { installTemperatureLayoutSection } from "./temperature-layout-section.js";
+import { installTemperatureTrendSection } from "./temperature-trend-section.js";
 import { installAppliancesSection } from "./appliances-section.js";
 import { installApplianceLayoutSection } from "./appliance-layout-section.js";
 import { installBeta27ReleaseStability } from "./beta27-release-stability-section.js";
@@ -617,6 +618,7 @@ export function installSectionRuntime() {
     installHistorySection();
     installTemperatureSection();
     installTemperatureLayoutSection();
+    installTemperatureTrendSection();
     installAppliancesSection();
     installApplianceLayoutSection();
     // The showcase renderer must install before the KPI popups wrap

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -24,6 +24,7 @@ import { installBeta27ReleaseStability } from "./beta27-release-stability-sectio
 import { installApplianceShowcaseSection } from "./appliance-showcase-section.js";
 import { installApplianceEditorSection } from "./appliance-editor-section.js";
 import { installLightsAlertsSection } from "./lights-alerts-section.js";
+import { installLightsSceneSection } from "./lights-scene-section.js";
 import { installAlertsSection } from "./alerts-section.js";
 import { installLiveUiSection } from "./live-ui-section.js";
 import { installSecurityShowcaseSection } from "./security-showcase-section.js";
@@ -630,6 +631,9 @@ export function installSectionRuntime() {
     installAppliancePickerLayer();
     installApplianceEditorSection();
     installLightsAlertsSection();
+    // The editor owns the light list and the rooms; the scene owns the popup
+    // that controls them, so it installs after the model it reads.
+    installLightsSceneSection();
     installAlertsSection();
     // The redesigned Security page must own #cam-grid before the live-ui camera
     // owner starts filling the thumbnails, so the first paint is already the new
@@ -678,6 +682,7 @@ export function installSectionRuntime() {
         "appliance-showcase",
         "appliance-editor",
         "lights",
+        "lights-scene",
         "alerts",
         "security-showcase",
         "climate-thermal",

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -38,6 +38,7 @@ import { installShutterSceneSection } from "./shutter-scene-section.js";
 import { installPoolIrrigationSceneSection } from "./pool-irrigation-scene-section.js";
 import { installEvSection } from "./ev-section.js";
 import { installEvShowcaseSection } from "./ev-showcase-section.js";
+import { installEditorSlotsSection } from "./editor-slots-section.js";
 import { installSolarThermalDesignSection } from "./solar-thermal-design-section.js";
 import { installLegacySections, LEGACY_SECTION_KEYS } from "./legacy-sections-registry.js";
 import { allStates, clean, english, section, wrapFunction } from "./shared.js";
@@ -639,6 +640,8 @@ export function installSectionRuntime() {
     installEntitySearchSection();
     installEditorCrudSection();
     installEditorContractsSection();
+    // Readable entity rows for every section tab of the editor.
+    installEditorSlotsSection();
     installReportEditorSection();
     installShutterSection();
     installShutterSceneSection();
@@ -682,6 +685,7 @@ export function installSectionRuntime() {
         "entity-search",
         "editor-crud",
         "editor-contracts",
+        "editor-slots",
         "report-editor",
         "shutters",
         "pool-irrigation-scene",

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -32,6 +32,7 @@ import { installClimateThermalSection } from "./climate-thermal-section.js";
 import { installNavigationSection } from "./navigation-section.js";
 import { installUnifiedEditorsSection } from "./unified-editors-section.js";
 import { installEntitySearchSection } from "./entity-search-section.js";
+import { installEntityAutodetectSection } from "./entity-autodetect-section.js";
 import { installEditorCrudSection } from "./editor-crud-section.js";
 import { installEditorContractsSection } from "./editor-contracts-section.js";
 import { installReportEditorSection } from "./report-editor-section.js";
@@ -644,6 +645,7 @@ export function installSectionRuntime() {
     installNavigationSection();
     installUnifiedEditorsSection();
     installEntitySearchSection();
+    installEntityAutodetectSection();
     installEditorCrudSection();
     installEditorContractsSection();
     // Readable entity rows for every section tab of the editor.
@@ -690,6 +692,7 @@ export function installSectionRuntime() {
         "navigation",
         "unified-editors",
         "entity-search",
+        "entity-autodetect",
         "editor-crud",
         "editor-contracts",
         "editor-slots",

--- a/custom_components/dashboardmodern/frontend/src/sections/security-showcase-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/security-showcase-section.js
@@ -207,7 +207,6 @@ function cardMarkup(model, labels) {
   return `<article class="cam-card dm-cam" data-dm-cam="${esc(model.slug)}" data-dm-entity="${esc(model.entity)}" data-dm-title="${esc(model.title)}" role="button" tabindex="0" aria-label="${esc(labels.openCamera)}: ${esc(model.name)}">
       <div class="dm-cam-feed">
         <img id="${esc(model.slug)}" alt="" decoding="async">
-        <span class="dm-cam-scan" aria-hidden="true"></span>
         <span class="dm-cam-frame" aria-hidden="true"></span>
         <div class="dm-cam-top">
           <span class="dm-cam-live"><i aria-hidden="true"></i>${esc(labels.live)}</span>
@@ -619,11 +618,6 @@ function securityCss() {
   transition:transform .6s cubic-bezier(.16,1,.3,1),filter .35s ease
 }
 .dm-cam:hover .dm-cam-feed>img{transform:scale(1.05)}
-/* interlaced scan texture — very faint, reads as a monitor rather than a photo */
-.dm-cam-scan{
-  position:absolute;inset:0;z-index:2;pointer-events:none;opacity:.16;
-  background:repeating-linear-gradient(180deg,rgba(255,255,255,.14) 0 1px,transparent 1px 3px)
-}
 .dm-cam-frame{position:absolute;inset:9px;z-index:3;pointer-events:none;opacity:.45;transition:opacity .35s ease}
 .dm-cam-frame::before,.dm-cam-frame::after{
   content:"";position:absolute;width:15px;height:15px;border:2px solid rgba(226,238,251,.8)
@@ -678,7 +672,7 @@ function securityCss() {
 .dm-cam-off b{font-family:var(--dm-sec-mono);font-size:11px;letter-spacing:2.2px;text-transform:uppercase}
 .dm-cam.is-off .dm-cam-off{display:flex}
 .dm-cam.is-off .dm-cam-feed>img{filter:grayscale(1) brightness(.35)}
-.dm-cam.is-off .dm-cam-live,.dm-cam.is-off .dm-cam-open,.dm-cam.is-off .dm-cam-scan{display:none}
+.dm-cam.is-off .dm-cam-live,.dm-cam.is-off .dm-cam-open{display:none}
 .dm-cam.is-off .dm-cam-name{color:var(--dm-sec-dim)}
 
 /* empty state */

--- a/custom_components/dashboardmodern/frontend/src/sections/shared.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shared.js
@@ -239,6 +239,29 @@ export function installStyle(id, css) {
   return true;
 }
 
+/* The reading, projected onto the card as numbers the stylesheet can draw with.
+ *
+ * Three renderers build these cards; putting the gauge in the markup would mean
+ * three copies of it. Instead each updater hands the card its reading here, and
+ * the sheet draws the comfort scale and the humidity bar from these variables.
+ * The scale spans 10-32 °C: below or above simply pins to the ends. */
+export function applyTemperatureReading(card, temperature, humidity) {
+  if (!card?.style) return false;
+  const hasReading = Number.isFinite(temperature);
+  if (hasReading) {
+    const position = Math.min(100, Math.max(0, ((temperature - 10) / 22) * 100));
+    card.style.setProperty("--dm-temp-pos", position.toFixed(1));
+  } else {
+    card.style.removeProperty("--dm-temp-pos");
+  }
+  if (Number.isFinite(humidity))
+    card.style.setProperty("--dm-hum", Math.min(100, Math.max(0, humidity)).toFixed(0));
+  else card.style.removeProperty("--dm-hum");
+  card.dataset.dmReading = hasReading ? "on" : "off";
+  card.dataset.dmHumidity = Number.isFinite(humidity) ? "on" : "off";
+  return true;
+}
+
 /* One rule for the small label above the reading, wherever a card is drawn.
  *
  * It used to have three writers: the renderers wrote the generic word at

--- a/custom_components/dashboardmodern/frontend/src/sections/shared.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shared.js
@@ -188,6 +188,21 @@ export function section(name, fallback) {
   }
 }
 
+/* The vendored runtime declares its state with `const`, `let` and `var` at the
+ * top level of a classic script. Only `var` lands on `window`; the others are
+ * script-scope bindings that a module cannot see at all — reading `root.WIZ`
+ * quietly returns undefined instead of the wizard's data. Resolving the name in
+ * the runtime's own scope is the only way in, and it is the same door
+ * `allStates()` has always used for `_RAW_STATES`.
+ */
+export function lexicalGlobal(name) {
+  try {
+    const value = root.eval?.(`typeof ${name} !== "undefined" && ${name} ? ${name} : null`);
+    if (value) return value;
+  } catch (_error) {}
+  return root[name] ?? null;
+}
+
 export function allStates() {
   // Hosted Home Assistant surfaces do not all expose the live registry through
   // the same object at the same moment. Merge every supported source instead of
@@ -198,15 +213,8 @@ export function allStates() {
     ...(root.hass?.states || {}),
   };
   for (const name of ["_RAW_STATES", "STATES"]) {
-    let lexical = null;
-    try {
-      lexical = root.eval?.(`typeof ${name} !== "undefined" && ${name} ? ${name} : null`);
-    } catch (_error) {}
-    if (lexical && typeof lexical === "object") {
-      Object.assign(values, lexical);
-      continue;
-    }
-    if (root[name] && typeof root[name] === "object") Object.assign(values, root[name]);
+    const lexical = lexicalGlobal(name);
+    if (lexical && typeof lexical === "object") Object.assign(values, lexical);
   }
   return values;
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/shutter-scene-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shutter-scene-section.js
@@ -180,9 +180,10 @@ function groupMarkup(view, count) {
 }
 
 /**
- * The track is always drawn, so a cover that cannot be sent to a position still
- * shows one and every card in a row keeps the same window width. Only a cover
- * that reports SET_POSITION gets the input that makes it draggable.
+ * The track sits under the window, across the whole card, so the window itself
+ * is never narrowed to make room for it. It is always drawn, so a cover that
+ * cannot be sent to a position still shows where it stands; only a cover that
+ * reports SET_POSITION gets the input that makes it draggable.
  */
 function trackMarkup(view) {
   if (!view.settable) return `<div class="dm-tapp-track" data-dm-static aria-hidden="true"></div>`;
@@ -208,10 +209,12 @@ function cardMarkup(view) {
         <div class="tapp-glass"></div>
         <div class="tapp-shutter" data-dm-panel>${slats}</div>
       </div>
-      ${trackMarkup(view)}
     </div>
     <div class="dm-tapp-spill" aria-hidden="true"></div>
-    <div class="tapp-pos" data-dm-readout></div>
+    <div class="dm-tapp-bar">
+      ${trackMarkup(view)}
+      <div class="tapp-pos" data-dm-readout></div>
+    </div>
     <div class="tapp-ctl">
       <button type="button" class="tapp-btn" data-svc="open_cover" onclick="cdTappCmd(this)" aria-label="${esc(t("Apri", "Open"))}">▲</button>
       <button type="button" class="tapp-btn" data-svc="stop_cover" onclick="cdTappCmd(this)" aria-label="${esc(t("Ferma", "Stop"))}">■</button>
@@ -426,29 +429,34 @@ function installStyles() {
       overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important;
       color:var(--tapp-dim)!important;font-size:10px!important;font-weight:900!important;letter-spacing:1px!important;text-transform:uppercase!important}
 
-    html body #page-tapparelle#page-tapparelle .dm-tapp-stage{display:flex!important;align-items:stretch!important;gap:10px!important;min-width:0!important}
-    html body #page-tapparelle#page-tapparelle .dm-tapp-stage .tapp-win{flex:1 1 auto!important;min-width:0!important}
+    /* Nothing shares the row with the window, so it runs the full width of the
+       card and the panel closes across the whole opening. */
+    html body #page-tapparelle#page-tapparelle .dm-tapp-stage{display:block!important;min-width:0!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-stage .tapp-win{width:100%!important;min-width:0!important}
 
-    /* The track is the window in miniature: the shut part of the gradient is the
-       panel, the open part is the sky, and the thumb rides the closing edge. */
+    /* The position lives under the window instead of beside it: one rail the
+       width of the card, filled from the left by however much light gets in,
+       with the readout at its end. */
+    html body #page-tapparelle#page-tapparelle .dm-tapp-bar{display:flex!important;align-items:center!important;gap:10px!important;min-width:0!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-bar>.tapp-pos{flex:0 0 auto!important;align-self:center!important}
     html body #page-tapparelle#page-tapparelle .dm-tapp-track{
-      position:relative!important;flex:0 0 34px!important;box-sizing:border-box!important;height:132px!important;
+      position:relative!important;flex:1 1 auto!important;box-sizing:border-box!important;height:26px!important;min-width:0!important;
       border:1px solid var(--tapp-pill-line)!important;border-radius:13px!important;overflow:hidden!important;
-      background:linear-gradient(180deg,var(--tapp-slat-base) 0 calc((1 - var(--tapp-open,0)) * 100%),var(--tapp-track-sky) calc((1 - var(--tapp-open,0)) * 100%) 100%)!important;
+      background:linear-gradient(90deg,var(--tapp-track-sky) 0 calc(var(--tapp-open,0) * 100%),var(--tapp-slat-base) calc(var(--tapp-open,0) * 100%) 100%)!important;
       box-shadow:inset 0 1px 3px rgba(15,23,42,.28)!important;touch-action:none!important}
     html body #page-tapparelle#page-tapparelle .dm-tapp-track[data-dm-static]{opacity:.55!important}
     html body #page-tapparelle#page-tapparelle .dm-tapp-range{
-      position:absolute!important;left:50%!important;top:50%!important;box-sizing:border-box!important;
-      width:132px!important;height:34px!important;margin:0!important;padding:0!important;border:0!important;
-      transform:translate(-50%,-50%) rotate(-90deg)!important;appearance:none!important;-webkit-appearance:none!important;
-      background:transparent!important;cursor:ns-resize!important}
-    html body #page-tapparelle#page-tapparelle .dm-tapp-range::-webkit-slider-runnable-track{height:34px;background:transparent;border:0}
+      position:absolute!important;inset:0!important;box-sizing:border-box!important;
+      width:100%!important;height:100%!important;margin:0!important;padding:0!important;border:0!important;
+      appearance:none!important;-webkit-appearance:none!important;
+      background:transparent!important;cursor:ew-resize!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-range::-webkit-slider-runnable-track{height:100%;background:transparent;border:0}
     html body #page-tapparelle#page-tapparelle .dm-tapp-range::-webkit-slider-thumb{
-      -webkit-appearance:none;width:22px;height:14px;border-radius:5px;border:1px solid rgba(15,23,42,.35);
+      -webkit-appearance:none;width:14px;height:22px;border-radius:5px;border:1px solid rgba(15,23,42,.35);
       background:linear-gradient(180deg,#fdfeff,#c9d3e0);box-shadow:0 2px 5px rgba(15,23,42,.4)}
-    html body #page-tapparelle#page-tapparelle .dm-tapp-range::-moz-range-track{height:34px;background:transparent;border:0}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-range::-moz-range-track{height:100%;background:transparent;border:0}
     html body #page-tapparelle#page-tapparelle .dm-tapp-range::-moz-range-thumb{
-      width:22px;height:14px;border-radius:5px;border:1px solid rgba(15,23,42,.35);
+      width:14px;height:22px;border-radius:5px;border:1px solid rgba(15,23,42,.35);
       background:linear-gradient(180deg,#fdfeff,#c9d3e0);box-shadow:0 2px 5px rgba(15,23,42,.4)}
     html body #page-tapparelle#page-tapparelle .dm-tapp-range:focus-visible{outline:3px solid color-mix(in srgb,var(--tapp-accent) 55%,transparent)!important;outline-offset:2px!important}
 

--- a/custom_components/dashboardmodern/frontend/src/sections/solar-thermal-design-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/solar-thermal-design-section.js
@@ -1261,6 +1261,33 @@ function buildHeader() {
   );
 }
 
+/**
+ * The runtime hides any element whose onclick names only unmapped entities
+ * (`cdAutoHide`), and it does so symmetrically so cards return once mapped.
+ * The decorations added here have to follow: a collector that is hidden must
+ * take its readout and its ground shadow with it, and an empty probe rail must
+ * not keep its leader lines on screen. Everything below mirrors the runtime's
+ * own inline display, so mapping an entity brings the hardware straight back.
+ */
+function mirrorRuntimeVisibility() {
+  const hidden = (node) => node?.style.display === "none";
+
+  const collector = doc.querySelector("#page-boiler .dm-st-node-collector");
+  const panel = doc.querySelector("#page-boiler .syn-solar-panel");
+  if (collector && panel) collector.style.display = hidden(panel) ? "none" : "";
+
+  // A readout with a hidden value is a caption with nothing to caption.
+  const readout = doc.querySelector("#page-boiler .syn-solar-content");
+  const reading = doc.getElementById("syn-v-pannello");
+  if (readout && reading) readout.style.display = hidden(reading) ? "none" : "";
+
+  const probes = doc.querySelector("#page-boiler .tank-probes");
+  if (probes) {
+    const anyVisible = [...probes.querySelectorAll(".probe")].some((probe) => !hidden(probe));
+    probes.style.display = anyVisible ? "" : "none";
+  }
+}
+
 function decorate() {
   if (!doc?.getElementById("page-boiler")) return false;
   buildHeader();
@@ -1273,6 +1300,7 @@ function decorate() {
   routePipes(Boolean(state.query?.matches));
   highlightPipes();
   nameButtons();
+  mirrorRuntimeVisibility();
   return true;
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/temperature-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/temperature-section.js
@@ -2,6 +2,7 @@
 import { directEmoji, roomGlyph } from "../core/personalization-catalog.js";
 import {
   allStates,
+  applyTemperatureReading,
   clean,
   comfortBadgeText,
   dashboardStore,
@@ -181,6 +182,7 @@ function updateCard(card, room) {
   if (value) value.textContent = temperature == null ? "—" : temperature.toFixed(1);
   if (humidityValue)
     humidityValue.textContent = humidity == null ? "—%" : `${humidity.toFixed(0)}%`;
+  applyTemperatureReading(card, temperature, humidity);
   if (comfort) {
     const label = comfortLabel(temperature);
     comfort.textContent = comfortBadgeText(label);
@@ -487,13 +489,18 @@ function installStyles() {
        inside Home Assistant, so every mix has to fall back to the dashboard own
        --card-bg, or the card paints white under light text in dark theme. */
     #page-temp #temp-grid,.temp-grid{display:grid!important;grid-template-columns:repeat(auto-fit,minmax(268px,332px))!important;justify-content:start!important;align-items:start!important;gap:16px!important;width:100%!important;margin:16px 0 0!important;padding:0 18px 28px!important}
-    #page-temp .temp-card,#temp-grid .temp-card{--dm-temp-surface:var(--ha-card-background,var(--card-bg,#fff));--dm-temp-accent:100,116,139;position:relative!important;display:grid!important;grid-template-columns:minmax(0,1fr)!important;box-sizing:border-box!important;aspect-ratio:auto!important;width:100%!important;max-width:332px!important;min-height:132px!important;margin:0!important;padding:15px 16px 15px 19px!important;border:1px solid color-mix(in srgb,rgb(var(--dm-temp-accent)) 17%,var(--card-border,var(--divider-color,#e2e8f0)))!important;border-radius:22px!important;gap:13px!important;overflow:hidden!important;background:radial-gradient(118% 82% at 100% 0%,color-mix(in srgb,rgb(var(--dm-temp-accent)) 9%,transparent) 0%,transparent 64%),linear-gradient(180deg,var(--dm-temp-surface) 0%,color-mix(in srgb,rgb(var(--dm-temp-accent)) 3.5%,var(--dm-temp-surface)) 100%)!important;box-shadow:0 14px 30px -18px color-mix(in srgb,rgb(var(--dm-temp-accent)) 34%,rgba(15,23,42,.3))!important;transition:transform .16s ease,box-shadow .16s ease!important}
+    #page-temp .temp-card,#temp-grid .temp-card{--dm-temp-surface:var(--ha-card-background,var(--card-bg,#fff));--dm-temp-accent:100,116,139;position:relative!important;display:grid!important;grid-template-columns:minmax(0,1fr)!important;box-sizing:border-box!important;aspect-ratio:auto!important;width:100%!important;max-width:332px!important;min-height:132px!important;margin:0!important;padding:15px 16px 18px 19px!important;border:1px solid color-mix(in srgb,rgb(var(--dm-temp-accent)) 17%,var(--card-border,var(--divider-color,#e2e8f0)))!important;border-radius:22px!important;gap:13px!important;overflow:hidden!important;background:radial-gradient(118% 82% at 100% 0%,color-mix(in srgb,rgb(var(--dm-temp-accent)) 9%,transparent) 0%,transparent 64%),linear-gradient(180deg,var(--dm-temp-surface) 0%,color-mix(in srgb,rgb(var(--dm-temp-accent)) 3.5%,var(--dm-temp-surface)) 100%)!important;box-shadow:0 14px 30px -18px color-mix(in srgb,rgb(var(--dm-temp-accent)) 34%,rgba(15,23,42,.3))!important;transition:transform .16s ease,box-shadow .16s ease!important}
     /* The comfort state colours the whole tile, so a room reads at a glance. */
     #temp-grid .temp-card:has(.temp-comfort-badge[data-comfort="freddo"]),#temp-grid .temp-card:has(.temp-comfort-badge[data-comfort="cold"]){--dm-temp-accent:14,165,233}
     #temp-grid .temp-card:has(.temp-comfort-badge[data-comfort="comfort"]){--dm-temp-accent:16,185,129}
     #temp-grid .temp-card:has(.temp-comfort-badge[data-comfort="caldo"]),#temp-grid .temp-card:has(.temp-comfort-badge[data-comfort="hot"]){--dm-temp-accent:239,68,68}
     @media(hover:hover) and (pointer:fine){#temp-grid .temp-card:hover{transform:translateY(-2px)!important;box-shadow:0 20px 38px -18px color-mix(in srgb,rgb(var(--dm-temp-accent)) 52%,rgba(15,23,42,.34))!important}}
     #page-temp .temp-card::before,#temp-grid .temp-card::before{content:""!important;position:absolute!important;inset:0 auto 0 0!important;width:4px!important;background:linear-gradient(180deg,rgb(var(--dm-temp-accent)),color-mix(in srgb,rgb(var(--dm-temp-accent)) 28%,transparent))!important;opacity:.92!important}
+    /* The comfort scale at the foot of the card: cold to hot from left to right,
+       with the reading punched out of it as a notch. It is drawn from the
+       --dm-temp-pos variable the updaters set, so no renderer grows markup. */
+    #temp-grid .temp-card::after{content:""!important;position:absolute!important;inset:auto 0 0 4px!important;height:5px!important;background-image:linear-gradient(90deg,transparent calc(var(--dm-temp-pos,50) * 1% - 1px),color-mix(in srgb,var(--text,#0f172a) 62%,transparent) calc(var(--dm-temp-pos,50) * 1% - 1px) calc(var(--dm-temp-pos,50) * 1% + 1px),transparent calc(var(--dm-temp-pos,50) * 1% + 1px)),linear-gradient(90deg,transparent calc(var(--dm-temp-pos,50) * 1% - 3.5px),var(--dm-temp-surface) calc(var(--dm-temp-pos,50) * 1% - 3.5px) calc(var(--dm-temp-pos,50) * 1% + 3.5px),transparent calc(var(--dm-temp-pos,50) * 1% + 3.5px)),linear-gradient(90deg,rgb(14,165,233) 0%,rgb(16,185,129) 40%,rgb(250,204,21) 62%,rgb(239,68,68) 100%)!important;opacity:.82!important}
+    #temp-grid .temp-card[data-dm-reading="off"]::after{background-image:linear-gradient(90deg,color-mix(in srgb,var(--text-dim,#64748b) 22%,transparent),transparent)!important;opacity:.5!important}
     #page-temp .temp-card-header,#temp-grid .temp-card-header{display:flex!important;min-width:0!important;align-items:center!important;justify-content:space-between!important;gap:10px!important;min-height:40px!important;margin:0!important;padding:0!important}
     #page-temp .cp-title-wrap,#temp-grid .cp-title-wrap{display:flex!important;align-items:center!important;gap:10px!important;min-width:0!important;flex:1 1 0!important}
     #page-temp .cp-icon,#temp-grid .cp-icon{display:grid!important;place-items:center!important;flex:0 0 40px!important;width:40px!important;height:40px!important;margin:0!important;border:1px solid color-mix(in srgb,rgb(var(--dm-temp-accent)) 24%,transparent)!important;border-radius:14px!important;background:color-mix(in srgb,rgb(var(--dm-temp-accent)) 12%,var(--dm-temp-surface))!important;box-shadow:inset 0 1px 0 color-mix(in srgb,#fff 20%,transparent)!important;font-family:Apple Color Emoji,Segoe UI Emoji,Noto Color Emoji,sans-serif!important}
@@ -511,7 +518,10 @@ function installStyles() {
        has to change, and it goes away on the card that has nothing to show. */
     #temp-grid .cp-temp-current::after{content:"°"!important;margin-left:2px!important;font-size:.46em!important;font-weight:800!important;letter-spacing:0!important;vertical-align:.52em!important;color:color-mix(in srgb,var(--text,#0f172a) 55%,transparent)!important}
     #temp-grid .temp-card:has(.temp-comfort-badge[data-comfort="non-disponibile"]) .cp-temp-current::after,#temp-grid .temp-card:has(.temp-comfort-badge[data-comfort="unavailable"]) .cp-temp-current::after{content:""!important}
-    #page-temp .cp-temp-target,#temp-grid .cp-temp-target{display:grid!important;align-content:end!important;gap:5px!important;min-width:0!important;margin:0!important;padding:5px 0 1px 13px!important;border-left:1px solid transparent!important;border-image:linear-gradient(180deg,transparent 4%,color-mix(in srgb,rgb(var(--dm-temp-accent)) 32%,var(--card-border,var(--divider-color,#dbe4ee))) 44%,transparent 100%) 1!important;text-align:left!important}
+    #page-temp .cp-temp-target,#temp-grid .cp-temp-target{position:relative!important;display:grid!important;align-content:end!important;gap:5px!important;min-width:0!important;margin:0!important;padding:5px 0 9px 13px!important;border-left:1px solid transparent!important;border-image:linear-gradient(180deg,transparent 4%,color-mix(in srgb,rgb(var(--dm-temp-accent)) 32%,var(--card-border,var(--divider-color,#dbe4ee))) 44%,transparent 100%) 1!important;text-align:left!important}
+    /* How full the air is, at a glance: the bar fills to the humidity reading. */
+    #temp-grid .cp-temp-target::after{content:""!important;position:absolute!important;left:13px!important;right:0!important;bottom:0!important;height:3px!important;border-radius:999px!important;background:linear-gradient(90deg,rgb(56,189,248) 0 calc(var(--dm-hum,0) * 1%),color-mix(in srgb,var(--text-dim,#64748b) 18%,transparent) 0)!important}
+    #temp-grid .temp-card[data-dm-humidity="off"] .cp-temp-target::after{background:color-mix(in srgb,var(--text-dim,#64748b) 14%,transparent)!important}
     #temp-grid .cp-temp-target .lbl{overflow:hidden!important;text-overflow:ellipsis!important;font-size:8px!important;font-weight:900!important;letter-spacing:.08em!important;text-transform:uppercase!important;white-space:nowrap!important;color:var(--text-dim,var(--secondary-text-color,#64748b))!important}
     #temp-grid .cp-temp-target .val{font-size:23px!important;font-weight:850!important;line-height:1!important;letter-spacing:-.4px!important;font-variant-numeric:tabular-nums!important;white-space:nowrap!important;color:var(--text-dim,var(--secondary-text-color,#64748b))!important}
     #temp-grid .dm-temperature-icon-fallback{display:block!important;font-size:24px!important;line-height:1!important}
@@ -522,7 +532,7 @@ function installStyles() {
     #editor-modal [data-temperature-form] #dm-temperature-icon,#editor-modal [data-temperature-form] [data-icon-field],#editor-modal [data-temperature-form] label.ed-slot:has(#dm-temperature-icon){display:none!important}
     #editor-modal [data-temperature-form] .dm-temperature-actions button{min-height:44px!important}
     #editor-modal [data-temperature-form] #dm-temperature-room[data-dm-temperature-room-editable="true"]{border-color:var(--primary-color,#0ea5e9)!important;box-shadow:0 0 0 3px color-mix(in srgb,var(--primary-color,#0ea5e9) 10%,transparent)!important}
-    @media(max-width:680px){#page-temp #temp-grid,.temp-grid{grid-template-columns:minmax(0,360px)!important;justify-content:center!important;gap:13px!important;margin-top:12px!important;padding:0 14px 22px!important}#page-temp .temp-card,#temp-grid .temp-card{width:100%!important;max-width:360px!important;min-height:124px!important;padding:13px 14px 13px 17px!important;border-radius:20px!important;gap:11px!important}#page-temp .cp-temp-current,#temp-grid .cp-temp-current{font-size:36px!important}#temp-grid .cp-temp-target .val{font-size:22px!important}}
+    @media(max-width:680px){#page-temp #temp-grid,.temp-grid{grid-template-columns:minmax(0,360px)!important;justify-content:center!important;gap:13px!important;margin-top:12px!important;padding:0 14px 22px!important}#page-temp .temp-card,#temp-grid .temp-card{width:100%!important;max-width:360px!important;min-height:124px!important;padding:13px 14px 16px 17px!important;border-radius:20px!important;gap:11px!important}#page-temp .cp-temp-current,#temp-grid .cp-temp-current{font-size:36px!important}#temp-grid .cp-temp-target .val{font-size:22px!important}}
   `,
   );
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/temperature-trend-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/temperature-trend-section.js
@@ -1,0 +1,527 @@
+// The Temperature page answers "how is it now". This panel answers "how has it
+// been": one chart under the cards, following the room tabs above them. Picking
+// a room draws its probes; "all" compares the rooms against each other.
+//
+// It is drawn as plain SVG from the same history Home Assistant already serves
+// to the card popup — no chart library, so it costs nothing to load and scales
+// to any width the page happens to have.
+import { temperatureEntries } from "./beta25-real-device-fixes-section.js";
+import { normalizeHistoryRows } from "./history-section.js";
+import { clean, doc, english, installStyle, root, section } from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_TEMPERATURE_TREND__";
+const state = (root[KEY] ||= {
+  installed: false,
+  listeners: false,
+  cache: new Map(),
+  pending: new Map(),
+  frame: 0,
+  hours: 24,
+  signature: "",
+});
+
+const FRESH_FOR = 9 * 60 * 1000;
+// A dashboard often paints before Home Assistant answers. A failed read must not
+// pin an empty chart for the whole refresh window, so it is retried much sooner.
+const RETRY_AFTER = 25 * 1000;
+const VIEW = Object.freeze({ width: 720, height: 250, left: 38, right: 54, top: 14, bottom: 24 });
+
+/* The chart is drawn one unit per pixel: a fixed viewBox stretched to the panel
+ * width would distort every label and tick with it. */
+function viewFor(panel) {
+  const plot = panel?.querySelector?.(".dm-trend-plot");
+  const width = Math.max(320, Math.round(plot?.clientWidth || VIEW.width));
+  const height = width < 520 ? 210 : VIEW.height;
+  return { ...VIEW, width, height };
+}
+const COMFORT = Object.freeze({ low: 18, high: 26 });
+const SERIES_COLOURS = Object.freeze([
+  "14,165,233",
+  "244,63,94",
+  "16,185,129",
+  "168,85,247",
+  "249,115,22",
+  "234,179,8",
+]);
+
+function rooms() {
+  const values = section("rooms", []);
+  return Array.isArray(values) ? values : [];
+}
+
+/* The tab strip is the single owner of the room selection, so the panel reads
+ * the active tab from the DOM instead of keeping a second copy of that state. */
+export function activeRoomId() {
+  const active = doc?.querySelector?.(
+    "#dm-beta16-temperature-tabs .dm-beta27-temperature-tab.active[data-room-filter]",
+  );
+  return clean(active?.dataset?.roomFilter) || "all";
+}
+
+/* What the chart should draw right now: one series per probe of the selected
+ * room, or one per room when the selection is "all". */
+export function trendSeriesModel(roomValues = rooms(), roomId = "all") {
+  const configured = roomValues.filter((room) => temperatureEntries(room).length > 0);
+  if (roomId && roomId !== "all") {
+    const room = configured.find((item) => clean(item.id) === roomId);
+    if (!room) return { title: "", series: [] };
+    return {
+      title: clean(room.name) || (english() ? "Room" : "Stanza"),
+      series: temperatureEntries(room)
+        .filter((entry) => clean(entry.temp))
+        .map((entry, index) => ({
+          id: `${clean(room.id)}::${clean(entry.id) || "primary"}`,
+          name:
+            clean(entry.name) ||
+            clean(room.temp_name) ||
+            clean(room.name) ||
+            (english() ? "Temperature" : "Temperatura"),
+          entity: clean(entry.temp),
+          colour: SERIES_COLOURS[index % SERIES_COLOURS.length],
+        })),
+    };
+  }
+  return {
+    title: english() ? "All rooms" : "Tutte le stanze",
+    series: configured
+      .map((room, index) => {
+        const entry = temperatureEntries(room).find((item) => clean(item.temp));
+        if (!entry) return null;
+        return {
+          id: clean(room.id),
+          name: clean(room.name) || (english() ? "Room" : "Stanza"),
+          entity: clean(entry.temp),
+          colour: SERIES_COLOURS[index % SERIES_COLOURS.length],
+        };
+      })
+      .filter(Boolean),
+  };
+}
+
+/* Rows in, drawable geometry out. Everything is mapped into a fixed viewBox so
+ * the drawing stretches to the card width without recomputing on resize. */
+export function trendGeometry(series, window, view = VIEW) {
+  const plotWidth = view.width - view.left - view.right;
+  const plotHeight = view.height - view.top - view.bottom;
+  const drawn = series
+    .map((item) => ({
+      ...item,
+      points: (item.rows || [])
+        .map((row) => ({ value: Number.parseFloat(row?.state), time: Number(row?.time) }))
+        .filter((point) => Number.isFinite(point.value) && Number.isFinite(point.time))
+        .filter((point) => point.time >= window.start && point.time <= window.end)
+        .sort((left, right) => left.time - right.time),
+    }))
+    .filter((item) => item.points.length > 1);
+  if (!drawn.length) return null;
+
+  const values = drawn.flatMap((item) => item.points.map((point) => point.value));
+  // Scale to the readings, not to the comfort band: a room that spent the day
+  // between 26° and 32° deserves the whole height, and the band is then drawn
+  // only where it actually reaches into view.
+  const low = Math.min(...values);
+  const high = Math.max(...values);
+  const padding = Math.max(0.4, (high - low) * 0.12);
+  const min = low - padding;
+  const max = high + padding;
+  const span = max - min || 1;
+  const x = (time) => view.left + ((time - window.start) / (window.end - window.start)) * plotWidth;
+  const y = (value) => view.top + (1 - (value - min) / span) * plotHeight;
+
+  return {
+    min,
+    max,
+    x,
+    y,
+    plotWidth,
+    plotHeight,
+    band: (() => {
+      const top = Math.max(view.top, y(Math.min(COMFORT.high, max)));
+      const bottom = Math.min(view.height - view.bottom, y(Math.max(COMFORT.low, min)));
+      const visible = COMFORT.low < max && COMFORT.high > min && bottom - top > 2;
+      return { top, bottom, visible };
+    })(),
+    series: drawn.map((item) => {
+      const line = item.points
+        .map((point, index) => `${index ? "L" : "M"}${x(point.time).toFixed(1)} ${y(point.value).toFixed(1)}`)
+        .join(" ");
+      const last = item.points[item.points.length - 1];
+      const seriesValues = item.points.map((point) => point.value);
+      return {
+        ...item,
+        line,
+        area: `${line} L${x(last.time).toFixed(1)} ${(view.height - view.bottom).toFixed(1)} L${x(item.points[0].time).toFixed(1)} ${(view.height - view.bottom).toFixed(1)} Z`,
+        last: { x: x(last.time), y: y(last.value), value: last.value },
+        low: Math.min(...seriesValues),
+        high: Math.max(...seriesValues),
+      };
+    }),
+  };
+}
+
+function degrees(value) {
+  return `${value.toFixed(1).replace(".", english() ? "." : ",")}°`;
+}
+
+async function fetchHistory(entity, hours) {
+  const broker = root.DashboardModernEnergyService?.broker;
+  if (typeof broker?.request !== "function") throw new Error("history transport unavailable");
+  const end = new Date();
+  const start = new Date(end.getTime() - hours * 60 * 60 * 1000);
+  const result = await broker.request({
+    type: "history/history_during_period",
+    start_time: start.toISOString(),
+    end_time: end.toISOString(),
+    entity_ids: [entity],
+    include_start_time_state: true,
+    significant_changes_only: false,
+    minimal_response: true,
+    no_attributes: true,
+  });
+  return normalizeHistoryRows(result, entity);
+}
+
+function rowsFor(entity, hours) {
+  const key = `${entity}@${hours}`;
+  const cached = state.cache.get(key);
+  const now = Date.now();
+  const freshFor = cached?.failed ? RETRY_AFTER : FRESH_FOR;
+  if (cached && now - cached.at < freshFor) return cached.rows;
+  if (state.pending.has(key)) return cached?.rows || null;
+
+  state.pending.set(
+    key,
+    fetchHistory(entity, hours)
+      .then((rows) => {
+        state.cache.set(key, { rows, at: Date.now(), failed: !rows.length });
+        return rows;
+      })
+      .catch(() => {
+        state.cache.set(key, { rows: [], at: Date.now(), failed: true });
+        return [];
+      })
+      .finally(() => {
+        state.pending.delete(key);
+        schedule();
+      }),
+  );
+  return cached?.rows || null;
+}
+
+function svg(name, attributes = {}) {
+  const node = doc.createElementNS("http://www.w3.org/2000/svg", name);
+  for (const [key, value] of Object.entries(attributes)) node.setAttribute(key, String(value));
+  return node;
+}
+
+function element(tag, className, text) {
+  const node = doc.createElement(tag);
+  if (className) node.className = className;
+  if (text != null) node.textContent = text;
+  return node;
+}
+
+function hourLabels(window) {
+  const labels = [];
+  const step = window.hours > 48 ? 24 : 6;
+  const first = new Date(window.start);
+  first.setMinutes(0, 0, 0);
+  for (let time = first.getTime(); time <= window.end; time += step * 60 * 60 * 1000) {
+    if (time < window.start) continue;
+    const date = new Date(time);
+    labels.push({
+      time,
+      text:
+        window.hours > 48
+          ? date.toLocaleDateString(english() ? "en-GB" : "it-IT", { weekday: "short" })
+          : `${String(date.getHours()).padStart(2, "0")}:00`,
+    });
+  }
+  return labels;
+}
+
+function ensurePanel() {
+  const grid = doc?.getElementById?.("temp-grid");
+  if (!grid?.parentElement) return null;
+  let panel = doc.getElementById("dm-temperature-trend");
+  if (panel) {
+    if (panel.previousElementSibling !== grid) grid.after(panel);
+    return panel;
+  }
+  panel = element("section", "dm-trend");
+  panel.id = "dm-temperature-trend";
+  panel.innerHTML = "";
+
+  const head = element("header", "dm-trend-head");
+  const titles = element("div", "dm-trend-titles");
+  titles.append(
+    element("span", "dm-trend-kicker", english() ? "Trend" : "Andamento"),
+    element("h3", "dm-trend-title", ""),
+  );
+  const ranges = element("div", "dm-trend-ranges");
+  for (const hours of [24, 168]) {
+    const button = element(
+      "button",
+      "dm-trend-range",
+      hours === 24 ? (english() ? "24 h" : "24 h") : english() ? "7 days" : "7 giorni",
+    );
+    button.type = "button";
+    button.dataset.hours = String(hours);
+    button.addEventListener("click", () => {
+      state.hours = hours;
+      state.signature = "";
+      schedule();
+    });
+    ranges.append(button);
+  }
+  head.append(titles, ranges);
+
+  const plot = element("div", "dm-trend-plot");
+  plot.append(
+    svg("svg", {
+      class: "dm-trend-chart",
+      viewBox: `0 0 ${VIEW.width} ${VIEW.height}`,
+      role: "img",
+    }),
+  );
+  const legend = element("div", "dm-trend-legend");
+  const empty = element(
+    "p",
+    "dm-trend-empty",
+    english()
+      ? "No history yet for this room."
+      : "Nessuno storico disponibile per questa stanza.",
+  );
+  panel.append(head, plot, legend, empty);
+  grid.after(panel);
+  return panel;
+}
+
+function drawChart(chart, geometry, window, view) {
+  chart.replaceChildren();
+  const baseline = view.height - view.bottom;
+
+  // Night hours as quiet bands: the shape of a day reads without a legend.
+  const night = svg("g", { class: "dm-trend-night" });
+  for (let time = window.start; time <= window.end; time += 60 * 60 * 1000) {
+    const hour = new Date(time).getHours();
+    if (hour >= 7 && hour < 20) continue;
+    const from = geometry.x(time);
+    const to = geometry.x(Math.min(time + 60 * 60 * 1000, window.end));
+    night.append(
+      svg("rect", { x: from, y: view.top, width: Math.max(0, to - from), height: geometry.plotHeight }),
+    );
+  }
+  chart.append(night);
+
+  if (geometry.band.visible)
+    chart.append(
+      svg("rect", {
+        class: "dm-trend-band",
+        x: view.left,
+        y: geometry.band.top,
+        width: geometry.plotWidth,
+        height: Math.max(0, geometry.band.bottom - geometry.band.top),
+        rx: 3,
+      }),
+    );
+
+  if (geometry.band.visible) {
+    const bandLabel = svg("text", {
+      class: "dm-trend-band-label",
+      x: view.left + 6,
+      y: Math.min(geometry.band.bottom - 5, geometry.band.top + 11),
+    });
+    bandLabel.textContent = "comfort";
+    chart.append(bandLabel);
+  }
+
+  const axis = svg("g", { class: "dm-trend-axis" });
+  const ticks = [COMFORT.high, COMFORT.low].filter(
+    (value) => value > geometry.min && value < geometry.max,
+  );
+  if (!ticks.length) ticks.push(Math.round(geometry.max - 0.5), Math.round(geometry.min + 0.5));
+  for (const value of ticks) {
+    const y = geometry.y(value);
+    axis.append(svg("line", { x1: view.left, x2: view.width - view.right, y1: y, y2: y }));
+    const label = svg("text", { x: view.left - 7, y: y + 3, class: "dm-trend-tick" });
+    label.textContent = `${value}°`;
+    axis.append(label);
+  }
+  axis.append(
+    svg("line", {
+      class: "dm-trend-baseline",
+      x1: view.left,
+      x2: view.width - view.right,
+      y1: baseline,
+      y2: baseline,
+    }),
+  );
+  for (const mark of hourLabels(window)) {
+    const x = geometry.x(mark.time);
+    const label = svg("text", { x, y: view.height - 6, class: "dm-trend-time" });
+    label.textContent = mark.text;
+    axis.append(label);
+  }
+  chart.append(axis);
+
+  const single = geometry.series.length === 1;
+  for (const item of geometry.series) {
+    const group = svg("g", { class: "dm-trend-series", style: `--dm-series:${item.colour}` });
+    if (single) group.append(svg("path", { class: "dm-trend-area", d: item.area }));
+    group.append(
+      svg("path", { class: "dm-trend-line", d: item.line }),
+      svg("circle", { class: "dm-trend-dot", cx: item.last.x, cy: item.last.y, r: 3.4 }),
+    );
+    // the current reading rides at the end of its own line
+    const tag = svg("text", {
+      class: "dm-trend-value",
+      x: Math.min(item.last.x + 7, view.width - 4),
+      y: Math.max(view.top + 4, Math.min(item.last.y + 3.5, view.height - view.bottom - 2)),
+    });
+    tag.textContent = degrees(item.last.value);
+    group.append(tag);
+    chart.append(group);
+  }
+}
+
+function drawLegend(legend, geometry) {
+  legend.replaceChildren();
+  for (const item of geometry.series) {
+    const chip = element("span", "dm-trend-chip");
+    chip.style.setProperty("--dm-series", item.colour);
+    chip.append(
+      element("i", "dm-trend-swatch"),
+      element("b", "dm-trend-chip-name", item.name),
+      element("span", "dm-trend-chip-now", degrees(item.last.value)),
+      element("small", "dm-trend-chip-range", `${degrees(item.low)} · ${degrees(item.high)}`),
+    );
+    legend.append(chip);
+  }
+}
+
+export function renderTemperatureTrend() {
+  const panel = ensurePanel();
+  if (!panel) return false;
+  const roomId = activeRoomId();
+  const model = trendSeriesModel(rooms(), roomId);
+  const hours = state.hours;
+  panel.querySelectorAll(".dm-trend-range").forEach((button) =>
+    button.classList.toggle("active", Number(button.dataset.hours) === hours),
+  );
+  panel.querySelector(".dm-trend-title").textContent = model.title;
+
+  if (!model.series.length) {
+    panel.dataset.state = "empty";
+    return false;
+  }
+
+  const end = Date.now();
+  const window = { start: end - hours * 60 * 60 * 1000, end, hours };
+  const withRows = model.series.map((item) => ({ ...item, rows: rowsFor(item.entity, hours) }));
+  if (withRows.some((item) => item.rows === null)) panel.dataset.state = "loading";
+
+  const view = viewFor(panel);
+  const chart = panel.querySelector(".dm-trend-chart");
+  chart.setAttribute("viewBox", `0 0 ${view.width} ${view.height}`);
+  chart.style.height = `${view.height}px`;
+  const geometry = trendGeometry(
+    withRows.filter((item) => Array.isArray(item.rows)),
+    window,
+    view,
+  );
+  if (!geometry) {
+    panel.dataset.state = panel.dataset.state === "loading" ? "loading" : "empty";
+    return false;
+  }
+
+  drawChart(chart, geometry, window, view);
+  drawLegend(panel.querySelector(".dm-trend-legend"), geometry);
+  panel.dataset.state = "ready";
+  return true;
+}
+
+function schedule() {
+  if (state.frame) return;
+  state.frame =
+    root.requestAnimationFrame?.(() => {
+      state.frame = 0;
+      renderTemperatureTrend();
+    }) || 0;
+}
+
+/* The panel lives beside the grid, not inside it: a card rebuild changes
+ * nothing it draws. What moves it is the room selection — a tap on the tab
+ * strip — plus the runtime events and the history reads themselves, so it needs
+ * no observer of its own. ensurePanel() puts it back after the grid if some
+ * other layer ever reorders the page. */
+
+function installStyles() {
+  installStyle(
+    "dm-temperature-trend-style",
+    `
+    #dm-temperature-trend{--dm-trend-surface:var(--ha-card-background,var(--card-bg,#fff));box-sizing:border-box!important;display:grid!important;gap:12px!important;width:calc(100% - 36px)!important;max-width:1024px!important;margin:6px 18px 30px!important;padding:16px 18px 14px!important;border:1px solid var(--card-border,var(--divider-color,#e2e8f0))!important;border-radius:24px!important;background:linear-gradient(180deg,var(--dm-trend-surface),color-mix(in srgb,var(--primary-color,#0ea5e9) 3%,var(--dm-trend-surface)))!important;box-shadow:0 16px 34px -22px rgba(15,23,42,.5)!important}
+    #dm-temperature-trend[data-state="empty"] .dm-trend-plot,#dm-temperature-trend[data-state="empty"] .dm-trend-legend,#dm-temperature-trend[data-state="loading"] .dm-trend-plot,#dm-temperature-trend[data-state="loading"] .dm-trend-legend{display:none!important}
+    #dm-temperature-trend[data-state="ready"] .dm-trend-empty{display:none!important}
+    #dm-temperature-trend .dm-trend-empty{margin:2px 0 4px!important;color:var(--text-dim,#64748b)!important;font-size:12.5px!important;font-weight:750!important}
+    #dm-temperature-trend .dm-trend-head{display:flex!important;align-items:center!important;justify-content:space-between!important;gap:12px!important;flex-wrap:wrap!important}
+    #dm-temperature-trend .dm-trend-titles{display:grid!important;gap:2px!important;min-width:0!important}
+    #dm-temperature-trend .dm-trend-kicker{font-size:8.5px!important;font-weight:900!important;letter-spacing:.16em!important;text-transform:uppercase!important;color:var(--primary-color,#0284c7)!important}
+    #dm-temperature-trend .dm-trend-title{margin:0!important;font-size:17px!important;font-weight:900!important;letter-spacing:-.3px!important;line-height:1.15!important;color:var(--text,#0f172a)!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important}
+    #dm-temperature-trend .dm-trend-ranges{display:inline-flex!important;gap:4px!important;padding:3px!important;border-radius:999px!important;background:color-mix(in srgb,var(--text-dim,#64748b) 10%,transparent)!important}
+    #dm-temperature-trend .dm-trend-range{min-height:30px!important;padding:6px 12px!important;border:0!important;border-radius:999px!important;background:transparent!important;color:var(--text-dim,#64748b)!important;font:inherit!important;font-size:11.5px!important;font-weight:850!important;cursor:pointer!important}
+    #dm-temperature-trend .dm-trend-range.active{background:var(--dm-trend-surface)!important;color:var(--text,#0f172a)!important;box-shadow:0 4px 12px -6px rgba(15,23,42,.5)!important}
+    #dm-temperature-trend .dm-trend-plot{width:100%!important;min-width:0!important}
+    #dm-temperature-trend .dm-trend-chart{display:block!important;width:100%!important;height:250px!important}
+    #dm-temperature-trend .dm-trend-night rect{fill:color-mix(in srgb,var(--text-dim,#64748b) 8%,transparent)!important}
+    #dm-temperature-trend .dm-trend-band{fill:color-mix(in srgb,var(--success-color,#10b981) 12%,transparent)!important}
+    #dm-temperature-trend .dm-trend-axis line{stroke:color-mix(in srgb,var(--text-dim,#64748b) 24%,transparent)!important;stroke-width:1!important;stroke-dasharray:3 4!important;vector-effect:non-scaling-stroke!important}
+    #dm-temperature-trend .dm-trend-axis line.dm-trend-baseline{stroke-dasharray:none!important;stroke:color-mix(in srgb,var(--text-dim,#64748b) 30%,transparent)!important}
+    #dm-temperature-trend .dm-trend-tick,#dm-temperature-trend .dm-trend-time{fill:var(--text-dim,#64748b)!important;font-size:9px!important;font-weight:800!important}
+    #dm-temperature-trend .dm-trend-tick{text-anchor:end!important}
+    #dm-temperature-trend .dm-trend-band-label{fill:var(--success-color,#10b981)!important;font-size:8.5px!important;font-weight:900!important;letter-spacing:.14em!important;text-transform:uppercase!important}
+    #dm-temperature-trend .dm-trend-value{fill:rgb(var(--dm-series))!important;font-size:11px!important;font-weight:900!important}
+    #dm-temperature-trend .dm-trend-time{text-anchor:middle!important}
+    #dm-temperature-trend .dm-trend-area{fill:color-mix(in srgb,rgb(var(--dm-series)) 14%,transparent)!important}
+    #dm-temperature-trend .dm-trend-line{fill:none!important;stroke:rgb(var(--dm-series))!important;stroke-width:2!important;stroke-linecap:round!important;stroke-linejoin:round!important;vector-effect:non-scaling-stroke!important}
+    #dm-temperature-trend .dm-trend-dot{fill:rgb(var(--dm-series))!important;stroke:var(--dm-trend-surface)!important;stroke-width:2!important;vector-effect:non-scaling-stroke!important}
+    #dm-temperature-trend .dm-trend-legend{display:flex!important;flex-wrap:wrap!important;gap:8px!important}
+    #dm-temperature-trend .dm-trend-chip{display:inline-flex!important;align-items:baseline!important;gap:7px!important;padding:7px 11px!important;border:1px solid color-mix(in srgb,rgb(var(--dm-series)) 26%,transparent)!important;border-radius:13px!important;background:color-mix(in srgb,rgb(var(--dm-series)) 8%,var(--dm-trend-surface))!important}
+    #dm-temperature-trend .dm-trend-swatch{width:9px!important;height:9px!important;border-radius:3px!important;background:rgb(var(--dm-series))!important;align-self:center!important}
+    #dm-temperature-trend .dm-trend-chip-name{font-size:12px!important;font-weight:850!important;color:var(--text,#0f172a)!important;max-width:150px!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important}
+    #dm-temperature-trend .dm-trend-chip-now{font-size:14px!important;font-weight:900!important;color:rgb(var(--dm-series))!important;font-variant-numeric:tabular-nums!important}
+    #dm-temperature-trend .dm-trend-chip-range{font-size:9.5px!important;font-weight:800!important;color:var(--text-dim,#64748b)!important;font-variant-numeric:tabular-nums!important}
+    @media(max-width:680px){#dm-temperature-trend{width:calc(100% - 28px)!important;margin:4px 14px 26px!important;padding:14px 14px 12px!important;border-radius:20px!important}#dm-temperature-trend .dm-trend-chart{height:210px!important}#dm-temperature-trend .dm-trend-title{font-size:15.5px!important}}
+  `,
+  );
+}
+
+export function installTemperatureTrendSection() {
+  if (!doc) return false;
+  installStyles();
+  renderTemperatureTrend();
+  if (!state.listeners) {
+    state.listeners = true;
+    for (const eventName of [
+      "dashboardmodern:legacy-ready",
+      "dashboardmodern:runtime-ready",
+      "dashboardmodern:states-ready",
+      "dashboardmodern:persistence-restored",
+    ])
+      root.addEventListener?.(eventName, schedule);
+    doc.addEventListener(
+      "click",
+      (event) => {
+        if (event.target?.closest?.("#dm-beta16-temperature-tabs,[data-tab='temp'],[data-tab='temperature'],#page-temp"))
+          schedule();
+      },
+      true,
+    );
+  }
+  state.installed = true;
+  return true;
+}
+
+if (doc?.readyState === "loading")
+  doc.addEventListener("DOMContentLoaded", installTemperatureTrendSection, { once: true });
+else installTemperatureTrendSection();

--- a/custom_components/dashboardmodern/frontend/tests/beta11-real-device-polish.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta11-real-device-polish.test.js
@@ -59,10 +59,24 @@ test("alerts get an expanded coherent visual picker without polling", async () =
   assert.doesNotMatch(source, /setInterval\s*\(/);
 });
 
-test("alert name, value and icon never receive entity picker buttons", async () => {
+test("plain-text and typed editor fields never receive entity picker buttons", async () => {
   const source = await readFile(entityGuardUrl, "utf8");
   assert.match(source, /id\.startsWith\("ed-avv-"\)\) return id === "ed-avv-ent"/);
-  assert.match(source, /ALERT_NON_ENTITY_IDS = new Set\(\["ed-avv-name", "ed-avv-val", "ed-avv-icon"\]\)/);
-  assert.match(source, /cleanupFalseAlertPicker\(input\)/);
+  // Alert name/value/icon plus the camera, irrigation and shutter names sit
+  // under an entity-shaped prefix but hold plain text.
+  for (const id of [
+    "ed-avv-name",
+    "ed-avv-val",
+    "ed-avv-icon",
+    "ed-cam-name",
+    "ed-cam-stream",
+    "ed-irr-name",
+    "ed-tp-name",
+  ])
+    assert.match(source, new RegExp(`NON_ENTITY_IDS = new Set\\(\\[[^\\]]*"${id}"`, "s"), id);
+  // Durations, thresholds, times and flags cannot hold an entity_id at all.
+  assert.match(source, /PICKABLE_TYPES = new Set\(\["text", "search", "url"\]\)/);
+  assert.match(source, /!PICKABLE_TYPES\.has\(input\.type\)\) return false/);
+  assert.match(source, /cleanupFalsePicker\(input\)/);
   assert.doesNotMatch(source, /\|avv-\)/);
 });

--- a/custom_components/dashboardmodern/frontend/tests/beta30-energy-flow-dynamic.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta30-energy-flow-dynamic.test.js
@@ -339,7 +339,7 @@ test("an mdi icon is drawn through the icon engine, not as an empty ha-icon box"
   }
 });
 
-test("with reduced motion the active line stays readable instead of freezing dashed", () => {
+test("the flow lines animate on every screen, reduced motion included", () => {
   configure({
     loads: [load("auto", 0, { name: "Auto" })],
     states: { "sensor.auto_power": { state: "3200" } },
@@ -348,11 +348,15 @@ test("with reduced motion the active line stays readable instead of freezing das
     .descendants()
     .map((node) => node.textContent)
     .join("\n");
-  const guard = css.slice(css.indexOf("@media(prefers-reduced-motion:reduce)"));
-  // The dash is the only signal that energy is moving: frozen, a dashed active
-  // line is indistinguishable from an idle one, so it is drawn solid instead.
-  assert.match(guard, /animation:none!important/);
-  assert.match(guard, /stroke-dasharray:none!important/);
+  const flow = css.slice(css.indexOf(".flow-line.dm-energy-flow-active"));
+
+  // The moving dash is not decoration: it is the only signal that energy is
+  // flowing, and the same dashboard must read the same on every screen. The
+  // preference is often on for a computer and almost never for a phone, so
+  // honouring it here froze the desktop while the phone kept moving.
+  assert.doesNotMatch(flow, /prefers-reduced-motion/);
+  assert.match(flow, /animation-name:dmEnergyFlowDash!important/);
+  assert.match(flow, /animation-play-state:running!important/);
 });
 
 test("an emoji icon still goes straight into the bubble", () => {

--- a/custom_components/dashboardmodern/frontend/tests/beta30-energy-flow-dynamic.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta30-energy-flow-dynamic.test.js
@@ -339,6 +339,22 @@ test("an mdi icon is drawn through the icon engine, not as an empty ha-icon box"
   }
 });
 
+test("with reduced motion the active line stays readable instead of freezing dashed", () => {
+  configure({
+    loads: [load("auto", 0, { name: "Auto" })],
+    states: { "sensor.auto_power": { state: "3200" } },
+  });
+  const css = globalThis.document.head
+    .descendants()
+    .map((node) => node.textContent)
+    .join("\n");
+  const guard = css.slice(css.indexOf("@media(prefers-reduced-motion:reduce)"));
+  // The dash is the only signal that energy is moving: frozen, a dashed active
+  // line is indistinguishable from an idle one, so it is drawn solid instead.
+  assert.match(guard, /animation:none!important/);
+  assert.match(guard, /stroke-dasharray:none!important/);
+});
+
 test("an emoji icon still goes straight into the bubble", () => {
   configure({
     loads: [load("auto", 0, { name: "Auto", icon: "🚗" })],

--- a/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
@@ -7,5 +7,5 @@ const manifest = JSON.parse(
 );
 
 test("the release manifest is versioned correctly", () => {
-  assert.equal(manifest.version, "1.0.0-beta.30.7");
+  assert.equal(manifest.version, "1.0.0-beta.30.8");
 });

--- a/custom_components/dashboardmodern/frontend/tests/editor-body-layout.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/editor-body-layout.test.js
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+const guard = await read("../src/sections/entity-picker-guard-section.js");
+const crud = await read("../src/sections/editor-crud-section.js");
+
+test("the picker row never lands on a container", () => {
+  // .dm-entity-picker-row is display:flex with min-width:0 children. The
+  // Tapparelle, Telecamere and Irrigazione forms put fields directly inside
+  // #ed-body, so flexing the parent laid the whole editor out as narrow
+  // columns of broken words on a phone.
+  assert.match(guard, /\.dm-entity-picker-row\{display:flex!important/);
+  assert.match(guard, /const NEVER_A_PICKER_ROW = "#ed-body,\.ed-body,\.ed-shell,#editor-modal,#setup-wizard,\.ed-list,\.dm-section-dialog,body"/);
+  assert.match(guard, /function markPickerRow\(parent\)/);
+  assert.match(guard, /if \(parent\.matches\?\.\(NEVER_A_PICKER_ROW\)\) return;/);
+  assert.match(guard, /if \(parent\.querySelectorAll\("input,select,textarea"\)\.length > 1\) return;/);
+  // The old unconditional call is gone, not merely shadowed.
+  assert.doesNotMatch(guard, /\["LABEL", "SPAN", "DIV"\]\.includes\(parent\.tagName\)\) parent\.classList\.add/);
+  // And an installation upgrading from a release that flexed a container gets
+  // it back as a block on the next reconcile.
+  assert.match(guard, /node\?\.classList\?\.remove\?\.\("dm-entity-picker-row"\)/);
+});
+
+test("the editor body stays a vertical stack whatever else runs", () => {
+  assert.match(crud, /#editor-modal \.ed-body\{display:block!important;columns:auto!important;column-count:auto!important\}/);
+  assert.match(crud, /#editor-modal \.ed-body>\*\{float:none!important\}/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/editor-slots-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/editor-slots-section.test.js
@@ -61,3 +61,19 @@ test("the section owns presentation only", () => {
   assert.doesNotMatch(body, /setInterval\s*\(/);
   assert.doesNotMatch(body, /MutationObserver/);
 });
+
+test("opening the editor decorates it, whatever the order the runtime loads in", () => {
+  /* The wrap used to be attached only inside the `legacy-ready`/`runtime-ready`
+   * handlers, so an editor opened before that event kept raw entity fields
+   * until the event finally landed. `wrapFunction` is a no-op while the legacy
+   * global is still undefined, so binding early costs nothing and binding again
+   * on the events covers the other order. */
+  assert.match(source, /function bindLegacyEntryPoints\(\)/);
+  assert.match(source, /wrapFunction\("apriConfigEntita", "__dmEditorSlots_apriConfigEntita", schedule\)/);
+  assert.match(source, /wrapFunction\("editorSwitch", "__dmEditorSlots_editorSwitch", schedule\)/);
+
+  // Called from the ready handlers and once at install, not only from one.
+  const install = source.slice(source.indexOf("export function installEditorSlotsSection"));
+  assert.equal((install.match(/bindLegacyEntryPoints\(\)/g) || []).length, 2);
+});
+

--- a/custom_components/dashboardmodern/frontend/tests/editor-slots-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/editor-slots-section.test.js
@@ -72,8 +72,12 @@ test("opening the editor decorates it, whatever the order the runtime loads in",
   assert.match(source, /wrapFunction\("apriConfigEntita", "__dmEditorSlots_apriConfigEntita", schedule\)/);
   assert.match(source, /wrapFunction\("editorSwitch", "__dmEditorSlots_editorSwitch", schedule\)/);
 
-  // Called from the ready handlers and once at install, not only from one.
+  /* Attached when the module loads AND on the ready events. Attaching only in
+   * the ready handlers meant never attaching at all when the bundle finished
+   * loading after the runtime had already announced itself — the handler never
+   * ran, and the editor printed rows nothing decorated. */
   const install = source.slice(source.indexOf("export function installEditorSlotsSection"));
   assert.equal((install.match(/bindLegacyEntryPoints\(\)/g) || []).length, 2);
+  assert.match(install, /addEventListener\?\.\(eventName, \(\) => \{\s*bindLegacyEntryPoints\(\);/);
 });
 

--- a/custom_components/dashboardmodern/frontend/tests/editor-slots-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/editor-slots-section.test.js
@@ -1,0 +1,63 @@
+// DM-FIX-20260817E
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(
+  new URL("../src/sections/editor-slots-section.js", import.meta.url),
+  "utf8",
+);
+
+async function loadSection() {
+  return import(`../src/sections/editor-slots-section.js?fix=${Date.now()}`);
+}
+
+test("a slot shows the name Home Assistant knows, not the raw id", async () => {
+  const { entityLabel } = await loadSection();
+  const states = {
+    "sensor.b10_soc": { attributes: { friendly_name: "B10 Stato di carica" } },
+    "sensor.no_name": { attributes: {} },
+    // Home Assistant falls back to the id as friendly_name; that is not a name.
+    "sensor.same": { attributes: { friendly_name: "sensor.same" } },
+  };
+  assert.equal(entityLabel("sensor.b10_soc", states), "B10 Stato di carica");
+  assert.equal(entityLabel("sensor.no_name", states), "");
+  assert.equal(entityLabel("sensor.same", states), "");
+  assert.equal(entityLabel("sensor.missing", states), "");
+  assert.equal(entityLabel("", states), "");
+});
+
+test("the accordion header counts how many slots are actually mapped", async () => {
+  const { slotCounts } = await loadSection();
+  const inputs = [{ value: "sensor.a" }, { value: "" }, { value: "  " }, { value: "sensor.b" }];
+  const scope = { querySelectorAll: () => inputs };
+  assert.deepEqual(slotCounts(scope), { total: 4, mapped: 2 });
+  assert.deepEqual(slotCounts({ querySelectorAll: () => [] }), { total: 0, mapped: 0 });
+  assert.deepEqual(slotCounts(null), { total: 0, mapped: 0 });
+});
+
+test("the row keeps the contracts the editor saves through", () => {
+  // edSetSlot fires on the input's change event and edSaveSezione re-reads the
+  // same inputs from .ed-acc-body, so the field must stay in the DOM.
+  assert.match(source, /\.ed-slot-in\[data-ref\]/);
+  assert.match(source, /wzPickEntity\?\.\(input\)/);
+  // Hidden, never removed: the picker guard reconciles the input/lens pair.
+  assert.match(source, /\.dm-slots:not\(\.dm-slots-raw\) \.dm-slot>div:has\(>\.ed-slot-in\)\{display:none!important\}/);
+  assert.doesNotMatch(source, /\.remove\(\)/);
+  // The chip is appended last so the lens stays the input's next sibling.
+  assert.match(source, /slot\.append\(chip\)/);
+});
+
+test("the loads editor keeps its own layout", () => {
+  // energy-loads-editor reuses .ed-slot for a different form; decorating it
+  // would fight its owner.
+  assert.match(source, /slot\.closest\("\[data-load-form\]"\)/);
+});
+
+test("the section owns presentation only", () => {
+  const body = source.slice(source.indexOf("\nimport {"));
+  for (const owned of ["edSetSlot", "edSaveSezione", "localStorage", "ENTITY_OVERRIDES"])
+    assert.doesNotMatch(body, new RegExp(owned), owned);
+  assert.doesNotMatch(body, /setInterval\s*\(/);
+  assert.doesNotMatch(body, /MutationObserver/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/entity-autodetect.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/entity-autodetect.test.js
@@ -1,0 +1,208 @@
+/* What the 🪄 button decides, held to the cases that made the old detector
+ * wrong: a slot in kWh taking a sensor in W, "oggi" taking a monthly meter, an
+ * early slot stealing the entity a later one matched exactly, and rooms falling
+ * back to name guessing while the Home Assistant areas sat unused. */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildEntityIndex } from "../src/core/entity-search-index.js";
+import {
+  buildPostings,
+  detectCategories,
+  detectSlots,
+  parseSlotPlan,
+  periodOf,
+  scoreSlotCandidate,
+} from "../src/core/entity-autodetect.js";
+
+const sensor = (id, name, extra = {}) => ({ id, name, state: "1", ...extra });
+
+const HOUSE = [
+  sensor("sensor.solaredge_produzione_oggi", "Produzione solare oggi", { dc: "energy", unit: "kWh", sc: "total_increasing", area: "Tetto" }),
+  sensor("sensor.solaredge_produzione_mese", "Produzione solare mese", { dc: "energy", unit: "kWh", sc: "total_increasing" }),
+  sensor("sensor.solaredge_potenza_pv", "Potenza fotovoltaico", { dc: "power", unit: "W" }),
+  sensor("sensor.casa_consumo_oggi", "Consumo casa oggi", { dc: "energy", unit: "kWh", sc: "total_increasing" }),
+  sensor("sensor.casa_potenza", "Potenza consumo casa", { dc: "power", unit: "W" }),
+  sensor("sensor.batteria_soc", "Stato carica batteria", { dc: "battery", unit: "%" }),
+  sensor("sensor.speedtest_download", "Speedtest download", { unit: "Mbit/s" }),
+  sensor("sensor.speedtest_upload", "Speedtest upload", { unit: "Mbit/s" }),
+  sensor("sensor.cucina_temperatura", "Temperatura cucina", { dc: "temperature", unit: "°C", area: "Cucina" }),
+  sensor("sensor.cucina_umidita", "Umidità cucina", { dc: "humidity", unit: "%", area: "Cucina" }),
+  sensor("sensor.salotto_temperatura", "Temperatura salotto", { dc: "temperature", unit: "°C", area: "Salotto" }),
+  sensor("sensor.mansarda_temperatura", "Temperatura mansarda", { dc: "temperature", unit: "°C" }),
+  sensor("sensor.mansarda_umidita", "Umidità mansarda", { dc: "humidity", unit: "%" }),
+  sensor("light.cucina", "Luce cucina", { area: "Cucina", state: "on" }),
+  sensor("light.salotto", "Luce salotto", { area: "Salotto", state: "off" }),
+  sensor("climate.salotto", "Clima salotto", { area: "Salotto", state: "cool" }),
+  sensor("climate.termosifone_bagno", "Termosifone bagno", { area: "Bagno", state: "heat" }),
+  sensor("camera.ingresso", "Camera ingresso", { area: "Ingresso", state: "idle" }),
+  sensor("binary_sensor.porta_ingresso", "Porta ingresso", { dc: "door", state: "off" }),
+  sensor("binary_sensor.finestra_bypass", "Finestra bypass", { dc: "window", state: "off" }),
+  sensor("sensor.telecomando_batteria", "Batteria telecomando", { dc: "battery", unit: "%" }),
+  sensor("script.apri_cancello", "Apri cancello", { state: "off" }),
+  sensor("weather.casa", "Meteo casa", { state: "sunny" }),
+  sensor("alarm_control_panel.antifurto", "Antifurto", { state: "disarmed" }),
+];
+
+const index = () => buildEntityIndex(HOUSE, { version: `t${Math.random()}` });
+
+const plan = (ref, lbl, section = "energy") => parseSlotPlan({ ref, lbl }, section);
+
+function assign(slots, options = {}) {
+  const built = index();
+  const result = detectSlots(built.records, slots, { postings: buildPostings(built.records), ...options });
+  return Object.fromEntries(result.assignments.map((item) => [item.ref, item.id]));
+}
+
+test("a slot label states its own constraints", () => {
+  const energy = plan("dm.energy_produzione_solare_oggi", "Produzione solare oggi (kWh)");
+  assert.deepEqual(energy.units, ["kWh", "Wh", "MWh"]);
+  assert.deepEqual(energy.deviceClasses, ["energy"]);
+  assert.equal(energy.period, "d");
+
+  const mode = plan("dm.ev_modalita_ricarica_evcc", "Modalità ricarica EVCC (select)", "ev");
+  assert.deepEqual(mode.domains, ["select", "input_select"]);
+
+  const script = plan("dm.home_script_apertura_cancello", "Script apertura cancello", "home");
+  assert.deepEqual(script.domains, ["script", "scene", "automation"]);
+
+  // Prose after an em dash describes the field to the person, not to the matcher.
+  const washer = plan("dm.lavatrice_potenza", "Potenza presa lavatrice (W) — per lavatrici non smart: >5W = in funzione", "lavatrice");
+  assert.deepEqual(washer.units, ["W", "kW"]);
+  assert.ok(!washer.keys.some((keys) => keys.includes("funzione")));
+});
+
+test("the unit in the label is a constraint, not a preference", () => {
+  const built = index();
+  const power = built.records.find((record) => record.id === "sensor.solaredge_potenza_pv");
+  const energyPlan = plan("dm.energy_produzione_solare_oggi", "Produzione solare oggi (kWh)");
+  // A sensor in W can never answer a slot in kWh, however well its words match.
+  assert.equal(scoreSlotCandidate(power, energyPlan), -Infinity);
+});
+
+test("a daily slot never takes a monthly meter", () => {
+  assert.equal(periodOf("Produzione solare mese"), "m");
+  const result = assign([
+    plan("dm.energy_produzione_solare_oggi", "Produzione solare oggi (kWh)"),
+    plan("dm.energy_produzione_solare_mese", "Produzione solare mese (kWh)"),
+  ]);
+  assert.equal(result["dm.energy_produzione_solare_oggi"], "sensor.solaredge_produzione_oggi");
+  assert.equal(result["dm.energy_produzione_solare_mese"], "sensor.solaredge_produzione_mese");
+});
+
+test("the strongest claim on an entity wins, whatever the slot order", () => {
+  /* Declared in the order that used to lose: the generic power slot comes
+   * first and would have taken the photovoltaic sensor on a word match. */
+  const result = assign([
+    plan("dm.energy_potenza_consumo_casa", "Potenza consumo casa (W)"),
+    plan("dm.energy_potenza_fotovoltaico", "Potenza fotovoltaico (W)"),
+  ]);
+  assert.equal(result["dm.energy_potenza_fotovoltaico"], "sensor.solaredge_potenza_pv");
+  assert.equal(result["dm.energy_potenza_consumo_casa"], "sensor.casa_potenza");
+});
+
+test("one entity is never proposed for two slots, nor re-proposed when already configured", () => {
+  const first = assign([
+    plan("dm.server_speedtest_download", "Speedtest Download (Mbit/s)", "server"),
+    plan("dm.server_speedtest_upload", "Speedtest Upload (Mbit/s)", "server"),
+  ]);
+  assert.equal(first["dm.server_speedtest_download"], "sensor.speedtest_download");
+  assert.equal(first["dm.server_speedtest_upload"], "sensor.speedtest_upload");
+
+  const taken = assign([plan("dm.server_speedtest_download", "Speedtest Download (Mbit/s)", "server")], {
+    taken: new Set(["sensor.speedtest_download"]),
+  });
+  assert.equal(taken["dm.server_speedtest_download"], undefined);
+});
+
+test("domains stated by the label are honoured", () => {
+  const result = assign([
+    plan("dm.home_meteo", "Meteo (entità weather)", "home"),
+    plan("dm.security_centrale_allarme", "Centrale allarme (alarm_control_panel)", "security"),
+    plan("dm.home_script_apertura_cancello", "Script apertura cancello", "home"),
+  ]);
+  assert.equal(result["dm.home_meteo"], "weather.casa");
+  assert.equal(result["dm.security_centrale_allarme"], "alarm_control_panel.antifurto");
+  assert.equal(result["dm.home_script_apertura_cancello"], "script.apri_cancello");
+});
+
+test("two equally plausible candidates are reported instead of guessed", () => {
+  const records = buildEntityIndex(
+    [
+      sensor("sensor.pannello_sonda", "Sonda temperatura", { dc: "temperature", unit: "°C" }),
+      sensor("sensor.serbatoio_sonda", "Sonda temperatura", { dc: "temperature", unit: "°C" }),
+    ],
+    { version: "ambiguous" },
+  );
+  const result = detectSlots(records.records, [plan("dm.boiler_sonda_temperatura_1", "Sonda temperatura 1 (°C)", "boiler")]);
+  assert.deepEqual(result.assignments, []);
+  assert.equal(result.undecided.length, 1);
+  assert.equal(result.undecided[0].reason, "ambiguous");
+});
+
+test("the small words a label uses to tell two slots apart are kept", () => {
+  /* "Temperatura AC inverter" and "Temperatura DC inverter" are the same label
+   * once two-letter words are dropped, and so are "Sonda temperatura 1" and its
+   * neighbours once digits are. Both pairs used to end up undecided. */
+  const built = buildEntityIndex(
+    [
+      sensor("sensor.inverter_temperatura_ac", "Temperatura AC", { dc: "temperature", unit: "°C" }),
+      sensor("sensor.inverter_temperatura_dc", "Temperatura DC", { dc: "temperature", unit: "°C" }),
+      sensor("sensor.sonda_1", "Sonda 1", { dc: "temperature", unit: "°C" }),
+      sensor("sensor.sonda_2", "Sonda 2", { dc: "temperature", unit: "°C" }),
+    ],
+    { version: "short-words" },
+  );
+  const result = detectSlots(built.records, [
+    plan("dm.energy_temperatura_ac_inverter", "Temperatura AC inverter (°C)"),
+    plan("dm.energy_temperatura_dc_inverter", "Temperatura DC inverter (°C)"),
+    plan("dm.boiler_sonda_temperatura_2", "Sonda temperatura 2 (°C)", "boiler"),
+  ]);
+  const byRef = Object.fromEntries(result.assignments.map((item) => [item.ref, item.id]));
+  assert.equal(byRef["dm.energy_temperatura_ac_inverter"], "sensor.inverter_temperatura_ac");
+  assert.equal(byRef["dm.energy_temperatura_dc_inverter"], "sensor.inverter_temperatura_dc");
+  assert.equal(byRef["dm.boiler_sonda_temperatura_2"], "sensor.sonda_2");
+});
+
+test("rooms come from the Home Assistant areas, with the humidity twin of each", () => {
+  const { rooms } = detectCategories(index().records);
+  assert.deepEqual(rooms.slice(0, 2), [
+    { name: "Cucina", icon: "🌡️", temp: "sensor.cucina_temperatura", hum: "sensor.cucina_umidita" },
+    { name: "Salotto", icon: "🌡️", temp: "sensor.salotto_temperatura" },
+  ]);
+  // A sensor with no area still lands, through its name and its id twin.
+  const mansarda = rooms.find((room) => room.temp === "sensor.mansarda_temperatura");
+  assert.equal(mansarda.hum, "sensor.mansarda_umidita");
+});
+
+test("lights, climate units and cameras carry their area in the name", () => {
+  const { lights, climate, cameras } = detectCategories(index().records);
+  assert.equal(lights["light.cucina"], "Luce cucina");
+  assert.equal(cameras[0].entity, "camera.ingresso");
+  const heating = climate.find((unit) => unit.entity === "climate.termosifone_bagno");
+  assert.equal(heating.type, "termo");
+  assert.equal(heating.name, "Bagno");
+  assert.equal(climate.find((unit) => unit.entity === "climate.salotto").type, "clima");
+});
+
+test("alert groups keep the openings and the batteries apart, and drop the bypass", () => {
+  const { groups } = detectCategories(index().records);
+  assert.deepEqual(groups.win, ["binary_sensor.porta_ingresso"]);
+  assert.deepEqual(groups.batt, ["sensor.batteria_soc", "sensor.telecomando_batteria"]);
+  assert.deepEqual(groups.luci, ["light.cucina", "light.salotto"]);
+  assert.deepEqual(groups.risc, ["climate.termosifone_bagno"]);
+  assert.deepEqual(groups.clima, ["climate.salotto"]);
+});
+
+test("a slot only looks at the entities that share a word with it", () => {
+  const many = [];
+  for (let position = 0; position < 4000; position += 1) {
+    many.push(sensor(`sensor.filler_${position}`, `Filler ${position}`, { unit: "W" }));
+  }
+  const built = buildEntityIndex([...HOUSE, ...many], { version: "scale" });
+  const postings = buildPostings(built.records);
+  const plans = [plan("dm.energy_produzione_solare_oggi", "Produzione solare oggi (kWh)")];
+  const result = detectSlots(built.records, plans, { postings });
+  assert.equal(result.assignments[0].id, "sensor.solaredge_produzione_oggi");
+  // Four thousand unrelated entities never enter the scoring at all.
+  assert.ok(result.scanned <= 8, `scored ${result.scanned} pairs`);
+});

--- a/custom_components/dashboardmodern/frontend/tests/ev-showcase-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/ev-showcase-section.test.js
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { readFile } from "node:fs/promises";
 
+const { resolveVehicleAsset } = await import("../src/sections/ev-section.js");
+
 const source = await readFile(new URL("../src/sections/ev-showcase-section.js", import.meta.url), "utf8");
 
 async function loadSection() {
@@ -128,4 +130,26 @@ test("each mode button gets its own animation and reduced motion stops them all"
   for (const keyframe of ["dmEvvOffRing", "dmEvvSpin", "dmEvvCloud", "dmEvvZoom"])
     assert.match(source, new RegExp(`@keyframes ${keyframe}`), keyframe);
   assert.match(source, /prefers-reduced-motion:reduce[\s\S]*?animation:none!important/);
+});
+
+test("a www image saved without the /local prefix still resolves", () => {
+  const base = "https://home.test/api/dashboardmodern/abc/dashboard.html";
+  // What the EV editor had stored: the file lives in /config/www/ev/, which
+  // Home Assistant serves as /local/ev/. Without the prefix it 404s and the
+  // photo silently disappears.
+  assert.equal(resolveVehicleAsset("/ev/idle.png", base), "/local/ev/idle.png");
+  assert.equal(resolveVehicleAsset("/auto/b10.jpg", base), "/local/auto/b10.jpg");
+  // Paths Home Assistant already serves are left alone.
+  assert.equal(resolveVehicleAsset("/local/ev/idle.png", base), "/local/ev/idle.png");
+  assert.equal(resolveVehicleAsset("/api/image/serve/x/512x512", base), "/api/image/serve/x/512x512");
+  assert.equal(resolveVehicleAsset("/media/local/car.png", base), "/media/local/car.png");
+  assert.equal(resolveVehicleAsset("/hacsfiles/pack/car.png", base), "/hacsfiles/pack/car.png");
+});
+
+test("the frame falls back to the placeholder when the photo cannot load", () => {
+  // A configured but broken URL used to leave an empty slab: the skin marks the
+  // hero from the image itself instead of trusting the configured value.
+  assert.match(source, /dataset\.dmEvvPhoto/);
+  assert.match(source, /naturalWidth/);
+  assert.match(source, /data-dm-evv-photo="off"/);
 });

--- a/custom_components/dashboardmodern/frontend/tests/light-model.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/light-model.test.js
@@ -1,0 +1,281 @@
+/* What a configured light can do, and what the dashboard asks Home Assistant
+ * to do about it. The controls are built from these answers, so a wrong one is
+ * a missing dimmer or a rejected service call on a real installation. */
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DEFAULT_MAX_KELVIN,
+  DEFAULT_MIN_KELVIN,
+  LIGHT_DOMAINS,
+  brightnessToPercent,
+  entityDomain,
+  hexToRgb,
+  hsvToRgb,
+  isLightEntity,
+  kelvinToHex,
+  lightColorHex,
+  lightCommand,
+  lightControls,
+  lightSummary,
+  lightView,
+  lightsSignature,
+  readableInk,
+  rgbToHex,
+  rgbToHsv,
+} from "../src/core/light-model.js";
+
+const rgbLamp = {
+  state: "on",
+  attributes: {
+    friendly_name: "Strip salone",
+    supported_color_modes: ["hs", "color_temp"],
+    color_mode: "hs",
+    brightness: 128,
+    rgb_color: [255, 0, 0],
+    min_color_temp_kelvin: 2202,
+    max_color_temp_kelvin: 6535,
+    effect_list: ["Arcobaleno", "Fuoco"],
+    effect: "Fuoco",
+  },
+};
+const dimmer = {
+  state: "on",
+  attributes: { supported_color_modes: ["brightness"], brightness: 255 },
+};
+const relay = { state: "off", attributes: { friendly_name: "Lampada garage" } };
+
+test("a light may be a light, a switch or anything the wizard has ever written", () => {
+  assert.deepEqual(LIGHT_DOMAINS, ["light", "switch", "input_boolean", "fan", "group"]);
+  assert.ok(isLightEntity("light.salone"));
+  assert.ok(isLightEntity("switch.lampada_garage"));
+  assert.ok(isLightEntity("input_boolean.luce_finta"));
+  // The legacy wizard has always accepted these, so the editor cannot reject
+  // a light that is already configured.
+  assert.ok(isLightEntity("fan.ventola_luce"));
+  assert.ok(isLightEntity("group.luci_piano_terra"));
+  assert.equal(isLightEntity("sensor.lux"), false);
+  assert.equal(isLightEntity("light."), false);
+  assert.equal(isLightEntity("salone"), false);
+  assert.equal(entityDomain("switch.x"), "switch");
+  assert.equal(entityDomain("nonsense"), "");
+});
+
+test("capabilities come from the entity, never from the domain", () => {
+  const rgb = lightView("light.strip", { state: rgbLamp });
+  assert.deepEqual(
+    { dimmable: rgb.dimmable, colorful: rgb.colorful, tunable: rgb.tunable },
+    { dimmable: true, colorful: true, tunable: true },
+  );
+  assert.deepEqual(lightControls(rgb), ["power", "brightness", "color", "white", "effect"]);
+  assert.equal(rgb.brightness, 50);
+  assert.deepEqual(rgb.effects, ["Arcobaleno", "Fuoco"]);
+
+  const dim = lightView("light.faretti", { state: dimmer });
+  assert.deepEqual(lightControls(dim), ["power", "brightness"]);
+  assert.equal(dim.brightness, 100);
+
+  // A lamp behind a relay is a light on this dashboard and an on/off entity to
+  // Home Assistant: it gets a power button and nothing that would be rejected.
+  const plain = lightView("switch.lampada_garage", { state: relay });
+  assert.deepEqual(lightControls(plain), ["power"]);
+  assert.equal(plain.name, "Lampada garage");
+  assert.equal(plain.on, false);
+  assert.equal(plain.available, true);
+});
+
+test("a pre-2021 integration keeps its dimmer through the legacy feature bits", () => {
+  const legacy = lightView("light.vecchia", {
+    state: { state: "on", attributes: { supported_features: 1 | 2 | 16, brightness: 51 } },
+  });
+  assert.equal(legacy.dimmable, true);
+  assert.equal(legacy.colorful, true);
+  assert.equal(legacy.tunable, true);
+  assert.equal(legacy.brightness, 20);
+});
+
+test("a configured light with no entity is unavailable, not absent", () => {
+  const missing = lightView("light.staccata", { name: "Staccata" });
+  assert.equal(missing.available, false);
+  assert.equal(missing.on, false);
+  assert.equal(missing.name, "Staccata");
+  const unknown = lightView("light.x", { state: { state: "unavailable", attributes: {} } });
+  assert.equal(unknown.available, false);
+});
+
+test("brightness is reported the way it is set: 1-100, and never 0 while lit", () => {
+  assert.equal(brightnessToPercent(255), 100);
+  assert.equal(brightnessToPercent(128), 50);
+  assert.equal(brightnessToPercent(1), 1);
+  assert.equal(brightnessToPercent(0), null);
+  assert.equal(brightnessToPercent(undefined), null);
+});
+
+test("the kelvin range follows the lamp, in kelvin or in mireds", () => {
+  const kelvin = lightView("light.a", {
+    state: {
+      state: "on",
+      attributes: {
+        supported_color_modes: ["color_temp"],
+        min_color_temp_kelvin: 2700,
+        max_color_temp_kelvin: 6500,
+        color_temp_kelvin: 3000,
+      },
+    },
+  });
+  assert.deepEqual([kelvin.minKelvin, kelvin.maxKelvin, kelvin.kelvin], [2700, 6500, 3000]);
+
+  const mireds = lightView("light.b", {
+    state: {
+      state: "on",
+      attributes: {
+        supported_color_modes: ["color_temp"],
+        min_mireds: 153,
+        max_mireds: 500,
+        color_temp: 250,
+      },
+    },
+  });
+  assert.equal(mireds.minKelvin, 2000);
+  assert.equal(mireds.maxKelvin, 6536);
+  assert.equal(mireds.kelvin, 4000);
+
+  const none = lightView("light.c", {
+    state: { state: "on", attributes: { supported_color_modes: ["color_temp"] } },
+  });
+  assert.deepEqual([none.minKelvin, none.maxKelvin], [DEFAULT_MIN_KELVIN, DEFAULT_MAX_KELVIN]);
+});
+
+test("the card colour is the lamp's own, and amber only when there is none", () => {
+  assert.equal(lightColorHex(lightView("light.strip", { state: rgbLamp })), "#ff0000");
+  const white = lightView("light.w", {
+    state: {
+      state: "on",
+      attributes: {
+        supported_color_modes: ["color_temp"],
+        color_mode: "color_temp",
+        color_temp_kelvin: 2700,
+      },
+    },
+  });
+  assert.equal(lightColorHex(white), kelvinToHex(2700));
+  assert.equal(lightColorHex(lightView("switch.x", { state: relay })), "#f59e0b");
+});
+
+test("colour conversions round-trip", () => {
+  assert.equal(rgbToHex([255, 0, 0]), "#ff0000");
+  assert.deepEqual(hexToRgb("#00ff80"), [0, 255, 128]);
+  assert.deepEqual(hexToRgb("#0f8"), [0, 255, 136]);
+  assert.deepEqual(hexToRgb("nonsense"), [255, 255, 255]);
+  assert.deepEqual(hsvToRgb(0, 100, 100), [255, 0, 0]);
+  assert.deepEqual(hsvToRgb(120, 100, 100), [0, 255, 0]);
+  assert.deepEqual(hsvToRgb(240, 100, 100), [0, 0, 255]);
+  assert.deepEqual(hsvToRgb(0, 0, 100), [255, 255, 255]);
+  assert.deepEqual(rgbToHsv([255, 0, 0]), [0, 100, 100]);
+  assert.deepEqual(rgbToHsv([0, 0, 255]), [240, 100, 100]);
+  // The hue slider sets a colour, the sheet reads it back: what comes out has
+  // to be the hue that went in, or the handle jumps on the next repaint.
+  for (const hue of [0, 37, 120, 210, 300, 359]) {
+    assert.equal(rgbToHsv(hsvToRgb(hue, 100, 100))[0], hue);
+  }
+  // Tungsten is warm and daylight is cold; both would be white without the
+  // black-body curve.
+  const warm = hexToRgb(kelvinToHex(2200));
+  const cold = hexToRgb(kelvinToHex(6500));
+  assert.ok(warm[0] > warm[2], "2200K must be redder than it is blue");
+  assert.ok(cold[2] > warm[2], "6500K must be bluer than 2200K");
+});
+
+test("the ink on a coloured control follows the colour, not a constant", () => {
+  // The power button and the glyph in the orb are painted on the lamp's own
+  // colour: a deep blue lamp needs white ink, a pale amber one needs dark.
+  assert.equal(readableInk("#2f7bff"), "#ffffff");
+  assert.equal(readableInk("#ff0000"), "#ffffff");
+  assert.equal(readableInk("#000000"), "#ffffff");
+  assert.equal(readableInk("#f59e0b"), "#0f172a");
+  assert.equal(readableInk("#ffe066"), "#0f172a");
+  assert.equal(readableInk("#ffffff"), "#0f172a");
+});
+
+test("one requested change becomes one service call the entity accepts", () => {
+  const rgb = lightView("light.strip", { state: rgbLamp });
+  assert.deepEqual(lightCommand(rgb, { hex: "#00ff00" }), {
+    domain: "light",
+    service: "turn_on",
+    data: { entity_id: "light.strip", rgb_color: [0, 255, 0] },
+  });
+  assert.deepEqual(lightCommand(rgb, { brightnessPct: 40 }), {
+    domain: "light",
+    service: "turn_on",
+    data: { entity_id: "light.strip", brightness_pct: 40 },
+  });
+  assert.deepEqual(lightCommand(rgb, { effect: "Arcobaleno", power: true }), {
+    domain: "light",
+    service: "turn_on",
+    data: { entity_id: "light.strip", effect: "Arcobaleno" },
+  });
+  // 0% is off, not a light burning at zero.
+  assert.deepEqual(lightCommand(rgb, { brightnessPct: 0 }), {
+    domain: "light",
+    service: "turn_off",
+    data: { entity_id: "light.strip" },
+  });
+  // A white point outside what the lamp reports is clamped rather than sent.
+  assert.equal(lightCommand(rgb, { kelvin: 9000 }).data.color_temp_kelvin, 6535);
+  assert.equal(lightCommand(rgb, { kelvin: 1000 }).data.color_temp_kelvin, 2202);
+  assert.deepEqual(lightCommand(rgb, {}), {
+    domain: "light",
+    service: "toggle",
+    data: { entity_id: "light.strip" },
+  });
+});
+
+test("a switch is never asked for a colour or a brightness", () => {
+  const plain = lightView("switch.lampada_garage", { state: relay });
+  assert.deepEqual(lightCommand(plain, { power: true }), {
+    domain: "switch",
+    service: "turn_on",
+    data: { entity_id: "switch.lampada_garage" },
+  });
+  assert.deepEqual(lightCommand(plain, { power: false }), {
+    domain: "switch",
+    service: "turn_off",
+    data: { entity_id: "switch.lampada_garage" },
+  });
+  assert.deepEqual(lightCommand(plain, { hex: "#00ff00", brightnessPct: 50 }), {
+    domain: "switch",
+    service: "toggle",
+    data: { entity_id: "switch.lampada_garage" },
+  });
+  // A light that reports only on/off is treated the same way: sending
+  // brightness_pct to it is what makes Home Assistant refuse the call.
+  const onoff = lightView("light.onoff", {
+    state: { state: "on", attributes: { supported_color_modes: ["onoff"] } },
+  });
+  assert.deepEqual(lightCommand(onoff, { brightnessPct: 50 }).data, { entity_id: "light.onoff" });
+  assert.equal(lightCommand(null, {}), null);
+});
+
+test("the popup counts what it shows and rebuilds only when its shape changes", () => {
+  const views = [
+    lightView("light.strip", { state: rgbLamp, room: "Salone" }),
+    lightView("light.faretti", { state: dimmer, room: "Salone" }),
+    lightView("switch.garage", { state: relay, room: "Garage" }),
+    lightView("light.staccata", {}),
+  ];
+  assert.deepEqual(lightSummary(views), {
+    total: 4,
+    on: 2,
+    unavailable: 1,
+    dimmable: 2,
+    colorful: 1,
+  });
+  const signature = lightsSignature(views);
+  const dimmed = views.map((view) =>
+    view.id === "light.strip" ? { ...view, brightness: 10, on: false } : view,
+  );
+  assert.equal(lightsSignature(dimmed), signature, "a value change must not rebuild the list");
+  const renamed = views.map((view) =>
+    view.id === "light.strip" ? { ...view, name: "Strip cucina" } : view,
+  );
+  assert.notEqual(lightsSignature(renamed), signature, "a rename must rebuild the list");
+});

--- a/custom_components/dashboardmodern/frontend/tests/lights-scene.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/lights-scene.test.js
@@ -1,0 +1,166 @@
+/* The Gestione Luci popup: what each light is given to control it with, and
+ * who owns the paint. The controls are built from the entity's own
+ * capabilities, so these assertions are about a dimmer having a dimmer and a
+ * relay not being offered a colour wheel it would reject. */
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { lightView } from "../src/core/light-model.js";
+import {
+  renderLightControlMarkup,
+  renderLightsPopupMarkup,
+} from "../src/sections/lights-scene-section.js";
+
+const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+const scene = await read("../src/sections/lights-scene-section.js");
+const editor = await read("../src/sections/lights-alerts-section.js");
+const runtime = await read("../src/sections/section-runtime.js");
+
+const strip = lightView("light.strip", {
+  name: "Strip TV",
+  room: "Salone",
+  state: {
+    state: "on",
+    attributes: {
+      supported_color_modes: ["hs", "color_temp"],
+      color_mode: "hs",
+      brightness: 128,
+      rgb_color: [255, 0, 0],
+      min_color_temp_kelvin: 2202,
+      max_color_temp_kelvin: 6535,
+      effect_list: ["Arcobaleno", "Fuoco"],
+      effect: "Fuoco",
+    },
+  },
+});
+const spots = lightView("light.faretti", {
+  name: "Faretti",
+  room: "Salone",
+  state: { state: "on", attributes: { supported_color_modes: ["brightness"], brightness: 255 } },
+});
+const relay = lightView("switch.garage", {
+  name: "Lampada garage",
+  room: "Garage",
+  state: { state: "off", attributes: {} },
+});
+const missing = lightView("light.staccata", { name: "Staccata", room: "Cantina" });
+
+test("every light gets the controls its entity declares, and no others", () => {
+  const html = renderLightsPopupMarkup([strip, spots, relay]);
+  // A dimmer and an RGB strip carry the brightness track on the card itself:
+  // the common case is "a bit less light", not "open a dialog".
+  assert.equal((html.match(/data-dm-light-brightness/g) || []).length, 2);
+  assert.match(html, /data-dm-light="light\.strip"[\s\S]*?data-dm-light-open/);
+  // The relay has nothing to tune, so it is not offered a controls button.
+  const relayCard = html.slice(html.indexOf('data-dm-light="switch.garage"'));
+  assert.doesNotMatch(relayCard.slice(0, 1200), /data-dm-light-open/);
+  assert.doesNotMatch(relayCard.slice(0, 1200), /data-dm-light-brightness/);
+  assert.match(relayCard, /data-kind="switch">SWITCH/);
+});
+
+test("the card is painted with the colour the lamp is emitting", () => {
+  const html = renderLightsPopupMarkup([strip, spots, relay]);
+  assert.match(html, /--dm-light-color:#ff0000;--dm-light-ink:#ffffff;--dm-light-level:50%/);
+  // A lamp with no colour of its own keeps the dashboard amber, and the ink on
+  // it flips to dark so the glyph and the power button stay readable.
+  assert.match(html, /--dm-light-color:#f59e0b;--dm-light-ink:#0f172a;--dm-light-level:0%/);
+  assert.match(html, /data-dm-light-state>ACCESA · 50%/);
+  assert.match(html, /data-dm-light-state>SPENTA/);
+});
+
+test("a configured light whose entity is gone is shown as unavailable", () => {
+  const html = renderLightsPopupMarkup([strip, missing]);
+  assert.match(html, /data-dm-light="light\.staccata" data-dm-light-available="false"/);
+  assert.match(html, /data-dm-light-state>NON DISPONIBILE/);
+});
+
+test("rooms keep the legacy grouping and gain their own on/off command", () => {
+  const html = renderLightsPopupMarkup([strip, spots, relay]);
+  assert.match(html, /data-dm-light-group="Salone"[\s\S]*?dm-lightx-room-count">2\/2/);
+  assert.match(html, /data-dm-light-room="off" data-dm-light-room-name="Salone">Spegni/);
+  // One light in its own room is still merged into the closing group, where the
+  // card carries the room as its title and the light name below it.
+  assert.match(html, /data-dm-light-group="Altre zone"/);
+  assert.match(html, /<span class="lgx-name">Garage<\/span>\s*<span class="lgx-sub">Lampada garage/);
+  assert.match(html, /<b>2<\/b><span>accese<\/span>/);
+  assert.match(html, /data-dm-light-all="off">Spegni tutte/);
+});
+
+test("an empty popup says where lights are added and which entities count", () => {
+  const html = renderLightsPopupMarkup([]);
+  assert.match(html, /Tutte spente/);
+  assert.match(html, /light\.\* sia switch\.\*/);
+  assert.doesNotMatch(html, /data-dm-light=/);
+});
+
+test("the control sheet offers colour, white and effects to the lamp that has them", () => {
+  const html = renderLightControlMarkup(strip);
+  assert.match(html, /data-block="brightness"/);
+  assert.match(html, /data-block="color"/);
+  assert.match(html, /data-block="white"/);
+  assert.match(html, /data-block="effect"/);
+  assert.match(html, /data-dm-light-hue/);
+  assert.match(html, /data-dm-light-saturation/);
+  assert.match(html, /type="color" value="#ff0000" data-dm-light-hex/);
+  assert.equal((html.match(/data-dm-light-color="#/g) || []).length, 12);
+  // The white track never leaves what the lamp reports, so a value it would
+  // refuse cannot be sent from the slider.
+  assert.match(html, /min="2202" max="6535"/);
+  assert.match(html, /<option value="Fuoco" selected>Fuoco<\/option>/);
+});
+
+test("a dimmer gets a dimmer, and a relay gets a power button and an explanation", () => {
+  const dim = renderLightControlMarkup(spots);
+  assert.match(dim, /data-block="brightness"/);
+  assert.doesNotMatch(dim, /data-block="color"/);
+  assert.doesNotMatch(dim, /data-block="white"/);
+
+  const plain = renderLightControlMarkup(relay);
+  assert.doesNotMatch(plain, /data-block=/);
+  assert.match(plain, /data-dm-light-power/);
+  assert.match(plain, /collegata a uno switch/);
+  assert.match(plain, /🔌/);
+
+  const gone = renderLightControlMarkup(missing);
+  assert.match(gone, /Entità non disponibile/);
+});
+
+test("the popup has one paint owner and stays event-driven", () => {
+  // apriGestioneLuci is decorated rather than replaced: it is the only writer
+  // of the runtime's lexical currentPopupType, which is what makes the tick
+  // call updateGestioneLuci at all.
+  assert.match(scene, /root\.apriGestioneLuci = ownedOpen/);
+  assert.match(scene, /root\.updateGestioneLuci = ownedUpdate/);
+  assert.match(scene, /if \(typeof open === "function" && !open\[MARKER\]\)/);
+  assert.doesNotMatch(scene, /setInterval\s*\(/);
+  assert.doesNotMatch(scene, /MutationObserver/);
+  // Values are written into the cards that exist; markup is rebuilt only when
+  // the shape of the list changes.
+  assert.match(scene, /lightsSignature\(views\) !== state\.signature/);
+  assert.match(scene, /function syncCard\(card, view\)/);
+  assert.equal((runtime.match(/lights-scene-section\.js/g) || []).length, 1);
+  assert.equal((runtime.match(/installLightsSceneSection\(\)/g) || []).length, 1);
+});
+
+test("commands go through the model and the legacy service bridge", () => {
+  assert.match(scene, /lightCommand\(view, change\)/);
+  assert.match(scene, /root\.dmCallHaService === "function"/);
+  // A drag must not become one service call per pixel, and the value the user
+  // set must survive the ticks that arrive before the lamp reports it.
+  assert.match(scene, /const LIVE_MS = 320/);
+  assert.match(scene, /const HOLD_MS = 6000/);
+  assert.match(scene, /function applyLive\(view, field, value\)/);
+});
+
+test("the Luci tab accepts a switch and says what each light can do", () => {
+  assert.match(editor, /import \{ LIGHT_DOMAINS, isLightEntity, lightView \}/);
+  assert.match(editor, /if \(!isLightEntity\(entity\) \|\| !name\)/);
+  assert.doesNotMatch(editor, /\^light\\\.\[a-z0-9_\]\+\$/);
+  assert.match(editor, /placeholder="light\.salone · switch\.lampada"/);
+  assert.match(editor, /function lightMeta\(id\)/);
+  assert.match(editor, /class="dm-light-badges"/);
+  // The badges describe the entity currently in the field, not the one the
+  // modal was opened with.
+  assert.match(editor, /entityInput\.addEventListener\("input", describe\)/);
+  assert.match(editor, /root\.dmOpenLightControl\?\.\(clean\(entityInput\.value\)\)/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/navbar-desktop-scroll.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/navbar-desktop-scroll.test.js
@@ -1,0 +1,109 @@
+// Field regression: on a desktop plancia with every section enabled the dock
+// is wider than the screen. It is fixed and centered, so the page scroll never
+// moves it and the tabs past the viewport edge were unreachable — there was no
+// way to scroll the bar itself. The tabs now live in their own scroll port.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const sourceUrl = new URL("../src/sections/navigation-section.js", import.meta.url);
+const source = await readFile(sourceUrl, "utf8");
+const { navCenterTarget, navPageStep, navScrollState, navTabIsVisible, navWheelDelta } =
+  await import(sourceUrl.href);
+
+test("the dock is capped to the viewport and its tabs keep their own scroll port", () => {
+  assert.match(source, /width:max-content!important;min-width:0!important;max-width:calc\(100% - 48px\)/);
+  assert.match(source, /overflow-x:auto!important;overflow-y:hidden!important/);
+  // The tabs must not shrink to fit the port, otherwise they squash instead of
+  // overflowing and there is nothing left to scroll.
+  assert.match(source, /\.tab\{flex:0 0 auto!important\}/);
+  // The port clips vertically, so the Mac-dock bubble needs room inside it that
+  // the negative margin takes back out of the layout.
+  assert.match(source, /padding:34px 12px 26px!important;margin:-34px -12px -26px!important/);
+  assert.match(source, /scrollbar-width:none!important/);
+});
+
+test("mobile keeps the bar it already had", () => {
+  // Outside the desktop media query the port is display:contents, so the nav
+  // stays the scroll container the touch layout has always used.
+  assert.match(source, /\.bottom-nav-bar \.\$\{SCROLLER_CLASS\}\{display:contents\}/);
+  assert.match(source, /\.bottom-nav-bar \.\$\{ARROW_CLASS\}\{display:none\}/);
+  const desktop = source.slice(source.indexOf("@media(min-width:769px)"));
+  assert.match(desktop, /\$\{CAN_SCROLL_CLASS\} \.\$\{ARROW_CLASS\}\{display:flex/);
+});
+
+test("the scroll port stays event driven", () => {
+  assert.doesNotMatch(source, /setInterval|MutationObserver/);
+  // Enabling or disabling a section resizes the bar: that is the signal that
+  // says when the arrows are needed, with no polling behind it.
+  assert.match(source, /new root\.ResizeObserver\(sync\)\.observe\(scroller\)/);
+  for (const listener of ["wheel", "pointerdown", "pointermove", "scroll", "keydown"]) {
+    assert.match(source, new RegExp(`"${listener}"`));
+  }
+});
+
+test("arrow state follows the scroll position", () => {
+  const idle = navScrollState({ scrollLeft: 0, scrollWidth: 900, clientWidth: 900 });
+  assert.deepEqual({ ...idle }, { max: 0, scrollable: false, atStart: true, atEnd: true });
+
+  const start = navScrollState({ scrollLeft: 0, scrollWidth: 1414, clientWidth: 1138 });
+  assert.equal(start.max, 276);
+  assert.equal(start.scrollable, true);
+  assert.equal(start.atStart, true);
+  assert.equal(start.atEnd, false);
+
+  const middle = navScrollState({ scrollLeft: 120, scrollWidth: 1414, clientWidth: 1138 });
+  assert.equal(middle.atStart, false);
+  assert.equal(middle.atEnd, false);
+
+  const end = navScrollState({ scrollLeft: 276, scrollWidth: 1414, clientWidth: 1138 });
+  assert.equal(end.atStart, false);
+  assert.equal(end.atEnd, true);
+});
+
+test("one arrow press moves close to a full port without ever standing still", () => {
+  assert.equal(navPageStep(1138), 819);
+  assert.equal(navPageStep(0), 120);
+  assert.equal(navPageStep(100), 120);
+});
+
+test("the vertical wheel of a plain mouse scrolls the dock sideways", () => {
+  assert.equal(navWheelDelta({ deltaX: 0, deltaY: 120 }), 120);
+  assert.equal(navWheelDelta({ deltaX: -40, deltaY: 6 }), -40);
+  assert.equal(navWheelDelta({ deltaX: 0, deltaY: 3, deltaMode: 1 }), 54);
+  assert.equal(navWheelDelta({}), 0);
+  assert.equal(navWheelDelta({ deltaY: Number.NaN }), 0);
+});
+
+test("the open section is recentred only when it is off screen", () => {
+  assert.equal(
+    navTabIsVisible({ portLeft: 100, portRight: 900, tabLeft: 120, tabRight: 220 }),
+    true,
+  );
+  assert.equal(
+    navTabIsVisible({ portLeft: 100, portRight: 900, tabLeft: 860, tabRight: 980 }),
+    false,
+  );
+  assert.equal(navTabIsVisible({ portLeft: 100, portRight: 900, tabLeft: 20, tabRight: 140 }), false);
+
+  assert.equal(
+    navCenterTarget({
+      scrollLeft: 0,
+      portLeft: 100,
+      portWidth: 800,
+      tabLeft: 1000,
+      tabWidth: 120,
+      max: 600,
+    }),
+    560,
+  );
+  // Never past the ends of the track.
+  assert.equal(
+    navCenterTarget({ scrollLeft: 0, portLeft: 100, portWidth: 800, tabLeft: 120, tabWidth: 120, max: 600 }),
+    0,
+  );
+  assert.equal(
+    navCenterTarget({ scrollLeft: 500, portLeft: 100, portWidth: 800, tabLeft: 1400, tabWidth: 120, max: 600 }),
+    600,
+  );
+});

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -197,8 +197,12 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // editor prints, hides the raw entity field behind "Modifica manuale" and
   // routes the tap to the legacy wzPickEntity(), which the fast search above
   // owns. No polling, no observer.
+  // The Temperature trend panel adds exactly one owner: it draws the history
+  // chart under the cards from the same history/history_during_period the card
+  // popup already uses, follows the room tabs by reading the active tab, and
+  // watches #temp-grid so any renderer rebuild redraws it. No polling.
   // All facade/cycle/orphan/polling/global-observer checks stay active.
-  assert.ok(relative.length <= 97, `production graph unexpectedly grew to ${relative.length} modules`);
+  assert.ok(relative.length <= 98, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -201,8 +201,19 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // chart under the cards from the same history/history_during_period the card
   // popup already uses, follows the room tabs by reading the active tab, and
   // watches #temp-grid so any renderer rebuild redraws it. No polling.
+  // The Luci redesign adds exactly two: the pure light model — capabilities,
+  // colour maths and the service call for one requested change — and the scene
+  // that owns the Gestione Luci popup and the control sheet of a single light.
+  // The scene decorates `apriGestioneLuci` rather than replacing it, because
+  // that function is the only writer of the runtime's lexical
+  // `currentPopupType` and no module can reach a lexical binding; it repaints
+  // the list in the same task, so the legacy markup is never shown. It renders
+  // per structural signature rather than per tick, writes values into the
+  // existing cards while the tick runs, and adds no polling and no observer.
+  // The Luci editor keeps its own owner and now reads the same model, so the
+  // capability badges in the tab and the controls in the popup cannot disagree.
   // All facade/cycle/orphan/polling/global-observer checks stay active.
-  assert.ok(relative.length <= 98, `production graph unexpectedly grew to ${relative.length} modules`);
+  assert.ok(relative.length <= 100, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -193,8 +193,12 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // renderer and one stylesheet. It is event-driven (state-changed + the legacy
   // render loop) and leaves every service call — setTemp, toggleClima and the
   // HVAC/fan popup — in the legacy runtime.
+  // The editor slot rows add exactly one owner: it decorates the rows the legacy
+  // editor prints, hides the raw entity field behind "Modifica manuale" and
+  // routes the tap to the legacy wzPickEntity(), which the fast search above
+  // owns. No polling, no observer.
   // All facade/cycle/orphan/polling/global-observer checks stay active.
-  assert.ok(relative.length <= 96, `production graph unexpectedly grew to ${relative.length} modules`);
+  assert.ok(relative.length <= 97, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -212,8 +212,11 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // existing cards while the tick runs, and adds no polling and no observer.
   // The Luci editor keeps its own owner and now reads the same model, so the
   // capability badges in the tab and the controls in the popup cannot disagree.
+  // The Config auto-detection adds two more of the same shape: the pure matcher
+  // and the section that installs it over the vendored `edAutoRileva`, reusing
+  // that index instead of building a second one.
   // All facade/cycle/orphan/polling/global-observer checks stay active.
-  assert.ok(relative.length <= 100, `production graph unexpectedly grew to ${relative.length} modules`);
+  assert.ok(relative.length <= 102, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 

--- a/custom_components/dashboardmodern/frontend/tests/shutter-scene.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/shutter-scene.test.js
@@ -87,6 +87,20 @@ test("the page keeps the same way back home as every other section", () => {
   assert.match(scene, /dropLegacyBackHome\(\);\n {2}const views = coverList\(\);/);
 });
 
+test("nothing shares the row with the window", () => {
+  // The track used to stand beside the window, which narrowed the window and
+  // left the panel short of the card edge with an empty column next to it.
+  assert.match(scene, /\.dm-tapp-stage\{display:block!important;min-width:0!important\}/);
+  assert.match(scene, /\.dm-tapp-stage \.tapp-win\{width:100%!important/);
+  // The position is a full-width rail under the window with the readout at its
+  // end, so it is one horizontal control instead of a vertical one at the side.
+  assert.match(scene, /<div class="dm-tapp-bar">\n\s+\$\{trackMarkup\(view\)\}\n\s+<div class="tapp-pos" data-dm-readout><\/div>\n\s+<\/div>/);
+  assert.match(scene, /\.dm-tapp-track\{\n\s+position:relative!important;flex:1 1 auto!important/);
+  assert.match(scene, /background:linear-gradient\(90deg,var\(--tapp-track-sky\) 0 calc\(var\(--tapp-open,0\) \* 100%\)/);
+  assert.doesNotMatch(scene, /rotate\(-90deg\)/);
+  assert.doesNotMatch(scene, /cursor:ns-resize/);
+});
+
 test("a position the user asked for survives the next legacy repaint", () => {
   // Home Assistant keeps reporting the old position until the motor arrives.
   assert.match(scene, /const GRAB_MS = \d+/);

--- a/custom_components/dashboardmodern/frontend/tests/temperature-labels-regression.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/temperature-labels-regression.test.js
@@ -131,3 +131,50 @@ test("Temperature cards are theme-safe and cannot spill out of their own box", a
   assert.match(source, /\.cp-temp-current::after\{content:"°"!important/);
   assert.match(source, /data-comfort="non-disponibile"\]\) \.cp-temp-current::after/);
 });
+
+test("the reading is projected onto the card so the sheet can draw it", async () => {
+  const { applyTemperatureReading } = await import("../src/sections/shared.js");
+  const card = {
+    dataset: {},
+    style: {
+      values: {},
+      setProperty(name, value) {
+        this.values[name] = value;
+      },
+      removeProperty(name) {
+        delete this.values[name];
+      },
+    },
+  };
+
+  // The comfort scale spans 10-32 °C, so 21 °C sits halfway along it.
+  applyTemperatureReading(card, 21, 54);
+  assert.equal(card.style.values["--dm-temp-pos"], "50.0");
+  assert.equal(card.style.values["--dm-hum"], "54");
+  assert.equal(card.dataset.dmReading, "on");
+  assert.equal(card.dataset.dmHumidity, "on");
+
+  // Readings outside the scale pin to its ends instead of running off the card.
+  applyTemperatureReading(card, -4, 140);
+  assert.equal(card.style.values["--dm-temp-pos"], "0.0");
+  assert.equal(card.style.values["--dm-hum"], "100");
+  applyTemperatureReading(card, 48, 0);
+  assert.equal(card.style.values["--dm-temp-pos"], "100.0");
+
+  // Nothing to draw when the sensor has nothing to say.
+  applyTemperatureReading(card, null, null);
+  assert.equal(card.style.values["--dm-temp-pos"], undefined);
+  assert.equal(card.style.values["--dm-hum"], undefined);
+  assert.equal(card.dataset.dmReading, "off");
+  assert.equal(card.dataset.dmHumidity, "off");
+
+  // Every renderer hands its reading to the same function.
+  for (const name of [
+    "temperature-section.js",
+    "beta25-real-device-fixes-section.js",
+    "beta26-real-device-stability-section.js",
+  ]) {
+    const source = await readFile(new URL(`../src/sections/${name}`, import.meta.url), "utf8");
+    assert.match(source, /applyTemperatureReading\(card/, name);
+  }
+});

--- a/custom_components/dashboardmodern/frontend/tests/temperature-trend.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/temperature-trend.test.js
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  trendGeometry,
+  trendSeriesModel,
+} from "../src/sections/temperature-trend-section.js";
+
+const rooms = [
+  {
+    id: "room-cameretta",
+    name: "Cameretta",
+    temp: "sensor.cameretta_temperature",
+    temp_name: "Cameretta",
+    metadata: {
+      temperature_entries: [
+        { id: "temperature-extra-1", name: "Seconda sonda", temp: "sensor.seconda_temperature" },
+      ],
+    },
+  },
+  { id: "room-salone", name: "Salone", temp: "sensor.salone_temperature" },
+  { id: "room-vuota", name: "Ripostiglio" },
+];
+
+test("a room draws its own probes, all rooms draw one line each", () => {
+  const room = trendSeriesModel(rooms, "room-cameretta");
+  assert.equal(room.title, "Cameretta");
+  assert.deepEqual(
+    room.series.map((item) => [item.name, item.entity]),
+    [
+      ["Cameretta", "sensor.cameretta_temperature"],
+      ["Seconda sonda", "sensor.seconda_temperature"],
+    ],
+  );
+
+  const all = trendSeriesModel(rooms, "all");
+  assert.equal(all.title, "Tutte le stanze");
+  // One line per configured room — the extra probe belongs to the room view —
+  // and a room without sensors is not a line with nothing in it.
+  assert.deepEqual(
+    all.series.map((item) => [item.name, item.entity]),
+    [
+      ["Cameretta", "sensor.cameretta_temperature"],
+      ["Salone", "sensor.salone_temperature"],
+    ],
+  );
+  assert.deepEqual(trendSeriesModel(rooms, "room-inesistente").series, []);
+});
+
+function series(values, window) {
+  const step = (window.end - window.start) / (values.length - 1);
+  return [
+    {
+      id: "s",
+      name: "s",
+      colour: "14,165,233",
+      rows: values.map((value, index) => ({
+        state: String(value),
+        time: window.start + index * step,
+      })),
+    },
+  ];
+}
+
+test("the chart scales to the readings and keeps the comfort band honest", () => {
+  const end = 1_760_000_000_000;
+  const window = { start: end - 24 * 60 * 60 * 1000, end, hours: 24 };
+  const view = { width: 600, height: 250, left: 38, right: 54, top: 14, bottom: 24 };
+
+  // A room that spent the day between 26° and 32° gets the whole height, and the
+  // comfort band is then only partly in view instead of squashing the curve.
+  const hot = trendGeometry(series([26, 29, 32], window), window, view);
+  assert.ok(hot.min > 24 && hot.max < 34, `${hot.min}..${hot.max}`);
+  assert.equal(hot.band.visible, true);
+  assert.ok(hot.band.top >= view.top);
+
+  // A cellar far below the band never draws it at all.
+  const cold = trendGeometry(series([9, 9.4, 9.2], window), window, view);
+  assert.equal(cold.band.visible, false);
+
+  // A flat day still gets a readable line instead of collapsing onto an edge.
+  const flat = trendGeometry(series([21, 21, 21], window), window, view);
+  // 0.4 of padding on each side, give or take floating point
+  assert.ok(flat.max - flat.min > 0.75, String(flat.max - flat.min));
+  assert.ok(flat.series[0].line.startsWith("M"));
+  assert.equal(flat.series[0].low, 21);
+  assert.equal(flat.series[0].high, 21);
+
+  // Nothing to draw with a single sample, and nothing to crash on either.
+  assert.equal(trendGeometry(series([21], window), window, view), null);
+  assert.equal(trendGeometry([], window, view), null);
+});
+
+test("the panel is one owner that reads the selection instead of copying it", async () => {
+  const source = await readFile(
+    new URL("../src/sections/temperature-trend-section.js", import.meta.url),
+    "utf8",
+  );
+  // The tab strip owns the room selection; a second copy of that state is how
+  // the filter broke in the first place.
+  assert.match(source, /dm-beta16-temperature-tabs .dm-beta27-temperature-tab.active/);
+  assert.doesNotMatch(source, /setInterval|MutationObserver/);
+  // The history transport is the one the card popup already uses.
+  assert.match(source, /history\/history_during_period/);
+  assert.match(source, /normalizeHistoryRows/);
+});

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.30.7"
+  "version": "1.0.0-beta.30.8"
 }


### PR DESCRIPTION
Segnalazioni dal dispositivo reale arrivate dopo il merge della #152, tutte visibili nelle schermate dell'utente.

## La lente sui campi sbagliati

Nella configurazione delle telecamere comparivano **tre** lenti di ricerca: una accanto al nome della telecamera, una accanto all'entità e una accanto al nome dello stream go2rtc. Solo quella centrale ha senso — le altre due aprono un selettore di entità per campi che entità non sono.

Il markup dell'editor ne dichiara una sola, correttamente legata a `#ed-cam-ent`. Le altre le aggiungeva `entity-picker-guard-section.js`, che considera "campo entità" qualunque input il cui id inizi per `ed-cam-`, `ed-irr-`, `ed-pl-`, `ed-tp-` o `ed-luce-`:

```js
if (/^(?:luce|light)-add-ent$|^appl-ent-new$|^ed-(?:pl-|irr-|tp-|luce-|cam-)/.test(id)) return true;
```

Il prefisso però copre l'intero form, non il solo campo entità. Oltre ai due campi della telecamera, la stessa regola metteva la lente su durate, soglie, orari e caselle di spunta di Piscina e Irrigazione — campi dove un `entity_id` non si può nemmeno scrivere, perché sono `type="number"`, `type="time"` e `type="checkbox"`.

### Correzione

Due regole, entrambe sul singolo proprietario già esistente:

- **si decorano solo input di testo** (`text`, `search`, `url`). Numeri, orari e caselle restano esclusi per costruzione, senza doverli elencare;
- **l'elenco dei campi esclusi per nome** — che già copriva `ed-avv-name`, `ed-avv-val` e `ed-avv-icon` degli Avvisi — comprende ora anche `ed-cam-name`, `ed-cam-stream`, `ed-irr-name` e `ed-tp-name`, cioè i nomi che l'utente dà al dispositivo e il nome dello stream go2rtc.

La pulizia delle lenti già generate segue le stesse due regole, così un editor ridisegnato non si porta dietro quelle vecchie.

Il risultato, misurato in Chromium sui cinque form che il prefisso toccava:

| Form | Lente su |
|---|---|
| Telecamere | `ed-cam-ent` |
| Irrigazione | `ed-irr-ent`, `ed-irr-rain` |
| Piscina | `ed-pl-pump` |
| Tapparelle | `ed-tp-ent` |
| Avvisi | `ed-avv-ent` |

Prima erano rispettivamente 3, 6, 3, 2 e 1.

## La trama sopra il video

La scheda telecamera portava un velo di righe orizzontali bianche al 16% sopra il fotogramma, aggiunto nella #152 per richiamare un monitor. Su un'immagine di sintesi non si notava; su un fotogramma vero schiarisce la scena e si legge come una filigrana sporca sopra il video.

L'overlay è rimosso. Sul fotogramma restano il badge LIVE, il numero di canale e i mirini agli angoli.

Il timestamp e la scritta del produttore che si vedono nelle schermate non sono nostri: li stampa la telecamera dentro il flusso.

---

## La foto dell'auto non compariva

Secondo commit, aggiunto qui su richiesta: tre correzioni sulla pagina EV e sul suo editor, sempre da schermate dell'utente.

### 1. La cornice restava vuota

Il percorso salvato in configurazione era `/ev/idle.png`. Home Assistant serve `/config/www` come `/local`, quindi il file va cercato in `/local/ev/idle.png`: il risolutore lasciava passare il percorso assoluto così com'era, la richiesta tornava 404 e `onerror` nascondeva l'immagine, lasciando la cornice vuota.

Ora un percorso assoluto che **non** punta a una radice già servita da Home Assistant — `/local/`, `/api/`, `/media/`, `/hacsfiles/`, `/static/`, `/frontend_latest/`, `/auth/` — viene ricondotto sotto `/local`. La foto già configurata torna visibile senza toccare la configurazione.

In più la cornice non resta una lastra vuota quando la foto manca o non carica: il segnaposto ora segue **l'immagine che si vede davvero** (`naturalWidth`, più i marcatori di errore che `ev-section` già scrive) invece del solo valore configurato, che diceva soltanto se un URL era impostato.

### 2. Marchio e modello stanno con il veicolo

Il pannello galleggiava in cima alla scheda EV dell'editor, staccato dalle entità della stessa auto. Ora apre la sezione "Auto elettrica", sopra le sue entità.

La sezione viene riconosciuta dai propri slot `dm.ev_*` e non dal testo, così una sezione rinominata continua a ospitarlo. Se l'editor sta ancora ridisegnando e gli accordion non ci sono, il pannello viene riportato a casa nei passaggi successivi, con un numero limitato di tentativi invece che con un'attesa attiva.

### 3. La configurazione non è più un modulo da compilare

Sedici caselle di testo in fila chiedevano di scrivere a mano un `entity_id`, quando l'entità si sceglie da un elenco. Nuovo owner `editor-slots-section`: ogni slot diventa **una riga sola** con il pallino di stato, il nome dell'entità come lo conosce Home Assistant e il suo id sotto. Si tocca la riga e si apre il selettore che la dashboard ha già.

Il campo di testo con l'id resta nel DOM, nascosto, e torna con **"Modifica manuale"** per chi preferisce scrivere. L'intestazione della sezione dice quante entità sono mappate sul totale — `3 su 16 mappate` — invece del solo totale.

### Contratti tenuti fermi

- l'input conserva `.ed-slot-in[data-ref]` e il suo `edSetSlot`, quindi un valore scelto si salva come uno digitato;
- il selettore è il `wzPickEntity()` legacy chiamato con l'elemento input, così `cdEpChoose()` scrive il valore e lancia `change`;
- la lente legacy viene solo nascosta, mai rimossa, e resta il fratello successivo dell'input come si aspetta `entity-picker-guard-section` — cioè la stessa guardia corretta nella prima parte di questa PR;
- `edSaveSezione()` continua a leggere gli stessi input dal proprio `.ed-acc-body`;
- il form dei carichi, che riusa `.ed-slot` per conto suo, non viene decorato.

Nessun polling, nessun observer, nessuna modifica ai file legacy vendorizzati.

## Verifiche

| Verifica | Esito |
|---|---|
| Suite frontend (inclusi 11 nuovi test) | 680 passati |
| E2E `editor-slots` + `ev-showcase`, desktop | 7 passati |
| E2E `editor-slots` + `ev-showcase`, mobile | 7 passati |
| `format:check` | pulito |
| `check:inline-syntax` | pulito |
| Lenti nei cinque form, in Chromium | come da tabella sopra, nessun errore in console |
| Pagina Sicurezza, in Chromium | nessun overlay a righe sul fotogramma, `dm-cam-scan` assente dal foglio di stile |
| Editor EV, in Chromium | 16 righe compatte, campo grezzo nascosto e ripristinato dall'interruttore, pannello marchio/modello dentro la sezione |

Il gate che pinnava l'elenco dei campi esclusi degli Avvisi diventa un test sui sette id esclusi più una guardia sulla regola dei tipi. Il gate sul grafo di produzione sale di un modulo, con la nota che spiega perché.

Una nota onesta: eseguendo `entity-search-picker.spec.js` insieme ad altre spec fallisce a intermittenza sull'attesa delle righe del selettore. Non dipende da queste modifiche — riprodotto anche sul commit precedente, tre volte su tre in combinata e mai su quattro esecuzioni singole.