### PR TITLE
Beta 31: Configurazione uniforme, telecamere vive, plancia veloce e MiniPC in scena 3D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## Non rilasciato
+
+### Modificato
+
+- **La pagina MiniPC è stata ridisegnata.** Prima erano tre barrette piatte,
+  quattro riquadri con un'emoji e molto bianco in mezzo. Ora la testata è il
+  pannello della macchina — il mini PC disegnato in assonometria, con i LED e la
+  ventola che girano finché la macchina risponde in rete — e CPU, RAM e Disco
+  sono tre anelli che si riempiono con il carico e passano all'ambra e al rosso
+  alle stesse soglie di prima. Sotto la testata c'è la traccia dal vivo del
+  carico CPU: le letture che la pagina ha già mostrato nella sessione, con il
+  picco a destra. La temperatura della CPU ha la sua scala da 20° a 100° con la
+  tacca del limite a 75°, e lo stato ("Ottimale", "Nella norma", "Alta") diventa
+  una pastiglia con il pallino colorato. Telemetria e stato rete hanno icone
+  disegnate al posto delle emoji e tre titoletti dividono la pagina in Termica,
+  Telemetria e Rete e impianto. Quando la connettività cade, la testata, i LED e
+  la traccia diventano rossi.
+- La pagina segue il tema: chiara su tema chiaro, scura su tema scuro. Nessun
+  valore è ricalcolato — le barre, l'arco della temperatura, il testo di stato e
+  le pastiglie restano scritti dal runtime della dashboard — e le card che
+  l'auto-nascondi toglie dalla pagina si portano dietro il loro titoletto.
+
 ## 1.0.0-beta.30.8 — 2026-08-18
 
 ### Aggiunto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,17 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   passa una volta sola: una riga ridisegnata dopo quella passata restava senza
   matita finché qualcosa non ne programmava un'altra. Ora la matita della cella
   principale si vede subito, e la passata continua a togliere i doppioni.
+- **Su iPad la Configurazione restava com'era.** Il runtime sceglie la sezione
+  della scheda nascondendo le altre dodici con uno `style` inline, senza
+  toccare nessun blocco: su una macchina lenta questo arriva dopo, e la passata
+  che ascoltava solo i blocchi non ne sapeva niente — la scheda restava con
+  tredici sezioni, senza interruttore e senza il salvataggio in fondo. Ora la
+  passata sente anche quel `display`.
+- **Il percorso della prima foto dell'auto si cancellava.** Scrivere il
+  percorso in «Cavo staccato» e passare a «Cavo attaccato» svuotava il primo
+  campo: il pannello si riallinea a quello che è salvato mentre la scheda si
+  assesta. Un campo scritto a mano e non ancora salvato ora non viene più
+  toccato.
 - **La Configurazione ora si riallinea quando la scheda cambia, non dopo un
   tempo fisso.** I pannelli che una scheda disegna per conto suo arrivano dopo
   lo scambio di scheda: se arrivavano tardi, l'interruttore della sezione

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,27 +8,29 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
 ### Modificato
 
-- **La pagina MiniPC è stata ridisegnata.** Prima erano tre barrette piatte,
-  quattro riquadri con un'emoji e molto bianco in mezzo. Ora la macchina è al
-  centro: il mini PC disegnato in assonometria, con i LED e la ventola che gira
-  finché risponde in rete, e attorno tre anelli concentrici — CPU, RAM e Disco —
-  con la loro lettura in fila accanto. Gli anelli si riempiono con il carico e
-  passano all'ambra e al rosso alle stesse soglie di prima, e il pallino accanto
-  all'etichetta prende il colore dell'anello. Sotto scorre la curva dal vivo del
-  carico CPU: le letture che la pagina ha già mostrato nella sessione, con il
-  picco a destra e il punto sull'ultimo valore.
+- **La pagina MiniPC è stata ridisegnata come una scena 3D.** Prima erano tre
+  barrette piatte, quattro riquadri con un'emoji e molto bianco in mezzo. Ora la
+  testata è una scena in prospettiva: il mini PC è un volume vero — sei facce,
+  con la griglia di ventilazione e la ventola disegnate sul coperchio e i LED sul
+  frontale — e accanto stanno CPU, RAM e Disco come tre prismi che crescono con
+  il carico, ciascuno con la sua ombra sul pavimento. I prismi passano all'ambra
+  e al rosso alle stesse soglie di prima, con il valore sopra e l'etichetta sotto.
+  Sotto la scena scorre la curva dal vivo del carico CPU: le letture che la
+  pagina ha già mostrato nella sessione, con il picco a destra.
+- **La pagina non è più una pila di blocchi ma una board a due colonne**: la
+  scena in alto, Termica a sinistra, Telemetria a destra, Rete e impianto in
+  fondo. Se l'auto-nascondi toglie la card della temperatura, la telemetria si
+  allarga su tutta la riga invece di lasciare un buco.
 - La temperatura della CPU ha la sua scala da 20° a 100° con la tacca del limite
   a 75°, e lo stato ("Ottimale", "Nella norma", "Alta") diventa una pastiglia con
   il pallino colorato. Telemetria e stato rete hanno icone disegnate al posto
   delle emoji, Download e Upload mostrano un flusso che scorre nel verso del
-  traffico, e tre titoletti dividono la pagina in Termica, Telemetria e Rete e
-  impianto. Quando la connettività cade, il pannello, i LED e la curva diventano
+  traffico. Quando la connettività cade, la scena, i LED e la curva diventano
   rossi.
 - La pagina segue il tema: chiara su tema chiaro, scura su tema scuro. Nessun
   valore è ricalcolato — le barre, l'arco della temperatura, il testo di stato e
-  le pastiglie restano scritti dal runtime della dashboard — e le card che
-  l'auto-nascondi toglie dalla pagina si portano dietro sia il loro anello sia il
-  loro titoletto.
+  le pastiglie restano scritti dal runtime della dashboard — e una card che
+  l'auto-nascondi toglie si porta via anche il suo prisma e il suo titoletto.
 
 ## 1.0.0-beta.30.8 — 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,13 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   da un solo punto, che rispetta l'ordine di costruzione e non accetta doppioni;
   vale anche per Aperture, Batterie, Clima e Riscaldamento quando le stesse
   entità arrivano sia dalla configurazione sia dal `config.js`.
+- **Nella pagina MiniPC restava il titolo di una colonna vuota.** Quando
+  l'auto-nascondi toglie la card della temperatura, il titoletto «Termica» deve
+  andarsene con lei. L'auto-nascondi però scrive solo uno `style` inline sulle
+  card e viene chiamato da dentro il runtime, quindi non c'è nessun nome da
+  intercettare e nessun evento da ascoltare: se arrivava dopo l'ultima passata,
+  il titolo restava da solo sulla plancia. Ora la pagina osserva quello `style`
+  — solo quello, e solo sotto `#page-server`.
 - **La Configurazione ora si riallinea quando la scheda cambia, non dopo un
   tempo fisso.** I pannelli che una scheda disegna per conto suo arrivano dopo
   lo scambio di scheda: se arrivavano tardi, l'interruttore della sezione

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,26 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 ### Modificato
 
 - **La pagina MiniPC è stata ridisegnata.** Prima erano tre barrette piatte,
-  quattro riquadri con un'emoji e molto bianco in mezzo. Ora la testata è il
-  pannello della macchina — il mini PC disegnato in assonometria, con i LED e la
-  ventola che girano finché la macchina risponde in rete — e CPU, RAM e Disco
-  sono tre anelli che si riempiono con il carico e passano all'ambra e al rosso
-  alle stesse soglie di prima. Sotto la testata c'è la traccia dal vivo del
+  quattro riquadri con un'emoji e molto bianco in mezzo. Ora la macchina è al
+  centro: il mini PC disegnato in assonometria, con i LED e la ventola che gira
+  finché risponde in rete, e attorno tre anelli concentrici — CPU, RAM e Disco —
+  con la loro lettura in fila accanto. Gli anelli si riempiono con il carico e
+  passano all'ambra e al rosso alle stesse soglie di prima, e il pallino accanto
+  all'etichetta prende il colore dell'anello. Sotto scorre la curva dal vivo del
   carico CPU: le letture che la pagina ha già mostrato nella sessione, con il
-  picco a destra. La temperatura della CPU ha la sua scala da 20° a 100° con la
-  tacca del limite a 75°, e lo stato ("Ottimale", "Nella norma", "Alta") diventa
-  una pastiglia con il pallino colorato. Telemetria e stato rete hanno icone
-  disegnate al posto delle emoji e tre titoletti dividono la pagina in Termica,
-  Telemetria e Rete e impianto. Quando la connettività cade, la testata, i LED e
-  la traccia diventano rossi.
+  picco a destra e il punto sull'ultimo valore.
+- La temperatura della CPU ha la sua scala da 20° a 100° con la tacca del limite
+  a 75°, e lo stato ("Ottimale", "Nella norma", "Alta") diventa una pastiglia con
+  il pallino colorato. Telemetria e stato rete hanno icone disegnate al posto
+  delle emoji, Download e Upload mostrano un flusso che scorre nel verso del
+  traffico, e tre titoletti dividono la pagina in Termica, Telemetria e Rete e
+  impianto. Quando la connettività cade, il pannello, i LED e la curva diventano
+  rossi.
 - La pagina segue il tema: chiara su tema chiaro, scura su tema scuro. Nessun
   valore è ricalcolato — le barre, l'arco della temperatura, il testo di stato e
   le pastiglie restano scritti dal runtime della dashboard — e le card che
-  l'auto-nascondi toglie dalla pagina si portano dietro il loro titoletto.
+  l'auto-nascondi toglie dalla pagina si portano dietro sia il loro anello sia il
+  loro titoletto.
 
 ## 1.0.0-beta.30.8 — 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,17 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   campo: il pannello si riallinea a quello che è salvato mentre la scheda si
   assesta. Un campo scritto a mano e non ancora salvato ora non viene più
   toccato.
+- **Le stesse luci comparivano due volte nel popup "Luci attive".** La lista
+  che alimenta quel popup e il contatore del Quadro Avvisi nasce da due sorgenti:
+  le luci della scheda Luci e il gruppo `cd_gruppi_extra`, dove finiscono anche
+  quelle rilevate da sole. Da quando la scheda Luci tiene allineato il secondo
+  gruppo, le due sorgenti nominano le stesse entità, e venivano concatenate senza
+  filtro: ogni luce compariva due volte nel popup e veniva contata due volte nel
+  riquadro "Luci accese", mentre in Configurazione restava una sola — perché lì
+  si legge una sorgente sola. Ora ogni aggiunta a un gruppo di monitoraggio passa
+  da un solo punto, che rispetta l'ordine di costruzione e non accetta doppioni;
+  vale anche per Aperture, Batterie, Clima e Riscaldamento quando le stesse
+  entità arrivano sia dalla configurazione sia dal `config.js`.
 - **La Configurazione ora si riallinea quando la scheda cambia, non dopo un
   tempo fisso.** I pannelli che una scheda disegna per conto suo arrivano dopo
   lo scambio di scheda: se arrivavano tardi, l'interruttore della sezione

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,95 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.0.0-beta.31 — 2026-08-18
+
+### Corretto
+
+- **La plancia era diventata lentissima.** Ogni renderer chiede alla dashboard
+  l'elenco delle entità, alcuni una volta per scheda e qualcuno una volta per
+  riga, due volte al secondo. Quella chiamata costruiva ogni volta una copia
+  nuova di tutto: prima le due mappe di Home Assistant, poi `_RAW_STATES` e poi
+  `STATES` — che è un Proxy del primo, quindi le stesse entità venivano copiate
+  una seconda volta passando per un intercettore che consulta la tabella degli
+  override chiave per chiave. Su una casa con qualche migliaio di entità una
+  sola chiamata costava più di un millisecondo. Ora, quando il runtime è l'unica
+  sorgente — cioè su ogni plancia ospitata — l'elenco viene restituito com'è:
+  nessuna copia, nessun intercettore e nessun dato vecchio di un ridisegno. Con
+  duemila entità la stessa sequenza è passata da 307 ms a 1 ms.
+- **Le telecamere erano tutte nere.** La parete delle telecamere viene
+  ricostruita quando si apre Sicurezza, e ricostruirla butta via ogni `<img>`
+  con dentro il fotogramma appena scaricato; nessun cambio di stato di una
+  telecamera segue per chiederne un altro, perché lo stato resta "idle" mentre
+  l'immagine cambia. Inoltre il timer che ricaricava i fotogrammi era stato
+  rimosso senza sostituirlo, quindi anche il primo fotogramma sopravvissuto
+  restava lì per sempre. Ora la parete chiede i fotogrammi appena si ricostruisce
+  e un timer li aggiorna ogni quattro secondi — solo mentre la pagina Sicurezza
+  è davvero sullo schermo e la scheda del browser non è nascosta.
+- **Il reset lasciava lo schermo bianco e mezza configurazione.** La plancia
+  ospitata vive dentro un documento `srcdoc`: il suo indirizzo è `about:srcdoc` e
+  ricaricarlo dall'interno, che è come finivano sia il reset sia
+  l'autorilevamento, nell'app di Home Assistant porta a una pagina vuota da cui
+  non si torna indietro. Ora la ricarica viene chiesta all'ospite, che ricostruisce
+  il documento esattamente come la prima volta; e se una ricarica sfugge lo stesso,
+  l'ospite se ne accorge e lo ricostruisce comunque. Il reset inoltre svuota anche
+  la configurazione tenuta in memoria: restava lì e veniva riscritta su disco al
+  primo salvataggio successivo, ed è così che tornava indietro un'azione rapida
+  "Luci" senza niente dentro. Quella voce vuota nasceva da una luce senza entità,
+  che veniva scritta come chiave `undefined`; una luce senza entità ora non viene
+  più scritta, e una sezione di forma inattesa non fa più fallire l'avvio con lo
+  schermo bianco.
+- **La tapparella non era allineata alla finestra.** Con la tapparella chiusa
+  restavano scoperti il cielo in alto e le colline negli angoli in basso: il
+  pannello era staccato di 9 px dai bordi. Quei 9 px venivano da una pelle della
+  Beta 7 che disegnava una finestra completamente diversa, alta 180 px, ed era
+  rimasta l'unico foglio a dichiarare `left`, `right` e `top` sul pannello —
+  quindi sopravviveva a ogni ridisegno successivo. La pagina Tapparelle ha ora un
+  solo proprietario e il pannello chiude esattamente sull'apertura.
+- **Nel Report Energia le icone non erano quelle degli elettrodomestici.** La
+  voce del Report partiva da un campo emoji che la scheda dell'elettrodomestico
+  non disegna mai: la scheda mostra il disegno scelto in Elettrodomestici, il
+  Report mostrava altro, e le due liste dicevano cose diverse dello stesso
+  apparecchio. Ora la voce segue lo stesso ordine della scheda, con davanti
+  l'icona eventualmente assegnata apposta al Report.
+- **Il menu in basso si comportava in modo diverso a seconda della sezione.** Le
+  pagine ridisegnate fermano la propagazione del tocco sulle proprie schede, e
+  il gestore che chiude la barra ascoltava in risalita: su Elettrodomestici o
+  Temperature il tocco fuori dalla barra non la chiudeva, su Home sì. Ora la
+  barra ha un solo comportamento, in fase di cattura e delegato — quindi vale
+  anche per una scheda riordinata dopo l'avvio — e ogni pagina lascia lo stesso
+  spazio sotto perché la barra non copra l'ultima riga. La modalità "barra
+  fissa" continua a vincere su tutto.
+- **La configurazione EV si apriva in due modi diversi.** Il pannello di marchio
+  e modello finiva in cima alla scheda o dentro la sezione dell'auto a seconda di
+  quanto velocemente l'editor disegnava. Ora viene costruito solo quando la sua
+  sezione esiste, e va lì.
+
+### Aggiunto
+
+- **Due foto dell'auto: cavo staccato e cavo attaccato.** Si caricano dalla
+  scheda EV della configurazione, una accanto all'altra e ciascuna con
+  l'anteprima di quello che punta. La plancia mostra quella con il cavo attaccato
+  mentre l'auto è in ricarica e l'altra nel resto del tempo, leggendo lo stato
+  dalla wallbox già mappata. La seconda è facoltativa: senza, resta la prima
+  come è sempre stato.
+
+### Modificato
+
+- **Il campo entità è la stessa riga leggibile in tutta la configurazione.** La
+  lente non è più un quadratino con dentro una lente di ingrandimento: è la riga,
+  e la riga dice quale entità è scelta, con il nome che le dà Home Assistant e
+  l'id sotto. Toccarla apre la ricerca entità, quella veloce con i suggerimenti
+  per il campo. L'id da scrivere a mano resta dietro la matita accanto. Prima
+  questo valeva solo per le sezioni della scheda Sezioni; ora vale per Luci,
+  Telecamere, Report, Temperature, Irrigazione e per ogni altro campo che accetta
+  un'entità.
+- **Nella configurazione Home spariscono due voci**: "Interruttore antifurto" e
+  "Script apertura cancello". Chiedevano una seconda volta cose che la plancia sa
+  già — la centrale allarme è la riga sopra, il cancello è un'azione rapida come
+  le altre — e due posti per la stessa mappatura vogliono dire due risposte
+  quando non vanno d'accordo. Quello che è già mappato continua a funzionare: le
+  voci escono dall'editor, non dalla configurazione.
+
 ## 1.0.0-beta.30.8 — 2026-08-18
 
 ### Aggiunto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,27 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 - **La configurazione EV si apriva in due modi diversi.** Il pannello di marchio
   e modello finiva in cima alla scheda o dentro la sezione dell'auto a seconda di
   quanto velocemente l'editor disegnava. Ora viene costruito solo quando la sua
-  sezione esiste, e va lì.
+  sezione esiste, e va lì. Per lo stesso motivo di tempo il pannello delle due
+  foto poteva non comparire affatto e il vecchio campo "URL immagine auto"
+  restare al suo posto: la scheda EV ora viene ripassata mentre finisce di
+  disegnarsi, e il campo singolo che le due foto sostituiscono sparisce davvero
+  invece di essere solo marcato come nascosto.
+- **La riga entità si rompeva nei moduli che si dispongono da soli.** Il modulo
+  "Aggiungi luce" fissa la propria griglia e il proprio campo, e vinceva sulle
+  regole della riga: lì restavano l'id grezzo in chiaro e il pulsante schiacciato
+  in una colonna da 58 px, mentre la matita andava a capo. Ora la riga vale in
+  ogni modulo della configurazione — l'id resta dietro la matita ovunque.
+- **Il pulsante "rinomina" spariva dalle righe di Visibilità.** Ogni riga della
+  scheda Visibilità ha una matita per rinominare la sezione. Il foglio che le dà
+  forma nascondeva ogni matita non ancora normalizzata, e la normalizzazione
+  passa una volta sola: una riga ridisegnata dopo quella passata restava senza
+  matita finché qualcosa non ne programmava un'altra. Ora la matita della cella
+  principale si vede subito, e la passata continua a togliere i doppioni.
+- **La Configurazione ora si riallinea quando la scheda cambia, non dopo un
+  tempo fisso.** I pannelli che una scheda disegna per conto suo arrivano dopo
+  lo scambio di scheda: se arrivavano tardi, l'interruttore della sezione
+  finiva sotto di loro. La passata segue le modifiche della scheda, quindi
+  l'interruttore resta in apertura e il salvataggio in fondo comunque.
 
 ### Modificato
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,23 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   quanto velocemente l'editor disegnava. Ora viene costruito solo quando la sua
   sezione esiste, e va lì.
 
+### Modificato
+
+- **La Configurazione si comporta allo stesso modo in ogni scheda.** Un audit
+  scheda per scheda contava le differenze: cinque schede non avevano nessun
+  pulsante di salvataggio (Temperatura, Tapparelle, Stanze, Luci, Avvisi),
+  Sicurezza ed EV ne avevano due in posti diversi, e in totale c'erano otto
+  diciture diverse per lo stesso gesto ("Salva sezione", "Salva Energia",
+  "Salva server", "Salva piscina", "Salva impostazioni", "Salva costi"…). Ora
+  ogni scheda ha **un solo 💾 Salva sezione, sempre in fondo**: preme lui i
+  salvataggi dei pannelli aperti, che restano i veri esecutori, e risponde con
+  lo stesso avviso di sempre. Il banner verde **"sezione visibile in dashboard"
+  è su ogni sezione** — c'era su nove schede e mancava da Temperatura — sempre
+  in cima e sempre con lo stesso interruttore del runtime. E ogni scheda
+  `Sezioni` portava con sé l'intero modulo: tredici fisarmoniche e 104 campi
+  entità, dodici sezioni nascoste ma ancora nel documento, che ogni decoratore
+  ripercorreva a ogni passata — ora una scheda contiene solo la propria sezione.
+
 ### Aggiunto
 
 - **Due foto dell'auto: cavo staccato e cavo attaccato.** Si caricano dalla

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Un ordine pratico di configurazione è:
 
 Quando modifichi una configurazione usa il pulsante **SALVA MODIFICHE** dell'editor prima di chiudere la finestra. DashboardModern salva la configurazione della plancia e mantiene le entità Home Assistant come sorgente dello stato reale.
 
+Ogni campo che accetta un'entità è una riga: dice quale entità è collegata, con il nome che le dà Home Assistant e l'id sotto. Toccala per aprire la ricerca entità, che propone per prime quelle adatte a quel campo. L'id da scrivere a mano resta dietro la matita accanto alla riga.
+
 ### Dove viene salvata la configurazione
 
 La configurazione della plancia è salvata dentro Home Assistant, in un archivio dell'integrazione (`.storage/dashboardmodern.config`), non nel browser. Non c'è niente da esportare o importare: il salvataggio e il ripristino sono automatici.
@@ -340,6 +342,8 @@ A seconda delle entità disponibili puoi collegare dati come:
 
 DashboardModern non sostituisce l'integrazione del veicolo o della wallbox: ne utilizza le entità presenti in Home Assistant.
 
+Nella scheda **EV** della configurazione puoi caricare due foto della stessa auto — una con il cavo staccato e una con il cavo attaccato — indicando il percorso sotto `/local`. La plancia mostra quella con il cavo attaccato mentre l'auto è in ricarica e l'altra nel resto del tempo. La seconda è facoltativa: senza, resta sempre la prima.
+
 ---
 
 ## 🛡️ Sicurezza e telecamere
@@ -347,6 +351,8 @@ DashboardModern non sostituisce l'integrazione del veicolo o della wallbox: ne u
 La sezione Sicurezza può raccogliere allarme, sensori e telecamere configurati. Le sorgenti restano le entità e i flussi già disponibili in Home Assistant.
 
 Per le telecamere verifica sempre che lo stream funzioni correttamente in Home Assistant prima di collegarlo alla plancia.
+
+Le anteprime si aggiornano ogni quattro secondi mentre la pagina Sicurezza è aperta; fuori da quella pagina, e con la scheda del browser in secondo piano, non viene scaricato nulla.
 
 ---
 

--- a/custom_components/dashboardmodern/frontend/e2e/beta13-real-device-regressions.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta13-real-device-regressions.spec.js
@@ -212,12 +212,16 @@ test("beta13: Temperature has no orphan icon row and Irrigation keeps a usable m
   ).toEqual({ type: "hidden", hidden: true, label: false });
 
   await openEditor(page, "irr");
+  // The entity field is a readable row now, with the raw id behind its pencil.
+  // What has to be comfortably wide on a phone is therefore the row.
   const irrigation = await page.evaluate(() => {
     const body = document.getElementById("ed-body");
     const input = document.getElementById("ed-irr-ent");
     if (!body || !input) return null;
+    const row =
+      input.closest('[data-dm-entity-chip="true"]')?.querySelector(".dm-slot-chip") || input;
     const bodyBox = body.getBoundingClientRect();
-    const inputBox = input.getBoundingClientRect();
+    const inputBox = row.getBoundingClientRect();
     return {
       bodyWidth: bodyBox.width,
       inputWidth: inputBox.width,

--- a/custom_components/dashboardmodern/frontend/e2e/beta2-persistence-ev-flow.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta2-persistence-ev-flow.spec.js
@@ -1,6 +1,7 @@
 // DM-FIX-20260812B
 import { expect, test } from "@playwright/test";
 import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { saveSection } from "./helpers/entity-field.js";
 
 const seed = {
   schema_version: 4,
@@ -173,7 +174,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await expect(modelSelect).toContainText("B10");
     await modelSelect.selectOption("B10");
     await expect(modelSelect).toHaveValue("B10");
-    await appearance.locator("button[data-save]").click();
+    await saveSection(page);
 
     await expect
       .poll(() => page.evaluate(() => DashboardModernModules.store.getSection("ev")[0]))

--- a/custom_components/dashboardmodern/frontend/e2e/beta2-persistence-ev-flow.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta2-persistence-ev-flow.spec.js
@@ -209,7 +209,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
           };
         }),
       )
-      .toEqual({ profile: "primary", keysRevision: 2, model: "B10" });
+      .toEqual({ profile: "primary", keysRevision: 3, model: "B10" });
 
     const persisted = await page.evaluate(() => {
       const remote = JSON.parse(localStorage.getItem("__beta2_remote_config__"));

--- a/custom_components/dashboardmodern/frontend/e2e/beta25-real-device-regressions.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta25-real-device-regressions.spec.js
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { fillEntityFieldByHand } from "./helpers/entity-field.js";
 
 const seed = {
   schema_version: 4,
@@ -116,8 +117,8 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await expect(room.locator('option[value="room-cameretta"]')).toBeEnabled();
     await room.selectOption("room-cameretta");
     await page.locator("#dm-temperature-name").fill("Comodino");
-    await page.locator("#ed-pl-temp").fill("sensor.cameretta_temperature_2");
-    await page.locator("#dm-humidity-new").fill("sensor.cameretta_humidity_2");
+    await fillEntityFieldByHand(page, "#ed-pl-temp", "sensor.cameretta_temperature_2");
+    await fillEntityFieldByHand(page, "#dm-humidity-new", "sensor.cameretta_humidity_2");
     await page.locator("[data-beta25-temperature-submit]").click();
 
     await expect

--- a/custom_components/dashboardmodern/frontend/e2e/beta31-real-device-fixes.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta31-real-device-fixes.spec.js
@@ -127,6 +127,9 @@ test.describe("beta31", () => {
   });
 
   test("the bottom bar closes on a page that swallows the tap", async ({ page }, testInfo) => {
+    // The dock is the touch navigation: on a pointer viewport there is no bar
+    // to close, and the sidebar takes its place.
+    test.skip(!testInfo.project.use.hasTouch, "touch navigation only");
     await boot(page, testInfo);
     await openPage(page, "security");
     // The section modules install after the legacy runtime announces itself.
@@ -149,6 +152,7 @@ test.describe("beta31", () => {
   });
 
   test("the handle still opens the dock, and opens it once", async ({ page }, testInfo) => {
+    test.skip(!testInfo.project.use.hasTouch, "touch navigation only");
     await boot(page, testInfo);
     await page.waitForFunction(() => Boolean(window.__DASHBOARDMODERN_NAVIGATION_SECTION__));
     const handle = page.locator("#bottomNavHandle");
@@ -205,6 +209,47 @@ test.describe("beta31", () => {
     }
   });
 
+  /* Some forms pin their own layout for the very field the row replaces: the
+   * "Aggiungi luce" form fixes its entity input to display:block and gives the
+   * lens a 58px column, which used to leave that one row showing the raw id
+   * beside a chip squeezed into the column. */
+  test("the readable row survives the forms that lay themselves out", async ({
+    page,
+  }, testInfo) => {
+    await boot(page, testInfo);
+    for (const tab of ["luci", "irr"]) {
+      const rows = await page.evaluate(async (name) => {
+        if (!document.getElementById("editor-modal")?.classList.contains("show")) {
+          window.apriConfigEntita();
+        }
+        window.editorSwitch(name);
+        await new Promise((resolve) => setTimeout(resolve, 600));
+        const body = document.getElementById("ed-body");
+        return [...body.querySelectorAll('[data-dm-entity-chip="true"]')]
+          .filter((host) => host.getClientRects().length > 0)
+          .map((host) => {
+            const raw = host.querySelector(".dm-chip-raw");
+            const chip = host.querySelector(".dm-entity-picker.dm-slot-chip");
+            const manual = host.querySelector(".dm-chip-manual");
+            return {
+              id: raw?.id || raw?.dataset.ref || "",
+              rawHidden: raw ? getComputedStyle(raw).display === "none" : null,
+              chipWidth: Math.round(chip?.getBoundingClientRect().width || 0),
+              manualWidth: Math.round(manual?.getBoundingClientRect().width || 0),
+            };
+          });
+      }, tab);
+      expect(rows.length, `${tab}: has rows to check`).toBeGreaterThan(0);
+      for (const row of rows) {
+        expect(row.rawHidden, `${tab}/${row.id}: the id stays behind the pencil`).toBe(true);
+        expect(row.chipWidth, `${tab}/${row.id}: the chip is the row`).toBeGreaterThan(140);
+        expect(row.manualWidth, `${tab}/${row.id}: the pencil is a square`).toBeGreaterThanOrEqual(
+          36,
+        );
+      }
+    }
+  });
+
   test("the EV configuration takes two photos of the car", async ({ page }, testInfo) => {
     await boot(page, testInfo);
     await page.evaluate(() => {
@@ -219,6 +264,21 @@ test.describe("beta31", () => {
     await expect(photos).toHaveCount(1);
     await expect(photos.locator('[data-ev-photo="idle"] input')).toHaveCount(1);
     await expect(photos.locator('[data-ev-photo="plugged"] input')).toHaveCount(1);
+    // And the single field these two replace is gone from the tab, not merely
+    // marked hidden under an editor rule that keeps drawing it.
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            [...document.querySelectorAll("#ed-body .ed-slot")].filter(
+              (slot) =>
+                /immagine auto|car image/i.test(
+                  slot.querySelector(".ed-slot-lbl")?.textContent || "",
+                ) && slot.getClientRects().length > 0,
+            ).length,
+        ),
+      )
+      .toBe(0);
 
     await photos.locator('[data-ev-photo="idle"] input').fill("/local/auto.png");
     await photos.locator('[data-ev-photo="plugged"] input').fill("/local/auto-cavo.png");

--- a/custom_components/dashboardmodern/frontend/e2e/beta31-real-device-fixes.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta31-real-device-fixes.spec.js
@@ -222,7 +222,8 @@ test.describe("beta31", () => {
 
     await photos.locator('[data-ev-photo="idle"] input').fill("/local/auto.png");
     await photos.locator('[data-ev-photo="plugged"] input').fill("/local/auto-cavo.png");
-    await photos.locator("[data-ev-photos-save]").click();
+    // The panel save sits behind the tab's single save now.
+    await page.locator("#ed-body [data-dm-save-all]").click();
     await expect
       .poll(() =>
         page.evaluate(() => ({

--- a/custom_components/dashboardmodern/frontend/e2e/beta31-real-device-fixes.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta31-real-device-fixes.spec.js
@@ -282,6 +282,14 @@ test.describe("beta31", () => {
 
     await photos.locator('[data-ev-photo="idle"] input').fill("/local/auto.png");
     await photos.locator('[data-ev-photo="plugged"] input').fill("/local/auto-cavo.png");
+    // Both paths are still there after the tab has finished settling: the panel
+    // is refreshed while it does, and it used to blank the field the person had
+    // just left to type in the other one.
+    await page.waitForTimeout(2200);
+    await expect(photos.locator('[data-ev-photo="idle"] input')).toHaveValue("/local/auto.png");
+    await expect(photos.locator('[data-ev-photo="plugged"] input')).toHaveValue(
+      "/local/auto-cavo.png",
+    );
     // The panel save sits behind the tab's single save now.
     await page.locator("#ed-body [data-dm-save-all]").click();
     await expect

--- a/custom_components/dashboardmodern/frontend/e2e/beta31-real-device-fixes.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta31-real-device-fixes.spec.js
@@ -1,0 +1,266 @@
+// DM-FIX-20260818A
+/* The Beta 31 round, in a real browser: the parts that only exist once there is
+ * a document — the camera wall, the bottom bar, and the entity rows across the
+ * editors. */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const states = [
+  {
+    entity_id: "camera.strada",
+    state: "idle",
+    attributes: {
+      friendly_name: "Strada",
+      entity_picture: "/api/camera_proxy/camera.strada?token=a",
+    },
+  },
+  {
+    entity_id: "camera.cortile",
+    state: "idle",
+    attributes: {
+      friendly_name: "Cortile",
+      entity_picture: "/api/camera_proxy/camera.cortile?token=b",
+    },
+  },
+  {
+    entity_id: "cover.tapparella",
+    state: "closed",
+    attributes: { friendly_name: "Tapparella", current_position: 0, supported_features: 15 },
+  },
+];
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    cameras: [
+      { id: "camera-strada", name: "Strada", entity: "camera.strada" },
+      { id: "camera-cortile", name: "Cortile destro", entity: "camera.cortile" },
+    ],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [{ id: "cover-tapparella", name: "Tapparella", entity: "cover.tapparella" }],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  visibility: { home: true, security: true, tapparelle: true, ev: true },
+};
+
+async function boot(page, testInfo) {
+  await page.route("**/api/camera_proxy/**", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: "<svg xmlns='http://www.w3.org/2000/svg' width='4' height='3'><rect width='4' height='3' fill='#0f0'/></svg>",
+    }),
+  );
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+  await page.evaluate((haStates) => {
+    const registry = eval("_RAW_STATES");
+    for (const entry of haStates) registry[entry.entity_id] = entry;
+  }, states);
+}
+
+async function openPage(page, name) {
+  await page.evaluate((id) => {
+    document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
+    document.getElementById(`page-${id}`)?.classList.add("active");
+  }, name);
+}
+
+test.describe("beta31", () => {
+  test("a rebuilt camera wall gets its frames back", async ({ page }, testInfo) => {
+    await boot(page, testInfo);
+    await openPage(page, "security");
+
+    // The exact sequence that left every camera black: the frames are asked for
+    // and the wall is rebuilt on top of them in the same turn.
+    await page.evaluate(() => {
+      const grid = document.getElementById("cam-grid");
+      if (grid) {
+        grid.innerHTML = "";
+        grid._sig = "";
+      }
+      window.refreshCameras?.();
+      window.renderSecurity?.();
+    });
+
+    const images = page.locator("#cam-grid .dm-cam img");
+    await expect(images).toHaveCount(2);
+    await expect
+      .poll(() =>
+        images.evaluateAll((nodes) =>
+          nodes.every(
+            (node) => Boolean(node.getAttribute("src")) && node.dataset.dmCameraState === "ready",
+          ),
+        ),
+      )
+      .toBe(true);
+  });
+
+  test("the closed shutter covers the whole opening", async ({ page }, testInfo) => {
+    await boot(page, testInfo);
+    await openPage(page, "tapparelle");
+    await page.evaluate(() => window.renderTapparelle?.());
+    const geometry = await page.evaluate(() => {
+      const win = document.querySelector("#page-tapparelle .tapp-win");
+      const panel = document.querySelector("#page-tapparelle .tapp-shutter");
+      if (!win || !panel) return null;
+      const style = getComputedStyle(win);
+      const border = Number.parseFloat(style.borderTopWidth) || 0;
+      const winBox = win.getBoundingClientRect();
+      const panelBox = panel.getBoundingClientRect();
+      return {
+        top: Math.round(panelBox.top - (winBox.top + border)),
+        left: Math.round(panelBox.left - (winBox.left + border)),
+        right: Math.round(winBox.right - border - panelBox.right),
+        height: Math.round(panelBox.height - (winBox.height - border * 2)),
+      };
+    });
+    expect(geometry).not.toBeNull();
+    // Flush with the opening on every side: no sky above it, no hills beside it.
+    expect(geometry).toEqual({ top: 0, left: 0, right: 0, height: 0 });
+  });
+
+  test("the bottom bar closes on a page that swallows the tap", async ({ page }, testInfo) => {
+    await boot(page, testInfo);
+    await openPage(page, "security");
+    // The section modules install after the legacy runtime announces itself.
+    await page.waitForFunction(() => Boolean(window.__DASHBOARDMODERN_NAVIGATION_SECTION__));
+    const closed = await page.evaluate(() => {
+      const nav = document.querySelector("nav.bottom-nav-bar");
+      const host = document.getElementById("page-security");
+      // A redesigned page that stops propagation on its own cards, which is
+      // what used to leave the dock open here and closed on Home.
+      host.addEventListener("click", (event) => event.stopPropagation());
+      nav.classList.add("visible");
+      document.body.classList.add("nav-visible");
+      host.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      return {
+        nav: nav.classList.contains("visible"),
+        body: document.body.classList.contains("nav-visible"),
+      };
+    });
+    expect(closed).toEqual({ nav: false, body: false });
+  });
+
+  test("the handle still opens the dock, and opens it once", async ({ page }, testInfo) => {
+    await boot(page, testInfo);
+    await page.waitForFunction(() => Boolean(window.__DASHBOARDMODERN_NAVIGATION_SECTION__));
+    const handle = page.locator("#bottomNavHandle");
+    await expect(handle).toBeVisible();
+    await handle.evaluate((node) => node.click());
+    // One tap, one toggle: the runtime binds the handle too, and both acting on
+    // the same tap would cancel each other out.
+    await expect(page.locator("nav.bottom-nav-bar")).toHaveClass(/visible/);
+  });
+
+  test("the Home configuration no longer asks twice for the alarm and the gate", async ({
+    page,
+  }, testInfo) => {
+    await boot(page, testInfo);
+    await page.evaluate(() => {
+      window.apriConfigEntita();
+      window.editorSwitch("sez0");
+    });
+    await expect(page.locator("#ed-body .ed-slot").first()).toBeVisible();
+    await expect(
+      page.locator('#ed-body .ed-slot-in[data-ref="dm.home_interruttore_antifurto"]'),
+    ).toHaveCount(0);
+    await expect(
+      page.locator('#ed-body .ed-slot-in[data-ref="dm.home_script_apertura_cancello"]'),
+    ).toHaveCount(0);
+    // The rows that stay are untouched.
+    await expect(page.locator('#ed-body .ed-slot-in[data-ref="dm.home_meteo"]')).toHaveCount(1);
+  });
+
+  test("every entity field in the editors is the same readable row", async ({ page }, testInfo) => {
+    await boot(page, testInfo);
+    for (const tab of ["luci", "tapp", "irr", "sez1", "sez0"]) {
+      const counts = await page.evaluate(async (name) => {
+        if (!document.getElementById("editor-modal")?.classList.contains("show")) {
+          window.apriConfigEntita();
+        }
+        window.editorSwitch(name);
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        const body = document.getElementById("ed-body");
+        const fields = [...body.querySelectorAll('input[data-entity-input="true"]')];
+        const rows = fields.filter(
+          (input) => input.closest(".dm-slot") || input.closest('[data-dm-entity-chip="true"]'),
+        );
+        const bareLens = [...body.querySelectorAll(".dm-entity-picker")].filter(
+          (button) =>
+            !button.classList.contains("dm-slot-chip") &&
+            !button.closest(".dm-slot") &&
+            button.getClientRects().length > 0,
+        );
+        return { fields: fields.length, rows: rows.length, bareLens: bareLens.length };
+      }, tab);
+      expect(counts.rows, `${tab}: every entity field is a row`).toBe(counts.fields);
+      expect(counts.bareLens, `${tab}: no bare lens left`).toBe(0);
+    }
+  });
+
+  test("the EV configuration takes two photos of the car", async ({ page }, testInfo) => {
+    await boot(page, testInfo);
+    await page.evaluate(() => {
+      window.apriConfigEntita();
+      window.editorSwitch("sez2");
+      const accordion = [...document.querySelectorAll("#ed-body details.ed-acc")].find((node) =>
+        node.querySelector('.ed-slot-in[data-ref^="dm.ev_"]'),
+      );
+      if (accordion) accordion.open = true;
+    });
+    const photos = page.locator("#ed-body [data-ev-photos]");
+    await expect(photos).toHaveCount(1);
+    await expect(photos.locator('[data-ev-photo="idle"] input')).toHaveCount(1);
+    await expect(photos.locator('[data-ev-photo="plugged"] input')).toHaveCount(1);
+
+    await photos.locator('[data-ev-photo="idle"] input').fill("/local/auto.png");
+    await photos.locator('[data-ev-photo="plugged"] input').fill("/local/auto-cavo.png");
+    await photos.locator("[data-ev-photos-save]").click();
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          idle: localStorage.getItem("cd_ev_image"),
+          plugged: localStorage.getItem("cd_ev_image_plugged"),
+        })),
+      )
+      .toEqual({ idle: '"/local/auto.png"', plugged: '"/local/auto-cavo.png"' });
+  });
+
+  test("brand and model come up in the same place every time", async ({ page }, testInfo) => {
+    await boot(page, testInfo);
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      await page.evaluate(() => {
+        if (!document.getElementById("editor-modal")?.classList.contains("show")) {
+          window.apriConfigEntita();
+        }
+        window.editorSwitch("sez7");
+        window.editorSwitch("sez2");
+        const accordion = [...document.querySelectorAll("#ed-body details.ed-acc")].find((node) =>
+          node.querySelector('.ed-slot-in[data-ref^="dm.ev_"]'),
+        );
+        if (accordion) accordion.open = true;
+      });
+      const panel = page.locator("#ed-body [data-ev-appearance]");
+      await expect(panel).toHaveCount(1);
+      // Always inside the vehicle accordion, never floating at the top of the tab.
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const node = document.querySelector("#ed-body [data-ev-appearance]");
+            return Boolean(
+              node?.parentElement?.classList.contains("ed-acc-body") &&
+              node.parentElement.querySelector('.ed-slot-in[data-ref^="dm.ev_"]'),
+            );
+          }),
+        )
+        .toBe(true);
+    }
+  });
+});

--- a/custom_components/dashboardmodern/frontend/e2e/beta9-real-device-screenshots.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta9-real-device-screenshots.spec.js
@@ -181,12 +181,19 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await openEditor(page, "sez2");
     const appearance = page.locator("#ed-body [data-ev-appearance]");
     await expect(appearance).toBeVisible();
+    // First of the tab's own content. The one block above it is the section
+    // switch, which opens every tab of the configuration alike.
     const appearanceIsVisuallyFirst = await appearance.evaluate((node) => {
       const parent = node.parentElement;
       if (!parent) return false;
       const top = node.getBoundingClientRect().top;
       return [...parent.children]
-        .filter((sibling) => sibling !== node && sibling.getClientRects().length > 0)
+        .filter(
+          (sibling) =>
+            sibling !== node &&
+            sibling.getClientRects().length > 0 &&
+            !sibling.matches("[data-key][onclick*='edSecTog']"),
+        )
         .every((sibling) => sibling.getBoundingClientRect().top >= top - 1);
     });
     expect(appearanceIsVisuallyFirst).toBe(true);
@@ -257,22 +264,27 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       '#ed-body .dm-light-add-form[data-dm-light-add-layout="beta9-real"]',
     );
     await expect(lightForm).toBeVisible();
+    /* The entity field of this form is the readable row: the picker says what is
+     * chosen and takes the width, the pencil beside it is a square, and the raw
+     * id is behind that pencil. The row is measured, not the id field. */
     const lightGeometry = await lightForm.evaluate((form) => {
       const row = form.querySelector(".dm-light-add-entity-row");
       const entity = form.querySelector("#luce-add-ent");
-      const search = row?.querySelector(".dm-entity-picker");
+      const chip = row?.querySelector(".dm-entity-picker");
+      const manual = row?.querySelector(".dm-chip-manual");
       const name = form.querySelector("#luce-add-name");
       return {
         noOverflow: form.scrollWidth <= form.clientWidth + 1,
-        rowColumns: row ? getComputedStyle(row).gridTemplateColumns : "",
-        entityWidth: entity?.getBoundingClientRect().width || 0,
-        searchWidth: search?.getBoundingClientRect().width || 0,
+        rawHidden: entity ? getComputedStyle(entity).display === "none" : false,
+        chipWidth: chip?.getBoundingClientRect().width || 0,
+        manualWidth: manual?.getBoundingClientRect().width || 0,
         nameWidth: name?.getBoundingClientRect().width || 0,
       };
     });
     expect(lightGeometry.noOverflow).toBe(true);
-    expect(lightGeometry.entityWidth).toBeGreaterThan(180);
-    expect(lightGeometry.searchWidth).toBeGreaterThanOrEqual(54);
+    expect(lightGeometry.rawHidden).toBe(true);
+    expect(lightGeometry.chipWidth).toBeGreaterThan(180);
+    expect(lightGeometry.manualWidth).toBeGreaterThanOrEqual(36);
     expect(lightGeometry.nameWidth).toBeGreaterThan(240);
 
     await page.locator("#editor-modal .ed-head-close").last().click();

--- a/custom_components/dashboardmodern/frontend/e2e/config-uniformity.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/config-uniformity.spec.js
@@ -1,0 +1,208 @@
+// DM-FIX-20260818B
+/* The Configuration, tab by tab, answering the same questions the same way.
+ *
+ * The audit that motivated this counted, on every tab: how many ways there were
+ * to save, whether the section switch was there, and how much of *other*
+ * sections the tab was carrying. These are those three counts, asserted.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const states = [
+  {
+    entity_id: "sensor.temp",
+    state: "21",
+    attributes: { friendly_name: "Temp", unit_of_measurement: "°C", device_class: "temperature" },
+  },
+  { entity_id: "light.salone", state: "on", attributes: { friendly_name: "Salone" } },
+  { entity_id: "switch.pompa", state: "off", attributes: { friendly_name: "Pompa" } },
+  {
+    entity_id: "sensor.casa_totale",
+    state: "100",
+    attributes: {
+      friendly_name: "Casa totale",
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "total_increasing",
+    },
+  },
+  { entity_id: "weather.casa", state: "sunny", attributes: { friendly_name: "Meteo casa" } },
+];
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [{ id: "room-salone", name: "Salone", icon: "mdi:sofa", temp: "sensor.temp" }],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [{ id: "light-salone", name: "Salone", entities: ["light.salone"] }],
+    climate: [],
+    ev: [{ id: "ev-b10", name: "B10", brand: "Leapmotor", model: "B10" }],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  visibility: {
+    home: true,
+    energy: true,
+    ev: true,
+    temp: true,
+    tapparelle: true,
+    piscina: true,
+    irrigazione: true,
+    appliances: true,
+  },
+};
+
+/* Every tab of the configuration, and what it is: a section of the dashboard
+ * with a visibility switch, or one of the two that are neither. */
+const SECTION_TABS = [
+  "sez0",
+  "sez1",
+  "sez2",
+  "sez3",
+  "sez4",
+  "sez6",
+  "sez7",
+  "sez9",
+  "tapp",
+  "pool",
+  "irr",
+  "appliances",
+];
+const PLAIN_TABS = ["sez8", "stanze", "luci", "avvisi"];
+const NO_SAVE_TABS = ["runtime"];
+
+async function boot(page, testInfo) {
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+  await page.evaluate((haStates) => {
+    const registry = eval("_RAW_STATES");
+    for (const entry of haStates) registry[entry.entity_id] = entry;
+  }, states);
+  await page.waitForFunction(() => Boolean(window.__DASHBOARDMODERN_CONFIG_UNIFORMITY__));
+}
+
+async function openTab(page, tab) {
+  await page.evaluate(async (name) => {
+    if (!document.getElementById("editor-modal")?.classList.contains("show")) {
+      window.apriConfigEntita();
+    }
+    window.editorSwitch(name);
+    // The tab settles over a few frames: panels of their own arrive after it.
+    await new Promise((resolve) => setTimeout(resolve, 600));
+  }, tab);
+}
+
+function tabState(page) {
+  return page.evaluate(() => {
+    const body = document.getElementById("ed-body");
+    const seen = (node) => node.getClientRects().length > 0;
+    const saves = [...body.querySelectorAll("button,.ed-btn-add,.ed-save-btn")].filter(
+      (node) => /salva|save/i.test(node.textContent || "") && seen(node),
+    );
+    const banners = [...body.querySelectorAll("[data-key][onclick*='edSecTog']")].filter(seen);
+    const footer = body.querySelector(":scope > [data-dm-save-footer]");
+    return {
+      saveLabels: saves.map((node) => node.textContent.replace(/\s+/g, " ").trim()),
+      banners: banners.length,
+      bannerIsFirst: banners.length
+        ? body.firstElementChild === banners[0] ||
+          Boolean(body.firstElementChild?.contains(banners[0]))
+        : null,
+      footerIsLast: footer ? body.lastElementChild === footer : null,
+      accordions: body.querySelectorAll("details.ed-acc").length,
+      entityFields: body.querySelectorAll('input[data-entity-input="true"]').length,
+    };
+  });
+}
+
+test.describe("the configuration behaves the same on every tab", () => {
+  test("one save, in one place, wherever you are", async ({ page }, testInfo) => {
+    await boot(page, testInfo);
+    for (const tab of [...SECTION_TABS, ...PLAIN_TABS]) {
+      await openTab(page, tab);
+      const view = await tabState(page);
+      // "＋ Salva attuale" saves the current EV mapping as a new profile: it is
+      // an add, not a save of the section, and stays where it is.
+      const sectionSaves = view.saveLabels.filter((label) => !label.startsWith("＋"));
+      expect(sectionSaves, `${tab}: one way to save`).toEqual(["💾 Salva sezione"]);
+      expect(view.footerIsLast, `${tab}: the save is the last thing on the tab`).toBe(true);
+    }
+  });
+
+  test("read-only tabs offer no save at all", async ({ page }, testInfo) => {
+    await boot(page, testInfo);
+    for (const tab of NO_SAVE_TABS) {
+      await openTab(page, tab);
+      const view = await tabState(page);
+      expect(view.saveLabels, `${tab}`).toEqual([]);
+    }
+  });
+
+  test("the section switch is on every section, and always first", async ({ page }, testInfo) => {
+    await boot(page, testInfo);
+    for (const tab of SECTION_TABS) {
+      await openTab(page, tab);
+      const view = await tabState(page);
+      expect(view.banners, `${tab}: exactly one switch`).toBe(1);
+      expect(view.bannerIsFirst, `${tab}: the switch opens the tab`).toBe(true);
+    }
+    for (const tab of PLAIN_TABS) {
+      await openTab(page, tab);
+      const view = await tabState(page);
+      // These four are not sections of the dashboard, so they have no switch.
+      expect(view.banners, `${tab}: no switch`).toBe(0);
+    }
+  });
+
+  test("a tab carries its own section and nothing else", async ({ page }, testInfo) => {
+    await boot(page, testInfo);
+    for (const tab of ["sez0", "sez3", "sez9"]) {
+      await openTab(page, tab);
+      const view = await tabState(page);
+      // It used to be thirteen accordions and 104 entity fields on every one of
+      // these tabs, twelve sections of it hidden.
+      expect(view.accordions, `${tab}: one section`).toBeLessThanOrEqual(2);
+      expect(view.entityFields, `${tab}: only its own fields`).toBeLessThan(40);
+    }
+  });
+
+  test("the one save really saves — a section slot", async ({ page }, testInfo) => {
+    await boot(page, testInfo);
+    await openTab(page, "sez0");
+    await page.evaluate(() => {
+      const input = document.querySelector('#ed-body .ed-slot-in[data-ref="dm.home_meteo"]');
+      input.value = "weather.casa";
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await page.locator("#ed-body [data-dm-save-all]").click();
+    await expect
+      .poll(() =>
+        page.evaluate(() => JSON.parse(localStorage.getItem("cd_entity_overrides") || "{}")),
+      )
+      .toMatchObject({ "dm.home_meteo": "weather.casa" });
+  });
+
+  test("the one save really saves — a tab that had none", async ({ page }, testInfo) => {
+    await boot(page, testInfo);
+    await openTab(page, "luci");
+    await page.evaluate(() => {
+      window.__DM_SAVE_ACK__ = 0;
+      const previous = window.edSecSave;
+      window.edSecSave = function patched(...args) {
+        window.__DM_SAVE_ACK__ += 1;
+        return previous?.apply(this, args);
+      };
+    });
+    await page.locator("#ed-body [data-dm-save-all]").click();
+    // Rows here are written as they are edited; the gesture still answers, with
+    // the runtime's own acknowledgement.
+    await expect.poll(() => page.evaluate(() => window.__DM_SAVE_ACK__)).toBe(1);
+    // The acknowledgement is the runtime's own toast, the same one every other
+    // save in the editor raises.
+    await expect(page.locator("#ed-toast")).toHaveClass(/show/);
+  });
+});

--- a/custom_components/dashboardmodern/frontend/e2e/config-uniformity.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/config-uniformity.spec.js
@@ -86,14 +86,27 @@ async function boot(page, testInfo) {
 }
 
 async function openTab(page, tab) {
-  await page.evaluate(async (name) => {
+  await page.evaluate((name) => {
     if (!document.getElementById("editor-modal")?.classList.contains("show")) {
       window.apriConfigEntita();
     }
     window.editorSwitch(name);
-    // The tab settles over a few frames: panels of their own arrive after it.
-    await new Promise((resolve) => setTimeout(resolve, 600));
   }, tab);
+  // The tab settles over several frames, and how many depends on the machine:
+  // panels of their own arrive after the switch, and the runtime narrows the
+  // tab to its own section later still. Waiting a fixed number of milliseconds
+  // passes on a fast runner and fails on a slow one, so each assertion below
+  // polls instead — a build that never settles still fails, at the timeout.
+  await page.waitForFunction(
+    (name) => document.getElementById("ed-body")?.dataset.dmConfigUniform === name,
+    tab,
+    { timeout: 10_000 },
+  );
+}
+
+/* The state of the tab, once it stops changing. */
+function settledTabState(page, pick, message) {
+  return expect.poll(async () => pick(await tabState(page)), { message, timeout: 10_000 });
 }
 
 function tabState(page) {
@@ -124,12 +137,18 @@ test.describe("the configuration behaves the same on every tab", () => {
     await boot(page, testInfo);
     for (const tab of [...SECTION_TABS, ...PLAIN_TABS]) {
       await openTab(page, tab);
-      const view = await tabState(page);
       // "＋ Salva attuale" saves the current EV mapping as a new profile: it is
       // an add, not a save of the section, and stays where it is.
-      const sectionSaves = view.saveLabels.filter((label) => !label.startsWith("＋"));
-      expect(sectionSaves, `${tab}: one way to save`).toEqual(["💾 Salva sezione"]);
-      expect(view.footerIsLast, `${tab}: the save is the last thing on the tab`).toBe(true);
+      await settledTabState(
+        page,
+        (view) => view.saveLabels.filter((label) => !label.startsWith("＋")),
+        `${tab}: one way to save`,
+      ).toEqual(["💾 Salva sezione"]);
+      await settledTabState(
+        page,
+        (view) => view.footerIsLast,
+        `${tab}: the save is the last thing on the tab`,
+      ).toBe(true);
     }
   });
 
@@ -137,8 +156,7 @@ test.describe("the configuration behaves the same on every tab", () => {
     await boot(page, testInfo);
     for (const tab of NO_SAVE_TABS) {
       await openTab(page, tab);
-      const view = await tabState(page);
-      expect(view.saveLabels, `${tab}`).toEqual([]);
+      await settledTabState(page, (view) => view.saveLabels, `${tab}`).toEqual([]);
     }
   });
 
@@ -146,15 +164,17 @@ test.describe("the configuration behaves the same on every tab", () => {
     await boot(page, testInfo);
     for (const tab of SECTION_TABS) {
       await openTab(page, tab);
-      const view = await tabState(page);
-      expect(view.banners, `${tab}: exactly one switch`).toBe(1);
-      expect(view.bannerIsFirst, `${tab}: the switch opens the tab`).toBe(true);
+      await settledTabState(page, (view) => view.banners, `${tab}: exactly one switch`).toBe(1);
+      await settledTabState(
+        page,
+        (view) => view.bannerIsFirst,
+        `${tab}: the switch opens the tab`,
+      ).toBe(true);
     }
     for (const tab of PLAIN_TABS) {
       await openTab(page, tab);
-      const view = await tabState(page);
       // These four are not sections of the dashboard, so they have no switch.
-      expect(view.banners, `${tab}: no switch`).toBe(0);
+      await settledTabState(page, (view) => view.banners, `${tab}: no switch`).toBe(0);
     }
   });
 
@@ -162,11 +182,18 @@ test.describe("the configuration behaves the same on every tab", () => {
     await boot(page, testInfo);
     for (const tab of ["sez0", "sez3", "sez9"]) {
       await openTab(page, tab);
-      const view = await tabState(page);
       // It used to be thirteen accordions and 104 entity fields on every one of
       // these tabs, twelve sections of it hidden.
-      expect(view.accordions, `${tab}: one section`).toBeLessThanOrEqual(2);
-      expect(view.entityFields, `${tab}: only its own fields`).toBeLessThan(40);
+      await settledTabState(
+        page,
+        (view) => view.accordions,
+        `${tab}: one section`,
+      ).toBeLessThanOrEqual(2);
+      await settledTabState(
+        page,
+        (view) => view.entityFields,
+        `${tab}: only its own fields`,
+      ).toBeLessThan(40);
     }
   });
 

--- a/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { clickStableButton } from "./helpers/navigation.js";
+import { editEntityFieldByHand, showRawEntityFields } from "./helpers/entity-field.js";
 
 async function disableSriForMockedExternalScripts(page) {
   // These E2E routes replace the pinned CDN files with deterministic stubs.
@@ -245,22 +246,29 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await page.evaluate(() => window.editorSwitch("sez1"));
     await expect(page.locator('#ed-body[data-renderer="energy"]')).toBeVisible();
     await page.screenshot({ path: `test-results/${testInfo.project.name}-${variant}-energy.png` });
+    // One picker per entity field, and each picker pointing at a field that is
+    // really there. The field itself is behind the pencil now, so the row —
+    // the picker — is what has to be on screen, not the raw id box.
     const assertPickerInvariant = async () => {
-      const counts = await page.locator("#ed-body").evaluate((body) => ({
-        inputs: [...body.querySelectorAll("[data-entity-input]")].filter(
-          (input) => input.getClientRects().length > 0,
-        ).length,
-        pickers: [...body.querySelectorAll(".dm-entity-picker")].filter(
-          (button) => button.getClientRects().length > 0,
-        ).length,
-        uniqueTargets: new Set(
-          [...body.querySelectorAll(".dm-entity-picker")]
-            .filter((button) => button.getClientRects().length > 0)
-            .map((button) => button.dataset.entityTarget),
-        ).size,
-      }));
+      const counts = await page.locator("#ed-body").evaluate((body) => {
+        const onScreen = (node) => Boolean(node) && node.getClientRects().length > 0;
+        const pickers = [...body.querySelectorAll(".dm-entity-picker")].filter(onScreen);
+        const fields = [...body.querySelectorAll("[data-entity-input]")].filter(
+          (input) => onScreen(input) || onScreen(input.closest('[data-dm-entity-chip="true"]')),
+        );
+        return {
+          inputs: fields.length,
+          pickers: pickers.length,
+          uniqueTargets: new Set(pickers.map((button) => button.dataset.entityTarget)).size,
+          orphans: pickers.filter(
+            (button) =>
+              !body.querySelector(`[data-entity-input][id="${button.dataset.entityTarget}"]`),
+          ).length,
+        };
+      });
       expect(counts.pickers).toBe(counts.inputs);
       expect(counts.uniqueTargets).toBe(counts.inputs);
+      expect(counts.orphans).toBe(0);
     };
     await assertPickerInvariant();
     await clickStableButton(
@@ -291,6 +299,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     });
     await page.evaluate(() => window.editorSwitch("sez1"));
     const housePower = page.locator('[data-energy-panel="flows"] input').first();
+    await editEntityFieldByHand(page, "#dm-energy-house-power");
     await housePower.fill("sensor.house_power");
     await housePower.blur();
     await expect(page.locator("[data-energy-actions]")).toHaveAttribute("data-state", "dirty");
@@ -345,6 +354,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     expect(report).toMatch(/Salva Report|Save Report/);
     expect(report).not.toContain("dm-load-category");
     await clickStableButton(page, page.locator("[data-report-add]"), testInfo);
+    await showRawEntityFields(page);
     await page.locator("[data-manual-name]").fill("Manual water");
     await page.locator("#dm-manual-report-icon").fill("💧");
     await page.locator("#dm-manual-report-entity").fill("sensor.water_month");
@@ -363,6 +373,8 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     const firstReport = page.locator(".dm-report-row").first();
     await firstReport.locator("[data-report-toggle]").check();
     await firstReport.locator("[data-report-label]").fill("Canonical label");
+    // The entity row shows what is chosen and keeps the id behind the pencil.
+    await showRawEntityFields(page);
     await firstReport.locator("[data-entity-field] input").first().fill("sensor.canonical_month");
     await page.locator("[data-report-save]").click();
     await expect(page.locator("[data-report-actions]")).toHaveAttribute("data-state", "success");

--- a/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { clickStableButton } from "./helpers/navigation.js";
-import { editEntityFieldByHand, showRawEntityFields } from "./helpers/entity-field.js";
+import { editEntityFieldByHand, saveSection, showRawEntityFields } from "./helpers/entity-field.js";
 
 async function disableSriForMockedExternalScripts(page) {
   // These E2E routes replace the pinned CDN files with deterministic stubs.
@@ -303,7 +303,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await housePower.fill("sensor.house_power");
     await housePower.blur();
     await expect(page.locator("[data-energy-actions]")).toHaveAttribute("data-state", "dirty");
-    await page.locator("[data-energy-save]").click();
+    await saveSection(page);
     await expect(page.locator("[data-energy-actions]")).toHaveAttribute("data-state", "success");
     await expect(page.locator('#ed-body[data-renderer="energy"]')).toBeVisible();
     await expect(
@@ -335,7 +335,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
 
     // Saving goes through the canonical section, and the appliance is stored
     // inside the load that owns it.
-    await clickStableButton(page, page.locator("[data-dm-loads-save]"), testInfo);
+    await saveSection(page);
     await expect
       .poll(() =>
         page.evaluate(() =>
@@ -376,7 +376,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     // The entity row shows what is chosen and keeps the id behind the pencil.
     await showRawEntityFields(page);
     await firstReport.locator("[data-entity-field] input").first().fill("sensor.canonical_month");
-    await page.locator("[data-report-save]").click();
+    await saveSection(page);
     await expect(page.locator("[data-report-actions]")).toHaveAttribute("data-state", "success");
     await expect(page.locator('[data-energy-panel="report"]')).toBeVisible();
     // The popup mirror is derived from the loads on save: the appliance sits

--- a/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
@@ -434,6 +434,10 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await assertPickerInvariant();
     const lightAddEntity = page.locator("#ed-body [data-light-add-entity]");
     await expect(lightAddEntity).toHaveCount(1);
+    // The id itself sits behind the pencil here as it does on every other
+    // entity field: the row is what is on screen until the pencil is pressed.
+    await expect(lightAddEntity).toBeHidden();
+    await editEntityFieldByHand(page, "#ed-body [data-light-add-entity]");
     await expect(lightAddEntity).toBeVisible();
     await expect(lightAddEntity).toHaveAttribute("data-entity-input", "true");
     const lightAddEntityId = await lightAddEntity.getAttribute("id");

--- a/custom_components/dashboardmodern/frontend/e2e/entity-search-picker.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/entity-search-picker.spec.js
@@ -7,6 +7,7 @@
  */
 import { expect, test } from "@playwright/test";
 import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { editEntityFieldByHand } from "./helpers/entity-field.js";
 
 const ROOMS = ["kitchen", "living", "bathroom", "garage", "garden"];
 
@@ -111,6 +112,9 @@ test.describe("entity picker search", () => {
         apriConfigEntita();
         editorSwitch("sez7");
       }, STATES);
+      // The entity field is a readable row; the id itself lives behind the
+      // pencil beside it, which is where this test types.
+      await editEntityFieldByHand(page, "#ed-pl-temp");
       await expect(page.locator("#ed-pl-temp")).toBeVisible();
 
       await openTemperaturePicker(page);

--- a/custom_components/dashboardmodern/frontend/e2e/ev-showcase.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/ev-showcase.spec.js
@@ -116,10 +116,13 @@ test.describe("EV page redesign", () => {
     await expect(page.locator(".dm-evv-power")).toHaveCount(1);
     await expect(page.locator(".dm-evv-row")).toHaveCount(3);
     await expect(page.locator("#m-btn-pv .dm-evv-fx")).toHaveCount(1);
-    // The page must never scroll sideways on a phone.
-    const overflow = await page.evaluate(
-      () => document.documentElement.scrollWidth <= window.innerWidth + 1,
-    );
-    expect(overflow).toBe(true);
+    // The page must never scroll sideways on a phone. Measured once the page has
+    // stopped being rebuilt: a re-render in flight can be a few pixels wide for
+    // a frame, and what matters is where it comes to rest.
+    await expect
+      .poll(() =>
+        page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1),
+      )
+      .toBe(true);
   });
 });

--- a/custom_components/dashboardmodern/frontend/e2e/helpers/entity-field.js
+++ b/custom_components/dashboardmodern/frontend/e2e/helpers/entity-field.js
@@ -1,0 +1,45 @@
+/*
+ * Entity fields in the editors are drawn as one readable row: the picker button
+ * says what is chosen, and the raw entity id sits behind the pencil beside it.
+ *
+ * A test that wants to read or type an id does what a person does — it taps the
+ * pencil first. Nothing here reaches past the UI: the pencil is the control the
+ * dashboard ships, and these helpers only press it.
+ */
+
+/** Put one field into manual mode, by its pencil. */
+export async function editEntityFieldByHand(page, selector) {
+  const manual = page.locator(`${selector} ~ .dm-chip-manual`).first();
+  // The row is decorated on the frame after the editor prints it, so wait for
+  // the pencil the way a person waits for the form to finish drawing.
+  await manual.waitFor({ state: "attached", timeout: 5_000 }).catch(() => {});
+  if ((await manual.count()) === 0) return false;
+  if ((await manual.getAttribute("aria-pressed")) === "true") return true;
+  await manual.click();
+  return true;
+}
+
+/** Tap the pencil, then type the id, the way the editor is used by hand. */
+export async function fillEntityFieldByHand(page, selector, value) {
+  await editEntityFieldByHand(page, selector);
+  await page.locator(selector).fill(value);
+}
+
+/**
+ * Put every entity field currently on screen into manual mode.
+ *
+ * For the specs that assert on the raw fields themselves — the picker
+ * invariants, the persistence round trips — rather than on the row that
+ * normally stands in for them.
+ */
+export async function showRawEntityFields(page) {
+  return page.evaluate(() => {
+    let opened = 0;
+    for (const manual of document.querySelectorAll(".dm-chip-manual")) {
+      if (manual.getAttribute("aria-pressed") === "true") continue;
+      manual.click();
+      opened += 1;
+    }
+    return opened;
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/helpers/entity-field.js
+++ b/custom_components/dashboardmodern/frontend/e2e/helpers/entity-field.js
@@ -43,3 +43,14 @@ export async function showRawEntityFields(page) {
     return opened;
   });
 }
+
+/**
+ * Save the open tab through the one control the Configuration now offers.
+ *
+ * The per-panel save buttons stay in the document but are hidden behind the
+ * single "Salva sezione" footer, which presses them for the panels on screen —
+ * so pressing the footer is what a person does, and what these tests do.
+ */
+export async function saveSection(page) {
+  await page.locator("#ed-body [data-dm-save-all]").click();
+}

--- a/custom_components/dashboardmodern/frontend/e2e/minipc-showcase.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/minipc-showcase.spec.js
@@ -1,0 +1,169 @@
+// DM-FIX-20260818A
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+/** The MiniPC entities mapped, which is what keeps cdAutoHide() from hiding the cards. */
+const MAPPED = Object.freeze({
+  "dm.server_cpu": "sensor.cpu",
+  "dm.server_ram": "sensor.ram",
+  "dm.server_disco": "sensor.disk",
+  "dm.server_temperatura_cpu": "sensor.temp",
+  "dm.server_potenza_raspberry_server": "sensor.power",
+  "dm.server_uptime_home_assistant": "sensor.uptime",
+  "dm.server_speedtest_download": "sensor.download",
+  "dm.server_speedtest_upload": "sensor.upload",
+});
+
+function seedWith(entityOverrides) {
+  return {
+    schema_version: 4,
+    sections: {
+      rooms: [],
+      cameras: [],
+      appliances: [],
+      loads: [],
+      lights: [],
+      climate: [],
+      ev: [],
+      covers: [],
+      pool: {},
+      irrigation: { zones: [] },
+      energy: {},
+      entityOverrides,
+    },
+    visibility: { home: true },
+  };
+}
+
+/** Put the MiniPC page on screen with the values the render loop would have written. */
+async function openServerPage(page) {
+  await page.evaluate(() => {
+    document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
+    document.getElementById("page-server")?.classList.add("active");
+    const text = (id, value) => {
+      const node = document.getElementById(id);
+      if (node) node.textContent = value;
+    };
+    const bar = (id, value) => {
+      const node = document.getElementById(id);
+      if (node) node.style.width = `${value}%`;
+    };
+    text("v-srv-cpu", "23.4");
+    bar("srv-fill-cpu", 23.4);
+    text("v-srv-ram", "61");
+    bar("srv-fill-ram", 61);
+    text("v-srv-disk", "88");
+    bar("srv-fill-disk", 88);
+    text("v-srv-cputemp", "52");
+    text("v-srv-temp-status", "🟢 Ottimale");
+    const ring = document.getElementById("srv-temp-circle");
+    if (ring) {
+      const circumference = 2 * Math.PI * 36;
+      const drawn = ((52 - 20) / 80) * circumference;
+      ring.setAttribute("stroke-dasharray", `${drawn.toFixed(1)} ${circumference.toFixed(1)}`);
+    }
+    const badge = document.getElementById("waw-net-badge");
+    if (badge) badge.className = "srv-status-badge online";
+    window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: {} }));
+  });
+}
+
+/** Share of the ring an arc covers, as the page drew it. */
+async function arcShare(locator) {
+  const [drawn, gap] = ((await locator.getAttribute("stroke-dasharray")) || "")
+    .split(" ")
+    .map(Number);
+  return Math.round((drawn / (drawn + gap)) * 100);
+}
+
+test.describe("MiniPC page redesign", () => {
+  test("the gauges draw what the legacy bars carry, without losing a hook", async ({
+    page,
+  }, testInfo) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await bootNamespacedDashboard(page, "dashboard.html", testInfo, seedWith(MAPPED));
+    await openServerPage(page);
+
+    await expect(page.locator("#page-server")).toHaveClass(/dm-srvx/);
+    // The bars stay in the DOM: they are what the render loop writes and what
+    // the rings read. Losing them would freeze every gauge.
+    for (const id of ["srv-fill-cpu", "srv-fill-ram", "srv-fill-disk"])
+      await expect(page.locator(`#${id}`)).toHaveCount(1);
+
+    // The value nodes moved into the middle of their ring, and only there.
+    await expect(page.locator(".dm-srvx-gauge-val #v-srv-cpu")).toHaveText("23.4");
+    await expect(page.locator("#v-srv-ram")).toHaveCount(1);
+    await expect(page.locator(".dm-srvx-gauge-val #u-srv-ram")).toHaveCount(1);
+
+    const arcs = page.locator(".dm-srvx-ring-arc");
+    expect(await arcShare(arcs.nth(0))).toBe(23);
+    expect(await arcShare(arcs.nth(1))).toBe(61);
+    expect(await arcShare(arcs.nth(2))).toBe(88);
+    // Past the legacy alert threshold the disk gauge turns red on its own.
+    await expect(arcs.nth(2)).toHaveAttribute("stroke", "#ef4444");
+    await expect(page.locator(".srv-metric").nth(2)).toHaveAttribute("data-dm-srvx-level", "alert");
+    await expect(page.locator(".srv-metric").nth(0)).toHaveAttribute("data-dm-srvx-level", "ok");
+  });
+
+  test("the thermal card mirrors the status line the runtime owns", async ({ page }, testInfo) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await bootNamespacedDashboard(page, "dashboard.html", testInfo, seedWith(MAPPED));
+    await openServerPage(page);
+
+    const card = page.locator(".srv-temp-card");
+    await expect(card).toHaveAttribute("data-dm-srvx-temp", "ok");
+    await expect(page.locator(".dm-srvx-temp-txt")).toHaveText("Ottimale");
+    // #srv-temp-circle is still the one arc on the page, drawn by the runtime.
+    await expect(page.locator("#srv-temp-circle")).toHaveCount(1);
+
+    await page.evaluate(() => {
+      const node = document.getElementById("v-srv-temp-status");
+      if (node) node.textContent = "🔴 Alta — Controllare";
+      window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: {} }));
+    });
+    await expect(card).toHaveAttribute("data-dm-srvx-temp", "hot");
+    await expect(page.locator(".dm-srvx-temp-txt")).toHaveText("Alta — Controllare");
+  });
+
+  test("the page follows the connectivity badge and fills the live trace", async ({
+    page,
+  }, testInfo) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await bootNamespacedDashboard(page, "dashboard.html", testInfo, seedWith(MAPPED));
+    await openServerPage(page);
+    await expect(page.locator("#page-server")).toHaveAttribute("data-dm-srv-net", "on");
+
+    // A few ticks of load, the way the render loop would deliver them.
+    await page.evaluate(async () => {
+      const bar = document.getElementById("srv-fill-cpu");
+      for (const value of [18, 44, 71, 26]) {
+        if (bar) bar.style.width = `${value}%`;
+        window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: {} }));
+        await new Promise((resolve) => setTimeout(resolve, 40));
+      }
+    });
+    await expect(page.locator(".dm-srvx-trace")).toHaveAttribute("data-dm-srvx-trace", "on");
+    await expect(page.locator(".dm-srvx-trace-peak")).toContainText("71%");
+    expect((await page.locator(".dm-srvx-trace-line").getAttribute("d"))?.length).toBeGreaterThan(10);
+
+    await page.evaluate(() => {
+      const badge = document.getElementById("waw-net-badge");
+      if (badge) badge.className = "srv-status-badge offline";
+      window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: {} }));
+    });
+    await expect(page.locator("#page-server")).toHaveAttribute("data-dm-srv-net", "off");
+  });
+
+  test("a block the auto-hide empties takes its heading with it", async ({ page }, testInfo) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    // Nothing mapped: cdAutoHide() hides every card that opens a dm.* entity.
+    await bootNamespacedDashboard(page, "dashboard.html", testInfo, seedWith({}));
+    await openServerPage(page);
+
+    await expect(page.locator(".srv-temp-card")).toBeHidden();
+    await expect(page.locator('.dm-srvx-head[data-dm-srvx-head=".srv-temp-card"]')).toBeHidden();
+    // The rows that open no entity stay, and so does their heading.
+    await expect(page.locator('.dm-srvx-head[data-dm-srvx-head=".srv-status-grid"]')).toBeVisible();
+    await expect(page.locator(".srv-status-card").first()).toBeVisible();
+  });
+});

--- a/custom_components/dashboardmodern/frontend/e2e/minipc-showcase.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/minipc-showcase.spec.js
@@ -68,12 +68,11 @@ async function openServerPage(page) {
   });
 }
 
-/** Share of the ring an arc covers, as the page drew it. */
-async function arcShare(locator) {
-  const [drawn, gap] = ((await locator.getAttribute("stroke-dasharray")) || "")
-    .split(" ")
-    .map(Number);
-  return Math.round((drawn / (drawn + gap)) * 100);
+/** Height a prism was given, in pixels, as the scene drew it. */
+async function prismHeight(page, index) {
+  return page.locator(".srv-hero-metrics .srv-metric").nth(index).evaluate((card) =>
+    Number.parseFloat(getComputedStyle(card).getPropertyValue("--dm-srvx-h")),
+  );
 }
 
 test.describe("MiniPC page redesign", () => {
@@ -95,20 +94,21 @@ test.describe("MiniPC page redesign", () => {
     await expect(page.locator("#v-srv-ram")).toHaveCount(1);
     await expect(page.locator("#u-srv-ram")).toHaveCount(1);
 
-    // Three arcs around one machine, drawn at three radii.
-    await expect(page.locator(".dm-srvx-ring-arc")).toHaveCount(3);
-    await expect(page.locator(".dm-srvx-core .srv-hero-icon .dm-srvx-box")).toHaveCount(1);
-    const radii = await page.locator(".dm-srvx-ring-arc").evaluateAll((arcs) =>
-      arcs.map((arc) => Number(arc.getAttribute("r"))),
-    );
-    expect(radii).toEqual([86, 68, 50]);
+    // One machine and three prisms, six faces each, in a single scene.
+    await expect(page.locator(".dm-srvx-machine .dm-srvx-f")).toHaveCount(6);
+    await expect(page.locator(".dm-srvx-bar")).toHaveCount(3);
 
-    const arcs = page.locator(".dm-srvx-ring-arc");
-    expect(await arcShare(arcs.nth(0))).toBe(23);
-    expect(await arcShare(arcs.nth(1))).toBe(61);
-    expect(await arcShare(arcs.nth(2))).toBe(88);
-    // Past the legacy alert threshold the disk gauge turns red on its own.
-    await expect(arcs.nth(2)).toHaveAttribute("stroke", "#ef4444");
+    // The prisms stand as tall as the loads they carry.
+    const heights = [await prismHeight(page, 0), await prismHeight(page, 1), await prismHeight(page, 2)];
+    expect(heights[0]).toBeLessThan(heights[1]);
+    expect(heights[1]).toBeLessThan(heights[2]);
+    expect(heights[0]).toBeGreaterThan(6);
+
+    // Past the legacy alert threshold the disk prism turns red on its own.
+    const diskColour = await page.locator(".srv-metric").nth(2).evaluate((card) =>
+      getComputedStyle(card).getPropertyValue("--dm-srvx-col").trim(),
+    );
+    expect(diskColour).toBe("#ef4444");
     await expect(page.locator(".srv-metric").nth(2)).toHaveAttribute("data-dm-srvx-level", "alert");
     await expect(page.locator(".srv-metric").nth(0)).toHaveAttribute("data-dm-srvx-level", "ok");
   });
@@ -170,11 +170,13 @@ test.describe("MiniPC page redesign", () => {
 
     await expect(page.locator(".srv-temp-card")).toBeHidden();
     await expect(page.locator('.dm-srvx-head[data-dm-srvx-head=".srv-temp-card"]')).toBeHidden();
-    // A hidden metric card takes its arc and its row off the dial together.
-    await expect(page.locator(".dm-srvx-ring-arc").first()).toBeHidden();
+    // A hidden metric card takes its prism, its label and its value with it.
+    await expect(page.locator(".dm-srvx-bar").first()).toBeHidden();
     await expect(page.locator("#v-srv-cpu")).toBeHidden();
-    // The machine keeps standing in the middle of the empty dial.
-    await expect(page.locator(".dm-srvx-core .dm-srvx-box")).toBeVisible();
+    // The machine keeps standing on the empty floor.
+    await expect(page.locator(".dm-srvx-machine")).toBeVisible();
+    // Telemetry takes the whole row instead of leaving the thermal column empty.
+    await expect(page.locator("#page-server")).toHaveAttribute("data-dm-srvx-thermal", "off");
     // The rows that open no entity stay, and so does their heading.
     await expect(page.locator('.dm-srvx-head[data-dm-srvx-head=".srv-status-grid"]')).toBeVisible();
     await expect(page.locator(".srv-status-card").first()).toBeVisible();

--- a/custom_components/dashboardmodern/frontend/e2e/minipc-showcase.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/minipc-showcase.spec.js
@@ -90,10 +90,18 @@ test.describe("MiniPC page redesign", () => {
     for (const id of ["srv-fill-cpu", "srv-fill-ram", "srv-fill-disk"])
       await expect(page.locator(`#${id}`)).toHaveCount(1);
 
-    // The value nodes moved into the middle of their ring, and only there.
-    await expect(page.locator(".dm-srvx-gauge-val #v-srv-cpu")).toHaveText("23.4");
+    // The reading stays the node the render loop writes, one of each.
+    await expect(page.locator(".srv-metric #v-srv-cpu")).toHaveText("23.4");
     await expect(page.locator("#v-srv-ram")).toHaveCount(1);
-    await expect(page.locator(".dm-srvx-gauge-val #u-srv-ram")).toHaveCount(1);
+    await expect(page.locator("#u-srv-ram")).toHaveCount(1);
+
+    // Three arcs around one machine, drawn at three radii.
+    await expect(page.locator(".dm-srvx-ring-arc")).toHaveCount(3);
+    await expect(page.locator(".dm-srvx-core .srv-hero-icon .dm-srvx-box")).toHaveCount(1);
+    const radii = await page.locator(".dm-srvx-ring-arc").evaluateAll((arcs) =>
+      arcs.map((arc) => Number(arc.getAttribute("r"))),
+    );
+    expect(radii).toEqual([86, 68, 50]);
 
     const arcs = page.locator(".dm-srvx-ring-arc");
     expect(await arcShare(arcs.nth(0))).toBe(23);
@@ -162,6 +170,11 @@ test.describe("MiniPC page redesign", () => {
 
     await expect(page.locator(".srv-temp-card")).toBeHidden();
     await expect(page.locator('.dm-srvx-head[data-dm-srvx-head=".srv-temp-card"]')).toBeHidden();
+    // A hidden metric card takes its arc and its row off the dial together.
+    await expect(page.locator(".dm-srvx-ring-arc").first()).toBeHidden();
+    await expect(page.locator("#v-srv-cpu")).toBeHidden();
+    // The machine keeps standing in the middle of the empty dial.
+    await expect(page.locator(".dm-srvx-core .dm-srvx-box")).toBeVisible();
     // The rows that open no entity stay, and so does their heading.
     await expect(page.locator('.dm-srvx-head[data-dm-srvx-head=".srv-status-grid"]')).toBeVisible();
     await expect(page.locator(".srv-status-card").first()).toBeVisible();

--- a/custom_components/dashboardmodern/frontend/e2e/phase6-functional.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/phase6-functional.spec.js
@@ -1,6 +1,7 @@
 // DM-FIX-20260812B
 import { expect, test } from "@playwright/test";
 import { bootConsolidatedDashboard } from "./helpers/consolidated-runtime.js";
+import { editEntityFieldByHand } from "./helpers/entity-field.js";
 
 for (const variant of ["dashboard.html", "dashboard-en.html"]) {
   test(`${variant}: Phase 6 Energy, appliances and mobile layout`, async ({ page }, testInfo) => {
@@ -76,6 +77,9 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await page.evaluate(() => window.editorSwitch("appliances"));
     await expect(page.locator("#appl-name")).toBeVisible();
     await expect(page.locator("#appl-room")).toBeVisible();
+    // The entity field is one readable row now; the pencil brings the id back.
+    await expect(page.locator("#appl-ent ~ .dm-entity-picker.dm-slot-chip")).toBeVisible();
+    await editEntityFieldByHand(page, "#appl-ent");
     await expect(page.locator("#appl-ent")).toBeVisible();
     if (testInfo.project.name === "mobile") {
       const applianceEditorGeometry = await page.evaluate(() => {

--- a/custom_components/dashboardmodern/frontend/e2e/real-ha-runtime-contracts.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/real-ha-runtime-contracts.spec.js
@@ -1,6 +1,7 @@
 // DM-FIX-20260812B
 import { expect, test } from "@playwright/test";
 import { bootConsolidatedDashboard } from "./helpers/consolidated-runtime.js";
+import { editEntityFieldByHand } from "./helpers/entity-field.js";
 import { clickBottomTab } from "./helpers/navigation.js";
 
 async function openEditor(page, tab) {
@@ -80,6 +81,9 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
         const group = node.closest("details");
         if (group) group.open = true;
       });
+      // The row is what is on screen; the id itself sits behind its pencil.
+      await expect(page.locator(`${selector} ~ .dm-entity-picker.dm-slot-chip`)).toBeVisible();
+      await editEntityFieldByHand(page, selector);
       await expect(field).toBeVisible();
       await expect(field).toHaveValue(value);
       const nativeTotalField = field.locator(

--- a/custom_components/dashboardmodern/frontend/e2e/real-ui-regressions.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/real-ui-regressions.spec.js
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { fillEntityFieldByHand, showRawEntityFields } from "./helpers/entity-field.js";
 import { clickBottomTab, clickStableButton } from "./helpers/navigation.js";
 
 const haStates = [
@@ -159,7 +160,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       ["Tapparella cucina", "cover.cucina"],
     ]) {
       await page.locator("#ed-tp-name").fill(name);
-      await page.locator("#ed-tp-ent").fill(entity);
+      await fillEntityFieldByHand(page, "#ed-tp-ent", entity);
       await page.locator("#ed-tp-room").selectOption("room-salone");
       await page.locator("#ed-body .ed-btn-add", { hasText: /tapparella|shutter/i }).click();
     }
@@ -277,6 +278,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     for (let index = 0; index < 20; index += 1)
       await page.evaluate(() => editorSwitch("appliances"));
     await expect(page.locator("#ed-body #appl-ent")).toHaveCount(1);
+    await showRawEntityFields(page);
     await expect(
       page.locator('#ed-body .dm-entity-picker[data-entity-target="appl-ent"]'),
     ).toHaveCount(1);

--- a/custom_components/dashboardmodern/frontend/e2e/save-engine.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/save-engine.spec.js
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
-import { showRawEntityFields } from "./helpers/entity-field.js";
+import { saveSection, showRawEntityFields } from "./helpers/entity-field.js";
 import { clickBottomTab } from "./helpers/navigation.js";
 
 const haStates = [
@@ -150,7 +150,8 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     // This is the exact real-device flow that was broken: the user filled the
     // pending appliance and pressed Save section instead of the separate Add
     // appliance button. The old implementation only displayed a success toast.
-    await page.locator("#ed-body .ed-btn-add", { hasText: /Salva sezione|Save section/i }).click();
+    // The per-panel button is behind the single section save now.
+    await saveSection(page);
 
     await expect
       .poll(() =>
@@ -206,7 +207,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await total.fill("sensor.solarman_total_load_consumption");
     await expect(page.locator("[data-energy-actions]")).toHaveAttribute("data-state", "dirty");
     await expect(page.locator("[data-energy-save]")).toBeEnabled();
-    await page.locator("[data-energy-save]").click();
+    await saveSection(page);
 
     await expect
       .poll(() =>

--- a/custom_components/dashboardmodern/frontend/e2e/save-engine.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/save-engine.spec.js
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { showRawEntityFields } from "./helpers/entity-field.js";
 import { clickBottomTab } from "./helpers/navigation.js";
 
 const haStates = [
@@ -136,6 +137,9 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await boot(page, variant, testInfo);
     await openEditor(page, "appliances");
 
+    // The entity fields are readable rows now; the id itself is behind the
+    // pencil on each row, so the form is put into manual mode first.
+    await showRawEntityFields(page);
     await page.locator("#appl-name").fill("Lavatrice");
     await page.locator("#appl-room").selectOption("room-matrimoniale");
     for (const entity of ["switch.lavatrice", "sensor.lavatrice_power"]) {
@@ -197,6 +201,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
     await boot(page, variant, testInfo);
     await openEditor(page, "sez1");
 
+    await showRawEntityFields(page);
     const total = page.locator("#dm-energy-house-total_energy");
     await total.fill("sensor.solarman_total_load_consumption");
     await expect(page.locator("[data-energy-actions]")).toHaveAttribute("data-state", "dirty");

--- a/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
@@ -2,6 +2,7 @@
 import { expect, test } from "@playwright/test";
 import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
 import { clickBottomTab } from "./helpers/navigation.js";
+import { editEntityFieldByHand, fillEntityFieldByHand } from "./helpers/entity-field.js";
 
 const states = [
   {
@@ -125,6 +126,10 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
         }),
       ),
     ).toBe(true);
+    // The field itself lives behind the pencil now; the row that replaced the
+    // lens is what is on screen, and tapping the pencil brings the id back.
+    await expect(page.locator("#ed-pl-temp ~ .dm-entity-picker.dm-slot-chip")).toBeVisible();
+    await editEntityFieldByHand(page, "#ed-pl-temp");
     await expect(page.locator("#ed-pl-temp")).toBeVisible();
     for (let index = 0; index < 20; index++) await page.evaluate(() => editorSwitch("sez7"));
     expect(
@@ -162,7 +167,7 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
       .locator("div[onclick]")
       .click();
     await page.locator("#dm-temperature-room").selectOption("room-kitchen");
-    await page.locator("#dm-humidity-new").fill("sensor.kitchen_humidity");
+    await fillEntityFieldByHand(page, "#dm-humidity-new", "sensor.kitchen_humidity");
     await page.locator("[data-temperature-submit]").click();
     await expect
       .poll(() =>

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.30.8","dashboardVersion":"1.0.0-beta.30.8","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T09:27:11+00:00","commit":"1fbf366326e90603aa8541e360560c94cee3283f","assetHash":"6d79b590334f69e8"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.31","dashboardVersion":"1.0.0-beta.31","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T15:36:24+00:00","commit":"dbde500c64f5c93183b0b774eaf27d460cf81436","assetHash":"fbe8c43f4b673d77"});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.31","dashboardVersion":"1.0.0-beta.31","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T15:36:24+00:00","commit":"dbde500c64f5c93183b0b774eaf27d460cf81436","assetHash":"fbe8c43f4b673d77"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-beta.31","dashboardVersion":"1.0.0-beta.31","moduleVersion":14,"schemaVersion":4,"date":"2026-08-18T18:24:44+00:00","commit":"3f9fb6229ed7c51bcb72c5f805daf606d7afa66a","assetHash":"9aca0c65dc770ff2"});

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard-runtime-en.js
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard-runtime-en.js
@@ -705,6 +705,18 @@ const GRUPPI_MONITORAGGIO = {
   'batt': [],
 };
 
+/* Beta 31: a monitoring list is built from several sources that can name the
+   same entity — the lights of the Lights tab also land in cd_gruppi_extra.luci,
+   which synchronizeLightAlerts keeps in step — and concatenating them without a
+   filter listed every light twice in the ACTIVE LIGHTS popup and counted it
+   twice in the alerts board, while the editor kept showing it once. Every
+   addition goes through here: build order is kept, duplicates never enter. */
+function cdGruppoMerge(grp, ids) {
+  const target = GRUPPI_MONITORAGGIO[grp];
+  if (!Array.isArray(target) || !Array.isArray(ids)) return;
+  ids.forEach(id => { if (id && !target.includes(id)) target.push(id); });
+}
+
 /* ═══ v254: ESTENSIONI UTENTE (aggiunte da UI Configure Entities, solo admin) ═══
    - cd_subloads_extra: { "cucina": [{name, pwr, icon, bin?, pwrLive?}, ...], "lavanderia": [...] }
    - cd_gruppi_extra:   { "win": ["binary_sensor.x", ...], "batt": [...], "luci": [...] }
@@ -732,7 +744,7 @@ document.addEventListener('DOMContentLoaded', buildCustomLoadCards);
 try {
   const extGrp = cdCfg('cd_gruppi_extra');
   Object.entries(extGrp).forEach(([k, ids]) => {
-    if (GRUPPI_MONITORAGGIO[k] && Array.isArray(ids)) GRUPPI_MONITORAGGIO[k].push(...ids);
+    cdGruppoMerge(k, ids);
   });
 } catch(e) { console.warn('[Config Entità] gruppi_extra malformato:', e); }
 try {
@@ -745,7 +757,7 @@ try {
   const C = window.DASHBOARD_CONFIG || {};
   if (C.avvisi && typeof C.avvisi === 'object') {
     Object.entries(C.avvisi).forEach(([grp, ids]) => {
-      if (GRUPPI_MONITORAGGIO[grp] && Array.isArray(ids)) GRUPPI_MONITORAGGIO[grp].push(...ids);
+      cdGruppoMerge(grp, ids);
     });
   }
   if (C.avvisi_names && typeof C.avvisi_names === 'object') Object.assign(AVVISI_NAMES, C.avvisi_names);

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard-runtime-it.js
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard-runtime-it.js
@@ -706,6 +706,19 @@ const GRUPPI_MONITORAGGIO = {
   'batt': [],
 };
 
+/* Beta 31: una lista di monitoraggio nasce da piu' sorgenti che possono nominare
+   la stessa entita' — le luci della scheda Luci finiscono anche in
+   cd_gruppi_extra.luci, che synchronizeLightAlerts tiene allineato — e
+   concatenarle senza filtro faceva comparire ogni luce due volte nel popup
+   LUCI ATTIVE e contarla due volte nel Quadro Avvisi, mentre in Configurazione
+   restava singola. Ogni aggiunta passa da qui: l'ordine resta quello di
+   costruzione, i doppioni non entrano. */
+function cdGruppoMerge(grp, ids) {
+  const target = GRUPPI_MONITORAGGIO[grp];
+  if (!Array.isArray(target) || !Array.isArray(ids)) return;
+  ids.forEach(id => { if (id && !target.includes(id)) target.push(id); });
+}
+
 /* ═══ v254: ESTENSIONI UTENTE (aggiunte da UI Configura Entità, solo admin) ═══
    - cd_subloads_extra: { "cucina": [{name, pwr, icon, bin?, pwrLive?}, ...], "lavanderia": [...] }
    - cd_gruppi_extra:   { "win": ["binary_sensor.x", ...], "batt": [...], "luci": [...] }
@@ -733,7 +746,7 @@ document.addEventListener('DOMContentLoaded', buildCustomLoadCards);
 try {
   const extGrp = cdCfg('cd_gruppi_extra');
   Object.entries(extGrp).forEach(([k, ids]) => {
-    if (GRUPPI_MONITORAGGIO[k] && Array.isArray(ids)) GRUPPI_MONITORAGGIO[k].push(...ids);
+    cdGruppoMerge(k, ids);
   });
 } catch(e) { console.warn('[Config Entità] gruppi_extra malformato:', e); }
 try {
@@ -746,7 +759,7 @@ try {
   const C = window.DASHBOARD_CONFIG || {};
   if (C.avvisi && typeof C.avvisi === 'object') {
     Object.entries(C.avvisi).forEach(([grp, ids]) => {
-      if (GRUPPI_MONITORAGGIO[grp] && Array.isArray(ids)) GRUPPI_MONITORAGGIO[grp].push(...ids);
+      cdGruppoMerge(grp, ids);
     });
   }
   if (C.avvisi_names && typeof C.avvisi_names === 'object') Object.assign(AVVISI_NAMES, C.avvisi_names);

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -21,7 +21,7 @@ import { getDeviceDisplayName, getDeviceVisual, normalizeDevice } from "../src/c
 import { createEnergyReportRows, createRenderCoordinator, loadPopupMetrics, renderDeviceCard, renderEnergyEditor } from "../src/core/renderers.js";
 import { SCHEMA_VERSION } from "../src/core/device-model.js";
 import { BUILD_INFO } from "./build-info.js";
-import { canonicalReportDevices, reportEntityForDevice } from "../src/core/energy-projection.js";
+import { canonicalReportDevices, reportEntityForDevice, reportIconForDevice } from "../src/core/energy-projection.js";
 
 export const MODULES_VERSION = 14;
 const LOCALE = globalThis.document?.documentElement?.lang === "en" ? "en" : "it";
@@ -316,7 +316,7 @@ export function renderReportRow(item, index) {
   return `<div class="ed-row dm-report-row" data-report-id="${esc(item.id)}" data-section="${esc(item.section || "loads")}">
     <label><input type="checkbox" data-report-toggle ${item.show_in_report !== false ? "checked" : ""}> Report</label>
     <input class="ed-input" data-report-label placeholder="${t("reportLabel")}" value="${esc(item.report_label || item.name)}">
-    ${createIconField(`dm-report-icon-${fieldToken}`, item.report_icon || item.emoji_icon || item.icon)}
+    ${createIconField(`dm-report-icon-${fieldToken}`, item.report_icon || reportIconForDevice(item))}
     ${createEntityField({ id: `dm-report-entity-${fieldToken}`, label: t("reportEntity"), value: reportEntityForDevice(item, globalThis.STATES || {}), optional: false })}
     ${item.category === "manual-report" ? createEntityField({ id: `dm-report-history-${fieldToken}`, label: t("history"), value: item.history_entity }) : ""}
     <span><button type="button" data-report-up aria-label="${t("moveUp")}">▲</button><button type="button" data-report-down aria-label="${t("moveDown")}">▼</button>${item.category === "manual-report" ? `<button type="button" data-report-delete aria-label="${t("remove")}">🗑️</button>` : ""}</span>

--- a/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
+++ b/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
@@ -57,6 +57,29 @@ export function hasConfiguredData(section, value) {
   );
 }
 
+/* The legacy shape of the lights section: `{ "light.salone": "Salone" }`.
+ *
+ * Two things used to go wrong here. A section that is not an array — an older
+ * document, or a half-written one — threw on `.map`, and because this runs
+ * inside `persist()` the exception took the whole bootstrap with it: the
+ * dashboard came back blank. And a light with no entity produced the key
+ * `"undefined"`, which the runtime then showed as a nameless quick action that
+ * no editor could delete, because there was no entity behind it to delete.
+ *
+ * A light is a light when it has an entity. Anything else is dropped here
+ * rather than written back into the legacy document. */
+export function legacyLights(value) {
+  const entries = Array.isArray(value) ? value : Object.values(value || {});
+  const lights = {};
+  for (const item of entries) {
+    if (!item || typeof item !== "object") continue;
+    const entity = String(item.entity || item.entities?.[0] || "").trim();
+    if (!entity || !entity.includes(".")) continue;
+    lights[entity] = String(item.name || "").trim() || entity;
+  }
+  return lights;
+}
+
 export class DashboardStore {
   constructor({
     storage = globalThis.localStorage,
@@ -69,6 +92,18 @@ export class DashboardStore {
     this.listeners = new Set();
     this.persistedLegacyDigests = new Map();
     this.state = { schema_version: SCHEMA_VERSION, sections: {}, visibility: {} };
+  }
+  /* Forget the configuration held in memory.
+   *
+   * The reset clears storage, but this object keeps a complete copy of the
+   * plancia in `this.state`, and every legacy write that follows projects that
+   * copy straight back onto disk. That is how a reset used to come back with
+   * half a configuration — a quick action with nothing behind it, a light with
+   * no entity — in the seconds before the dashboard restarted. */
+  reset() {
+    this.state = { schema_version: SCHEMA_VERSION, sections: {}, visibility: {} };
+    this.persistedLegacyDigests.clear();
+    return this.state;
   }
   migrate() {
     const saved = this.storage.getItem("dm_dashboard_state");
@@ -154,8 +189,7 @@ export class DashboardStore {
       writeLegacy("cd_sections", this.state.visibility);
       for (const [section, key] of Object.entries(SECTION_KEYS)) {
         let value = this.state.sections[section] || [];
-        if (section === "lights")
-          value = Object.fromEntries(value.map((item) => [item.entities[0], item.name]));
+        if (section === "lights") value = legacyLights(value);
         writeLegacy(key, value);
       }
     } finally {

--- a/custom_components/dashboardmodern/frontend/src/core/editor-slots.js
+++ b/custom_components/dashboardmodern/frontend/src/core/editor-slots.js
@@ -16,6 +16,28 @@ export const EDITOR_SLOT_SECTIONS = Object.freeze({
   "dm.home_interruttore_antifurto": "security",
 });
 
+/* Slots the configuration no longer offers.
+ *
+ * Both of these were Home rows that asked a second time for something the
+ * plancia already knows. The alarm panel slot right above them carries the
+ * state of the alarm, and the gate is a quick action like any other, configured
+ * where quick actions are configured. Keeping them in the Home form meant two
+ * places to map the same thing and two answers when they disagreed.
+ *
+ * Whatever is already mapped to them keeps working: this list only takes them
+ * out of the editor, it never clears a stored override. The vendored runtime
+ * tries to hide these same two rows itself, with an inline `display:none` that
+ * the current row skin overrides — so the rows are removed here instead.
+ */
+export const RETIRED_EDITOR_SLOTS = Object.freeze([
+  "dm.home_interruttore_antifurto",
+  "dm.home_script_apertura_cancello",
+]);
+
+const RETIRED = new Set(RETIRED_EDITOR_SLOTS);
+
+export const isRetiredEditorSlot = (slot) => RETIRED.has(String(slot || "").trim());
+
 export function sectionForEditorSlot(slot) {
   if (EDITOR_SLOT_SECTIONS[slot]) return EDITOR_SLOT_SECTIONS[slot];
   // Families are declared once here for installations with additional slots.

--- a/custom_components/dashboardmodern/frontend/src/core/energy-projection.js
+++ b/custom_components/dashboardmodern/frontend/src/core/energy-projection.js
@@ -300,21 +300,54 @@ function glyphForMdi(icon) {
   return "⚡";
 }
 
-export function reportIconForDevice(item = {}) {
-  const explicit = configured(item.report_icon || item.emoji_icon || item.icon);
-  if (explicit && !explicit.startsWith("mdi:")) return explicit;
-  if (explicit.startsWith("mdi:")) return glyphForMdi(explicit);
-  const candidates = [item.visual_key, item.device_type, item.type, item.category, item.name].map(
-    normalizedToken,
-  );
-  for (const candidate of candidates) {
+function reportGlyphByType(...tokens) {
+  for (const candidate of tokens.map(normalizedToken).filter(Boolean)) {
     if (REPORT_ICON_BY_TYPE[candidate]) return REPORT_ICON_BY_TYPE[candidate];
     const match = Object.keys(REPORT_ICON_BY_TYPE).find((key) => candidate.includes(key));
     if (match) return REPORT_ICON_BY_TYPE[match];
   }
+  return "";
+}
+
+/* The Report entry shows the appliance it is about.
+ *
+ * This used to start from `emoji_icon`, which the appliance card itself never
+ * draws: the card draws what `getDeviceVisual()` returns — the artwork chosen
+ * in Elettrodomestici, or the mdi icon, or the one implied by the device type.
+ * So an appliance set up as a washing machine appeared in the Report as
+ * whatever emoji had been typed into some other field, and the two lists
+ * disagreed about the same device.
+ *
+ * The order here is the card's order, with one addition in front: `report_icon`
+ * is the icon deliberately given to the Report entry and always wins. Anything
+ * loose — an emoji field the card ignores — is the last resort, not the first.
+ */
+export function reportIconForDevice(item = {}) {
+  const override = configured(item.report_icon);
+  if (override) return override.startsWith("mdi:") ? glyphForMdi(override) : override;
+
   const visual = getDeviceVisual(item);
-  if (visual?.kind === "icon" && visual.value) return glyphForMdi(visual.value);
-  return "⚡";
+  // Anything but the generic fallback is a deliberate choice, and the card
+  // draws it: the Report follows it rather than inventing its own.
+  const chosenIcon =
+    visual?.kind === "icon" && visual.value && !/^mdi:devices?$/i.test(visual.value)
+      ? visual.value
+      : "";
+  if (chosenIcon) return glyphForMdi(chosenIcon);
+
+  const byType = reportGlyphByType(
+    visual?.kind === "asset" ? visual.value : "",
+    item.visual_key,
+    item.device_type,
+    item.type,
+    item.category,
+    item.name,
+  );
+  if (byType) return byType;
+
+  const loose = configured(item.emoji_icon || item.icon);
+  if (loose) return loose.startsWith("mdi:") ? glyphForMdi(loose) : loose;
+  return visual?.kind === "icon" && visual.value ? glyphForMdi(visual.value) : "⚡";
 }
 
 export function canonicalReportDevices(

--- a/custom_components/dashboardmodern/frontend/src/legacy/host.js
+++ b/custom_components/dashboardmodern/frontend/src/legacy/host.js
@@ -10,6 +10,8 @@
 import { createBridgeSocket } from "./bridge-socket.js";
 
 export const HOST_KEY = "__DASHBOARDMODERN_HOST__";
+/* Marker on the one message the hosted document is allowed to send its host. */
+export const HOST_MESSAGE_SOURCE = "dashboardmodern-host";
 export const LEGACY_FRAME_PERMISSIONS =
   "autoplay; fullscreen; picture-in-picture; encrypted-media";
 export const LEGACY_VARIANTS = Object.freeze({ it: "dashboard.html", en: "dashboard-en.html" });
@@ -32,6 +34,13 @@ function injectHostedPrelude(html, { baseUrl, instanceId, primary, configProfile
     window.__DASHBOARDMODERN_PRIMARY__=${primary !== false};
     window.__DASHBOARDMODERN_HOSTED__=true;
     window.__DASHBOARDMODERN_BRIDGED__=typeof bridge==='function';
+    /* The document lives at about:srcdoc, where location.reload() lands on a
+       blank page in the Home Assistant WebView. Anything that needs a fresh
+       dashboard asks the host to build one instead. The message carries no
+       data: the host only accepts it from this frame. */
+    window.__DASHBOARDMODERN_RELOAD__=function(){
+      try{ if(!p||p===window) return false; p.postMessage({source:'dashboardmodern-host',action:'reload'},'*'); return true; }catch(_e){ return false; }
+    };
     try{delete window.__DASHBOARDMODERN_REAL_TOKEN__;delete window.DASHBOARDMODERN_AUTH_TOKEN;delete window.LONG_LIVED_TOKEN;delete window.HA_TOKEN;}catch(_e){}
     if(typeof bridge==='function'){
       window.__DASHBOARDMODERN_BRIDGE_WS__=bridge;
@@ -165,7 +174,6 @@ export function mountLegacyHost(
     if (typeof frame.clientHeight === "number" && frame.clientHeight <= 0) frame.style.height = "100dvh";
   };
 
-  frame.addEventListener?.("load", install);
   container.replaceChildren(frame);
   install();
   ensureHeight();
@@ -177,18 +185,82 @@ export function mountLegacyHost(
       : async () => ({ ok: true, status: 200, text: async () => "<!doctype html><html><head></head><body></body></html>" });
   if (typeof loader !== "function") throw new Error("A fetch implementation is required.");
 
-  const ready = loadHostedDocument(frame, { staticBase, file, instanceId, primary, configProfile, fetchRef: loader, hostWindow }).catch((error) => {
-    console.error("[DashboardModern] hosted document bootstrap failed", error);
-    frame.srcdoc = `<main role="alert" style="padding:24px;font:16px sans-serif">DashboardModern: ${escapeAttribute(error.message)}</main>`;
-    return false;
-  });
+  const boot = () =>
+    loadHostedDocument(frame, { staticBase, file, instanceId, primary, configProfile, fetchRef: loader, hostWindow }).catch((error) => {
+      console.error("[DashboardModern] hosted document bootstrap failed", error);
+      frame.srcdoc = `<main role="alert" style="padding:24px;font:16px sans-serif">DashboardModern: ${escapeAttribute(error.message)}</main>`;
+      return false;
+    });
+
+  /* Reloading the dashboard.
+   *
+   * The dashboard document is handed to the frame through `srcdoc`, so its URL
+   * is `about:srcdoc`. Reloading that from the inside — which is what "reset
+   * the configuration" and "apply the auto-detection" both end with — lands on
+   * an empty document in the Home Assistant WebView: the plancia goes white and
+   * never comes back. The child asks for the reload instead, and the document
+   * is built again from here, exactly the way it was built the first time.
+   *
+   * The same rebuild also runs whenever the frame reports a load that left no
+   * document behind, which covers the reloads this host never hears about. */
+  let rebooting = false;
+  let booted = false;
+  const reboot = () => {
+    if (rebooting) return false;
+    rebooting = true;
+    Promise.resolve(boot()).finally(() => {
+      rebooting = false;
+    });
+    return true;
+  };
+
+  const lostItsDocument = () => {
+    try {
+      const childDocument = frame.contentDocument;
+      if (!childDocument) return false;
+      // A dashboard document always has a body with content in it. An
+      // about:blank replacement has an empty body and no dashboard marker.
+      return Boolean(
+        childDocument.body &&
+          !childDocument.body.firstElementChild &&
+          !frame.contentWindow?.__DASHBOARDMODERN_STORAGE_NS__,
+      );
+    } catch (_error) {
+      return false;
+    }
+  };
+
+  const onFrameLoad = () => {
+    install();
+    if (rebooting) return;
+    // The frame's first load is the empty document it is created with, before
+    // this host has written anything into it: that one is not a loss.
+    if (!lostItsDocument()) {
+      booted = true;
+      return;
+    }
+    if (booted) reboot();
+  };
+  frame.addEventListener?.("load", onFrameLoad);
+
+  const onChildMessage = (event) => {
+    if (event.source !== frame.contentWindow) return;
+    const data = event.data;
+    if (data?.source !== HOST_MESSAGE_SOURCE || data?.action !== "reload") return;
+    reboot();
+  };
+  hostWindow.addEventListener?.("message", onChildMessage);
+
+  const ready = boot();
 
   return {
     frame,
     ready,
     install,
     ensureHeight,
+    reboot,
     destroy() {
+      hostWindow.removeEventListener?.("message", onChildMessage);
       frame.remove();
       delete hostWindow[HOST_KEY];
       delete hostWindow.__DASHBOARDMODERN_INSTANCE__;

--- a/custom_components/dashboardmodern/frontend/src/sections/beta4-mobile-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta4-mobile-polish-section.js
@@ -551,7 +551,13 @@ function installStyles() {
     #ed-body .ed-row[data-section-key] .ed-row-main{display:grid!important;grid-template-columns:minmax(0,1fr) 44px!important;grid-template-rows:auto!important;align-items:center!important;gap:8px!important;min-width:0!important;padding-right:0!important;position:relative!important}
     #ed-body .ed-row[data-section-key] .ed-row-main>.ed-row-new{grid-column:1!important;grid-row:1!important;min-width:0!important}
     #ed-body .ed-row[data-section-key] .dm-inline-rename[data-dm-beta5-primary="true"]{grid-column:2!important;grid-row:1!important;position:static!important;inset:auto!important;transform:none!important;display:grid!important;place-items:center!important;width:44px!important;min-width:44px!important;height:44px!important;min-height:44px!important;margin:0!important;padding:0!important;border:1px solid color-mix(in srgb,var(--info-color,#0ea5e9) 28%,var(--divider-color,#dbe4ee))!important;border-radius:13px!important;background:color-mix(in srgb,var(--info-color,#0ea5e9) 10%,var(--card-background-color,#fff))!important;color:var(--text,#0f172a)!important;font-size:19px!important;line-height:1!important;box-shadow:none!important;overflow:visible!important}
-    #ed-body .ed-row[data-section-key] .dm-inline-rename[data-rename]:not([data-dm-beta5-primary="true"]){display:none!important}
+    /* Only the copies outside the row's main cell are hidden while this module's
+     * pass has not run yet. Hiding every unmarked button meant a row printed by
+     * another owner after the pass — which happens whenever the tab is redrawn
+     * — showed no rename at all until something scheduled another pass. The
+     * pass still removes the copies; this rule only covers the window before
+     * it. */
+    #ed-body .ed-row[data-section-key] :not(.ed-row-main)>.dm-inline-rename[data-rename]:not([data-dm-beta5-primary="true"]){display:none!important}
 
     .dm-car-brand{display:grid!important;place-items:center!important;color:var(--info-color,#0284c7)!important;background:transparent!important}
     .dm-beta5-brand-logo{display:grid!important;place-items:center!important;width:82px!important;height:54px!important;color:currentColor!important}

--- a/custom_components/dashboardmodern/frontend/src/sections/beta7-regression-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta7-regression-section.js
@@ -258,36 +258,25 @@ function installStyles() {
     #page-clima .cp-controls{min-height:58px!important;padding:6px!important;border-radius:17px!important}
     #page-clima .cp-btn{height:46px!important;font-size:20px!important}
 
-    /* Tapparella: finestra moderna, cassonetto e lamelle metalliche continue.
-       La funzione legacy viene anche protetta dai rerender identici ogni 2 s. */
-    #page-tapparelle .tapp-card{padding:16px!important;gap:12px!important;border-radius:24px!important;overflow:hidden!important}
-    #page-tapparelle .tapp-head{padding:0 2px!important}
-    #page-tapparelle .tapp-name{font-size:16px!important}
-    #page-tapparelle .tapp-win{position:relative!important;height:180px!important;border:1px solid rgba(100,116,139,.22)!important;border-radius:22px!important;overflow:hidden!important;background:linear-gradient(180deg,#dff4ff 0%,#cce9f7 45%,#eef7fb 100%)!important;box-shadow:inset 0 0 0 9px rgba(255,255,255,.82),inset 0 -28px 42px rgba(30,64,175,.08),0 10px 26px rgba(15,23,42,.08)!important}
-    #page-tapparelle .tapp-glass{position:absolute!important;inset:10px!important;border-radius:15px!important;background:linear-gradient(135deg,rgba(255,255,255,.72),rgba(255,255,255,.12) 42%,rgba(14,165,233,.08))!important;box-shadow:inset 0 0 0 1px rgba(100,116,139,.12)!important}
-    #page-tapparelle .tapp-glass::before{content:"";position:absolute;left:50%;top:0;bottom:0;width:2px;transform:translateX(-1px);background:rgba(148,163,184,.32)!important}
-    #page-tapparelle .tapp-glass::after{content:"";position:absolute;left:0;right:0;top:50%;height:2px;transform:translateY(-1px);background:rgba(148,163,184,.24)!important}
-    #page-tapparelle .tapp-shutter{left:9px!important;right:9px!important;top:9px!important;width:auto!important;border-radius:14px 14px 9px 9px!important;overflow:hidden!important;background:repeating-linear-gradient(180deg,#edf3f8 0 9px,#cbd6e0 9px 11px,#aab9c8 11px 13px)!important;box-shadow:0 10px 18px rgba(15,23,42,.18),inset 0 -1px 0 rgba(51,65,85,.28)!important;transition:height .58s cubic-bezier(.22,.82,.28,1)!important;will-change:height,background-position!important}
-    #page-tapparelle .tapp-shutter::before{content:"";position:absolute;left:0;right:0;top:0;height:12px;background:linear-gradient(180deg,#f8fbfd,#b9c7d4)!important;box-shadow:0 2px 4px rgba(15,23,42,.18)!important;z-index:2}
-    #page-tapparelle .tapp-shutter::after{content:"";position:absolute;left:5px;right:5px;bottom:0;height:7px;border-radius:0 0 7px 7px;background:linear-gradient(180deg,#9baabb,#718296)!important;box-shadow:0 2px 5px rgba(15,23,42,.2)!important}
-    #page-tapparelle .tapp-shutter i{opacity:0!important;flex:0 0 11px!important;height:11px!important;border:0!important;background:transparent!important}
-    #page-tapparelle .tapp-shutter.opening,#page-tapparelle .tapp-shutter.closing{animation:dmBeta7ShutterRoll .55s linear infinite!important}
-    @keyframes dmBeta7ShutterRoll{to{background-position:0 26px}}
-    #page-tapparelle .tapp-pos{font-size:15px!important;font-weight:900!important;opacity:1!important;color:var(--text,#0f172a)!important}
-    #page-tapparelle .tapp-ctl{gap:9px!important}
-    #page-tapparelle .tapp-btn{height:46px!important;border-radius:14px!important;font-weight:850!important;box-shadow:0 6px 14px rgba(14,165,233,.18)!important}
+    /* La Tapparella non è più skinnata qui.
+       Quella pelle risale a Beta 7 e disegnava una finestra alta 180px con il
+       pannello staccato di 9px dai bordi. Il disegno attuale è di
+       shutter-section.js (geometria e materiali) e di shutter-scene-section.js
+       (struttura della pagina): dei due fogli sopravviveva comunque questo
+       left/right/top:9px, perché è l'unico punto in cui quelle proprietà
+       venivano dichiarate. Risultato: con la tapparella chiusa restavano
+       scoperti il cielo in alto e le colline negli angoli in basso.
+       Un solo proprietario per pagina: qui non si tocca più. */
 
     @media(max-width:760px){
       #page-clima .clima-premium-grid{grid-template-columns:repeat(2,minmax(0,1fr))!important;gap:8px!important}
       #page-clima .cp-card{min-height:0!important;padding:18px 20px!important;gap:16px!important}
       #page-clima .cp-temp-target .val{font-size:43px!important}
-      #page-tapparelle #tapp-grid{grid-template-columns:1fr!important;padding:10px 0!important;gap:14px!important}
-      #page-tapparelle .tapp-win{height:190px!important}
       #editor-modal .ed-row.dm-beta7-action-row{grid-template-columns:44px minmax(0,1fr) 40px 40px!important;gap:7px!important;padding:9px!important}
     }
 
     @media(hover:none){
-      #page-clima .cp-card:hover,#page-tapparelle .tapp-card:hover,#qa-grid .qa-btn:hover{transform:none!important}
+      #page-clima .cp-card:hover,#qa-grid .qa-btn:hover{transform:none!important}
     }
   `);
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
@@ -1,10 +1,10 @@
 // DM-FIX-20260817A
 import { normalizeSection } from "../core/migrations.js";
-import { root } from "./shared.js";
+import { reloadDashboard, root } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_CONFIG_PERSISTENCE__";
 const USER_DATA_VERSION = 1;
-const CONFIG_KEYS_REVISION = 2;
+export const CONFIG_KEYS_REVISION = 3;
 const PERSIST_META_KEY = "dm_persistence_meta";
 const REMOTE_REFRESH_MIN_MS = 1200;
 
@@ -69,6 +69,7 @@ export const CONFIG_KEYS = Object.freeze([
   "cd_ev_car_active",
   "cd_ev_visual",
   "cd_ev_image",
+  "cd_ev_image_plugged",
   "cd_visual_prefer_image",
   "cd_tapparelle",
   "cd_piscina",
@@ -286,10 +287,13 @@ export function normalizeSharedSnapshot(snapshot) {
 }
 
 /**
- * Before revision 2 several real editor keys were not part of the modern cloud
- * snapshot. Absence in those payloads cannot mean "deleted". Fill only missing
- * old fields from the current device once; values actually present remotely
- * still win. Revision 2 is complete, so future absence means deletion again.
+ * A snapshot written before the current revision was written by a build that
+ * did not know about every key this one syncs, so absence in it cannot mean
+ * "deleted". Fill only the missing old fields from the current device once;
+ * values actually present remotely still win. At the current revision the
+ * payload is complete again, so absence means deletion.
+ *
+ * Revision 3 adds the second vehicle photo (`cd_ev_image_plugged`).
  */
 export function mergeLegacyMissingConfig(remote, local = {}) {
   if (!remote || Number(remote.keys_revision) >= CONFIG_KEYS_REVISION) return remote;
@@ -951,6 +955,14 @@ export async function resetAllConfig({ skipConfirm = false, reload = true } = {}
     return false;
   }
 
+  // Storage is empty, memory is not: the canonical store still holds the whole
+  // plancia and projects it back onto the legacy keys on the next write, which
+  // is why a reset used to leave a stray light and an empty quick action
+  // behind. Empty it here, before anything can write again.
+  try {
+    root.DashboardModernModules?.store?.reset?.();
+  } catch (_error) {}
+
   const empty = snapshot();
   try {
     if (sharedStoreEnabled()) {
@@ -976,7 +988,7 @@ export async function resetAllConfig({ skipConfirm = false, reload = true } = {}
   } catch (_error) {}
 
   root.dispatchEvent?.(new CustomEvent("dashboardmodern:config-reset", { detail: empty }));
-  if (reload) root.setTimeout?.(() => root.location?.reload?.(), 40);
+  if (reload) root.setTimeout?.(() => reloadDashboard(), 40);
   else {
     state.resetting = false;
     delete root.__DASHBOARDMODERN_CONFIG_RESETTING__;

--- a/custom_components/dashboardmodern/frontend/src/sections/config-uniformity-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/config-uniformity-section.js
@@ -253,10 +253,9 @@ const SETTLE_DELAYS = Object.freeze([120, 420, 900, 1800]);
 function watchEditorBody() {
   const body = editorBody();
   if (!body || state.watched === body) return;
-  const Observer = root.MutationObserver;
-  if (!Observer) return;
+  if (typeof root.MutationObserver !== "function") return;
   state.observer?.disconnect?.();
-  state.observer = new Observer(() => schedule({ settle: false }));
+  state.observer = new root.MutationObserver(() => schedule({ settle: false }));
   state.observer.observe(body, {
     childList: true,
     attributes: true,

--- a/custom_components/dashboardmodern/frontend/src/sections/config-uniformity-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/config-uniformity-section.js
@@ -236,11 +236,20 @@ export function uniformConfiguration(body = editorBody(), tab = activeTab()) {
  * changing — every time the block list of the tab changes, whoever changed it,
  * the pass runs again on the next frame. The two delays are kept for the panels
  * that arrive without touching that list. */
-const SETTLE_DELAYS = Object.freeze([120, 420]);
+const SETTLE_DELAYS = Object.freeze([120, 420, 900, 1800]);
 
-/* Scoped to `#ed-body` and to its own children: the switch and the save are
- * placed among those blocks, so that list is the whole of what this needs to
- * hear. Nothing deeper is observed, and the document never is. */
+/* Scoped to `#ed-body`: the blocks of the tab, and the inline `display` the
+ * runtime writes on them.
+ *
+ * Both matter. The switch and the save are placed among the blocks, so the
+ * block list is one half; the other half is `edFilterSez`, which chooses the
+ * tab's section by hiding the other twelve with an inline style and changes no
+ * block at all. On a slow device that filtering lands after the tab has
+ * switched — on the WebKit runner it landed after every timer this module had
+ * — and a pass that only heard about blocks never learned the tab had been
+ * narrowed. Nothing deeper than the inline style is observed, and the document
+ * never is. This module writes no inline styles itself, so it cannot wake
+ * itself. */
 function watchEditorBody() {
   const body = editorBody();
   if (!body || state.watched === body) return;
@@ -248,7 +257,12 @@ function watchEditorBody() {
   if (!Observer) return;
   state.observer?.disconnect?.();
   state.observer = new Observer(() => schedule({ settle: false }));
-  state.observer.observe(body, { childList: true });
+  state.observer.observe(body, {
+    childList: true,
+    attributes: true,
+    attributeFilter: ["style"],
+    subtree: true,
+  });
   state.watched = body;
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/config-uniformity-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/config-uniformity-section.js
@@ -28,7 +28,7 @@ import { clean, doc, installStyle, root, t, wrapFunction } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_CONFIG_UNIFORMITY__";
 const STYLE_ID = "dm-config-uniformity-style";
-const state = (root[KEY] ||= { installed: false, frame: 0 });
+const state = (root[KEY] ||= { installed: false, frame: 0, watched: null, observer: null });
 
 /* The tab of a dashboard section, and the visibility key that section has.
  *
@@ -120,7 +120,11 @@ export function ensureVisibilityBanner(body = editorBody(), tab = activeTab()) {
   const key = TAB_SECTION_KEYS[tab];
   const existing = [...body.querySelectorAll("[data-key][onclick*='edSecTog']")];
   if (!key) {
-    existing.forEach((node) => node.remove());
+    // Only ever a banner this module printed. The Visibilità tab is made of
+    // these very switches, one per section — taking them away there would empty
+    // the tab, and the runtime would print them again on the next pass, which is
+    // a fight with no end.
+    existing.filter((node) => node.dataset.dmSectionSwitch === "true").forEach((n) => n.remove());
     return false;
   }
   // More than one is the runtime's and ours together: keep the first.
@@ -133,6 +137,7 @@ export function ensureVisibilityBanner(body = editorBody(), tab = activeTab()) {
     holder.innerHTML = markup;
     banner = holder.firstElementChild;
     if (!banner) return false;
+    banner.dataset.dmSectionSwitch = "true";
     body.prepend(banner);
   } else if (!body.firstElementChild?.contains(banner)) {
     // Always in the block that opens the tab. Where the runtime already prints
@@ -224,12 +229,31 @@ export function uniformConfiguration(body = editorBody(), tab = activeTab()) {
  * Several panels of the configuration are printed by their own owner after the
  * tab has switched — the vehicle's brand and model, the server parameters, the
  * energy panels. A single pass would run before those exist and leave their
- * save buttons on screen next to the tab's own, which is the very thing this
- * module is here to prevent. The pass therefore runs again while the tab
- * settles, a fixed and small number of times. */
+ * save buttons on screen next to the tab's own, and a panel printed at the top
+ * would push the section switch out of the opening block. Waiting a fixed
+ * number of milliseconds only moves the race: on a loaded machine the owner
+ * still arrives late. What the pass answers to instead is the tab itself
+ * changing — every time the block list of the tab changes, whoever changed it,
+ * the pass runs again on the next frame. The two delays are kept for the panels
+ * that arrive without touching that list. */
 const SETTLE_DELAYS = Object.freeze([120, 420]);
 
+/* Scoped to `#ed-body` and to its own children: the switch and the save are
+ * placed among those blocks, so that list is the whole of what this needs to
+ * hear. Nothing deeper is observed, and the document never is. */
+function watchEditorBody() {
+  const body = editorBody();
+  if (!body || state.watched === body) return;
+  const Observer = root.MutationObserver;
+  if (!Observer) return;
+  state.observer?.disconnect?.();
+  state.observer = new Observer(() => schedule({ settle: false }));
+  state.observer.observe(body, { childList: true });
+  state.watched = body;
+}
+
 function schedule({ settle = true } = {}) {
+  watchEditorBody();
   if (settle) {
     for (const delay of SETTLE_DELAYS) {
       root.setTimeout?.(() => schedule({ settle: false }), delay);

--- a/custom_components/dashboardmodern/frontend/src/sections/config-uniformity-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/config-uniformity-section.js
@@ -1,0 +1,327 @@
+// DM-FIX-20260818B
+/* One Configuration, one set of gestures.
+ *
+ * The editor grew a tab at a time and each tab ended up answering the same
+ * questions differently. Opening every tab and counting what is on screen says
+ * it plainly:
+ *
+ * - five tabs had no way to save at all (Temperatura, Tapparelle, Stanze, Luci,
+ *   Avvisi) while the others had one — and Sicurezza and EV had two, in
+ *   different places, with eight different wordings for the same act between
+ *   them: "Salva sezione", "Salva Energia", "Salva server", "Salva piscina",
+ *   "Salva impostazioni", "Salva generali", "Salva costi", "Salva Report";
+ * - the green "sezione visibile in dashboard" banner was on nine tabs and
+ *   missing from Temperatura, which has exactly the same kind of switch as the
+ *   others — its tab is simply drawn by a different renderer;
+ * - every section tab carried the whole form: thirteen accordions and 104
+ *   entity fields, twelve of them hidden. Every decorator in the editor walked
+ *   all of them on every pass, and a stray `display` from anywhere put another
+ *   section's form on screen.
+ *
+ * This owns those three things, and only those three. It never renders a
+ * section's content and never saves anything itself: the save it offers is the
+ * tab's own save buttons, pressed for the panels that are on screen, and the
+ * visibility banner is the runtime's own `cdSecToggleHtml` markup with the
+ * runtime's own `edSecTog` handler.
+ */
+import { clean, doc, installStyle, root, t, wrapFunction } from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_CONFIG_UNIFORMITY__";
+const STYLE_ID = "dm-config-uniformity-style";
+const state = (root[KEY] ||= { installed: false, frame: 0 });
+
+/* The tab of a dashboard section, and the visibility key that section has.
+ *
+ * The `sez*` ordinals are the runtime's own (`cdSecKeyByOrd`); the rest are the
+ * keys `editorSwitch` already passes to `cdSecToggleHtml` when it prints those
+ * tabs. Temperature is in the list for the same reason as all the others — it
+ * has a switch — and it is the one the editor forgot. */
+export const TAB_SECTION_KEYS = Object.freeze({
+  sez0: "home",
+  sez1: "energy",
+  sez2: "ev",
+  sez3: "boiler",
+  sez4: "security",
+  sez6: "server",
+  sez7: "temp",
+  sez9: "clima",
+  tapp: "tapparelle",
+  pool: "piscina",
+  irr: "irrigazione",
+  appliances: "appliances",
+});
+
+/* Tabs that hold no configuration to save: diagnostics is read-only, and the
+ * visibility tab has its own single control. */
+const NO_SAVE_TABS = new Set(["runtime", "visib", "export", "rileva"]);
+
+/* What counts as "save this section". Add buttons, profile buttons and the
+ * visibility banner are not saves, however much their label looks like one:
+ * they are matched by the handler they carry, never by their wording. */
+const SAVE_SELECTOR = [
+  ".ed-save-btn",
+  "[data-energy-save]",
+  "[data-report-save]",
+  "[data-dm-loads-save]",
+  // Matched on any element: some of these controls are a div with an onclick,
+  // not a button.
+  '[onclick*="edSaveSezione"]',
+  '[onclick*="edSecSave"]',
+  '[onclick*="edSaveCosti"]',
+  '[onclick*="edPoolSaveCfg"]',
+  '[onclick*="edIrrSaveCfg"]',
+].join(",");
+
+export function activeTab() {
+  return clean(doc?.querySelector?.(".ed-tab.active")?.dataset?.tab);
+}
+
+function editorBody() {
+  return doc?.getElementById("ed-body") || null;
+}
+
+/* ── one section per tab ──────────────────────────────────────────────────── */
+
+/* `edFilterSez` leaves every other section in the document with `display:none`.
+ * Hidden is not gone: the fields are still decorated, the save buttons are
+ * still there to be found, and one stray rule puts another section's form on
+ * screen. The tab keeps exactly what the runtime chose to show. */
+export function pruneHiddenSections(body = editorBody(), tab = activeTab()) {
+  if (!body || !/^sez\d+$/.test(tab)) return 0;
+  const accordions = [...body.querySelectorAll("details.ed-acc")];
+  // Never empty the tab: if the runtime hid all of them, something upstream
+  // has not finished, and removing the lot would leave a blank page.
+  const visible = accordions.filter((node) => node.style.display !== "none");
+  if (!visible.length) return 0;
+  let removed = 0;
+  for (const node of accordions) {
+    if (node.style.display !== "none") continue;
+    node.remove();
+    removed += 1;
+  }
+  return removed;
+}
+
+/* ── the same switch, on every section ────────────────────────────────────── */
+
+function bannerMarkup(key) {
+  try {
+    return clean(root.cdSecToggleHtml?.(key));
+  } catch (_error) {
+    return "";
+  }
+}
+
+/* The runtime prints this banner itself on most tabs. Where it does not — the
+ * tabs a canonical renderer draws — it is printed here, from the same markup
+ * and the same handler, so the switch behaves identically wherever it is. */
+export function ensureVisibilityBanner(body = editorBody(), tab = activeTab()) {
+  if (!body) return false;
+  const key = TAB_SECTION_KEYS[tab];
+  const existing = [...body.querySelectorAll("[data-key][onclick*='edSecTog']")];
+  if (!key) {
+    existing.forEach((node) => node.remove());
+    return false;
+  }
+  // More than one is the runtime's and ours together: keep the first.
+  existing.slice(1).forEach((node) => node.remove());
+  let banner = existing[0];
+  if (!banner) {
+    const markup = bannerMarkup(key);
+    if (!markup) return false;
+    const holder = doc.createElement("div");
+    holder.innerHTML = markup;
+    banner = holder.firstElementChild;
+    if (!banner) return false;
+    body.prepend(banner);
+  } else if (!body.firstElementChild?.contains(banner)) {
+    // Always in the block that opens the tab. Where the runtime already prints
+    // it inside its own wrapper — the EV tab wraps the switch together with the
+    // vehicle profiles — it is left in that wrapper rather than torn out of it.
+    body.prepend(banner);
+  }
+  banner.classList.add("dm-section-switch");
+  return true;
+}
+
+/* ── one save, in one place, on every tab ─────────────────────────────────── */
+
+function sectionSaves(body) {
+  return [...body.querySelectorAll(SAVE_SELECTOR)].filter(
+    (button) => !button.closest("[data-dm-save-footer]"),
+  );
+}
+
+/* A save belongs to a panel; the panel is what tells us whether the user is
+ * looking at it. The button itself is hidden by this module, so it is never the
+ * thing measured. */
+function panelOnScreen(button) {
+  const panel =
+    button.closest("[data-energy-panel],details.ed-acc,.ed-form,.ed-list") || button.parentElement;
+  return !panel || panel.getClientRects().length > 0;
+}
+
+function pressTabSaves(body) {
+  const buttons = sectionSaves(body).filter(panelOnScreen);
+  if (!buttons.length) {
+    // Tabs whose rows are written as they are edited still answer the gesture,
+    // with the runtime's own "section saved" acknowledgement.
+    try {
+      root.edSecSave?.();
+    } catch (_error) {}
+    return 0;
+  }
+  let pressed = 0;
+  for (const button of buttons) {
+    try {
+      button.click();
+      pressed += 1;
+    } catch (_error) {}
+  }
+  return pressed;
+}
+
+export function ensureSaveFooter(body = editorBody(), tab = activeTab()) {
+  if (!body) return false;
+  if (NO_SAVE_TABS.has(tab)) {
+    body.querySelector(":scope > [data-dm-save-footer]")?.remove();
+    return false;
+  }
+  let footer = body.querySelector(":scope > [data-dm-save-footer]");
+  if (!footer) {
+    footer = doc.createElement("div");
+    footer.className = "dm-save-footer";
+    footer.dataset.dmSaveFooter = "true";
+    const button = doc.createElement("button");
+    button.type = "button";
+    button.className = "ed-save-btn dm-save-footer-btn";
+    button.dataset.dmSaveAll = "true";
+    button.textContent = `💾 ${t("Salva sezione", "Save section")}`;
+    footer.append(button);
+    // The acknowledgement is the runtime's own toast, the one every save in the
+    // editor has always raised. A second status of our own would be one more
+    // thing that behaves differently from tab to tab.
+    button.addEventListener("click", () => pressTabSaves(body));
+  }
+  // Always the last thing on the tab, whatever the tab appended after it.
+  if (body.lastElementChild !== footer) body.append(footer);
+  return true;
+}
+
+/* ── pass ─────────────────────────────────────────────────────────────────── */
+
+export function uniformConfiguration(body = editorBody(), tab = activeTab()) {
+  if (!body || !tab) return false;
+  pruneHiddenSections(body, tab);
+  ensureVisibilityBanner(body, tab);
+  ensureSaveFooter(body, tab);
+  body.dataset.dmConfigUniform = tab;
+  return true;
+}
+
+/* A tab does not finish drawing in one frame.
+ *
+ * Several panels of the configuration are printed by their own owner after the
+ * tab has switched — the vehicle's brand and model, the server parameters, the
+ * energy panels. A single pass would run before those exist and leave their
+ * save buttons on screen next to the tab's own, which is the very thing this
+ * module is here to prevent. The pass therefore runs again while the tab
+ * settles, a fixed and small number of times. */
+const SETTLE_DELAYS = Object.freeze([120, 420]);
+
+function schedule({ settle = true } = {}) {
+  if (settle) {
+    for (const delay of SETTLE_DELAYS) {
+      root.setTimeout?.(() => schedule({ settle: false }), delay);
+    }
+  }
+  if (state.frame) return;
+  const run = () => {
+    state.frame = 0;
+    uniformConfiguration();
+  };
+  state.frame = root.requestAnimationFrame?.(run) || root.setTimeout?.(run, 0) || 0;
+}
+
+function installStyles() {
+  installStyle(
+    STYLE_ID,
+    `
+    /* the section switch: same block, same place, on every tab that has one */
+    #ed-body > .dm-section-switch{
+      display:block!important;box-sizing:border-box!important;width:100%!important;
+      margin:0 0 12px!important;order:-1!important
+    }
+
+    /* The save: one control, at the end of the tab, the same everywhere.
+     *
+     * The tab's own save buttons are hidden by the rule itself rather than by a
+     * marker this module writes: a panel that redraws itself after the pass —
+     * Irrigazione does, and so do the vehicle and server panels — would come
+     * back with an unmarked button and a second save on screen. A selector
+     * cannot go stale. The buttons stay in the document and stay the thing that
+     * actually saves; the footer presses them. */
+    /* The id is repeated to outweigh the per-tab rules that pin these same
+     * buttons to display:flex — the Irrigazione one is
+     * #editor-modal #ed-body:has(#ed-irr-ent) .ed-btn-add, three ids' worth.
+     * Same element set, enough weight to be the one that decides. */
+    #ed-body#ed-body#ed-body[data-dm-config-uniform]:not([data-dm-config-uniform="visib"]):not([data-dm-config-uniform="runtime"]) :is(
+      .ed-save-btn,
+      [data-energy-save],
+      [data-report-save],
+      [data-dm-loads-save],
+      [onclick*="edSaveSezione"],
+      [onclick*="edSecSave"],
+      [onclick*="edSaveCosti"],
+      [onclick*="edPoolSaveCfg"],
+      [onclick*="edIrrSaveCfg"]
+    ):not(.dm-save-footer-btn){display:none!important}
+    #ed-body > .dm-save-footer{
+      display:flex!important;align-items:center!important;gap:12px!important;flex-wrap:wrap!important;
+      box-sizing:border-box!important;width:100%!important;margin:18px 0 4px!important;padding:14px 0 0!important;
+      border-top:1px solid var(--divider-color,#dbe4ee)!important
+    }
+    #ed-body > .dm-save-footer > .dm-save-footer-btn{
+      flex:1 1 220px!important;min-height:48px!important;margin:0!important
+    }
+    @media(max-width:600px){
+      #ed-body > .dm-save-footer > .dm-save-footer-btn{flex:1 1 100%!important}
+    }
+  `,
+  );
+}
+
+function bindLegacyEntryPoints() {
+  wrapFunction("editorSwitch", "__dmConfigUniform_editorSwitch", schedule);
+  wrapFunction("apriConfigEntita", "__dmConfigUniform_apriConfigEntita", schedule);
+  wrapFunction("edFilterSez", "__dmConfigUniform_edFilterSez", schedule);
+}
+
+export function installConfigUniformitySection() {
+  if (!doc || state.installed) return;
+  state.installed = true;
+  installStyles();
+  for (const eventName of ["dashboardmodern:legacy-ready", "dashboardmodern:runtime-ready"]) {
+    root.addEventListener?.(eventName, () => {
+      bindLegacyEntryPoints();
+      schedule();
+    });
+  }
+  doc.addEventListener(
+    "click",
+    (event) => {
+      if (event.target?.closest?.(".ed-tab,[data-tab],[data-energy-tab],.ed-btn-add,.ed-del")) {
+        root.setTimeout?.(schedule, 0);
+      }
+    },
+    true,
+  );
+  bindLegacyEntryPoints();
+  schedule();
+}
+
+if (doc?.readyState === "loading") {
+  doc.addEventListener("DOMContentLoaded", installConfigUniformitySection, { once: true });
+} else {
+  installConfigUniformitySection();
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
@@ -25,11 +25,12 @@
  * Nothing here reads or writes Home Assistant state beyond the friendly name of
  * an entity already in `_RAW_STATES`.
  */
+import { isRetiredEditorSlot } from "../core/editor-slots.js";
 import { clean, doc, root, installStyle, t, wrapFunction } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_EDITOR_SLOTS__";
 const STYLE_ID = "dm-editor-slots-style";
-const state = (root[KEY] ||= { installed: false, frame: 0 });
+const state = (root[KEY] ||= { installed: false, frame: 0, pending: 0, retries: 0 });
 
 /** Friendly name Home Assistant knows for an entity, "" when it knows none. */
 export function entityLabel(entity, states = root._RAW_STATES || root.STATES || {}) {
@@ -126,18 +127,199 @@ function decorateBody(body) {
   return true;
 }
 
+/* Rows the configuration no longer offers, taken out of the form.
+ *
+ * The runtime tries to hide these two itself, with an inline `display:none`
+ * that the row skin below overrides — an inline declaration cannot beat
+ * `!important`, so they came back. Taking the whole row out is the one answer
+ * that holds whichever owner paints last. The editor's save walks the rows that
+ * are present, so a row that is gone simply stops being written, and the
+ * override already stored behind it is never touched.
+ *
+ * Only a complete `.ed-slot` row is ever removed. A bare field with no row of
+ * its own belongs to some other form and is left exactly where it is — the
+ * fields this section decorates are never removed, only hidden. */
+export function dropRetiredSlots(scope = doc?.getElementById("ed-body")) {
+  if (!scope?.querySelectorAll) return 0;
+  let dropped = 0;
+  for (const input of scope.querySelectorAll(".ed-slot-in[data-ref]")) {
+    if (!isRetiredEditorSlot(input.dataset.ref)) continue;
+    const row = input.closest(".ed-slot");
+    if (!row) continue;
+    row.remove();
+    dropped += 1;
+  }
+  return dropped;
+}
+
+/* The same readable row, on every entity field in the configuration.
+ *
+ * The accordions of the Sezioni tab were the only place that got it. Everywhere
+ * else — Luci, Telecamere, Report, Temperature, Irrigazione — a field still
+ * asked for an entity id in a text box with a lens beside it, so the same job
+ * was done two different ways depending on which tab you happened to open.
+ *
+ * The rule for what is an entity field is not restated here: the picker guard
+ * already decides that, and marks what it decides with `data-entity-input`.
+ * This turns each of those into the same row: what is chosen, or an invitation
+ * to choose. The field and its lens stay in the document, one tap away under
+ * the pencil, because they are what the editors read when they save.
+ */
+const CHIP_MARKER = "dmEntityChip";
+
+const NEVER_A_HOST = "#ed-body,.ed-body,.ed-list,.ed-form,.ed-shell,#editor-modal,#setup-wizard,.dm-section-dialog,form,body";
+
+/** The lens the editors put next to an entity field, if it is there. */
+function lensOf(input) {
+  return input.nextElementSibling?.matches?.(".dm-entity-picker") ? input.nextElementSibling : null;
+}
+
+/* Where the row goes.
+ *
+ * The lens has to stay exactly where it is — it is the input's next sibling,
+ * and that pair is what the picker guard and the editors' own mount step
+ * reconcile; moving it makes them mount a second lens. So the row is built
+ * around it: the host is the element that already holds the pair. */
+function chipHost(input, lens) {
+  const wrapper = input.parentElement;
+  if (!wrapper || wrapper.matches(NEVER_A_HOST) || !wrapper.contains(lens)) return null;
+  return wrapper;
+}
+
+function paintFieldChip(host) {
+  const input = host.querySelector("input[data-entity-input]");
+  const chip = host.querySelector(".dm-entity-picker.dm-slot-chip");
+  if (!input || !chip) return;
+  const value = clean(input.value);
+  const label = entityLabel(value);
+  // Only ever write what actually changed. The editors watch their own panels
+  // for mutations and re-render when they see one, and a re-render throws away
+  // the draft the open form is collecting — so a row that repaints itself with
+  // identical content would quietly cost the user the value being typed.
+  const mapped = value ? "mapped" : "empty";
+  if (host.dataset.dmSlot !== mapped) host.dataset.dmSlot = mapped;
+  const name = chip.querySelector("[data-chip-name]");
+  const id = chip.querySelector("[data-chip-id]");
+  if (!name || !id) return;
+  const nameText = value ? label || value : t("Scegli entità", "Choose entity");
+  const idText = value && label ? value : "";
+  if (name.textContent !== nameText) name.textContent = nameText;
+  if (id.textContent !== idText) id.textContent = idText;
+  const fieldName =
+    clean(input.closest(".ed-slot,[data-entity-field]")?.querySelector(".ed-slot-lbl")?.textContent) ||
+    clean(input.getAttribute("aria-label")) ||
+    t("Entità", "Entity");
+  chip.setAttribute("aria-label", `${fieldName}: ${nameText}`);
+}
+
+/* One entity field, made readable.
+ *
+ * The lens becomes the row: same button, same handler, same
+ * `data-entity-target` — it simply stops being a 50px square with a magnifier
+ * in it and starts saying what is chosen, or inviting a choice. The raw id
+ * field goes behind the pencil next to it, which is where the Sezioni tab has
+ * kept it since it got these rows. */
+function decorateField(input) {
+  // A slot of a section accordion belongs to the row decorator above, which
+  // builds its own chip: giving it a second one leaves two rows saying the same
+  // thing, and the one the editor repaints is then anyone's guess.
+  if (input.closest(".dm-slot") || input.matches(".ed-slot-in[data-ref]")) return false;
+  const lens = lensOf(input);
+  if (!lens) return false;
+  const host = chipHost(input, lens);
+  if (!host) return false;
+  if (host.dataset[CHIP_MARKER] === "true") {
+    paintFieldChip(host);
+    return false;
+  }
+  host.dataset[CHIP_MARKER] = "true";
+  input.classList.add("dm-chip-raw");
+  lens.classList.add("dm-slot-chip");
+  lens.innerHTML = chipMarkup();
+
+  const manual = doc.createElement("button");
+  manual.type = "button";
+  manual.className = "dm-chip-manual";
+  manual.textContent = "✎";
+  manual.setAttribute("aria-label", t("Modifica manuale", "Edit by hand"));
+  manual.setAttribute("aria-pressed", "false");
+  manual.addEventListener("click", (event) => {
+    event.preventDefault();
+    const on = host.dataset.dmEntityRaw !== "true";
+    host.dataset.dmEntityRaw = on ? "true" : "false";
+    manual.setAttribute("aria-pressed", String(on));
+    if (on) input.focus();
+  });
+  // After the lens, never between the field and the lens: that pair is a
+  // contract every other owner of these forms reconciles.
+  lens.insertAdjacentElement("afterend", manual);
+
+  // After the form's own change handlers, never during them.
+  input.addEventListener("change", () => {
+    if (typeof root.requestAnimationFrame !== "function") {
+      paintFieldChip(host);
+      return;
+    }
+    root.requestAnimationFrame(() => paintFieldChip(host));
+  });
+  paintFieldChip(host);
+  return true;
+}
+
+/* Returns how many fields are still waiting for their row.
+ *
+ * The lens is mounted by the picker guard on its own frame, and the row is
+ * built around the lens — so a field reached before its lens exists has to be
+ * come back for, or it stays a bare id box while every other field is a row. */
+export function decorateEntityFields(scope = doc?.getElementById("ed-body")) {
+  if (!scope?.querySelectorAll) return 0;
+  let pending = 0;
+  for (const input of scope.querySelectorAll('input[data-entity-input="true"]')) {
+    if (
+      input.closest(".dm-slot") ||
+      input.matches(".ed-slot-in[data-ref]") ||
+      input.closest('[data-dm-entity-chip="true"]')
+    ) {
+      continue;
+    }
+    if (!decorateField(input)) pending += 1;
+  }
+  return pending;
+}
+
 export function decorateEditorSlots(scope = doc?.getElementById("ed-body")) {
   if (!scope) return 0;
+  dropRetiredSlots(scope);
   let count = 0;
   for (const body of scope.querySelectorAll(".ed-acc-body")) if (decorateBody(body)) count += 1;
+  state.pending = decorateEntityFields(scope);
   return count;
 }
+
+const MAX_RETRIES = 6;
 
 function schedule() {
   if (state.frame) return;
   const run = () => {
     state.frame = 0;
-    decorateEditorSlots();
+    let pending = 0;
+    for (const scope of [
+      doc?.getElementById("ed-body"),
+      doc?.getElementById("editor-modal"),
+      doc?.getElementById("setup-wizard"),
+      ...(doc?.querySelectorAll?.(".dm-section-modal") || []),
+    ].filter(Boolean)) {
+      decorateEditorSlots(scope);
+      pending += state.pending;
+    }
+    // A field whose lens has not been mounted yet gets one more frame, a
+    // bounded number of times, instead of staying a bare id box for good.
+    if (pending && (state.retries || 0) < MAX_RETRIES) {
+      state.retries = (state.retries || 0) + 1;
+      schedule();
+      return;
+    }
+    state.retries = 0;
   };
   state.frame = root.requestAnimationFrame?.(run) || root.setTimeout?.(run, 0);
 }
@@ -193,6 +375,32 @@ function installStyles() {
 }
 .dm-slot[data-dm-slot="empty"] .dm-slot-chip-copy b{color:var(--secondary-text-color,#64748b)!important;font-weight:650!important}
 .dm-slot-chip-go{flex:0 0 auto!important;font-size:18px!important;color:var(--secondary-text-color,#94a3b8)!important;line-height:1!important}
+
+/* the same row, on every other entity field in the configuration */
+[data-dm-entity-chip="true"]{min-width:0!important;flex-wrap:wrap!important}
+[data-dm-entity-chip="true"]>.dm-entity-picker.dm-slot-chip{
+  display:flex!important;align-items:center!important;gap:10px!important;
+  flex:1 1 auto!important;width:auto!important;min-width:0!important;
+  height:auto!important;min-height:44px!important;padding:9px 11px!important;
+  border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:12px!important;
+  background:var(--secondary-background-color,#f6f8fb)!important;color:var(--text,#0f172a)!important;
+  box-shadow:none!important;font:inherit!important;font-size:inherit!important;text-align:left!important
+}
+[data-dm-entity-chip="true"]>.dm-entity-picker.dm-slot-chip:hover{
+  transform:none!important;filter:none!important;border-color:var(--primary-color,#0ea5e9)!important
+}
+[data-dm-entity-chip="true"] .dm-chip-manual{
+  flex:0 0 44px!important;width:44px!important;min-width:44px!important;height:44px!important;padding:0!important;
+  border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:12px!important;
+  background:var(--secondary-background-color,#f6f8fb)!important;color:var(--secondary-text-color,#64748b)!important;
+  font-size:14px!important;line-height:1!important;cursor:pointer!important
+}
+[data-dm-entity-chip="true"] .dm-chip-manual[aria-pressed="true"]{
+  border-color:var(--primary-color,#0ea5e9)!important;color:var(--primary-color,#0ea5e9)!important;
+  background:color-mix(in srgb,var(--primary-color,#0ea5e9) 8%,transparent)!important
+}
+[data-dm-entity-chip="true"]:not([data-dm-entity-raw="true"])>.dm-chip-raw{display:none!important}
+[data-dm-entity-chip="true"][data-dm-entity-raw="true"]>.dm-chip-raw{flex:1 1 100%!important;order:9!important;grid-column:1/-1!important}
   `);
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
@@ -401,6 +401,28 @@ function installStyles() {
 }
 [data-dm-entity-chip="true"]:not([data-dm-entity-raw="true"])>.dm-chip-raw{display:none!important}
 [data-dm-entity-chip="true"][data-dm-entity-raw="true"]>.dm-chip-raw{flex:1 1 100%!important;order:9!important;grid-column:1/-1!important}
+
+/* Some forms lay their entity row out themselves — the "Aggiungi luce" form
+ * pins its own two column grid and its own id'd field to display:block, which
+ * outweighs the rules above and left that one row showing the raw id next to a
+ * chip squeezed into a 58px column. The id is repeated so the row that carries
+ * a chip is laid out by the chip's own rules wherever it is, and the raw field
+ * stays behind the pencil on every tab. */
+#ed-body#ed-body [data-dm-entity-chip="true"]{
+  display:flex!important;align-items:center!important;gap:9px!important;flex-wrap:wrap!important;
+  grid-template-columns:none!important;min-width:0!important
+}
+#ed-body#ed-body [data-dm-entity-chip="true"]>.dm-entity-picker.dm-slot-chip{
+  flex:1 1 auto!important;width:auto!important;min-width:0!important;max-width:none!important;
+  height:auto!important;min-height:44px!important
+}
+#ed-body#ed-body [data-dm-entity-chip="true"] .dm-chip-manual{
+  flex:0 0 44px!important;width:44px!important;min-width:44px!important;max-width:44px!important;height:44px!important
+}
+#ed-body#ed-body [data-dm-entity-chip="true"]:not([data-dm-entity-raw="true"])>.dm-chip-raw{display:none!important}
+#ed-body#ed-body [data-dm-entity-chip="true"][data-dm-entity-raw="true"]>.dm-chip-raw{
+  display:block!important;flex:1 1 100%!important;order:9!important;width:100%!important;max-width:100%!important
+}
   `);
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/entity-autodetect-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/entity-autodetect-section.js
@@ -37,7 +37,7 @@
 import { ENERGY_SLOT_MAP } from "../core/energy-projection.js";
 import { buildEntityIndex } from "../core/entity-search-index.js";
 import { buildPostings, detectCategories, detectSlots, parseSlotPlan } from "../core/entity-autodetect.js";
-import { allStates, clean, dashboardStore, doc, installStyle, lexicalGlobal, readJson, root, t } from "./shared.js";
+import { allStates, clean, dashboardStore, doc, installStyle, lexicalGlobal, readJson, reloadDashboard, root, t } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_ENTITY_AUTODETECT__";
 const HOSTED_ENOUGH = 200;
@@ -444,7 +444,7 @@ export async function applyProposal(proposal) {
     root.cdMarkDirty?.();
     root.cdSyncPush?.();
   } catch (_error) {}
-  const reload = () => root.setTimeout?.(() => root.location?.reload?.(), 400);
+  const reload = () => root.setTimeout?.(() => reloadDashboard(), 400);
   try {
     if (typeof root.cdRegEnrich === "function") root.cdRegEnrich(reload);
     else reload();

--- a/custom_components/dashboardmodern/frontend/src/sections/entity-picker-guard-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/entity-picker-guard-section.js
@@ -1,3 +1,4 @@
+import { decorateEntityFields } from "./editor-slots-section.js";
 import { clean, doc, installStyle, root, wrapFunction } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_ENTITY_PICKER_GUARD__";
@@ -136,6 +137,9 @@ export function reconcileEntityPickers(scope = doc) {
   }
   let count = 0;
   scope.querySelectorAll("input").forEach((input) => { if (mountOne(input)) count += 1; });
+  // The readable row is built around the lens, so it is built here, the moment
+  // the lens is known to exist — not on a frame that hopes it already does.
+  try { decorateEntityFields(scope); } catch (_error) {}
   return count;
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
@@ -1,5 +1,5 @@
 import { carBrandVisual } from "../core/personalization-catalog.js";
-import { clean, doc, esc, installStyle, readJson, root, section, t } from "./shared.js";
+import { allStates, clean, doc, esc, installStyle, readJson, root, section, t } from "./shared.js";
 
 globalThis.__DM_20260815C__ = true;
 const KEY = "__DASHBOARDMODERN_EV_SECTION__";
@@ -51,17 +51,74 @@ export function resolveVehicleAsset(value, base = doc?.baseURI || root.location?
   try { return new URL(raw.replace(/^\.\//, ""), base).href; } catch (_error) { return ""; }
 }
 
-function configuredImage() {
-  const stored = root.localStorage?.getItem("cd_ev_image") || "";
+/* The two photos of the car.
+ *
+ * `cd_ev_image` has always been the car as it sits there, cable unplugged.
+ * `cd_ev_image_plugged` is the same car with the cable in — the picture worth
+ * looking at while it charges. Only the first is required: with no second photo
+ * configured the hero simply keeps showing the first one, which is exactly what
+ * every existing configuration does today. */
+export const EV_PHOTO_KEYS = Object.freeze({ idle: "cd_ev_image", plugged: "cd_ev_image_plugged" });
+
+function storedPhoto(key) {
+  const stored = root.localStorage?.getItem(key) || "";
   try { const parsed = JSON.parse(stored); return typeof parsed === "string" ? parsed : parsed?.url || parsed?.path || ""; }
   catch (_error) { return stored.replace(/^"|"$/g, ""); }
 }
 
+export function configuredPhotos() {
+  return { idle: storedPhoto(EV_PHOTO_KEYS.idle), plugged: storedPhoto(EV_PHOTO_KEYS.plugged) };
+}
+
+function liveState(reference) {
+  const id = clean(reference); if (!id) return null;
+  let resolved = id;
+  try { resolved = clean(root.resolveEntity?.(id)) || id; } catch (_error) {}
+  const states = allStates();
+  return states[resolved] || states[id] || null;
+}
+
+/* What a wallbox says when the cable is out. The negatives are read first and
+ * the two that contain a positive inside them — "disconnected" contains
+ * "connected", "scollegato" contains "collegato" — are what make the order
+ * matter. */
+const UNPLUGGED_WORDS = /(disconnect|scollegat|staccat|unplug|not[_ ]?connected|no[_ ]?vehicle)/i;
+const UNPLUGGED_STATES = /^(off|idle|unknown|unavailable|none|available|free|libero|nessuno|standby|ready)$/i;
+const PLUGGED_WORDS = /(charg|ricaric|in carica|connect|collegat|plug|attacc|occupied|preparing|suspended)/i;
+
+/** Is the cable in? Read from the wallbox the configuration already maps. */
+export function vehiclePlugged() {
+  const status = clean(liveState("dm.ev_stato_ricarica")?.state);
+  if (status) {
+    if (UNPLUGGED_STATES.test(status) || UNPLUGGED_WORDS.test(status)) return false;
+    if (PLUGGED_WORDS.test(status)) return true;
+  }
+  // No usable text: a wallbox drawing power has a cable in it.
+  for (const reference of ["dm.ev_potenza_wallbox", "dm.ev_charge_power"]) {
+    const power = Number(liveState(reference)?.state);
+    if (Number.isFinite(power) && power > 10) return true;
+  }
+  return false;
+}
+
+/** The photo the hero should be showing right now. */
+export function activeVehiclePhoto(photos = configuredPhotos(), plugged = vehiclePlugged()) {
+  const chosen = plugged ? photos.plugged || photos.idle : photos.idle || photos.plugged;
+  return clean(chosen);
+}
+
 export function applyVehicleAsset() {
   if (!doc) return false;
-  const original = configuredImage();
+  const photos = configuredPhotos();
+  const plugged = vehiclePlugged();
+  const original = activeVehiclePhoto(photos, plugged);
   const url = resolveVehicleAsset(original);
-  if (url && clean(original) !== url) root.localStorage?.setItem("cd_ev_image", JSON.stringify(url));
+  // Only the key the value came from is rewritten in its resolved form, so the
+  // other photo is never overwritten with this one.
+  if (url && clean(original) !== url) {
+    const key = clean(photos.plugged) === clean(original) && plugged ? EV_PHOTO_KEYS.plugged : EV_PHOTO_KEYS.idle;
+    root.localStorage?.setItem(key, JSON.stringify(url));
+  }
   state.lastUrl = url;
   let mounted = false;
   for (const id of ["ev-mod-car-img", "ev-new-car-img"]) {
@@ -71,10 +128,112 @@ export function applyVehicleAsset() {
     image.onload = () => { delete image.dataset.evImageError; delete image.dataset.evFailed; image.style.display = "block"; image.style.visibility = "visible"; image.style.opacity = "1"; };
     const resolved = new URL(url, doc.baseURI).href;
     if (image.src !== resolved || image.dataset.evFailed === "1") { delete image.dataset.evFailed; delete image.dataset.evImageError; image.src = url; }
+    image.dataset.evPhoto = plugged ? "plugged" : "idle";
     image.style.display = "block"; mounted = true;
   }
-  const hero = doc.getElementById("lm-hero-card"); if (hero) hero.dataset.evImage = url ? "configured" : "missing";
+  const hero = doc.getElementById("lm-hero-card");
+  if (hero) {
+    hero.dataset.evImage = url ? "configured" : "missing";
+    hero.dataset.evCable = plugged ? "plugged" : "unplugged";
+  }
   return mounted;
+}
+
+/* ── the two photos, in the configuration ──────────────────────────────── */
+
+/* The vendored EV form has one field for one photo. It stays in the document —
+ * it is what a very old build reads — but it is folded away and this panel
+ * takes over the row, because there are two photos now and they are easier to
+ * get right side by side, each with the picture it points at underneath. */
+function evEditorBody() {
+  const body = doc?.getElementById("ed-body");
+  if (!body) return null;
+  const active = clean(doc.querySelector(".ed-tab.active")?.dataset?.tab);
+  if (active !== "sez2") return null;
+  return [...body.querySelectorAll(".ed-acc-body")].find((node) =>
+    node.querySelector('.ed-slot-in[data-ref^="dm.ev_"]'),
+  ) || null;
+}
+
+function legacyPhotoRow(body) {
+  return [...body.querySelectorAll(".ed-slot")].find((slot) =>
+    /immagine auto|car image/i.test(clean(slot.querySelector(".ed-slot-lbl")?.textContent)),
+  ) || null;
+}
+
+function photoFieldMarkup(kind, label, hint, value) {
+  return `<label class="dm-ev-photo" data-ev-photo="${kind}">
+    <span class="dm-ev-photo-lbl">${esc(label)}</span>
+    <span class="dm-ev-photo-row"><input class="ed-input mono" data-ev-photo-input value="${esc(value)}" placeholder="/local/auto-${kind}.png" autocomplete="off" spellcheck="false"></span>
+    <small class="dm-ev-photo-hint">${esc(hint)}</small>
+    <span class="dm-ev-photo-preview" data-ev-photo-preview></span>
+  </label>`;
+}
+
+function paintPhotoPreview(field) {
+  const preview = field.querySelector("[data-ev-photo-preview]");
+  const value = clean(field.querySelector("[data-ev-photo-input]")?.value);
+  const url = resolveVehicleAsset(value);
+  if (!preview) return;
+  if (!url) { preview.replaceChildren(); field.dataset.evPhotoState = "empty"; return; }
+  let image = preview.querySelector("img");
+  if (!image) { image = doc.createElement("img"); image.alt = ""; image.decoding = "async"; preview.replaceChildren(image); }
+  image.onload = () => { field.dataset.evPhotoState = "ok"; };
+  image.onerror = () => { field.dataset.evPhotoState = "broken"; };
+  if (image.getAttribute("src") !== url) { field.dataset.evPhotoState = "loading"; image.src = url; }
+}
+
+function savePhotos(panelNode) {
+  for (const field of panelNode.querySelectorAll("[data-ev-photo]")) {
+    const kind = field.dataset.evPhoto === "plugged" ? "plugged" : "idle";
+    const value = clean(field.querySelector("[data-ev-photo-input]")?.value);
+    const stored = value ? resolveVehicleAsset(value) || value : "";
+    root.localStorage?.setItem(EV_PHOTO_KEYS[kind], JSON.stringify(stored));
+  }
+  root.cdMarkDirty?.();
+  root.cdSyncPush?.();
+  applyVehicleAsset();
+}
+
+export function ensureVehiclePhotoEditor() {
+  const body = evEditorBody();
+  if (!body) return false;
+  const legacyRow = legacyPhotoRow(body);
+  legacyRow?.setAttribute("hidden", "hidden");
+  let panelNode = body.querySelector(":scope > [data-ev-photos]");
+  const photos = configuredPhotos();
+  if (!panelNode) {
+    panelNode = doc.createElement("section");
+    panelNode.className = "ed-form dm-ev-photos";
+    panelNode.dataset.evPhotos = "true";
+    panelNode.innerHTML = `<div class="ed-sec-title">📸 ${t("Foto dell'auto", "Vehicle photos")}</div>
+      <div class="ed-intro">${t(
+        "Due scatti della stessa auto: la plancia mostra quello con il cavo attaccato mentre è in ricarica e l'altro nel resto del tempo. Basta la prima: senza la seconda resta sempre quella.",
+        "Two shots of the same car: the dashboard shows the plugged-in one while it charges and the other one the rest of the time. The first is enough — without the second it simply stays.",
+      )}</div>
+      <div class="dm-ev-photo-grid">
+        ${photoFieldMarkup("idle", t("Cavo staccato", "Cable unplugged"), t("Percorso sotto /local, es. /local/auto.png", "Path under /local, e.g. /local/car.png"), photos.idle)}
+        ${photoFieldMarkup("plugged", t("Cavo attaccato", "Cable plugged in"), t("Facoltativa: mostrata durante la ricarica", "Optional: shown while charging"), photos.plugged)}
+      </div>
+      <button type="button" class="ed-save-btn" data-ev-photos-save>💾 ${t("Salva foto", "Save photos")}</button>`;
+    (legacyRow || body.lastElementChild)?.insertAdjacentElement?.("beforebegin", panelNode) ||
+      body.append(panelNode);
+    panelNode.addEventListener("input", (event) => {
+      const field = event.target?.closest?.("[data-ev-photo]");
+      if (field) paintPhotoPreview(field);
+    });
+    panelNode.querySelector("[data-ev-photos-save]").addEventListener("click", () => {
+      savePhotos(panelNode);
+      panelNode.dataset.saved = "true";
+    });
+  } else {
+    for (const field of panelNode.querySelectorAll("[data-ev-photo]")) {
+      const input = field.querySelector("[data-ev-photo-input]");
+      if (input && input !== doc.activeElement) input.value = photos[field.dataset.evPhoto] || "";
+    }
+  }
+  for (const field of panelNode.querySelectorAll("[data-ev-photo]")) paintPhotoPreview(field);
+  return true;
 }
 
 function legacyProfiles() { const cars = readJson("cd_ev_cars", []); return Array.isArray(cars) ? cars : []; }
@@ -180,11 +339,25 @@ function installLegacyWrappers() {
 
 export function scheduleEvSync() {
   if (state.frame) return;
-  const run=()=>{state.frame=0;installLegacyWrappers();renderVehicleSelector();applyVehicleAsset();};
+  const run=()=>{state.frame=0;installLegacyWrappers();renderVehicleSelector();applyVehicleAsset();ensureVehiclePhotoEditor();};
   state.frame=root.requestAnimationFrame?.(run)||root.setTimeout?.(run,0)||0;
 }
 
 function installStyles() {
+  installStyle("dm-ev-photos-style",`
+.dm-ev-photos .dm-ev-photo-grid{display:grid!important;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))!important;gap:12px!important}
+.dm-ev-photos .dm-ev-photo{display:grid!important;gap:6px!important;margin:0!important;padding:11px 12px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:16px!important;background:var(--card-background-color,#fff)!important}
+.dm-ev-photos .dm-ev-photo[data-ev-photo-state="ok"]{border-color:color-mix(in srgb,#16a34a 32%,var(--divider-color,#dbe4ee))!important}
+.dm-ev-photos .dm-ev-photo[data-ev-photo-state="broken"]{border-color:color-mix(in srgb,#dc2626 38%,var(--divider-color,#dbe4ee))!important}
+.dm-ev-photos .dm-ev-photo-lbl{font-size:13px!important;font-weight:800!important;color:var(--text,#0f172a)!important}
+.dm-ev-photos .dm-ev-photo-row{display:flex!important;gap:8px!important;min-width:0!important}
+.dm-ev-photos .dm-ev-photo-row>input{flex:1 1 auto!important;min-width:0!important}
+.dm-ev-photos .dm-ev-photo-hint{color:var(--secondary-text-color,#64748b)!important;font-size:11px!important;font-weight:650!important}
+.dm-ev-photos .dm-ev-photo-preview{display:block!important;min-height:0!important}
+.dm-ev-photos .dm-ev-photo-preview img{display:block!important;width:100%!important;max-height:112px!important;object-fit:contain!important;border-radius:11px!important;background:var(--secondary-background-color,#f6f8fb)!important}
+.dm-ev-photos .dm-ev-photo[data-ev-photo-state="broken"] .dm-ev-photo-preview img{display:none!important}
+.dm-ev-photos .dm-ev-photo[data-ev-photo-state="broken"] .dm-ev-photo-preview::after{content:"⚠️";display:block;text-align:center;font-size:20px}
+  `);
   installStyle("dm-ev-section-style",`
 #ev-mod-car-img[data-ev-image-error],#ev-new-car-img[data-ev-image-error],#ev-mod-car-img[data-ev-failed="1"],#ev-new-car-img[data-ev-failed="1"]{display:none!important}
 #ev-car-picker.dm-vehicle-profile-host{box-sizing:border-box!important;width:fit-content!important;max-width:calc(100% - 28px)!important;margin:12px auto 10px!important;padding:0!important;border:0!important;background:transparent!important;box-shadow:none!important}#ev-car-picker.dm-vehicle-profile-host>.dm-vehicle-native-select{position:absolute!important;width:1px!important;height:1px!important;margin:-1px!important;padding:0!important;overflow:hidden!important;clip:rect(0 0 0 0)!important;white-space:nowrap!important;border:0!important;opacity:0!important;pointer-events:none!important}
@@ -200,7 +373,7 @@ export function installEvSection() {
   root.dmRenderVehicleSelector=renderVehicleSelector; installStyles(); installLegacyWrappers(); scheduleEvSync();
   if (!state.installed) {
     state.installed=true;
-    doc.addEventListener("click",(event)=>{if(event.target?.closest?.('[data-tab="ev"],[data-page="ev"],.ed-tab[data-tab="sez2"]'))scheduleEvSync();},true);
+    doc.addEventListener("click",(event)=>{if(event.target?.closest?.('[data-tab="ev"],[data-page="ev"],.ed-tab[data-tab="sez2"],.ed-acc-head'))root.setTimeout?.(scheduleEvSync,0);},true);
     for (const eventName of ["dashboardmodern:legacy-ready","dashboardmodern:runtime-ready","pageshow"]) root.addEventListener?.(eventName,scheduleEvSync);
     root.addEventListener?.("dashboardmodern:state-changed",(event)=>{ if (stateChangeAffectsEv(event)) scheduleEvSync(); });
   }

--- a/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
@@ -1,5 +1,5 @@
 import { carBrandVisual } from "../core/personalization-catalog.js";
-import { allStates, clean, doc, esc, installStyle, readJson, root, section, t } from "./shared.js";
+import { allStates, clean, doc, esc, installStyle, readJson, root, section, t, wrapFunction } from "./shared.js";
 
 globalThis.__DM_20260815C__ = true;
 const KEY = "__DASHBOARDMODERN_EV_SECTION__";
@@ -337,6 +337,16 @@ function installLegacyWrappers() {
   return Boolean(root.cdEvCarsRefresh || root.cdEvApplyCar);
 }
 
+/* The EV tab of the configuration is printed over a few frames: the accordion
+ * that holds the vehicle's fields — and the single legacy photo row this panel
+ * replaces — arrives after the tab has switched. One pass at switch time would
+ * find no accordion, leave the panel out of the tab and the old row on screen,
+ * which is what a run that never clicked the tab by hand showed. */
+export function scheduleEvSyncSettled() {
+  scheduleEvSync();
+  for (const delay of [120, 420]) root.setTimeout?.(scheduleEvSync, delay);
+}
+
 export function scheduleEvSync() {
   if (state.frame) return;
   const run=()=>{state.frame=0;installLegacyWrappers();renderVehicleSelector();applyVehicleAsset();ensureVehiclePhotoEditor();};
@@ -357,6 +367,11 @@ function installStyles() {
 .dm-ev-photos .dm-ev-photo-preview img{display:block!important;width:100%!important;max-height:112px!important;object-fit:contain!important;border-radius:11px!important;background:var(--secondary-background-color,#f6f8fb)!important}
 .dm-ev-photos .dm-ev-photo[data-ev-photo-state="broken"] .dm-ev-photo-preview img{display:none!important}
 .dm-ev-photos .dm-ev-photo[data-ev-photo-state="broken"] .dm-ev-photo-preview::after{content:"⚠️";display:block;text-align:center;font-size:20px}
+/* The single legacy photo field this panel replaces is marked hidden when the
+ * panel goes in. The editor's own layout pins .ed-slot to display:grid, which
+ * outweighs the browser's meaning of the attribute and left the old field on
+ * screen under the two new ones. */
+#ed-body#ed-body .ed-slot[hidden]{display:none!important}
   `);
   installStyle("dm-ev-section-style",`
 #ev-mod-car-img[data-ev-image-error],#ev-new-car-img[data-ev-image-error],#ev-mod-car-img[data-ev-failed="1"],#ev-new-car-img[data-ev-failed="1"]{display:none!important}
@@ -368,13 +383,18 @@ function installStyles() {
   `);
 }
 
+function bindEditorEntryPoints() {
+  wrapFunction("editorSwitch", "__dmEvSection_editorSwitch", scheduleEvSyncSettled);
+  wrapFunction("apriConfigEntita", "__dmEvSection_apriConfigEntita", scheduleEvSyncSettled);
+}
+
 export function installEvSection() {
   if (!doc) return;
-  root.dmRenderVehicleSelector=renderVehicleSelector; installStyles(); installLegacyWrappers(); scheduleEvSync();
+  root.dmRenderVehicleSelector=renderVehicleSelector; installStyles(); installLegacyWrappers(); bindEditorEntryPoints(); scheduleEvSync();
   if (!state.installed) {
     state.installed=true;
     doc.addEventListener("click",(event)=>{if(event.target?.closest?.('[data-tab="ev"],[data-page="ev"],.ed-tab[data-tab="sez2"],.ed-acc-head'))root.setTimeout?.(scheduleEvSync,0);},true);
-    for (const eventName of ["dashboardmodern:legacy-ready","dashboardmodern:runtime-ready","pageshow"]) root.addEventListener?.(eventName,scheduleEvSync);
+    for (const eventName of ["dashboardmodern:legacy-ready","dashboardmodern:runtime-ready","pageshow"]) root.addEventListener?.(eventName,()=>{scheduleEvSyncSettled();bindEditorEntryPoints();});
     root.addEventListener?.("dashboardmodern:state-changed",(event)=>{ if (stateChangeAffectsEv(event)) scheduleEvSync(); });
   }
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
@@ -189,6 +189,8 @@ function savePhotos(panelNode) {
     const value = clean(field.querySelector("[data-ev-photo-input]")?.value);
     const stored = value ? resolveVehicleAsset(value) || value : "";
     root.localStorage?.setItem(EV_PHOTO_KEYS[kind], JSON.stringify(stored));
+    // Written: what is on screen and what is stored say the same thing again.
+    delete field.dataset.evPhotoEdited;
   }
   root.cdMarkDirty?.();
   root.cdSyncPush?.();
@@ -220,7 +222,11 @@ export function ensureVehiclePhotoEditor() {
       body.append(panelNode);
     panelNode.addEventListener("input", (event) => {
       const field = event.target?.closest?.("[data-ev-photo]");
-      if (field) paintPhotoPreview(field);
+      if (!field) return;
+      // Typed and not saved yet: from here on this field belongs to the person
+      // at the keyboard, and no later pass writes over it.
+      field.dataset.evPhotoEdited = "true";
+      paintPhotoPreview(field);
     });
     panelNode.querySelector("[data-ev-photos-save]").addEventListener("click", () => {
       savePhotos(panelNode);
@@ -229,7 +235,12 @@ export function ensureVehiclePhotoEditor() {
   } else {
     for (const field of panelNode.querySelectorAll("[data-ev-photo]")) {
       const input = field.querySelector("[data-ev-photo-input]");
-      if (input && input !== doc.activeElement) input.value = photos[field.dataset.evPhoto] || "";
+      if (!input || input === doc.activeElement) continue;
+      // A path typed into the other field and not yet saved must survive this:
+      // moving from the first photo to the second used to blank the first,
+      // because the panel is refreshed while the tab settles.
+      if (field.dataset.evPhotoEdited === "true") continue;
+      input.value = photos[field.dataset.evPhoto] || "";
     }
   }
   for (const field of panelNode.querySelectorAll("[data-ev-photo]")) paintPhotoPreview(field);
@@ -344,7 +355,7 @@ function installLegacyWrappers() {
  * which is what a run that never clicked the tab by hand showed. */
 export function scheduleEvSyncSettled() {
   scheduleEvSync();
-  for (const delay of [120, 420]) root.setTimeout?.(scheduleEvSync, delay);
+  for (const delay of [120, 420, 900, 1800]) root.setTimeout?.(scheduleEvSync, delay);
 }
 
 export function scheduleEvSync() {

--- a/custom_components/dashboardmodern/frontend/src/sections/live-ui-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/live-ui-section.js
@@ -13,6 +13,8 @@ const state = (root[KEY] ||= {
   frame: 0,
   previousCameraRefresh: null,
   cameraUrls: new Map(),
+  cameraTimer: 0,
+  building: false,
 });
 
 function unique(values) {
@@ -186,13 +188,61 @@ export async function refreshCameraThumbnails({ force = false } = {}) {
   if (!cameras.length) return false;
   const grid = doc.getElementById("cam-grid");
   if (grid && !grid.querySelector(".cam-card") && typeof root.buildCamCards === "function") {
-    root.buildCamCards();
+    // Reentrancy guard: the wall owner calls back here as soon as it has built
+    // its cards, and building them from inside that call would loop.
+    if (!state.building) {
+      state.building = true;
+      try {
+        root.buildCamCards();
+      } finally {
+        state.building = false;
+      }
+    }
   }
   await Promise.all(cameras.map(loadCameraImage));
+  // However the page was reached — a tab, a card, a restored session — asking
+  // for frames is also what arms the timer that keeps them coming.
+  syncCameraTimer();
   return true;
 }
 
+/* A camera frame is a still picture fetched over and over: nothing in Home
+ * Assistant pushes a new one, and the entity state stays "idle" while the view
+ * changes completely. Losing the legacy 4s timer therefore left the wall on
+ * whatever frame happened to load first — and on a wall rebuilt right after
+ * that first load, on no frame at all, which is a grid of black rectangles.
+ *
+ * The timer is back, but only while the Sicurezza page is actually on screen:
+ * off it, and on a hidden tab, nothing is fetched. */
+const CAMERA_REFRESH_MS = 4000;
+
+function stopCameraTimer() {
+  if (!state.cameraTimer) return;
+  root.clearInterval?.(state.cameraTimer);
+  state.cameraTimer = 0;
+}
+
+export function syncCameraTimer() {
+  const wanted = securityVisible() && doc?.visibilityState !== "hidden" && configuredCameras().length > 0;
+  if (!wanted) {
+    stopCameraTimer();
+    return false;
+  }
+  if (state.cameraTimer) return true;
+  state.cameraTimer =
+    root.setInterval?.(() => {
+      if (!securityVisible() || doc?.visibilityState === "hidden") {
+        stopCameraTimer();
+        return;
+      }
+      refreshCameraThumbnails();
+    }, CAMERA_REFRESH_MS) || 0;
+  return Boolean(state.cameraTimer);
+}
+
 function installCameraOwner() {
+  // The legacy timer refreshed every camera every 4s whatever page was open and
+  // whatever the tab was doing. Ours is armed by visibility instead.
   if (root.camInterval) {
     root.clearInterval?.(root.camInterval);
     root.camInterval = null;
@@ -214,6 +264,7 @@ function syncVisibleLiveUi() {
   state.frame = 0;
   syncLightsAlert();
   syncOpenLightsPopup();
+  syncCameraTimer();
   if (securityVisible()) refreshCameraThumbnails();
 }
 
@@ -246,14 +297,24 @@ export function installLiveUiSection() {
     if (targets.cameras && securityVisible()) refreshCameraThumbnails();
   });
 
+  doc.addEventListener("visibilitychange", () => {
+    syncCameraTimer();
+    if (doc.visibilityState === "visible" && securityVisible()) refreshCameraThumbnails();
+  });
+
   doc.addEventListener(
     "click",
     (event) => {
       if (event.target?.closest?.('[data-tab="security"]')) {
-        root.queueMicrotask?.(() => {
+        // The wall owner rebuilds its cards on the same click, and a frame
+        // written into an <img> that is about to be replaced is a frame lost —
+        // which is what left every camera black. The refresh is scheduled after
+        // that rebuild, and the wall asks for one itself whenever it rebuilds.
+        root.setTimeout?.(() => {
           installCameraOwner();
+          syncCameraTimer();
           refreshCameraThumbnails({ force: true });
-        });
+        }, 0);
       }
       if (event.target?.closest?.('[data-tab="home"]')) root.queueMicrotask?.(syncLightsAlert);
     },

--- a/custom_components/dashboardmodern/frontend/src/sections/minipc-showcase-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/minipc-showcase-section.js
@@ -1,21 +1,22 @@
 // DM-FIX-20260818A
 /* MiniPC section redesign — "Sala macchine".
  *
- * Reskins `#page-server` as one composition instead of a column of boxes: the
- * machine is drawn in isometry at the centre of the panel and CPU, RAM and Disk
- * orbit it as three concentric arcs, each with its reading on the right. Under
- * them runs a live curve of the CPU load, the CPU temperature gets a thermal
- * scale next to its ring, download and upload carry a moving stream, and three
- * headings split the page into thermal, telemetry and network. The page follows
- * the theme: light on a light dashboard, deep navy only when the theme is dark.
+ * `#page-server` becomes a small 3D scene plus a two column board. The machine
+ * is a real CSS box — six faces in one perspective, vents and a turning fan on
+ * the top face, LEDs on the front — and CPU, RAM and Disk stand next to it as
+ * three prisms that grow with the load, each casting its own shadow on the
+ * floor. Under the scene runs a live curve of the CPU load. Below, the page is
+ * a board rather than a stack: thermal on the left, telemetry on the right,
+ * network across the bottom. The page follows the theme: light on a light
+ * dashboard, deep navy only when the theme is dark.
  *
  * Contracts preserved on purpose — the legacy runtime keeps owning every value:
  * - the three metric bars `#srv-fill-cpu` / `#srv-fill-ram` / `#srv-fill-disk`
- *   stay in the DOM and keep being the only writers of the load: the arcs read
- *   their width instead of parsing a sensor again, and the colour of each arc
- *   comes from the colour that bar was configured with;
+ *   stay in the DOM and keep being the only writers of the load: each prism
+ *   reads the width of its bar instead of parsing a sensor again, and takes the
+ *   colour that bar was configured with;
  * - `#v-srv-cpu`, `#v-srv-ram` + `#u-srv-ram` and `#v-srv-disk` are placed by
- *   the grid, never copied into a second node, so the dynamic RAM unit (%, GB)
+ *   the scene, never copied into a second node, so the dynamic RAM unit (%, GB)
  *   the render loop writes still lands on screen;
  * - `#srv-temp-circle` keeps its `stroke-dasharray` and its `stroke`: the
  *   threshold colour stays the legacy one and the thermal scale reads the arc
@@ -26,13 +27,13 @@
  * - `#waw-net-badge` / `#waw-inv-badge` keep the `srv-status-badge online` and
  *   `offline` class the render loop rewrites on every tick; the page mirrors the
  *   connectivity one onto `#page-server` as `data-dm-srv-net`, which is what
- *   turns the panel, the LEDs and the curve red when the machine drops off the
+ *   turns the scene, the LEDs and the curve red when the machine drops off the
  *   network;
  * - every card keeps its `onclick`, so `apriStorico()` and `apriSrvHistory()`
- *   still open the history popups. A metric card becomes `display:contents` so
- *   its arc and its row can live in the same grid: that is a layout mode, not a
- *   forced display, so the inline `display:none` that `cdAutoHide()` writes on
- *   an unmapped card still wins and takes both pieces off the page together.
+ *   still open the history popups, and no `display` is forced with `!important`
+ *   on a card `cdAutoHide()` shows or hides by writing an inline `display`. When
+ *   the thermal card is the one hidden, the board is told through
+ *   `data-dm-srvx-thermal` so telemetry widens instead of leaving a hole.
  *
  * The live curve is the one thing drawn from more than the current tick: it
  * keeps the last readings of `#srv-fill-cpu` in memory for the session, so it is
@@ -49,18 +50,18 @@ const STYLE_ID = "dm-minipc-showcase-style";
 const state = (root[KEY] ||= { installed: false, listeners: false, frame: 0, trace: [] });
 if (!Array.isArray(state.trace)) state.trace = [];
 
-/* Same pair as the legacy setRing(): above 85% the arc is red, above 65% amber,
-   below that it keeps the colour the card was configured with. */
+/* Same pair as the legacy setRing(): above 85% the prism is red, above 65%
+   amber, below that it keeps the colour the card was configured with. */
 const WARN_LEVEL = 65;
 const ALERT_LEVEL = 85;
 const WARN_COLOUR = "#f59e0b";
 const ALERT_COLOUR = "#ef4444";
 
-/* The arcs follow the order of the cards in the hero, which is the order the
-   legacy markup writes the bars in: CPU outside, RAM in the middle, Disk in. */
+/* The prisms follow the order of the cards in the hero, which is the order the
+   legacy markup writes the bars in: CPU, RAM, Disk. */
 const METRIC_BARS = Object.freeze(["srv-fill-cpu", "srv-fill-ram", "srv-fill-disk"]);
-const RING_RADII = Object.freeze([86, 68, 50]);
-const RING_BOX = 200;
+/* Height of a prism at 100%, in the units the scene is laid out with. */
+const BAR_MAX = 168;
 
 /* Readings kept for the curve: about ten minutes of a dashboard that ticks
    every few seconds, and short enough to stay a glance rather than a chart. */
@@ -121,22 +122,21 @@ export function metricLevel(barId, scope = doc) {
   return Math.max(0, Math.min(100, width));
 }
 
-/** Dash pair drawing `level` percent of a ring of that circumference. */
-export function ringDash(level, circumference) {
+/** Height of a prism for that load, so a reading of 0 still shows a base. */
+export function barHeight(level, max = BAR_MAX) {
   const value = Number.isFinite(level) ? Math.max(0, Math.min(100, level)) : 0;
-  const drawn = (value / 100) * circumference;
-  return `${drawn.toFixed(1)} ${(circumference - drawn).toFixed(1)}`;
+  return Math.round((6 + (value / 100) * (max - 6)) * 10) / 10;
 }
 
-/** Colour of a gauge: the card's own colour until the legacy thresholds bite. */
-export function ringColour(level, colour) {
+/** Colour of a prism: the card's own colour until the legacy thresholds bite. */
+export function levelColour(level, colour) {
   if (Number.isFinite(level) && level > ALERT_LEVEL) return ALERT_COLOUR;
   if (Number.isFinite(level) && level > WARN_LEVEL) return WARN_COLOUR;
   return colour;
 }
 
-/** How loaded a gauge reads, for the styling of its row. */
-export function ringLevelName(level) {
+/** How loaded a gauge reads, for the styling of its label and value. */
+export function levelName(level) {
   if (!Number.isFinite(level)) return "";
   if (level > ALERT_LEVEL) return "alert";
   if (level > WARN_LEVEL) return "warn";
@@ -238,119 +238,89 @@ export function sampleCpu(scope = doc, samples = state.trace) {
   return samples;
 }
 
-/* ── mount ────────────────────────────────────────────────────────────── */
+/* ── the scene ────────────────────────────────────────────────────────── */
 
-const CHASSIS = `
-    <svg class="dm-srvx-box" viewBox="0 0 120 104" aria-hidden="true">
-      <defs>
-        <linearGradient id="dmSrvxTop" x1="0" y1="0" x2="1" y2="1">
-          <stop offset="0" style="stop-color:var(--srvx-case-top-a)"/>
-          <stop offset="1" style="stop-color:var(--srvx-case-top-b)"/>
-        </linearGradient>
-        <linearGradient id="dmSrvxLeft" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0" style="stop-color:var(--srvx-case-left-a)"/>
-          <stop offset="1" style="stop-color:var(--srvx-case-left-b)"/>
-        </linearGradient>
-        <linearGradient id="dmSrvxRight" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0" style="stop-color:var(--srvx-case-right-a)"/>
-          <stop offset="1" style="stop-color:var(--srvx-case-right-b)"/>
-        </linearGradient>
-      </defs>
-      <ellipse class="dm-srvx-box-glow" cx="60" cy="86" rx="40" ry="9"/>
-      <g class="dm-srvx-box-body">
-        <path d="M60 16 100 39 60 62 20 39Z" fill="url(#dmSrvxTop)"/>
-        <path d="M20 39 60 62v20L20 59Z" fill="url(#dmSrvxLeft)"/>
-        <path d="M100 39 60 62v20l40-23Z" fill="url(#dmSrvxRight)"/>
-        <path class="dm-srvx-box-edge" d="M60 16 100 39 60 62 20 39Z" fill="none" stroke-width="1.1" stroke-linejoin="round"/>
-        <path class="dm-srvx-box-edge dm-srvx-box-edge-soft" d="M20 39v20l40 23 40-23V39" fill="none" stroke-width="1.1" stroke-linejoin="round"/>
-      </g>
-      <g class="dm-srvx-vents" stroke-width="1.6" stroke-linecap="round">
-        <path d="M74 34.5 87 42M70 37 83 44.5M66 39.5 79 47"/>
-      </g>
-      <g transform="rotate(-29.7 45 39)">
-        <ellipse class="dm-srvx-fan-hole" cx="45" cy="39" rx="12.8" ry="12.8" stroke-width="1.2" transform="scale(1 .5)" transform-origin="45 39"/>
-        <g class="dm-srvx-fan" transform="scale(1 .5)" transform-origin="45 39">
-          <path d="M45 39c1.4-4.4 4.6-7.4 8.4-7.9.4 4.2-2.8 8.1-8.4 7.9Z" transform="rotate(0 45 39)"/>
-          <path d="M45 39c1.4-4.4 4.6-7.4 8.4-7.9.4 4.2-2.8 8.1-8.4 7.9Z" transform="rotate(72 45 39)"/>
-          <path d="M45 39c1.4-4.4 4.6-7.4 8.4-7.9.4 4.2-2.8 8.1-8.4 7.9Z" transform="rotate(144 45 39)"/>
-          <path d="M45 39c1.4-4.4 4.6-7.4 8.4-7.9.4 4.2-2.8 8.1-8.4 7.9Z" transform="rotate(216 45 39)"/>
-          <path d="M45 39c1.4-4.4 4.6-7.4 8.4-7.9.4 4.2-2.8 8.1-8.4 7.9Z" transform="rotate(288 45 39)"/>
-          <circle class="dm-srvx-fan-hub" cx="45" cy="39" r="2.2" stroke-width="1"/>
-        </g>
-      </g>
-      <g class="dm-srvx-front">
-        <path class="dm-srvx-strip" d="M25.5 47.5 54 63.8"/>
-        <circle class="dm-srvx-led dm-srvx-led-pwr" cx="28" cy="57" r="2.6"/>
-        <circle class="dm-srvx-led dm-srvx-led-act" cx="35.5" cy="61.4" r="2.6"/>
-        <path class="dm-srvx-port" d="M44 66.5 52 71" stroke-width="3.4" stroke-linecap="round"/>
-      </g>
-      <g class="dm-srvx-side" stroke-width="1.5" stroke-linecap="round">
-        <path d="M70 63.5v9M76 60v9M82 56.5v9M88 53v9"/>
-      </g>
-    </svg>`;
+/* One CSS box, six faces, laid out by the stylesheet from --w / --h / --d. */
+const BOX_FACES = ["front", "back", "left", "right", "top", "bottom"]
+  .map((face) => `<span class="dm-srvx-f dm-srvx-f-${face}"></span>`)
+  .join("");
+
+/** The machine: a real box in the scene, with vents, a fan and its LEDs. */
+function mountMachine(scene) {
+  let machine = scene.querySelector(":scope > .dm-srvx-machine");
+  if (machine) return machine;
+  machine = doc.createElement("div");
+  machine.className = "dm-srvx-machine";
+  machine.setAttribute("aria-hidden", "true");
+  machine.innerHTML = `
+    <span class="dm-srvx-drop"></span>
+    <div class="dm-srvx-box">
+      ${BOX_FACES}
+      <span class="dm-srvx-panel">
+        <i class="dm-srvx-led dm-srvx-led-pwr"></i>
+        <i class="dm-srvx-led dm-srvx-led-act"></i>
+        <i class="dm-srvx-slot"></i>
+      </span>
+    </div>`;
+  scene.prepend(machine);
+  return machine;
+}
+
+/** The floor the machine and the prisms stand on. */
+function mountFloor(scene) {
+  if (scene.querySelector(":scope > .dm-srvx-floor")) return;
+  const floor = doc.createElement("div");
+  floor.className = "dm-srvx-floor";
+  floor.setAttribute("aria-hidden", "true");
+  scene.prepend(floor);
+}
 
 /**
- * Turn one metric card into a layer of the dial: an arc at its own radius over
- * the machine, and its label and value as a row beside it. The card becomes
- * `display:contents`, so both pieces sit in the hero grid and both leave the
- * page together when the auto-hide writes `display:none` on the card.
+ * Turn one metric card into a prism standing on the floor: the bar, its shadow
+ * and the two legacy nodes — label and value — placed around it. Nothing is
+ * copied: the card keeps its own reading and its own click.
  */
-function mountGauge(card, index) {
-  if (card.dataset.dmSrvxGauge) return;
-  card.dataset.dmSrvxGauge = "true";
-  card.style.setProperty("--dm-srvx-row", String(index + 1));
-  const radius = RING_RADII[index] ?? RING_RADII[RING_RADII.length - 1];
-  const length = 2 * Math.PI * radius;
-  const gauge = doc.createElement("div");
-  gauge.className = "dm-srvx-gauge";
-  gauge.innerHTML = `
-    <svg class="dm-srvx-ring" viewBox="0 0 ${RING_BOX} ${RING_BOX}" aria-hidden="true">
-      <circle class="dm-srvx-ring-track" cx="100" cy="100" r="${radius}" fill="none" stroke-width="13"/>
-      <circle class="dm-srvx-ring-arc" cx="100" cy="100" r="${radius}" fill="none" stroke-width="13" stroke-linecap="round" stroke-dasharray="0 ${length.toFixed(1)}"/>
-    </svg>`;
-  card.prepend(gauge);
-  const label = card.querySelector(".srv-metric-lbl");
-  if (label && !card.querySelector(".dm-srvx-key")) {
-    const key = doc.createElement("span");
-    key.className = "dm-srvx-key";
-    label.insertAdjacentElement("beforebegin", key);
-  }
+function mountPrism(card, index) {
+  if (card.dataset.dmSrvxPrism) return;
+  card.dataset.dmSrvxPrism = "true";
+  card.style.setProperty("--dm-srvx-slot", String(index));
+  const bar = doc.createElement("div");
+  bar.className = "dm-srvx-bar";
+  bar.setAttribute("aria-hidden", "true");
+  bar.innerHTML = BOX_FACES;
+  card.prepend(bar);
+  const shadow = doc.createElement("span");
+  shadow.className = "dm-srvx-drop";
+  shadow.setAttribute("aria-hidden", "true");
+  card.prepend(shadow);
   const glyph = card.querySelector(".srv-metric-icon");
   const name = METRIC_ICONS[cardEntity(card)];
-  if (glyph && name) glyph.innerHTML = icon(name, 15);
+  if (glyph && name) glyph.innerHTML = icon(name, 14);
 }
 
-/**
- * The machine itself, at the centre of the dial. The drawing goes into the slot
- * the hero already had and that slot is moved, never copied, so the header
- * keeps owning its own markup.
- */
-function mountCore(page) {
-  const metrics = page.querySelector(".srv-hero-metrics");
+/** Move the three cards into the scene so they share one perspective. */
+function mountScene(page) {
+  const scene = page.querySelector(".srv-hero-metrics");
+  if (!scene) return null;
+  mountFloor(scene);
+  mountMachine(scene);
+  // The hero slot is emptied: the machine is a box now, not a glyph.
   const slot = page.querySelector(".srv-hero-icon");
-  if (!metrics || !slot) return;
-  if (!slot.dataset.dmSrvxChassis) {
-    slot.dataset.dmSrvxChassis = "true";
-    slot.innerHTML = CHASSIS;
+  if (slot && !slot.dataset.dmSrvxRetired) {
+    slot.dataset.dmSrvxRetired = "true";
+    slot.textContent = "";
   }
-  let core = metrics.querySelector(":scope > .dm-srvx-core");
-  if (!core) {
-    core = doc.createElement("div");
-    core.className = "dm-srvx-core";
-    core.innerHTML = '<span class="dm-srvx-core-halo" aria-hidden="true"></span>';
-    metrics.prepend(core);
-  }
-  if (slot.parentElement !== core) core.append(slot);
+  return scene;
 }
 
 /**
- * The band under the dial: the readings this page has already shown, kept for
+ * The band under the scene: the readings this page has already shown, kept for
  * the session so the machine has a shape over time and not just a number.
  */
 function mountTrace(page) {
   const hero = page.querySelector(".srv-hero");
-  const metrics = hero?.querySelector(".srv-hero-metrics");
-  if (!metrics) return null;
+  const scene = hero?.querySelector(".srv-hero-metrics");
+  if (!scene) return null;
   let trace = hero.querySelector(":scope > .dm-srvx-trace");
   if (trace) return trace;
   trace = doc.createElement("div");
@@ -375,12 +345,12 @@ function mountTrace(page) {
       </svg>
       <span class="dm-srvx-trace-dot"></span>
     </div>`;
-  metrics.insertAdjacentElement("afterend", trace);
+  scene.insertAdjacentElement("afterend", trace);
   return trace;
 }
 
-/* Headings that give the page its three blocks. Each one is tied to the block
-   below it, so a block emptied by cdAutoHide() does not leave a title behind. */
+/* Headings that name the three blocks of the board. Each one is tied to the
+   block it labels, so a block emptied by cdAutoHide() drops its title too. */
 const GROUPS = Object.freeze([
   { block: ".srv-temp-card", card: ".srv-temp-card", it: "Termica", en: "Thermal" },
   { block: ".srv-tel-grid", card: ".srv-tel-card", it: "Telemetria", en: "Telemetry" },
@@ -399,7 +369,10 @@ function mountHeadings(page) {
   }
 }
 
-/** Hide a heading whose whole block the auto-hide has taken off the page. */
+/**
+ * Hide a heading whose whole block the auto-hide has taken off the page, and
+ * tell the board when the thermal column is gone so telemetry can widen.
+ */
 function syncHeadings(page) {
   for (const group of GROUPS) {
     const block = page.querySelector(group.block);
@@ -409,18 +382,11 @@ function syncHeadings(page) {
     const empty = cards.length > 0 && cards.every((card) => card.style.display === "none");
     const display = empty ? "none" : "";
     if (heading.style.display !== display) heading.style.display = display;
+    if (group.block === ".srv-temp-card") {
+      const value = empty ? "off" : "on";
+      if (page.dataset.dmSrvxThermal !== value) page.dataset.dmSrvxThermal = value;
+    }
   }
-}
-
-/** Aurora and board grid behind the panel — decoration, not a reading. */
-function mountHeroEffect(page) {
-  const hero = page.querySelector(".srv-hero");
-  if (!hero || hero.dataset.dmSrvxFx) return;
-  hero.dataset.dmSrvxFx = "true";
-  const effect = doc.createElement("div");
-  effect.className = "dm-srvx-fx";
-  effect.setAttribute("aria-hidden", "true");
-  hero.prepend(effect);
 }
 
 /** Thermal scale and mirrored status badge next to the temperature ring. */
@@ -502,24 +468,20 @@ function renderTrace(trace) {
   if (peak && peak.textContent !== value) peak.textContent = value;
 }
 
-/** Draw one layer of the dial from the bar the legacy loop keeps writing. */
-function renderGauge(card, index) {
-  const arc = card.querySelector(".dm-srvx-ring-arc");
-  if (!arc) return;
-  const radius = RING_RADII[index] ?? RING_RADII[RING_RADII.length - 1];
+/** Stand one prism at the height of the bar the legacy loop keeps writing. */
+function renderPrism(card, index) {
   const level = metricLevel(METRIC_BARS[index] || "", doc);
-  const dash = ringDash(level ?? 0, 2 * Math.PI * radius);
-  if (arc.getAttribute("stroke-dasharray") !== dash) arc.setAttribute("stroke-dasharray", dash);
+  const height = `${barHeight(level)}px`;
+  if (clean(card.style.getPropertyValue("--dm-srvx-h")) !== height) {
+    card.style.setProperty("--dm-srvx-h", height);
+  }
   // The bar carries the colour the markup configured for this metric.
-  const own = clean(card.querySelector(".srv-metric-fill")?.style?.background) || "currentColor";
-  const colour = ringColour(level, own);
-  // The key next to the label is the legend of that arc, so it takes the colour
-  // the arc ended up with rather than the one the card was configured with.
+  const own = clean(card.querySelector(".srv-metric-fill")?.style?.background) || "#94a3b8";
+  const colour = levelColour(level, own);
   if (clean(card.style.getPropertyValue("--dm-srvx-col")) !== colour) {
     card.style.setProperty("--dm-srvx-col", colour);
   }
-  if (arc.getAttribute("stroke") !== colour) arc.setAttribute("stroke", colour);
-  const name = ringLevelName(level);
+  const name = levelName(level);
   if (card.dataset.dmSrvxLevel !== name) card.dataset.dmSrvxLevel = name;
 }
 
@@ -528,8 +490,7 @@ export function renderMinipcShowcase() {
   if (!page) return false;
   page.classList.add("dm-srvx");
   page.querySelector(".srv-hero")?.parentElement?.classList.add("dm-srvx-shell");
-  mountHeroEffect(page);
-  mountCore(page);
+  mountScene(page);
   mountTelemetry(page);
   mountStatusIcons(page);
   mountHeadings(page);
@@ -538,8 +499,8 @@ export function renderMinipcShowcase() {
   const thermal = mountThermal(page) || page.querySelector(".srv-temp-card");
 
   [...page.querySelectorAll(".srv-hero-metrics .srv-metric")].forEach((card, index) => {
-    mountGauge(card, index);
-    renderGauge(card, index);
+    mountPrism(card, index);
+    renderPrism(card, index);
   });
 
   if (thermal) {
@@ -586,7 +547,7 @@ export function installMinipcShowcaseSection() {
       root.addEventListener?.(eventName, scheduleMinipcShowcase);
     }
     // The bars, the temperature arc and the badges repaint through the legacy
-    // render loop, so the dial follows the same events instead of a timer.
+    // render loop, so the scene follows the same events instead of a timer.
     root.addEventListener?.("dashboardmodern:state-changed", () => {
       // Sampling is three DOM reads, so it runs on every tick; the repaint only
       // happens while the page is the one on screen.
@@ -621,60 +582,64 @@ function minipcShowcaseCss() {
   --srvx-shadow:0 20px 38px -26px rgba(10,26,44,.55),0 2px 6px -3px rgba(10,26,44,.12);
   --srvx-shadow-s:0 16px 30px -24px rgba(10,26,44,.6),0 2px 5px -3px rgba(10,26,44,.12);
   --srvx-live:#10b981;--srvx-live-rgb:16,185,129;
-  /* the panel follows the theme: light surfaces on a light dashboard */
-  --srvx-hero-bg:linear-gradient(150deg,#fbfdff 0%,#eef4fb 55%,#e5edf7 100%);
+  /* the scene follows the theme: light surfaces on a light dashboard */
+  --srvx-hero-bg:linear-gradient(170deg,#fdfeff 0%,#eef4fb 52%,#e2ebf6 100%);
   --srvx-hero-text:var(--srvx-text);
   --srvx-hero-dim:var(--srvx-dim);
-  --srvx-hero-line:rgba(15,23,42,.08);
+  --srvx-hero-line:rgba(15,23,42,.09);
   --srvx-hero-shadow:0 24px 44px -30px rgba(10,26,44,.55),0 2px 6px -3px rgba(10,26,44,.1);
   --srvx-hero-inset:inset 0 0 0 1px rgba(15,23,42,.05);
-  --srvx-track:rgba(15,23,42,.07);
-  --srvx-case-top-a:#eef3fa;--srvx-case-top-b:#c3d0e0;
-  --srvx-case-left-a:#a9b7ca;--srvx-case-left-b:#8b9bb1;
-  --srvx-case-right-a:#93a2b8;--srvx-case-right-b:#76869d;
-  --srvx-case-edge:rgba(255,255,255,.9);
-  --srvx-case-ink:rgba(15,23,42,.34);
-  --srvx-case-hole:rgba(15,23,42,.18);
-  --srvx-case-blade:rgba(15,23,42,.3);
-  --srvx-case-shadow:0 12px 16px rgba(15,32,56,.22);
+  --srvx-floor:rgba(15,23,42,.07);
+  --srvx-floor-line:rgba(15,23,42,.09);
+  --srvx-drop:rgba(15,32,56,.4);
+  --srvx-case:#dfe7f1;--srvx-case-top:#f2f6fb;--srvx-case-side:#b9c6d6;
+  --srvx-case-front:#cfd9e6;--srvx-case-edge:rgba(255,255,255,.75);
+  --srvx-ink:rgba(15,23,42,.45);--srvx-vane:rgba(15,23,42,.3);
 }
 #page-server.dm-srvx[data-dm-srv-net="off"]{--srvx-live:#ef4444;--srvx-live-rgb:239,68,68}
-#page-server.dm-srvx .dm-srvx-shell{display:grid;gap:14px}
 #page-server.dm-srvx .dm-srvx-ico{display:block;flex:0 0 auto}
 
-/* ── the panel ────────────────────────────────────────────────────────── */
+/* ── the board ────────────────────────────────────────────────────────── */
+#page-server.dm-srvx .dm-srvx-shell{
+  display:grid;gap:14px 16px;align-content:start;
+  grid-template-columns:minmax(0,1.02fr) minmax(0,1fr)
+}
+#page-server.dm-srvx .srv-hero,
+#page-server.dm-srvx .srv-status-grid,
+#page-server.dm-srvx .dm-srvx-head[data-dm-srvx-head=".srv-status-grid"]{grid-column:1 / -1}
+#page-server.dm-srvx .dm-srvx-head[data-dm-srvx-head=".srv-temp-card"],
+#page-server.dm-srvx .srv-temp-card{grid-column:1}
+#page-server.dm-srvx .dm-srvx-head[data-dm-srvx-head=".srv-tel-grid"],
+#page-server.dm-srvx .srv-tel-grid{grid-column:2}
+#page-server.dm-srvx .dm-srvx-head[data-dm-srvx-head=".srv-temp-card"],
+#page-server.dm-srvx .dm-srvx-head[data-dm-srvx-head=".srv-tel-grid"]{grid-row:2}
+#page-server.dm-srvx .srv-temp-card,
+#page-server.dm-srvx .srv-tel-grid{grid-row:3}
+/* the thermal card hidden by the auto-hide: telemetry takes the whole row */
+#page-server.dm-srvx[data-dm-srvx-thermal="off"] .dm-srvx-head[data-dm-srvx-head=".srv-tel-grid"],
+#page-server.dm-srvx[data-dm-srvx-thermal="off"] .srv-tel-grid{grid-column:1 / -1}
+
+/* ── the panel that holds the scene ───────────────────────────────────── */
 #page-server.dm-srvx .srv-hero{
-  margin-bottom:0!important;padding:22px 24px 24px!important;border:0!important;
+  margin-bottom:0!important;padding:20px 22px 22px!important;border:0!important;
   border-radius:var(--srvx-r)!important;
   background:var(--srvx-hero-bg)!important;
   box-shadow:var(--srvx-hero-shadow),var(--srvx-hero-inset)!important;
-  color:var(--srvx-hero-text)!important
+  color:var(--srvx-hero-text)!important;
+  perspective:1250px;perspective-origin:50% 34%
 }
 #page-server.dm-srvx .srv-hero::before{
-  top:-46%!important;right:-12%!important;width:360px!important;height:360px!important;
-  background:radial-gradient(circle,rgba(var(--srvx-live-rgb),.14) 0%,transparent 68%)!important
+  top:-40%!important;right:-10%!important;width:340px!important;height:340px!important;
+  background:radial-gradient(circle,rgba(var(--srvx-live-rgb),.13) 0%,transparent 68%)!important
 }
 #page-server.dm-srvx .srv-hero::after{
-  bottom:-34%!important;left:-8%!important;width:300px!important;height:300px!important;
-  background:radial-gradient(circle,rgba(56,189,248,.14) 0%,transparent 70%)!important
+  bottom:-30%!important;left:-6%!important;width:280px!important;height:280px!important;
+  background:radial-gradient(circle,rgba(56,189,248,.13) 0%,transparent 70%)!important
 }
-#page-server.dm-srvx .dm-srvx-fx{
-  position:absolute;inset:0;z-index:1;pointer-events:none;overflow:hidden;
-  border-radius:inherit;opacity:.55;
-  background-image:
-    linear-gradient(var(--srvx-hero-line) 1px,transparent 1px),
-    linear-gradient(90deg,var(--srvx-hero-line) 1px,transparent 1px);
-  background-size:34px 34px,34px 34px;
-  -webkit-mask-image:radial-gradient(120% 90% at 78% 6%,#000 0%,transparent 72%);
-  mask-image:radial-gradient(120% 90% at 78% 6%,#000 0%,transparent 72%)
-}
-#page-server.dm-srvx .dm-srvx-fx::after{
-  content:"";position:absolute;top:0;bottom:0;width:34%;left:-40%;
-  background:linear-gradient(90deg,transparent,rgba(var(--srvx-live-rgb),.10),transparent);
-  animation:dmSrvxSweep 9s ease-in-out infinite
-}
-#page-server.dm-srvx .srv-hero-top{margin-bottom:14px!important;z-index:2}
-#page-server.dm-srvx .srv-hero-brand>div{min-width:0}
+#page-server.dm-srvx .srv-hero-top{margin-bottom:8px!important;z-index:3}
+#page-server.dm-srvx .srv-hero-brand{gap:0!important}
+/* the glyph slot is retired: the machine below is the real one */
+#page-server.dm-srvx .srv-hero-icon{display:none!important}
 #page-server.dm-srvx .srv-hero-title{color:var(--srvx-hero-text)!important;font-size:23px!important;letter-spacing:.06em!important}
 #page-server.dm-srvx .srv-hero-sub{color:var(--srvx-hero-dim)!important;letter-spacing:.14em!important}
 #page-server.dm-srvx .srv-hero-pill{
@@ -687,114 +652,171 @@ function minipcShowcaseCss() {
   box-shadow:0 0 0 4px rgba(var(--srvx-live-rgb),.16)!important
 }
 
-/* ── the dial: three arcs around the machine ──────────────────────────── */
+/* ── the 3D scene ─────────────────────────────────────────────────────── */
 #page-server.dm-srvx .srv-hero-metrics{
-  --srvx-dial:244px;--srvx-gap:22px;
-  display:grid!important;
-  grid-template-columns:var(--srvx-dial) minmax(120px,210px) minmax(74px,auto)!important;
-  grid-template-rows:repeat(3,auto)!important;
-  align-items:center!important;justify-content:center!important;
-  column-gap:var(--srvx-gap)!important;row-gap:0!important
+  --srvx-scene-h:300px;--srvx-bar-w:54px;--srvx-bar-d:54px;--srvx-gap:84px;
+  display:block!important;position:relative;height:var(--srvx-scene-h);
+  transform-style:preserve-3d;transform:rotateX(-20deg) rotateY(-17deg) translateY(-6px);
+  margin:0 auto!important;max-width:680px
 }
-/* display:contents is a layout mode, not a forced display: the inline
-   display:none cdAutoHide() writes on an unmapped card still wins. */
-#page-server.dm-srvx .srv-metric{
-  display:contents;background:none!important;border:0!important;box-shadow:none!important;padding:0!important
+#page-server.dm-srvx .dm-srvx-floor{
+  position:absolute;left:-30%;right:-30%;top:calc(var(--srvx-scene-h) - 56px);height:520px;
+  transform-origin:top center;transform:translateZ(-14px) rotateX(-90deg);
+  background:
+    linear-gradient(to bottom,var(--srvx-floor) 0%,transparent 70%),
+    repeating-linear-gradient(90deg,var(--srvx-floor-line) 0 1px,transparent 1px 54px),
+    repeating-linear-gradient(0deg,var(--srvx-floor-line) 0 1px,transparent 1px 54px);
+  -webkit-mask-image:radial-gradient(62% 58% at 50% 4%,#000 0%,transparent 76%);
+  mask-image:radial-gradient(62% 58% at 50% 4%,#000 0%,transparent 76%)
 }
-#page-server.dm-srvx .dm-srvx-core,
-#page-server.dm-srvx .dm-srvx-gauge{
-  grid-column:1;grid-row:1 / span 3;place-self:center;position:relative;
-  width:var(--srvx-dial);height:var(--srvx-dial)
+/* the soft contact shadow every object drops on that floor */
+#page-server.dm-srvx .dm-srvx-drop{
+  position:absolute;left:50%;top:100%;width:var(--srvx-drop-w,130%);height:var(--srvx-drop-h,120px);
+  transform-origin:top center;
+  transform:translateX(-50%) rotateX(-90deg) translateY(calc(var(--srvx-drop-h,120px) / -2 + 10px));
+  background:radial-gradient(ellipse 44% 40% at center,var(--srvx-drop) 0%,transparent 74%);
+  filter:blur(5px);pointer-events:none
 }
-#page-server.dm-srvx .dm-srvx-gauge{pointer-events:none}
-#page-server.dm-srvx .dm-srvx-ring{width:100%;height:100%;transform:rotate(-90deg);overflow:visible}
-#page-server.dm-srvx .dm-srvx-ring-track{stroke:var(--srvx-track)}
-#page-server.dm-srvx .dm-srvx-ring-arc{
-  pointer-events:stroke;cursor:pointer;
-  transition:stroke-dasharray 1.1s cubic-bezier(.2,.8,.25,1),stroke .45s ease;
-  filter:drop-shadow(0 3px 7px rgba(10,26,44,.2))
-}
-#page-server.dm-srvx .dm-srvx-core{display:grid;place-items:center}
-#page-server.dm-srvx .dm-srvx-core-halo{
-  position:absolute;width:48%;height:48%;border-radius:50%;
-  background:radial-gradient(circle,rgba(var(--srvx-live-rgb),.16) 0%,transparent 70%)
-}
-#page-server.dm-srvx .srv-hero-icon{
-  position:relative;z-index:1;
-  width:104px!important;height:92px!important;border:0!important;border-radius:0!important;
-  background:none!important;box-shadow:none!important;padding:0!important;overflow:visible!important
-}
-#page-server.dm-srvx .dm-srvx-box{width:100%;height:100%;display:block;overflow:visible}
-#page-server.dm-srvx .dm-srvx-box-body{filter:drop-shadow(var(--srvx-case-shadow))}
-#page-server.dm-srvx .dm-srvx-box-glow{fill:rgba(var(--srvx-live-rgb),.2);filter:blur(7px);transition:fill .5s ease}
-#page-server.dm-srvx .dm-srvx-box-edge{stroke:var(--srvx-case-edge)}
-#page-server.dm-srvx .dm-srvx-box-edge-soft{opacity:.45}
-#page-server.dm-srvx .dm-srvx-vents{stroke:var(--srvx-case-ink)}
-#page-server.dm-srvx .dm-srvx-side{stroke:var(--srvx-case-ink);opacity:.6}
-#page-server.dm-srvx .dm-srvx-port{stroke:var(--srvx-case-ink);opacity:.55}
-#page-server.dm-srvx .dm-srvx-fan-hole{fill:var(--srvx-case-hole);stroke:var(--srvx-case-edge);opacity:.9}
-#page-server.dm-srvx .dm-srvx-fan-hub{fill:var(--srvx-case-hole);stroke:var(--srvx-case-edge)}
-#page-server.dm-srvx .dm-srvx-fan{
-  fill:var(--srvx-case-blade);transform-box:fill-box;transform-origin:center;
-  animation:dmSrvxSpin 3.4s linear infinite
-}
-#page-server.dm-srvx .dm-srvx-strip{
-  stroke:var(--srvx-live);stroke-width:2.4;stroke-linecap:round;opacity:.9;
-  filter:drop-shadow(0 0 5px rgba(var(--srvx-live-rgb),.75))
-}
-#page-server.dm-srvx .dm-srvx-led{fill:var(--srvx-live)}
-#page-server.dm-srvx .dm-srvx-led-pwr{filter:drop-shadow(0 0 5px rgba(var(--srvx-live-rgb),.95))}
-#page-server.dm-srvx .dm-srvx-led-act{fill:#38bdf8;animation:dmSrvxBlink 2.6s steps(1,end) infinite}
-#page-server.dm-srvx[data-dm-srv-net="off"] .dm-srvx-led-act{fill:#94a3b8;animation:none}
-#page-server.dm-srvx[data-dm-srv-net="off"] .dm-srvx-fan{animation:none}
 
-/* ── the readings, one row per arc ────────────────────────────────────── */
-/* Two cells, one row: the label cell reaches under the gap so a hover lights up
-   the whole reading instead of two halves with a hole between them. */
+/* the machine: one box, six faces */
+#page-server.dm-srvx .dm-srvx-machine{
+  --w:206px;--h:48px;--d:132px;--srvx-drop-w:120%;--srvx-drop-h:150px;
+  position:absolute;left:6px;bottom:60px;width:var(--w);height:var(--h);
+  transform-style:preserve-3d
+}
+#page-server.dm-srvx .dm-srvx-box,
+#page-server.dm-srvx .dm-srvx-bar{position:absolute;inset:0;transform-style:preserve-3d}
+#page-server.dm-srvx .dm-srvx-f{position:absolute;left:50%;top:50%;background:var(--srvx-case)}
+#page-server.dm-srvx .dm-srvx-f-front,
+#page-server.dm-srvx .dm-srvx-f-back{
+  width:var(--w);height:var(--h);margin:calc(var(--h) / -2) 0 0 calc(var(--w) / -2)
+}
+#page-server.dm-srvx .dm-srvx-f-front{transform:translateZ(calc(var(--d) / 2));background:var(--srvx-case-front)}
+#page-server.dm-srvx .dm-srvx-f-back{transform:rotateY(180deg) translateZ(calc(var(--d) / 2));background:var(--srvx-case-side)}
+#page-server.dm-srvx .dm-srvx-f-left,
+#page-server.dm-srvx .dm-srvx-f-right{
+  width:var(--d);height:var(--h);margin:calc(var(--h) / -2) 0 0 calc(var(--d) / -2)
+}
+#page-server.dm-srvx .dm-srvx-f-right{transform:rotateY(90deg) translateZ(calc(var(--w) / 2));background:var(--srvx-case-side)}
+#page-server.dm-srvx .dm-srvx-f-left{transform:rotateY(-90deg) translateZ(calc(var(--w) / 2));background:var(--srvx-case-side)}
+#page-server.dm-srvx .dm-srvx-f-top,
+#page-server.dm-srvx .dm-srvx-f-bottom{
+  width:var(--w);height:var(--d);margin:calc(var(--d) / -2) 0 0 calc(var(--w) / -2)
+}
+#page-server.dm-srvx .dm-srvx-f-top{
+  transform:rotateX(90deg) translateZ(calc(var(--h) / 2));backface-visibility:visible;
+  background:linear-gradient(150deg,var(--srvx-case-top),var(--srvx-case));
+  box-shadow:inset 0 0 0 1px var(--srvx-case-edge)
+}
+#page-server.dm-srvx .dm-srvx-f-front,
+#page-server.dm-srvx .dm-srvx-f-right,
+#page-server.dm-srvx .dm-srvx-f-left{box-shadow:inset 0 0 0 1px rgba(15,23,42,.06)}
+#page-server.dm-srvx .dm-srvx-f-bottom{transform:rotateX(-90deg) translateZ(calc(var(--h) / 2));background:var(--srvx-case-side)}
+/* the lid of the machine, with its vent grille and its fan drawn into it: one
+   plane, painted, because a child element does not follow a rotated face */
+#page-server.dm-srvx .dm-srvx-machine .dm-srvx-f-top{
+  border-radius:3px;
+  background-image:
+    repeating-linear-gradient(0deg,var(--srvx-ink) 0 2px,transparent 2px 9px),
+    radial-gradient(circle,transparent 0 22%,var(--srvx-ink) 22% 24%,transparent 25%),
+    conic-gradient(from 0deg,var(--srvx-vane) 0 26deg,transparent 26deg 72deg,
+      var(--srvx-vane) 72deg 98deg,transparent 98deg 144deg,
+      var(--srvx-vane) 144deg 170deg,transparent 170deg 216deg,
+      var(--srvx-vane) 216deg 242deg,transparent 242deg 288deg,
+      var(--srvx-vane) 288deg 314deg,transparent 314deg 360deg),
+    linear-gradient(150deg,var(--srvx-case-top),var(--srvx-case));
+  background-size:34% 52%,40% 62%,32% 50%,cover;
+  background-position:76% 42%,17% 44%,18.6% 44%,0 0;
+  background-repeat:no-repeat,no-repeat,no-repeat,no-repeat
+}
+
+/* the front panel: LEDs and a slot, on the front face */
+#page-server.dm-srvx .dm-srvx-panel{
+  position:absolute;left:50%;top:50%;width:var(--w);height:var(--h);
+  margin:calc(var(--h) / -2) 0 0 calc(var(--w) / -2);
+  transform:translateZ(calc(var(--d) / 2 + .4px));
+  display:flex;align-items:center;gap:9px;padding:0 16px
+}
+#page-server.dm-srvx .dm-srvx-led{width:7px;height:7px;border-radius:50%;background:var(--srvx-live)}
+#page-server.dm-srvx .dm-srvx-led-pwr{box-shadow:0 0 9px 1px rgba(var(--srvx-live-rgb),.85)}
+#page-server.dm-srvx .dm-srvx-led-act{background:#38bdf8;animation:dmSrvxBlink 2.6s steps(1,end) infinite}
+#page-server.dm-srvx[data-dm-srv-net="off"] .dm-srvx-led-act{background:#94a3b8;animation:none}
+#page-server.dm-srvx .dm-srvx-slot{
+  margin-left:auto;width:52px;height:6px;border-radius:99px;background:var(--srvx-ink);opacity:.35
+}
+
+/* the three prisms */
+#page-server.dm-srvx .srv-hero-metrics .srv-metric{
+  position:absolute;bottom:60px;
+  left:calc(292px + var(--dm-srvx-slot,0) * var(--srvx-gap));
+  width:var(--srvx-bar-w);height:var(--dm-srvx-h,6px);
+  background:none!important;border:0!important;box-shadow:none!important;padding:0!important;
+  transform-style:preserve-3d;cursor:pointer;
+  transition:height .9s cubic-bezier(.2,.8,.25,1)
+}
+#page-server.dm-srvx .dm-srvx-bar{--w:var(--srvx-bar-w);--h:100%;--d:var(--srvx-bar-d)}
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f{background:var(--dm-srvx-col,#94a3b8)}
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f-front,
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f-back{
+  width:var(--srvx-bar-w);height:100%;margin:0;left:0;top:0
+}
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f-front{transform:translateZ(calc(var(--srvx-bar-d) / 2))}
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f-back{
+  transform:rotateY(180deg) translateZ(calc(var(--srvx-bar-d) / 2));filter:brightness(.7)
+}
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f-left,
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f-right{
+  width:var(--srvx-bar-d);height:100%;margin:0;left:0;top:0;filter:brightness(.78)
+}
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f-right{
+  transform:rotateY(90deg) translateZ(calc(var(--srvx-bar-w) - var(--srvx-bar-d) / 2))
+}
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f-left{transform:rotateY(-90deg) translateZ(calc(var(--srvx-bar-d) / 2))}
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f-top,
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f-bottom{
+  width:var(--srvx-bar-w);height:var(--srvx-bar-d);margin:0;left:0;top:0
+}
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f-top{
+  transform:translateY(calc(var(--srvx-bar-d) / -2)) rotateX(90deg);
+  backface-visibility:visible;filter:brightness(1.16)
+}
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f-bottom,
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f-back,
+#page-server.dm-srvx .dm-srvx-bar .dm-srvx-f-left{display:none}
+#page-server.dm-srvx .srv-hero-metrics .srv-metric .dm-srvx-drop{--srvx-drop-w:190%;--srvx-drop-h:150px}
+/* label under the prism and value above it, both turned back to the viewer */
 #page-server.dm-srvx .srv-metric-top{
-  grid-column:2;grid-row:var(--dm-srvx-row,1);
-  display:flex!important;align-items:center!important;justify-content:flex-start!important;
-  gap:9px!important;cursor:pointer;
-  padding:15px var(--srvx-gap) 15px 12px!important;margin-right:calc(var(--srvx-gap) * -1);
-  border-radius:14px 0 0 14px;transition:background .25s ease
+  position:absolute;left:50%;top:100%;width:120px;margin:30px 0 0 -60px;
+  display:flex!important;align-items:center!important;justify-content:center!important;
+  gap:6px!important;transform:rotateY(17deg) rotateX(20deg)
 }
-#page-server.dm-srvx .srv-metric>div:not(.srv-metric-top):not(.dm-srvx-gauge):not(.srv-metric-bar){
-  grid-column:3;grid-row:var(--dm-srvx-row,1);
-  display:flex;align-items:baseline;justify-content:flex-end;gap:2px;
-  padding:15px 12px 15px 0;cursor:pointer;
-  border-radius:0 14px 14px 0;transition:background .25s ease
-}
-#page-server.dm-srvx .srv-metric:hover .srv-metric-top,
-#page-server.dm-srvx .srv-metric:hover>div:not(.srv-metric-top):not(.dm-srvx-gauge):not(.srv-metric-bar){
-  background:color-mix(in srgb,var(--dm-srvx-col,#94a3b8) 9%,transparent)
-}
-#page-server.dm-srvx .dm-srvx-key{
-  width:10px;height:10px;border-radius:50%;flex:0 0 auto;
-  background:var(--dm-srvx-col,#94a3b8);
-  box-shadow:0 0 0 4px color-mix(in srgb,var(--dm-srvx-col,#94a3b8) 16%,transparent)
+#page-server.dm-srvx .srv-metric>div:not(.srv-metric-top):not(.dm-srvx-bar):not(.srv-metric-bar){
+  position:absolute;left:50%;bottom:100%;width:120px;margin:0 0 18px -60px;
+  display:flex;align-items:baseline;justify-content:center;gap:2px;
+  transform:rotateY(17deg) rotateX(20deg)
 }
 #page-server.dm-srvx .srv-metric-lbl{
-  font-size:11px!important;letter-spacing:.16em!important;color:var(--srvx-hero-dim)!important
+  font-size:10px!important;letter-spacing:.14em!important;color:var(--srvx-hero-dim)!important
 }
 #page-server.dm-srvx .srv-metric-icon{
-  display:grid!important;place-items:center!important;
-  font-size:0!important;color:var(--srvx-hero-dim)!important;opacity:.5!important
+  display:grid!important;place-items:center!important;font-size:0!important;
+  color:var(--srvx-hero-dim)!important;opacity:.5!important
 }
 #page-server.dm-srvx .srv-metric-val{
-  font-size:30px!important;font-weight:300!important;letter-spacing:-.04em!important;
+  font-size:25px!important;font-weight:300!important;letter-spacing:-.03em!important;
   color:var(--srvx-hero-text)!important;line-height:1!important
 }
 #page-server.dm-srvx .srv-metric-unit{
-  font-size:13px!important;font-weight:700!important;color:var(--srvx-hero-dim)!important
+  font-size:12px!important;font-weight:700!important;color:var(--srvx-hero-dim)!important
 }
-#page-server.dm-srvx .srv-metric[data-dm-srvx-level="alert"] .srv-metric-lbl,
-#page-server.dm-srvx .srv-metric[data-dm-srvx-level="alert"] .srv-metric-val{color:#dc2626!important}
-#page-server.dm-srvx .srv-metric:hover .srv-metric-lbl{color:var(--srvx-hero-text)!important}
-/* the bar stays: it is the value the arcs read, so it is hidden, not removed */
+#page-server.dm-srvx .srv-metric[data-dm-srvx-level="alert"] .srv-metric-val,
+#page-server.dm-srvx .srv-metric[data-dm-srvx-level="alert"] .srv-metric-lbl{color:#dc2626!important}
+#page-server.dm-srvx .srv-metric:hover .dm-srvx-bar{filter:brightness(1.06)}
+/* the bar stays: it is the value the prisms read, so it is hidden, not removed */
 #page-server.dm-srvx .srv-metric-bar{display:none!important}
 
 /* ── the live curve ───────────────────────────────────────────────────── */
-#page-server.dm-srvx .dm-srvx-trace{position:relative;z-index:2;margin:16px 0 0;display:grid;gap:6px}
+#page-server.dm-srvx .dm-srvx-trace{position:relative;z-index:2;margin:14px 0 0;display:grid;gap:6px}
 #page-server.dm-srvx .dm-srvx-trace[data-dm-srvx-trace="empty"]{display:none}
 #page-server.dm-srvx .dm-srvx-trace-head{
   display:flex;align-items:baseline;justify-content:space-between;gap:10px;
@@ -824,7 +846,7 @@ function minipcShowcaseCss() {
 
 /* ── section headings ─────────────────────────────────────────────────── */
 #page-server.dm-srvx .dm-srvx-head{
-  display:flex;align-items:center;gap:12px;margin:6px 2px -2px;
+  display:flex;align-items:center;gap:12px;margin:6px 2px -4px;
   font-size:9.5px;font-weight:800;letter-spacing:.18em;text-transform:uppercase;
   color:var(--srvx-dim)
 }
@@ -835,16 +857,16 @@ function minipcShowcaseCss() {
 
 /* ── CPU temperature ──────────────────────────────────────────────────── */
 #page-server.dm-srvx .srv-temp-card{
-  gap:24px!important;padding:20px 22px!important;margin-bottom:0!important;border:0!important;
+  gap:18px!important;padding:20px!important;margin-bottom:0!important;border:0!important;
   border-radius:var(--srvx-r)!important;background:var(--srvx-surface)!important;
-  box-shadow:var(--srvx-shadow)!important
+  box-shadow:var(--srvx-shadow)!important;align-items:center!important
 }
-#page-server.dm-srvx .srv-temp-ring{width:116px!important;height:116px!important}
+#page-server.dm-srvx .srv-temp-ring{width:112px!important;height:112px!important}
 #page-server.dm-srvx .srv-temp-ring svg{width:100%!important;height:100%!important}
 /* only the track: #srv-temp-circle keeps the stroke the legacy loop writes */
 #page-server.dm-srvx .srv-temp-ring circle:not([id]){stroke:var(--srvx-surface-2)!important;stroke-width:8!important}
 #page-server.dm-srvx #srv-temp-circle{stroke-width:8!important}
-#page-server.dm-srvx .srv-temp-num{font-size:30px!important;font-weight:300!important;letter-spacing:-.04em!important}
+#page-server.dm-srvx .srv-temp-num{font-size:29px!important;font-weight:300!important;letter-spacing:-.04em!important}
 #page-server.dm-srvx .srv-temp-unit{font-size:10px!important;letter-spacing:.12em!important;margin-top:2px!important}
 #page-server.dm-srvx .srv-temp-title{font-size:9.5px!important;letter-spacing:.18em!important;margin-bottom:8px!important}
 /* the legacy line stays the owner of the wording; the badge shows it */
@@ -883,23 +905,30 @@ function minipcShowcaseCss() {
 }
 
 /* ── telemetry ────────────────────────────────────────────────────────── */
-#page-server.dm-srvx .srv-tel-grid{grid-template-columns:repeat(4,1fr)!important;gap:12px!important;margin-bottom:0!important}
+#page-server.dm-srvx .srv-tel-grid{
+  grid-template-columns:repeat(2,minmax(0,1fr))!important;gap:12px!important;margin-bottom:0!important;
+  perspective:800px
+}
 #page-server.dm-srvx .srv-tel-card{
-  padding:16px 15px 19px!important;border:0!important;border-radius:var(--srvx-r-s)!important;
-  background:var(--srvx-surface)!important;box-shadow:var(--srvx-shadow-s)!important;gap:10px!important
+  padding:15px 15px 18px!important;border:0!important;border-radius:var(--srvx-r-s)!important;
+  background:var(--srvx-surface)!important;box-shadow:var(--srvx-shadow-s)!important;gap:8px!important;
+  transition:transform .35s cubic-bezier(.2,.8,.25,1),box-shadow .35s ease!important
 }
 #page-server.dm-srvx .srv-tel-card::before{
   width:120px!important;height:120px!important;
   background:radial-gradient(circle at top right,rgba(var(--tc-rgb,14,165,233),.14) 0%,transparent 68%)!important
 }
-#page-server.dm-srvx .srv-tel-card:hover{transform:translateY(-4px)!important;box-shadow:0 24px 36px -22px rgba(10,26,44,.62)!important}
+#page-server.dm-srvx .srv-tel-card:hover{
+  transform:translateY(-4px) rotateX(6deg)!important;
+  box-shadow:0 26px 38px -22px rgba(10,26,44,.62)!important
+}
 #page-server.dm-srvx .srv-tel-icon{
-  width:32px!important;height:32px!important;border-radius:11px!important;font-size:0!important;
+  width:30px!important;height:30px!important;border-radius:10px!important;font-size:0!important;
   background:rgba(var(--tc-rgb,14,165,233),.13)!important;border:0!important;
   color:rgb(var(--tc-rgb,14,165,233))!important
 }
 #page-server.dm-srvx .srv-tel-lbl{font-size:9.5px!important;letter-spacing:.12em!important}
-#page-server.dm-srvx .srv-tel-val{font-size:26px!important;letter-spacing:-.02em!important}
+#page-server.dm-srvx .srv-tel-val{font-size:24px!important;letter-spacing:-.02em!important}
 #page-server.dm-srvx .srv-tel-sub{font-size:9.5px!important;color:var(--srvx-dim)!important}
 /* download and upload run their own stream along the foot of the tile */
 #page-server.dm-srvx .dm-srvx-stream{
@@ -937,59 +966,57 @@ function minipcShowcaseCss() {
 }
 
 @keyframes dmSrvxSpin{to{transform:rotate(360deg)}}
-@keyframes dmSrvxSweep{0%{left:-40%}55%{left:106%}100%{left:106%}}
 @keyframes dmSrvxBlink{0%,44%{opacity:.25}50%,58%{opacity:1}64%,100%{opacity:.25}}
 @keyframes dmSrvxFlowIn{from{transform:translateX(-100%)}to{transform:translateX(192%)}}
 @keyframes dmSrvxFlowOut{from{transform:translateX(192%)}to{transform:translateX(-100%)}}
 
 /* ── responsive ───────────────────────────────────────────────────────── */
-@media(max-width:860px){
-  #page-server.dm-srvx .srv-hero-metrics{--srvx-dial:204px;column-gap:18px!important}
-  #page-server.dm-srvx .srv-metric-val{font-size:26px!important}
+@media(max-width:900px){
+  #page-server.dm-srvx .srv-hero-metrics{--srvx-gap:70px;--srvx-bar-w:46px;--srvx-bar-d:46px}
+  #page-server.dm-srvx .dm-srvx-machine{--w:160px;--d:104px}
+  #page-server.dm-srvx .srv-hero-metrics .srv-metric{left:calc(200px + var(--dm-srvx-slot,0) * var(--srvx-gap))}
 }
-@media(max-width:760px){
-  #page-server.dm-srvx .srv-tel-grid{grid-template-columns:repeat(2,1fr)!important}
+@media(max-width:820px){
+  #page-server.dm-srvx .dm-srvx-shell{grid-template-columns:minmax(0,1fr)}
+  #page-server.dm-srvx .dm-srvx-head,
+  #page-server.dm-srvx .srv-temp-card,
+  #page-server.dm-srvx .srv-tel-grid{grid-column:1 / -1!important;grid-row:auto!important}
 }
 @media(max-width:620px){
   #page-server.dm-srvx{--srvx-r:22px;--srvx-r-s:17px}
-  #page-server.dm-srvx .srv-hero{padding:16px 16px 18px!important}
-  /* the dial goes above the readings, which become three full-width rows */
+  #page-server.dm-srvx .srv-hero{padding:16px 14px 18px!important;perspective:900px}
   #page-server.dm-srvx .srv-hero-metrics{
-    --srvx-dial:min(232px,64vw);
-    grid-template-columns:minmax(0,1fr) auto!important;
-    grid-template-rows:auto repeat(3,auto)!important;
-    column-gap:12px!important
+    --srvx-scene-h:250px;--srvx-gap:clamp(52px,17vw,68px);--srvx-bar-w:40px;--srvx-bar-d:40px;
+    transform:rotateX(-18deg) rotateY(-15deg)
   }
-  #page-server.dm-srvx .dm-srvx-core,
-  #page-server.dm-srvx .dm-srvx-gauge{grid-column:1 / -1;grid-row:1}
-  #page-server.dm-srvx .srv-metric-top{grid-column:1;grid-row:calc(var(--dm-srvx-row,1) + 1);padding:12px 12px 12px 10px!important}
-  #page-server.dm-srvx .srv-metric>div:not(.srv-metric-top):not(.dm-srvx-gauge):not(.srv-metric-bar){
-    grid-column:2;grid-row:calc(var(--dm-srvx-row,1) + 1);padding:12px 10px 12px 0
+  #page-server.dm-srvx .dm-srvx-machine{--w:126px;--h:36px;--d:84px;left:2px;bottom:46px}
+  #page-server.dm-srvx .dm-srvx-panel{gap:7px;padding:0 11px}
+  #page-server.dm-srvx .dm-srvx-slot{width:34px;height:5px}
+  #page-server.dm-srvx .srv-hero-metrics .srv-metric{
+    bottom:46px;left:calc(148px + var(--dm-srvx-slot,0) * var(--srvx-gap))
   }
-  #page-server.dm-srvx .srv-metric-val{font-size:24px!important}
-  #page-server.dm-srvx .srv-hero-icon{width:96px!important;height:86px!important}
-  /* the legacy sheet stacks the header: the pill belongs next to the name */
-  #page-server.dm-srvx .srv-hero-top{
-    flex-direction:row!important;align-items:center!important;gap:10px!important;margin-bottom:6px!important
+  #page-server.dm-srvx .srv-metric-top{width:86px;margin:12px 0 0 -43px;gap:5px!important}
+  #page-server.dm-srvx .srv-metric>div:not(.srv-metric-top):not(.dm-srvx-bar):not(.srv-metric-bar){
+    width:86px;margin:0 0 10px -43px
   }
+  #page-server.dm-srvx .srv-metric-val{font-size:20px!important}
+  #page-server.dm-srvx .srv-metric-lbl{font-size:9px!important;letter-spacing:.1em!important}
+  #page-server.dm-srvx .srv-hero-top{margin-bottom:2px!important;flex-direction:row!important;align-items:center!important;gap:10px!important}
   #page-server.dm-srvx .srv-hero-pill{padding:6px 11px!important;font-size:10px!important;letter-spacing:.08em!important;flex-shrink:0!important}
-  #page-server.dm-srvx .srv-hero-brand{gap:11px!important;min-width:0!important}
+  #page-server.dm-srvx .srv-hero-brand{min-width:0!important}
   #page-server.dm-srvx .srv-hero-title,
   #page-server.dm-srvx .srv-hero-sub{
     white-space:nowrap!important;overflow:hidden!important;text-overflow:ellipsis!important
   }
-  #page-server.dm-srvx .dm-srvx-trace{margin-top:14px}
-  #page-server.dm-srvx .dm-srvx-trace-svg{height:44px}
-  #page-server.dm-srvx .dm-srvx-head{letter-spacing:.14em}
+  #page-server.dm-srvx .dm-srvx-trace-svg{height:42px}
   #page-server.dm-srvx .srv-temp-card{
-    flex-direction:row!important;text-align:left!important;align-items:center!important;
-    gap:15px!important;padding:16px!important
+    flex-direction:row!important;text-align:left!important;gap:14px!important;padding:16px!important
   }
   #page-server.dm-srvx .srv-temp-ring{width:92px!important;height:92px!important}
   #page-server.dm-srvx .srv-temp-num{font-size:24px!important}
   #page-server.dm-srvx .dm-srvx-temp-badge{font-size:12px!important;padding:5px 11px 5px 9px!important}
   #page-server.dm-srvx .dm-srvx-scale-ends{font-size:8px!important}
-  #page-server.dm-srvx .srv-tel-val{font-size:22px!important}
+  #page-server.dm-srvx .srv-tel-val{font-size:21px!important}
   #page-server.dm-srvx .srv-status-grid{grid-template-columns:1fr!important}
 }
 
@@ -998,24 +1025,20 @@ html[data-theme="dark"] #page-server.dm-srvx{
   --srvx-shadow:0 22px 40px -26px rgba(0,0,0,.78),0 2px 6px -3px rgba(0,0,0,.5);
   --srvx-shadow-s:0 16px 30px -24px rgba(0,0,0,.72),0 2px 5px -3px rgba(0,0,0,.45);
   --srvx-live:#34d399;--srvx-live-rgb:52,211,153;
-  --srvx-hero-bg:linear-gradient(150deg,#1b2740 0%,#111a2c 54%,#0a111e 100%);
+  --srvx-hero-bg:linear-gradient(170deg,#1c2842 0%,#111a2c 54%,#0a111e 100%);
   --srvx-hero-text:#f2f6ff;
   --srvx-hero-dim:rgba(198,214,240,.74);
   --srvx-hero-line:rgba(255,255,255,.1);
   --srvx-hero-shadow:0 28px 48px -28px rgba(0,0,0,.85),0 2px 6px -3px rgba(0,0,0,.5);
   --srvx-hero-inset:inset 0 1px 0 rgba(255,255,255,.06);
-  --srvx-track:rgba(255,255,255,.09);
-  --srvx-case-top-a:#6a80a8;--srvx-case-top-b:#2f3f5e;
-  --srvx-case-left-a:#2b3a56;--srvx-case-left-b:#141d31;
-  --srvx-case-right-a:#1b2540;--srvx-case-right-b:#0d1424;
-  --srvx-case-edge:rgba(224,239,255,.38);
-  --srvx-case-ink:rgba(190,220,255,.34);
-  --srvx-case-hole:rgba(6,12,24,.6);
-  --srvx-case-blade:rgba(198,224,255,.42);
-  --srvx-case-shadow:0 14px 18px rgba(4,10,20,.55)
+  --srvx-floor:rgba(148,197,255,.08);
+  --srvx-floor-line:rgba(148,197,255,.09);
+  --srvx-drop:rgba(0,0,0,.5);
+  --srvx-case:#33415c;--srvx-case-top:#4a5c7e;--srvx-case-side:#1d2740;
+  --srvx-case-front:#28344c;--srvx-case-edge:rgba(214,232,255,.22);
+  --srvx-ink:rgba(198,224,255,.4);--srvx-vane:rgba(198,224,255,.28)
 }
 html[data-theme="dark"] #page-server.dm-srvx[data-dm-srv-net="off"]{--srvx-live:#f87171;--srvx-live-rgb:248,113,113}
-html[data-theme="dark"] #page-server.dm-srvx .dm-srvx-ring-arc{filter:none}
 html[data-theme="dark"] #page-server.dm-srvx .dm-srvx-scale-pin{border-color:#dbe6f7!important}
 html[data-theme="dark"] #page-server.dm-srvx .dm-srvx-status-ico{background:rgba(255,255,255,.06)}
 

--- a/custom_components/dashboardmodern/frontend/src/sections/minipc-showcase-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/minipc-showcase-section.js
@@ -1,21 +1,22 @@
 // DM-FIX-20260818A
 /* MiniPC section redesign — "Sala macchine".
  *
- * Reskins `#page-server` around the machine itself: the hero becomes the panel
- * of the machine, with the mini PC drawn in isometry, its LEDs and its fan, and
- * a live trace of the CPU load under it. CPU / RAM / Disk turn from flat bars
- * into ring gauges, the CPU temperature gets a thermal scale next to its ring,
- * the telemetry tiles trade emoji for line icons and three headings split the
- * page into thermal, telemetry and network. The panel follows the theme: it is
- * light on a light dashboard and deep navy only when the theme is dark.
+ * Reskins `#page-server` as one composition instead of a column of boxes: the
+ * machine is drawn in isometry at the centre of the panel and CPU, RAM and Disk
+ * orbit it as three concentric arcs, each with its reading on the right. Under
+ * them runs a live curve of the CPU load, the CPU temperature gets a thermal
+ * scale next to its ring, download and upload carry a moving stream, and three
+ * headings split the page into thermal, telemetry and network. The page follows
+ * the theme: light on a light dashboard, deep navy only when the theme is dark.
  *
  * Contracts preserved on purpose — the legacy runtime keeps owning every value:
  * - the three metric bars `#srv-fill-cpu` / `#srv-fill-ram` / `#srv-fill-disk`
- *   stay in the DOM and keep being the only writers of the load: the rings read
- *   their width instead of parsing a sensor again;
- * - `#v-srv-cpu`, `#v-srv-ram` + `#u-srv-ram` and `#v-srv-disk` are moved into
- *   the middle of their ring, never copied, so the dynamic RAM unit (%, GB) the
- *   render loop writes still lands on screen;
+ *   stay in the DOM and keep being the only writers of the load: the arcs read
+ *   their width instead of parsing a sensor again, and the colour of each arc
+ *   comes from the colour that bar was configured with;
+ * - `#v-srv-cpu`, `#v-srv-ram` + `#u-srv-ram` and `#v-srv-disk` are placed by
+ *   the grid, never copied into a second node, so the dynamic RAM unit (%, GB)
+ *   the render loop writes still lands on screen;
  * - `#srv-temp-circle` keeps its `stroke-dasharray` and its `stroke`: the
  *   threshold colour stays the legacy one and the thermal scale reads the arc
  *   the runtime drew rather than re-deriving it from the sensor;
@@ -25,13 +26,15 @@
  * - `#waw-net-badge` / `#waw-inv-badge` keep the `srv-status-badge online` and
  *   `offline` class the render loop rewrites on every tick; the page mirrors the
  *   connectivity one onto `#page-server` as `data-dm-srv-net`, which is what
- *   turns the panel, the LEDs and the trace red when the machine drops off the
+ *   turns the panel, the LEDs and the curve red when the machine drops off the
  *   network;
  * - every card keeps its `onclick`, so `apriStorico()` and `apriSrvHistory()`
- *   still open the history popups, and no `display` is forced with `!important`
- *   on a card `cdAutoHide()` shows or hides by writing an inline `display`.
+ *   still open the history popups. A metric card becomes `display:contents` so
+ *   its arc and its row can live in the same grid: that is a layout mode, not a
+ *   forced display, so the inline `display:none` that `cdAutoHide()` writes on
+ *   an unmapped card still wins and takes both pieces off the page together.
  *
- * The live CPU trace is the one thing drawn from more than the current tick: it
+ * The live curve is the one thing drawn from more than the current tick: it
  * keeps the last readings of `#srv-fill-cpu` in memory for the session, so it is
  * a picture of what the page already showed rather than a second history engine.
  *
@@ -46,24 +49,24 @@ const STYLE_ID = "dm-minipc-showcase-style";
 const state = (root[KEY] ||= { installed: false, listeners: false, frame: 0, trace: [] });
 if (!Array.isArray(state.trace)) state.trace = [];
 
-const RING_RADIUS = 52;
-const RING_LENGTH = 2 * Math.PI * RING_RADIUS;
-/* Same pair as the legacy setRing(): above 85% the gauge is red, above 65%
-   amber, below that it keeps the colour configured on the card. */
+/* Same pair as the legacy setRing(): above 85% the arc is red, above 65% amber,
+   below that it keeps the colour the card was configured with. */
 const WARN_LEVEL = 65;
 const ALERT_LEVEL = 85;
 const WARN_COLOUR = "#f59e0b";
 const ALERT_COLOUR = "#ef4444";
 
-/* Readings kept for the trace: about ten minutes of a dashboard that ticks
+/* The arcs follow the order of the cards in the hero, which is the order the
+   legacy markup writes the bars in: CPU outside, RAM in the middle, Disk in. */
+const METRIC_BARS = Object.freeze(["srv-fill-cpu", "srv-fill-ram", "srv-fill-disk"]);
+const RING_RADII = Object.freeze([86, 68, 50]);
+const RING_BOX = 200;
+
+/* Readings kept for the curve: about ten minutes of a dashboard that ticks
    every few seconds, and short enough to stay a glance rather than a chart. */
 const TRACE_SAMPLES = 96;
 const TRACE_WIDTH = 300;
 const TRACE_HEIGHT = 56;
-
-/* The gauges follow the order of the cards in the hero, which is the order the
-   legacy markup writes the bars in. */
-const METRIC_BARS = Object.freeze(["srv-fill-cpu", "srv-fill-ram", "srv-fill-disk"]);
 
 const ICONS = Object.freeze({
   cpu: '<rect x="8.4" y="8.4" width="7.2" height="7.2" rx="1.6"/><rect x="4.6" y="4.6" width="14.8" height="14.8" rx="3"/><path d="M9 2.6v2M15 2.6v2M9 19.4v2M15 19.4v2M2.6 9h2M2.6 15h2M19.4 9h2M19.4 15h2"/>',
@@ -75,7 +78,6 @@ const ICONS = Object.freeze({
   up: '<path d="M12 20.4v-13M6.8 12.6 12 7.4l5.2 5.2M4.6 3.6h14.8"/>',
   wifi: '<path d="M2.6 8.8a14 14 0 0 1 18.8 0M5.8 12.4a9.4 9.4 0 0 1 12.4 0M9 16a4.8 4.8 0 0 1 6 0"/><circle cx="12" cy="19.4" r="1.1" fill="currentColor" stroke="none"/>',
   grid: '<path d="M12 2.6 4 8.4V21h16V8.4L12 2.6Z"/><path d="M12.8 10.2 9.4 15.4h3l-.8 4 3.8-5.6h-2.8l.2-3.6Z"/>',
-  thermo: '<path d="M14 14.4V5.2a2 2 0 1 0-4 0v9.2a3.9 3.9 0 1 0 4 0Z"/>',
 });
 
 /* The telemetry tiles are static markup: their emoji is decoration, so it can be
@@ -85,6 +87,12 @@ const TELEMETRY_ICONS = Object.freeze({
   "dm.server_uptime_home_assistant": "clock",
   "dm.server_speedtest_download": "down",
   "dm.server_speedtest_upload": "up",
+});
+
+/* Download and upload get a stream that runs the way the bytes go. */
+const TELEMETRY_FLOW = Object.freeze({
+  "dm.server_speedtest_download": "in",
+  "dm.server_speedtest_upload": "out",
 });
 
 const METRIC_ICONS = Object.freeze({
@@ -113,8 +121,8 @@ export function metricLevel(barId, scope = doc) {
   return Math.max(0, Math.min(100, width));
 }
 
-/** Dash pair drawing `level` percent of a ring. */
-export function ringDash(level, circumference = RING_LENGTH) {
+/** Dash pair drawing `level` percent of a ring of that circumference. */
+export function ringDash(level, circumference) {
   const value = Number.isFinite(level) ? Math.max(0, Math.min(100, level)) : 0;
   const drawn = (value / 100) * circumference;
   return `${drawn.toFixed(1)} ${(circumference - drawn).toFixed(1)}`;
@@ -125,6 +133,14 @@ export function ringColour(level, colour) {
   if (Number.isFinite(level) && level > ALERT_LEVEL) return ALERT_COLOUR;
   if (Number.isFinite(level) && level > WARN_LEVEL) return WARN_COLOUR;
   return colour;
+}
+
+/** How loaded a gauge reads, for the styling of its row. */
+export function ringLevelName(level) {
+  if (!Number.isFinite(level)) return "";
+  if (level > ALERT_LEVEL) return "alert";
+  if (level > WARN_LEVEL) return "warn";
+  return "ok";
 }
 
 /**
@@ -155,28 +171,6 @@ export function tempWording(text) {
   return clean(clean(text).replace(/^[🔴🟡🟢]\s*/u, ""));
 }
 
-/**
- * The trace, as the two paths that draw it: the line and the area under it.
- * A single reading is drawn flat across the band instead of as a lone dot.
- */
-/** Height of one reading inside the band, as a share of the band. */
-export function traceOffset(value, height = TRACE_HEIGHT) {
-  const level = Number.isFinite(value) ? Math.max(0, Math.min(100, value)) : 0;
-  return (height - 3 - (level / 100) * (height - 6)) / height;
-}
-
-export function tracePaths(values, width = TRACE_WIDTH, height = TRACE_HEIGHT) {
-  const points = (values || []).filter((value) => Number.isFinite(value));
-  if (!points.length) return { line: "", area: "" };
-  const span = points.length > 1 ? width / (points.length - 1) : width;
-  const y = (value) => traceOffset(value, height) * height;
-  const line =
-    points.length === 1
-      ? `M0 ${y(points[0]).toFixed(1)} L${width} ${y(points[0]).toFixed(1)}`
-      : points.map((value, index) => `${index ? "L" : "M"}${(index * span).toFixed(1)} ${y(value).toFixed(1)}`).join(" ");
-  return { line, area: `${line} L${width} ${height} L0 ${height} Z` };
-}
-
 /** Connectivity, read from the badge class the render loop rewrites per tick. */
 export function networkState(scope = doc) {
   const badge = scope?.getElementById?.("waw-net-badge");
@@ -185,9 +179,56 @@ export function networkState(scope = doc) {
   return "";
 }
 
+/** Height of one reading inside the curve band, as a share of the band. */
+export function traceOffset(value, height = TRACE_HEIGHT) {
+  const level = Number.isFinite(value) ? Math.max(0, Math.min(100, value)) : 0;
+  return (height - 3 - (level / 100) * (height - 6)) / height;
+}
+
+/**
+ * A Catmull-Rom spline through the readings, as cubic segments. The controls
+ * are clamped inside the band, so a spike cannot bow the curve out of the card.
+ */
+export function smoothPath(points, height = TRACE_HEIGHT) {
+  if (!points.length) return "";
+  const at = (index) => points[Math.max(0, Math.min(points.length - 1, index))];
+  const clamp = (y) => Math.max(1, Math.min(height - 1, y));
+  const round = (value) => value.toFixed(1);
+  let path = `M${round(points[0].x)} ${round(points[0].y)}`;
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const previous = at(index - 1);
+    const start = at(index);
+    const end = at(index + 1);
+    const next = at(index + 2);
+    const firstX = start.x + (end.x - previous.x) / 6;
+    const firstY = clamp(start.y + (end.y - previous.y) / 6);
+    const secondX = end.x - (next.x - start.x) / 6;
+    const secondY = clamp(end.y - (next.y - start.y) / 6);
+    path += ` C${round(firstX)} ${round(firstY)} ${round(secondX)} ${round(secondY)} ${round(end.x)} ${round(end.y)}`;
+  }
+  return path;
+}
+
+/**
+ * The curve, as the two paths that draw it: the line and the area under it.
+ * A single reading is drawn flat across the band instead of as a lone dot.
+ */
+export function tracePaths(values, width = TRACE_WIDTH, height = TRACE_HEIGHT) {
+  const levels = (values || []).filter((value) => Number.isFinite(value));
+  if (!levels.length) return { line: "", area: "" };
+  const span = levels.length > 1 ? width / (levels.length - 1) : width;
+  const points = levels.map((value, index) => ({
+    x: levels.length === 1 ? 0 : index * span,
+    y: traceOffset(value, height) * height,
+  }));
+  if (levels.length === 1) points.push({ x: width, y: points[0].y });
+  const line = smoothPath(points, height);
+  return { line, area: `${line} L${width} ${height} L0 ${height} Z` };
+}
+
 /**
  * Keep the reading the page is showing. Sampling happens on every state event,
- * page open or not, so the trace is already drawn when the section is opened.
+ * page open or not, so the curve is already drawn when the section is opened.
  */
 export function sampleCpu(scope = doc, samples = state.trace) {
   const level = metricLevel("srv-fill-cpu", scope);
@@ -199,42 +240,7 @@ export function sampleCpu(scope = doc, samples = state.trace) {
 
 /* ── mount ────────────────────────────────────────────────────────────── */
 
-function ringMarkup() {
-  return `
-    <svg class="dm-srvx-ring" viewBox="0 0 120 120" aria-hidden="true">
-      <circle class="dm-srvx-ring-track" cx="60" cy="60" r="${RING_RADIUS}" fill="none" stroke-width="8"/>
-      <circle class="dm-srvx-ring-arc" cx="60" cy="60" r="${RING_RADIUS}" fill="none" stroke-width="8" stroke-linecap="round" stroke-dasharray="0 ${RING_LENGTH.toFixed(1)}"/>
-    </svg>`;
-}
-
-/**
- * Turn one metric card into a ring gauge. The value nodes are moved into the
- * middle of the ring, never copied, so the render loop keeps one target.
- */
-function mountGauge(card) {
-  if (card.dataset.dmSrvxGauge) return;
-  card.dataset.dmSrvxGauge = "true";
-  const gauge = doc.createElement("div");
-  gauge.className = "dm-srvx-gauge";
-  gauge.innerHTML = `${ringMarkup()}<div class="dm-srvx-gauge-val"></div>`;
-  const value = card.querySelector(".srv-metric-val")?.parentElement;
-  card.prepend(gauge);
-  if (value) gauge.querySelector(".dm-srvx-gauge-val")?.append(value);
-  const glyph = card.querySelector(".srv-metric-icon");
-  const name = METRIC_ICONS[cardEntity(card)];
-  if (glyph && name) glyph.innerHTML = icon(name, 16);
-}
-
-/**
- * The machine itself: an isometric chassis drawn once in the slot the hero
- * already has. Only the LEDs and the fan move, and both stop when the badge
- * says the machine is off the network.
- */
-function mountChassis(page) {
-  const slot = page.querySelector(".srv-hero-icon");
-  if (!slot || slot.dataset.dmSrvxChassis) return;
-  slot.dataset.dmSrvxChassis = "true";
-  slot.innerHTML = `
+const CHASSIS = `
     <svg class="dm-srvx-box" viewBox="0 0 120 104" aria-hidden="true">
       <defs>
         <linearGradient id="dmSrvxTop" x1="0" y1="0" x2="1" y2="1">
@@ -282,16 +288,69 @@ function mountChassis(page) {
         <path d="M70 63.5v9M76 60v9M82 56.5v9M88 53v9"/>
       </g>
     </svg>`;
+
+/**
+ * Turn one metric card into a layer of the dial: an arc at its own radius over
+ * the machine, and its label and value as a row beside it. The card becomes
+ * `display:contents`, so both pieces sit in the hero grid and both leave the
+ * page together when the auto-hide writes `display:none` on the card.
+ */
+function mountGauge(card, index) {
+  if (card.dataset.dmSrvxGauge) return;
+  card.dataset.dmSrvxGauge = "true";
+  card.style.setProperty("--dm-srvx-row", String(index + 1));
+  const radius = RING_RADII[index] ?? RING_RADII[RING_RADII.length - 1];
+  const length = 2 * Math.PI * radius;
+  const gauge = doc.createElement("div");
+  gauge.className = "dm-srvx-gauge";
+  gauge.innerHTML = `
+    <svg class="dm-srvx-ring" viewBox="0 0 ${RING_BOX} ${RING_BOX}" aria-hidden="true">
+      <circle class="dm-srvx-ring-track" cx="100" cy="100" r="${radius}" fill="none" stroke-width="13"/>
+      <circle class="dm-srvx-ring-arc" cx="100" cy="100" r="${radius}" fill="none" stroke-width="13" stroke-linecap="round" stroke-dasharray="0 ${length.toFixed(1)}"/>
+    </svg>`;
+  card.prepend(gauge);
+  const label = card.querySelector(".srv-metric-lbl");
+  if (label && !card.querySelector(".dm-srvx-key")) {
+    const key = doc.createElement("span");
+    key.className = "dm-srvx-key";
+    label.insertAdjacentElement("beforebegin", key);
+  }
+  const glyph = card.querySelector(".srv-metric-icon");
+  const name = METRIC_ICONS[cardEntity(card)];
+  if (glyph && name) glyph.innerHTML = icon(name, 15);
 }
 
 /**
- * The band under the header: the readings this page has already shown, kept for
+ * The machine itself, at the centre of the dial. The drawing goes into the slot
+ * the hero already had and that slot is moved, never copied, so the header
+ * keeps owning its own markup.
+ */
+function mountCore(page) {
+  const metrics = page.querySelector(".srv-hero-metrics");
+  const slot = page.querySelector(".srv-hero-icon");
+  if (!metrics || !slot) return;
+  if (!slot.dataset.dmSrvxChassis) {
+    slot.dataset.dmSrvxChassis = "true";
+    slot.innerHTML = CHASSIS;
+  }
+  let core = metrics.querySelector(":scope > .dm-srvx-core");
+  if (!core) {
+    core = doc.createElement("div");
+    core.className = "dm-srvx-core";
+    core.innerHTML = '<span class="dm-srvx-core-halo" aria-hidden="true"></span>';
+    metrics.prepend(core);
+  }
+  if (slot.parentElement !== core) core.append(slot);
+}
+
+/**
+ * The band under the dial: the readings this page has already shown, kept for
  * the session so the machine has a shape over time and not just a number.
  */
 function mountTrace(page) {
   const hero = page.querySelector(".srv-hero");
-  const top = hero?.querySelector(".srv-hero-top");
-  if (!top) return null;
+  const metrics = hero?.querySelector(".srv-hero-metrics");
+  if (!metrics) return null;
   let trace = hero.querySelector(":scope > .dm-srvx-trace");
   if (trace) return trace;
   trace = doc.createElement("div");
@@ -306,7 +365,7 @@ function mountTrace(page) {
       <svg class="dm-srvx-trace-svg" viewBox="0 0 ${TRACE_WIDTH} ${TRACE_HEIGHT}" preserveAspectRatio="none" aria-hidden="true">
         <defs>
           <linearGradient id="dmSrvxTraceFill" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0" stop-color="currentColor" stop-opacity=".42"/>
+            <stop offset="0" stop-color="currentColor" stop-opacity=".38"/>
             <stop offset="1" stop-color="currentColor" stop-opacity="0"/>
           </linearGradient>
         </defs>
@@ -316,7 +375,7 @@ function mountTrace(page) {
       </svg>
       <span class="dm-srvx-trace-dot"></span>
     </div>`;
-  top.insertAdjacentElement("afterend", trace);
+  metrics.insertAdjacentElement("afterend", trace);
   return trace;
 }
 
@@ -353,7 +412,7 @@ function syncHeadings(page) {
   }
 }
 
-/** Aurora and sweep behind the chassis panel — decoration, not a reading. */
+/** Aurora and board grid behind the panel — decoration, not a reading. */
 function mountHeroEffect(page) {
   const hero = page.querySelector(".srv-hero");
   if (!hero || hero.dataset.dmSrvxFx) return;
@@ -385,13 +444,24 @@ function mountThermal(page) {
   return card;
 }
 
-function mountTelemetryIcons(page) {
+/** Line icons on the telemetry tiles, and a stream on the two speed tiles. */
+function mountTelemetry(page) {
   for (const tile of page.querySelectorAll(".srv-tel-card")) {
+    const entity = cardEntity(tile);
     const glyph = tile.querySelector(".srv-tel-icon");
-    const name = TELEMETRY_ICONS[cardEntity(tile)];
-    if (!glyph || !name || glyph.dataset.dmSrvxIcon) continue;
-    glyph.dataset.dmSrvxIcon = name;
-    glyph.innerHTML = icon(name, 19);
+    const name = TELEMETRY_ICONS[entity];
+    if (glyph && name && !glyph.dataset.dmSrvxIcon) {
+      glyph.dataset.dmSrvxIcon = name;
+      glyph.innerHTML = icon(name, 19);
+    }
+    const flow = TELEMETRY_FLOW[entity];
+    if (flow && !tile.dataset.dmSrvxFlow) {
+      tile.dataset.dmSrvxFlow = flow;
+      const stream = doc.createElement("span");
+      stream.className = "dm-srvx-stream";
+      stream.setAttribute("aria-hidden", "true");
+      tile.append(stream);
+    }
   }
 }
 
@@ -411,7 +481,7 @@ function mountStatusIcons(page) {
 
 /* ── render ───────────────────────────────────────────────────────────── */
 
-/** Draw the samples collected so far; an empty trace keeps the band hidden. */
+/** Draw the samples collected so far; an empty curve keeps the band hidden. */
 function renderTrace(trace) {
   if (!trace) return;
   const samples = state.trace;
@@ -432,34 +502,44 @@ function renderTrace(trace) {
   if (peak && peak.textContent !== value) peak.textContent = value;
 }
 
+/** Draw one layer of the dial from the bar the legacy loop keeps writing. */
+function renderGauge(card, index) {
+  const arc = card.querySelector(".dm-srvx-ring-arc");
+  if (!arc) return;
+  const radius = RING_RADII[index] ?? RING_RADII[RING_RADII.length - 1];
+  const level = metricLevel(METRIC_BARS[index] || "", doc);
+  const dash = ringDash(level ?? 0, 2 * Math.PI * radius);
+  if (arc.getAttribute("stroke-dasharray") !== dash) arc.setAttribute("stroke-dasharray", dash);
+  // The bar carries the colour the markup configured for this metric.
+  const own = clean(card.querySelector(".srv-metric-fill")?.style?.background) || "currentColor";
+  const colour = ringColour(level, own);
+  // The key next to the label is the legend of that arc, so it takes the colour
+  // the arc ended up with rather than the one the card was configured with.
+  if (clean(card.style.getPropertyValue("--dm-srvx-col")) !== colour) {
+    card.style.setProperty("--dm-srvx-col", colour);
+  }
+  if (arc.getAttribute("stroke") !== colour) arc.setAttribute("stroke", colour);
+  const name = ringLevelName(level);
+  if (card.dataset.dmSrvxLevel !== name) card.dataset.dmSrvxLevel = name;
+}
+
 export function renderMinipcShowcase() {
   const page = doc?.getElementById?.("page-server");
   if (!page) return false;
   page.classList.add("dm-srvx");
   page.querySelector(".srv-hero")?.parentElement?.classList.add("dm-srvx-shell");
   mountHeroEffect(page);
-  mountChassis(page);
-  mountTelemetryIcons(page);
+  mountCore(page);
+  mountTelemetry(page);
   mountStatusIcons(page);
   mountHeadings(page);
   syncHeadings(page);
   renderTrace(mountTrace(page));
   const thermal = mountThermal(page) || page.querySelector(".srv-temp-card");
 
-  const cards = [...page.querySelectorAll(".srv-hero-metrics .srv-metric")];
-  cards.forEach((card, index) => {
-    mountGauge(card);
-    const arc = card.querySelector(".dm-srvx-ring-arc");
-    if (!arc) return;
-    const level = metricLevel(METRIC_BARS[index] || "", doc);
-    const dash = ringDash(level ?? 0);
-    if (arc.getAttribute("stroke-dasharray") !== dash) arc.setAttribute("stroke-dasharray", dash);
-    // The bar carries the colour the markup configured for this metric.
-    const own = clean(card.querySelector(".srv-metric-fill")?.style?.background) || "currentColor";
-    const colour = ringColour(level, own);
-    if (arc.getAttribute("stroke") !== colour) arc.setAttribute("stroke", colour);
-    const loaded = level === null ? "" : level > ALERT_LEVEL ? "alert" : level > WARN_LEVEL ? "warn" : "ok";
-    if (card.dataset.dmSrvxLevel !== loaded) card.dataset.dmSrvxLevel = loaded;
+  [...page.querySelectorAll(".srv-hero-metrics .srv-metric")].forEach((card, index) => {
+    mountGauge(card, index);
+    renderGauge(card, index);
   });
 
   if (thermal) {
@@ -506,7 +586,7 @@ export function installMinipcShowcaseSection() {
       root.addEventListener?.(eventName, scheduleMinipcShowcase);
     }
     // The bars, the temperature arc and the badges repaint through the legacy
-    // render loop, so the gauges follow the same events instead of a timer.
+    // render loop, so the dial follows the same events instead of a timer.
     root.addEventListener?.("dashboardmodern:state-changed", () => {
       // Sampling is three DOM reads, so it runs on every tick; the repaint only
       // happens while the page is the one on screen.
@@ -541,16 +621,14 @@ function minipcShowcaseCss() {
   --srvx-shadow:0 20px 38px -26px rgba(10,26,44,.55),0 2px 6px -3px rgba(10,26,44,.12);
   --srvx-shadow-s:0 16px 30px -24px rgba(10,26,44,.6),0 2px 5px -3px rgba(10,26,44,.12);
   --srvx-live:#10b981;--srvx-live-rgb:16,185,129;
-  /* the hero follows the theme: light surfaces on a light dashboard */
-  --srvx-hero-bg:linear-gradient(150deg,#fbfdff 0%,#edf3fa 55%,#e4ecf6 100%);
+  /* the panel follows the theme: light surfaces on a light dashboard */
+  --srvx-hero-bg:linear-gradient(150deg,#fbfdff 0%,#eef4fb 55%,#e5edf7 100%);
   --srvx-hero-text:var(--srvx-text);
   --srvx-hero-dim:var(--srvx-dim);
-  --srvx-hero-tile:#ffffff;
-  --srvx-hero-tile-shadow:0 12px 24px -18px rgba(10,26,44,.5);
   --srvx-hero-line:rgba(15,23,42,.08);
   --srvx-hero-shadow:0 24px 44px -30px rgba(10,26,44,.55),0 2px 6px -3px rgba(10,26,44,.1);
   --srvx-hero-inset:inset 0 0 0 1px rgba(15,23,42,.05);
-  --srvx-track:rgba(15,23,42,.09);
+  --srvx-track:rgba(15,23,42,.07);
   --srvx-case-top-a:#eef3fa;--srvx-case-top-b:#c3d0e0;
   --srvx-case-left-a:#a9b7ca;--srvx-case-left-b:#8b9bb1;
   --srvx-case-right-a:#93a2b8;--srvx-case-right-b:#76869d;
@@ -564,49 +642,91 @@ function minipcShowcaseCss() {
 #page-server.dm-srvx .dm-srvx-shell{display:grid;gap:14px}
 #page-server.dm-srvx .dm-srvx-ico{display:block;flex:0 0 auto}
 
-/* ── the chassis panel ────────────────────────────────────────────────── */
+/* ── the panel ────────────────────────────────────────────────────────── */
 #page-server.dm-srvx .srv-hero{
-  margin-bottom:0!important;padding:20px!important;border:0!important;
+  margin-bottom:0!important;padding:22px 24px 24px!important;border:0!important;
   border-radius:var(--srvx-r)!important;
   background:var(--srvx-hero-bg)!important;
   box-shadow:var(--srvx-hero-shadow),var(--srvx-hero-inset)!important;
   color:var(--srvx-hero-text)!important
 }
 #page-server.dm-srvx .srv-hero::before{
-  top:-46%!important;right:-12%!important;width:340px!important;height:340px!important;
+  top:-46%!important;right:-12%!important;width:360px!important;height:360px!important;
   background:radial-gradient(circle,rgba(var(--srvx-live-rgb),.14) 0%,transparent 68%)!important
 }
 #page-server.dm-srvx .srv-hero::after{
-  bottom:-34%!important;left:-8%!important;width:280px!important;height:280px!important;
+  bottom:-34%!important;left:-8%!important;width:300px!important;height:300px!important;
   background:radial-gradient(circle,rgba(56,189,248,.14) 0%,transparent 70%)!important
 }
-/* faint board traces plus a sweep that crosses the panel */
 #page-server.dm-srvx .dm-srvx-fx{
   position:absolute;inset:0;z-index:1;pointer-events:none;overflow:hidden;
-  border-radius:inherit;opacity:.5;
+  border-radius:inherit;opacity:.55;
   background-image:
     linear-gradient(var(--srvx-hero-line) 1px,transparent 1px),
     linear-gradient(90deg,var(--srvx-hero-line) 1px,transparent 1px);
   background-size:34px 34px,34px 34px;
-  -webkit-mask-image:radial-gradient(120% 90% at 78% 8%,#000 0%,transparent 72%);
-  mask-image:radial-gradient(120% 90% at 78% 8%,#000 0%,transparent 72%)
+  -webkit-mask-image:radial-gradient(120% 90% at 78% 6%,#000 0%,transparent 72%);
+  mask-image:radial-gradient(120% 90% at 78% 6%,#000 0%,transparent 72%)
 }
 #page-server.dm-srvx .dm-srvx-fx::after{
   content:"";position:absolute;top:0;bottom:0;width:34%;left:-40%;
   background:linear-gradient(90deg,transparent,rgba(var(--srvx-live-rgb),.10),transparent);
   animation:dmSrvxSweep 9s ease-in-out infinite
 }
-#page-server.dm-srvx .srv-hero-top{margin-bottom:20px!important;z-index:2}
-/* the machine stands on the panel instead of sitting in a chip */
+#page-server.dm-srvx .srv-hero-top{margin-bottom:14px!important;z-index:2}
+#page-server.dm-srvx .srv-hero-brand>div{min-width:0}
+#page-server.dm-srvx .srv-hero-title{color:var(--srvx-hero-text)!important;font-size:23px!important;letter-spacing:.06em!important}
+#page-server.dm-srvx .srv-hero-sub{color:var(--srvx-hero-dim)!important;letter-spacing:.14em!important}
+#page-server.dm-srvx .srv-hero-pill{
+  background:rgba(var(--srvx-live-rgb),.12)!important;
+  border:1px solid rgba(var(--srvx-live-rgb),.32)!important;
+  color:var(--srvx-live)!important;padding:8px 15px!important
+}
+#page-server.dm-srvx .srv-hero-dot{
+  background:var(--srvx-live)!important;
+  box-shadow:0 0 0 4px rgba(var(--srvx-live-rgb),.16)!important
+}
+
+/* ── the dial: three arcs around the machine ──────────────────────────── */
+#page-server.dm-srvx .srv-hero-metrics{
+  --srvx-dial:244px;--srvx-gap:22px;
+  display:grid!important;
+  grid-template-columns:var(--srvx-dial) minmax(120px,210px) minmax(74px,auto)!important;
+  grid-template-rows:repeat(3,auto)!important;
+  align-items:center!important;justify-content:center!important;
+  column-gap:var(--srvx-gap)!important;row-gap:0!important
+}
+/* display:contents is a layout mode, not a forced display: the inline
+   display:none cdAutoHide() writes on an unmapped card still wins. */
+#page-server.dm-srvx .srv-metric{
+  display:contents;background:none!important;border:0!important;box-shadow:none!important;padding:0!important
+}
+#page-server.dm-srvx .dm-srvx-core,
+#page-server.dm-srvx .dm-srvx-gauge{
+  grid-column:1;grid-row:1 / span 3;place-self:center;position:relative;
+  width:var(--srvx-dial);height:var(--srvx-dial)
+}
+#page-server.dm-srvx .dm-srvx-gauge{pointer-events:none}
+#page-server.dm-srvx .dm-srvx-ring{width:100%;height:100%;transform:rotate(-90deg);overflow:visible}
+#page-server.dm-srvx .dm-srvx-ring-track{stroke:var(--srvx-track)}
+#page-server.dm-srvx .dm-srvx-ring-arc{
+  pointer-events:stroke;cursor:pointer;
+  transition:stroke-dasharray 1.1s cubic-bezier(.2,.8,.25,1),stroke .45s ease;
+  filter:drop-shadow(0 3px 7px rgba(10,26,44,.2))
+}
+#page-server.dm-srvx .dm-srvx-core{display:grid;place-items:center}
+#page-server.dm-srvx .dm-srvx-core-halo{
+  position:absolute;width:48%;height:48%;border-radius:50%;
+  background:radial-gradient(circle,rgba(var(--srvx-live-rgb),.16) 0%,transparent 70%)
+}
 #page-server.dm-srvx .srv-hero-icon{
-  width:112px!important;height:100px!important;border:0!important;border-radius:0!important;
+  position:relative;z-index:1;
+  width:104px!important;height:92px!important;border:0!important;border-radius:0!important;
   background:none!important;box-shadow:none!important;padding:0!important;overflow:visible!important
 }
 #page-server.dm-srvx .dm-srvx-box{width:100%;height:100%;display:block;overflow:visible}
 #page-server.dm-srvx .dm-srvx-box-body{filter:drop-shadow(var(--srvx-case-shadow))}
-#page-server.dm-srvx .dm-srvx-box-glow{
-  fill:rgba(var(--srvx-live-rgb),.20);filter:blur(7px);transition:fill .5s ease
-}
+#page-server.dm-srvx .dm-srvx-box-glow{fill:rgba(var(--srvx-live-rgb),.2);filter:blur(7px);transition:fill .5s ease}
 #page-server.dm-srvx .dm-srvx-box-edge{stroke:var(--srvx-case-edge)}
 #page-server.dm-srvx .dm-srvx-box-edge-soft{opacity:.45}
 #page-server.dm-srvx .dm-srvx-vents{stroke:var(--srvx-case-ink)}
@@ -619,29 +739,62 @@ function minipcShowcaseCss() {
   animation:dmSrvxSpin 3.4s linear infinite
 }
 #page-server.dm-srvx .dm-srvx-strip{
-  stroke:var(--srvx-live);stroke-width:2.4;stroke-linecap:round;opacity:.85;
-  filter:drop-shadow(0 0 5px rgba(var(--srvx-live-rgb),.8))
+  stroke:var(--srvx-live);stroke-width:2.4;stroke-linecap:round;opacity:.9;
+  filter:drop-shadow(0 0 5px rgba(var(--srvx-live-rgb),.75))
 }
 #page-server.dm-srvx .dm-srvx-led{fill:var(--srvx-live)}
 #page-server.dm-srvx .dm-srvx-led-pwr{filter:drop-shadow(0 0 5px rgba(var(--srvx-live-rgb),.95))}
-#page-server.dm-srvx .dm-srvx-led-act{fill:#60a5fa;animation:dmSrvxBlink 2.6s steps(1,end) infinite}
-#page-server.dm-srvx[data-dm-srv-net="off"] .dm-srvx-led-act{fill:#64748b;animation:none}
+#page-server.dm-srvx .dm-srvx-led-act{fill:#38bdf8;animation:dmSrvxBlink 2.6s steps(1,end) infinite}
+#page-server.dm-srvx[data-dm-srv-net="off"] .dm-srvx-led-act{fill:#94a3b8;animation:none}
 #page-server.dm-srvx[data-dm-srv-net="off"] .dm-srvx-fan{animation:none}
-#page-server.dm-srvx .srv-hero-brand>div{min-width:0}
-#page-server.dm-srvx .srv-hero-title{color:var(--srvx-hero-text)!important;font-size:23px!important;letter-spacing:.06em!important}
-#page-server.dm-srvx .srv-hero-sub{color:var(--srvx-hero-dim)!important;letter-spacing:.14em!important}
-#page-server.dm-srvx .srv-hero-pill{
-  background:rgba(var(--srvx-live-rgb),.14)!important;
-  border:1px solid rgba(var(--srvx-live-rgb),.34)!important;
-  color:var(--srvx-live)!important;padding:8px 15px!important
-}
-#page-server.dm-srvx .srv-hero-dot{
-  background:var(--srvx-live)!important;
-  box-shadow:0 0 0 4px rgba(var(--srvx-live-rgb),.18)!important
-}
 
-/* ── the live CPU trace ───────────────────────────────────────────────── */
-#page-server.dm-srvx .dm-srvx-trace{position:relative;z-index:2;margin:0 0 16px;display:grid;gap:6px}
+/* ── the readings, one row per arc ────────────────────────────────────── */
+/* Two cells, one row: the label cell reaches under the gap so a hover lights up
+   the whole reading instead of two halves with a hole between them. */
+#page-server.dm-srvx .srv-metric-top{
+  grid-column:2;grid-row:var(--dm-srvx-row,1);
+  display:flex!important;align-items:center!important;justify-content:flex-start!important;
+  gap:9px!important;cursor:pointer;
+  padding:15px var(--srvx-gap) 15px 12px!important;margin-right:calc(var(--srvx-gap) * -1);
+  border-radius:14px 0 0 14px;transition:background .25s ease
+}
+#page-server.dm-srvx .srv-metric>div:not(.srv-metric-top):not(.dm-srvx-gauge):not(.srv-metric-bar){
+  grid-column:3;grid-row:var(--dm-srvx-row,1);
+  display:flex;align-items:baseline;justify-content:flex-end;gap:2px;
+  padding:15px 12px 15px 0;cursor:pointer;
+  border-radius:0 14px 14px 0;transition:background .25s ease
+}
+#page-server.dm-srvx .srv-metric:hover .srv-metric-top,
+#page-server.dm-srvx .srv-metric:hover>div:not(.srv-metric-top):not(.dm-srvx-gauge):not(.srv-metric-bar){
+  background:color-mix(in srgb,var(--dm-srvx-col,#94a3b8) 9%,transparent)
+}
+#page-server.dm-srvx .dm-srvx-key{
+  width:10px;height:10px;border-radius:50%;flex:0 0 auto;
+  background:var(--dm-srvx-col,#94a3b8);
+  box-shadow:0 0 0 4px color-mix(in srgb,var(--dm-srvx-col,#94a3b8) 16%,transparent)
+}
+#page-server.dm-srvx .srv-metric-lbl{
+  font-size:11px!important;letter-spacing:.16em!important;color:var(--srvx-hero-dim)!important
+}
+#page-server.dm-srvx .srv-metric-icon{
+  display:grid!important;place-items:center!important;
+  font-size:0!important;color:var(--srvx-hero-dim)!important;opacity:.5!important
+}
+#page-server.dm-srvx .srv-metric-val{
+  font-size:30px!important;font-weight:300!important;letter-spacing:-.04em!important;
+  color:var(--srvx-hero-text)!important;line-height:1!important
+}
+#page-server.dm-srvx .srv-metric-unit{
+  font-size:13px!important;font-weight:700!important;color:var(--srvx-hero-dim)!important
+}
+#page-server.dm-srvx .srv-metric[data-dm-srvx-level="alert"] .srv-metric-lbl,
+#page-server.dm-srvx .srv-metric[data-dm-srvx-level="alert"] .srv-metric-val{color:#dc2626!important}
+#page-server.dm-srvx .srv-metric:hover .srv-metric-lbl{color:var(--srvx-hero-text)!important}
+/* the bar stays: it is the value the arcs read, so it is hidden, not removed */
+#page-server.dm-srvx .srv-metric-bar{display:none!important}
+
+/* ── the live curve ───────────────────────────────────────────────────── */
+#page-server.dm-srvx .dm-srvx-trace{position:relative;z-index:2;margin:16px 0 0;display:grid;gap:6px}
 #page-server.dm-srvx .dm-srvx-trace[data-dm-srvx-trace="empty"]{display:none}
 #page-server.dm-srvx .dm-srvx-trace-head{
   display:flex;align-items:baseline;justify-content:space-between;gap:10px;
@@ -651,23 +804,22 @@ function minipcShowcaseCss() {
 #page-server.dm-srvx .dm-srvx-trace-peak{color:var(--srvx-live);letter-spacing:.1em}
 #page-server.dm-srvx .dm-srvx-trace-plot{position:relative}
 #page-server.dm-srvx .dm-srvx-trace-svg{
-  display:block;width:100%;height:46px;
+  display:block;width:100%;height:46px;color:var(--srvx-live);
   border-bottom:1px solid var(--srvx-hero-line)
 }
 #page-server.dm-srvx .dm-srvx-trace-mid{
   stroke:var(--srvx-hero-line);stroke-width:1;stroke-dasharray:3 5;vector-effect:non-scaling-stroke
 }
-#page-server.dm-srvx .dm-srvx-trace-dot{
-  position:absolute;right:0;top:var(--dm-srvx-last,50%);
-  width:8px;height:8px;margin:-4px -4px 0 0;border-radius:50%;background:var(--srvx-live);
-  box-shadow:0 0 0 3px rgba(var(--srvx-live-rgb),.22);
-  transition:top .6s cubic-bezier(.2,.8,.25,1)
-}
-#page-server.dm-srvx .dm-srvx-trace-svg{color:var(--srvx-live)}
 #page-server.dm-srvx .dm-srvx-trace-area{fill:url(#dmSrvxTraceFill)}
 #page-server.dm-srvx .dm-srvx-trace-line{
   stroke:var(--srvx-live);stroke-width:2;stroke-linejoin:round;stroke-linecap:round;
   vector-effect:non-scaling-stroke
+}
+#page-server.dm-srvx .dm-srvx-trace-dot{
+  position:absolute;right:0;top:var(--dm-srvx-last,50%);
+  width:8px;height:8px;margin:-4px -4px 0 0;border-radius:50%;background:var(--srvx-live);
+  box-shadow:0 0 0 3px rgba(var(--srvx-live-rgb),.2);
+  transition:top .6s cubic-bezier(.2,.8,.25,1)
 }
 
 /* ── section headings ─────────────────────────────────────────────────── */
@@ -680,48 +832,6 @@ function minipcShowcaseCss() {
   content:"";flex:1;height:1px;
   background:linear-gradient(90deg,color-mix(in srgb,var(--srvx-dim) 32%,transparent),transparent)
 }
-
-/* ── the three ring gauges ────────────────────────────────────────────── */
-#page-server.dm-srvx .srv-hero-metrics{gap:14px!important}
-/* no !important on display: cdAutoHide() writes it inline on unmapped cards */
-#page-server.dm-srvx .srv-metric{
-  display:grid;grid-template-rows:auto auto;justify-items:center;gap:10px;
-  padding:16px 12px 14px!important;border-radius:var(--srvx-r-s)!important;
-  background:var(--srvx-hero-tile)!important;border:1px solid var(--srvx-hero-line)!important;
-  box-shadow:var(--srvx-hero-tile-shadow,none)!important;
-  transition:transform .3s cubic-bezier(.34,1.4,.5,1),background .3s ease,border-color .3s ease,box-shadow .3s ease!important
-}
-#page-server.dm-srvx .srv-metric:hover{
-  transform:translateY(-3px)!important;
-  box-shadow:0 18px 28px -20px rgba(10,26,44,.45)!important
-}
-#page-server.dm-srvx .dm-srvx-gauge{position:relative;width:104px;height:104px}
-#page-server.dm-srvx .dm-srvx-ring{width:100%;height:100%;transform:rotate(-90deg)}
-#page-server.dm-srvx .dm-srvx-ring-track{stroke:var(--srvx-track)}
-#page-server.dm-srvx .dm-srvx-ring-arc{transition:stroke-dasharray 1.1s cubic-bezier(.2,.8,.25,1),stroke .45s ease}
-#page-server.dm-srvx .dm-srvx-gauge-val{
-  position:absolute;inset:0;display:grid;place-content:center;text-align:center
-}
-#page-server.dm-srvx .srv-metric-val{
-  font-size:30px!important;font-weight:300!important;letter-spacing:-.04em!important;
-  color:var(--srvx-hero-text)!important;line-height:1!important
-}
-#page-server.dm-srvx .srv-metric-unit{
-  font-size:13px!important;font-weight:700!important;color:var(--srvx-hero-dim)!important;margin-left:2px!important
-}
-#page-server.dm-srvx .srv-metric-top{width:100%;justify-content:center!important;gap:7px}
-#page-server.dm-srvx .srv-metric-icon{order:-1}
-#page-server.dm-srvx .srv-metric-lbl{
-  font-size:10px!important;letter-spacing:.16em!important;color:var(--srvx-hero-dim)!important
-}
-#page-server.dm-srvx .srv-metric-icon{
-  display:grid!important;place-items:center!important;font-size:0!important;
-  color:var(--srvx-hero-dim)!important;opacity:.8!important
-}
-#page-server.dm-srvx .srv-metric[data-dm-srvx-level="alert"] .srv-metric-lbl{color:#dc2626!important}
-#page-server.dm-srvx .srv-metric[data-dm-srvx-level="alert"]{border-color:rgba(239,68,68,.35)!important}
-/* the bar stays: it is the value the rings read, so it is hidden, not removed */
-#page-server.dm-srvx .srv-metric-bar{display:none!important}
 
 /* ── CPU temperature ──────────────────────────────────────────────────── */
 #page-server.dm-srvx .srv-temp-card{
@@ -754,15 +864,15 @@ function minipcShowcaseCss() {
   background:linear-gradient(90deg,#38bdf8 0%,#34d399 34%,#fbbf24 68%,#ef4444 100%);
   opacity:.85
 }
+#page-server.dm-srvx .dm-srvx-scale-limit{
+  position:absolute;left:68.75%;top:-3px;bottom:-3px;width:2px;border-radius:2px;
+  background:var(--srvx-surface);opacity:.85
+}
 #page-server.dm-srvx .dm-srvx-scale-pin{
   position:absolute;top:50%;left:var(--dm-srvx-temp,0%);width:14px;height:14px;margin:-7px 0 0 -7px;
   border-radius:50%;background:var(--srvx-surface);border:3px solid var(--srvx-text);
   box-shadow:0 4px 10px -3px rgba(10,26,44,.6);
   transition:left 1.1s cubic-bezier(.2,.8,.25,1)
-}
-#page-server.dm-srvx .dm-srvx-scale-limit{
-  position:absolute;left:68.75%;top:-3px;bottom:-3px;width:2px;border-radius:2px;
-  background:var(--srvx-surface);opacity:.85
 }
 #page-server.dm-srvx .dm-srvx-scale-ends{
   position:relative;display:flex;justify-content:space-between;font-size:9px;font-weight:800;
@@ -775,7 +885,7 @@ function minipcShowcaseCss() {
 /* ── telemetry ────────────────────────────────────────────────────────── */
 #page-server.dm-srvx .srv-tel-grid{grid-template-columns:repeat(4,1fr)!important;gap:12px!important;margin-bottom:0!important}
 #page-server.dm-srvx .srv-tel-card{
-  padding:16px 15px!important;border:0!important;border-radius:var(--srvx-r-s)!important;
+  padding:16px 15px 19px!important;border:0!important;border-radius:var(--srvx-r-s)!important;
   background:var(--srvx-surface)!important;box-shadow:var(--srvx-shadow-s)!important;gap:10px!important
 }
 #page-server.dm-srvx .srv-tel-card::before{
@@ -791,6 +901,18 @@ function minipcShowcaseCss() {
 #page-server.dm-srvx .srv-tel-lbl{font-size:9.5px!important;letter-spacing:.12em!important}
 #page-server.dm-srvx .srv-tel-val{font-size:26px!important;letter-spacing:-.02em!important}
 #page-server.dm-srvx .srv-tel-sub{font-size:9.5px!important;color:var(--srvx-dim)!important}
+/* download and upload run their own stream along the foot of the tile */
+#page-server.dm-srvx .dm-srvx-stream{
+  position:absolute;left:15px;right:15px;bottom:11px;height:2px;border-radius:2px;overflow:hidden;
+  background:rgba(var(--tc-rgb,14,165,233),.14)
+}
+#page-server.dm-srvx .dm-srvx-stream::after{
+  content:"";position:absolute;top:0;bottom:0;left:0;width:52%;
+  background:linear-gradient(90deg,transparent,rgb(var(--tc-rgb,14,165,233)),transparent);
+  opacity:.75
+}
+#page-server.dm-srvx [data-dm-srvx-flow="in"] .dm-srvx-stream::after{animation:dmSrvxFlowIn 2.6s linear infinite}
+#page-server.dm-srvx [data-dm-srvx-flow="out"] .dm-srvx-stream::after{animation:dmSrvxFlowOut 2.6s linear infinite}
 
 /* ── connectivity and inverter ────────────────────────────────────────── */
 #page-server.dm-srvx .srv-status-grid{gap:12px!important}
@@ -817,44 +939,56 @@ function minipcShowcaseCss() {
 @keyframes dmSrvxSpin{to{transform:rotate(360deg)}}
 @keyframes dmSrvxSweep{0%{left:-40%}55%{left:106%}100%{left:106%}}
 @keyframes dmSrvxBlink{0%,44%{opacity:.25}50%,58%{opacity:1}64%,100%{opacity:.25}}
+@keyframes dmSrvxFlowIn{from{transform:translateX(-100%)}to{transform:translateX(192%)}}
+@keyframes dmSrvxFlowOut{from{transform:translateX(192%)}to{transform:translateX(-100%)}}
 
 /* ── responsive ───────────────────────────────────────────────────────── */
+@media(max-width:860px){
+  #page-server.dm-srvx .srv-hero-metrics{--srvx-dial:204px;column-gap:18px!important}
+  #page-server.dm-srvx .srv-metric-val{font-size:26px!important}
+}
 @media(max-width:760px){
   #page-server.dm-srvx .srv-tel-grid{grid-template-columns:repeat(2,1fr)!important}
 }
 @media(max-width:620px){
   #page-server.dm-srvx{--srvx-r:22px;--srvx-r-s:17px}
-  #page-server.dm-srvx .srv-hero{padding:16px!important}
-  /* the legacy sheet stacks these two: the pill belongs next to the name and
-     the temperature ring next to its scale, on a phone as much as on a desk */
+  #page-server.dm-srvx .srv-hero{padding:16px 16px 18px!important}
+  /* the dial goes above the readings, which become three full-width rows */
+  #page-server.dm-srvx .srv-hero-metrics{
+    --srvx-dial:min(232px,64vw);
+    grid-template-columns:minmax(0,1fr) auto!important;
+    grid-template-rows:auto repeat(3,auto)!important;
+    column-gap:12px!important
+  }
+  #page-server.dm-srvx .dm-srvx-core,
+  #page-server.dm-srvx .dm-srvx-gauge{grid-column:1 / -1;grid-row:1}
+  #page-server.dm-srvx .srv-metric-top{grid-column:1;grid-row:calc(var(--dm-srvx-row,1) + 1);padding:12px 12px 12px 10px!important}
+  #page-server.dm-srvx .srv-metric>div:not(.srv-metric-top):not(.dm-srvx-gauge):not(.srv-metric-bar){
+    grid-column:2;grid-row:calc(var(--dm-srvx-row,1) + 1);padding:12px 10px 12px 0
+  }
+  #page-server.dm-srvx .srv-metric-val{font-size:24px!important}
+  #page-server.dm-srvx .srv-hero-icon{width:96px!important;height:86px!important}
+  /* the legacy sheet stacks the header: the pill belongs next to the name */
   #page-server.dm-srvx .srv-hero-top{
-    flex-direction:row!important;align-items:center!important;gap:10px!important;margin-bottom:16px!important
+    flex-direction:row!important;align-items:center!important;gap:10px!important;margin-bottom:6px!important
   }
   #page-server.dm-srvx .srv-hero-pill{padding:6px 11px!important;font-size:10px!important;letter-spacing:.08em!important;flex-shrink:0!important}
   #page-server.dm-srvx .srv-hero-brand{gap:11px!important;min-width:0!important}
-  /* the subtitle gives way instead of pushing the pill onto its own line */
   #page-server.dm-srvx .srv-hero-title,
   #page-server.dm-srvx .srv-hero-sub{
     white-space:nowrap!important;overflow:hidden!important;text-overflow:ellipsis!important
   }
+  #page-server.dm-srvx .dm-srvx-trace{margin-top:14px}
+  #page-server.dm-srvx .dm-srvx-trace-svg{height:44px}
+  #page-server.dm-srvx .dm-srvx-head{letter-spacing:.14em}
   #page-server.dm-srvx .srv-temp-card{
-    flex-direction:row!important;text-align:left!important;align-items:center!important
+    flex-direction:row!important;text-align:left!important;align-items:center!important;
+    gap:15px!important;padding:16px!important
   }
+  #page-server.dm-srvx .srv-temp-ring{width:92px!important;height:92px!important}
   #page-server.dm-srvx .srv-temp-num{font-size:24px!important}
   #page-server.dm-srvx .dm-srvx-temp-badge{font-size:12px!important;padding:5px 11px 5px 9px!important}
   #page-server.dm-srvx .dm-srvx-scale-ends{font-size:8px!important}
-  #page-server.dm-srvx .srv-hero-metrics{gap:9px!important}
-  #page-server.dm-srvx .srv-metric{padding:13px 6px 11px!important}
-  #page-server.dm-srvx .dm-srvx-gauge{width:82px;height:82px}
-  #page-server.dm-srvx .srv-metric-val{font-size:23px!important}
-  #page-server.dm-srvx .srv-metric-unit{font-size:11px!important}
-  #page-server.dm-srvx .srv-hero-icon{width:78px!important;height:70px!important}
-  #page-server.dm-srvx .dm-srvx-trace{margin-bottom:13px}
-  #page-server.dm-srvx .dm-srvx-trace-svg{height:44px}
-  #page-server.dm-srvx .dm-srvx-head{letter-spacing:.14em}
-  #page-server.dm-srvx .srv-hero-title{font-size:19px!important}
-  #page-server.dm-srvx .srv-temp-card{gap:15px!important;padding:16px!important}
-  #page-server.dm-srvx .srv-temp-ring{width:92px!important;height:92px!important}
   #page-server.dm-srvx .srv-tel-val{font-size:22px!important}
   #page-server.dm-srvx .srv-status-grid{grid-template-columns:1fr!important}
 }
@@ -867,12 +1001,10 @@ html[data-theme="dark"] #page-server.dm-srvx{
   --srvx-hero-bg:linear-gradient(150deg,#1b2740 0%,#111a2c 54%,#0a111e 100%);
   --srvx-hero-text:#f2f6ff;
   --srvx-hero-dim:rgba(198,214,240,.74);
-  --srvx-hero-tile:rgba(255,255,255,.055);
-  --srvx-hero-tile-shadow:inset 0 1px 0 rgba(255,255,255,.07);
-  --srvx-hero-line:rgba(255,255,255,.10);
+  --srvx-hero-line:rgba(255,255,255,.1);
   --srvx-hero-shadow:0 28px 48px -28px rgba(0,0,0,.85),0 2px 6px -3px rgba(0,0,0,.5);
   --srvx-hero-inset:inset 0 1px 0 rgba(255,255,255,.06);
-  --srvx-track:rgba(255,255,255,.10);
+  --srvx-track:rgba(255,255,255,.09);
   --srvx-case-top-a:#6a80a8;--srvx-case-top-b:#2f3f5e;
   --srvx-case-left-a:#2b3a56;--srvx-case-left-b:#141d31;
   --srvx-case-right-a:#1b2540;--srvx-case-right-b:#0d1424;
@@ -883,6 +1015,7 @@ html[data-theme="dark"] #page-server.dm-srvx{
   --srvx-case-shadow:0 14px 18px rgba(4,10,20,.55)
 }
 html[data-theme="dark"] #page-server.dm-srvx[data-dm-srv-net="off"]{--srvx-live:#f87171;--srvx-live-rgb:248,113,113}
+html[data-theme="dark"] #page-server.dm-srvx .dm-srvx-ring-arc{filter:none}
 html[data-theme="dark"] #page-server.dm-srvx .dm-srvx-scale-pin{border-color:#dbe6f7!important}
 html[data-theme="dark"] #page-server.dm-srvx .dm-srvx-status-ico{background:rgba(255,255,255,.06)}
 

--- a/custom_components/dashboardmodern/frontend/src/sections/minipc-showcase-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/minipc-showcase-section.js
@@ -47,7 +47,14 @@ import { clean, doc, installStyle, root, t } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_MINIPC_SHOWCASE__";
 const STYLE_ID = "dm-minipc-showcase-style";
-const state = (root[KEY] ||= { installed: false, listeners: false, frame: 0, trace: [] });
+const state = (root[KEY] ||= {
+  installed: false,
+  listeners: false,
+  frame: 0,
+  trace: [],
+  watched: null,
+  observer: null,
+});
 if (!Array.isArray(state.trace)) state.trace = [];
 
 /* Same pair as the legacy setRing(): above 85% the prism is red, above 65%
@@ -521,6 +528,25 @@ export function renderMinipcShowcase() {
   return true;
 }
 
+/* The auto-hide is what empties a block, and all it does is write an inline
+ * `display` on the cards. It is called from inside the runtime, not through the
+ * global, so wrapping the name would never see it — and when it lands after the
+ * last pass, the title of an emptied column stays on the board on its own.
+ *
+ * So the page is watched instead, and only for that: the inline styles of the
+ * blocks under `#page-server`. Nothing else is observed, and the document never
+ * is. The pass writes an inline `display` on the headings, which wakes this
+ * once more and then finds nothing left to change. */
+function bindAutoHide() {
+  const page = doc?.getElementById?.("page-server");
+  if (!page || state.watched === page) return;
+  if (typeof root.MutationObserver !== "function") return;
+  state.observer?.disconnect?.();
+  state.observer = new root.MutationObserver(() => scheduleMinipcShowcase());
+  state.observer.observe(page, { attributes: true, attributeFilter: ["style"], subtree: true });
+  state.watched = page;
+}
+
 export function scheduleMinipcShowcase() {
   if (state.frame) return;
   const run = () => {
@@ -544,7 +570,10 @@ export function installMinipcShowcaseSection() {
       "dashboardmodern:runtime-ready",
       "pageshow",
     ]) {
-      root.addEventListener?.(eventName, scheduleMinipcShowcase);
+      root.addEventListener?.(eventName, () => {
+        bindAutoHide();
+        scheduleMinipcShowcase();
+      });
     }
     // The bars, the temperature arc and the badges repaint through the legacy
     // render loop, so the scene follows the same events instead of a timer.
@@ -565,6 +594,7 @@ export function installMinipcShowcaseSection() {
     );
   }
   state.installed = true;
+  bindAutoHide();
   sampleCpu();
   renderMinipcShowcase();
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/minipc-showcase-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/minipc-showcase-section.js
@@ -1,0 +1,902 @@
+// DM-FIX-20260818A
+/* MiniPC section redesign — "Sala macchine".
+ *
+ * Reskins `#page-server` around the machine itself: the hero becomes the panel
+ * of the machine, with the mini PC drawn in isometry, its LEDs and its fan, and
+ * a live trace of the CPU load under it. CPU / RAM / Disk turn from flat bars
+ * into ring gauges, the CPU temperature gets a thermal scale next to its ring,
+ * the telemetry tiles trade emoji for line icons and three headings split the
+ * page into thermal, telemetry and network. The panel follows the theme: it is
+ * light on a light dashboard and deep navy only when the theme is dark.
+ *
+ * Contracts preserved on purpose — the legacy runtime keeps owning every value:
+ * - the three metric bars `#srv-fill-cpu` / `#srv-fill-ram` / `#srv-fill-disk`
+ *   stay in the DOM and keep being the only writers of the load: the rings read
+ *   their width instead of parsing a sensor again;
+ * - `#v-srv-cpu`, `#v-srv-ram` + `#u-srv-ram` and `#v-srv-disk` are moved into
+ *   the middle of their ring, never copied, so the dynamic RAM unit (%, GB) the
+ *   render loop writes still lands on screen;
+ * - `#srv-temp-circle` keeps its `stroke-dasharray` and its `stroke`: the
+ *   threshold colour stays the legacy one and the thermal scale reads the arc
+ *   the runtime drew rather than re-deriving it from the sensor;
+ * - `#v-srv-temp-status` stays the owner of the status wording; the badge next
+ *   to the ring mirrors it and takes its level from the 🟢/🟡/🔴 marker the
+ *   runtime already put in that text, so no threshold is duplicated here;
+ * - `#waw-net-badge` / `#waw-inv-badge` keep the `srv-status-badge online` and
+ *   `offline` class the render loop rewrites on every tick; the page mirrors the
+ *   connectivity one onto `#page-server` as `data-dm-srv-net`, which is what
+ *   turns the panel, the LEDs and the trace red when the machine drops off the
+ *   network;
+ * - every card keeps its `onclick`, so `apriStorico()` and `apriSrvHistory()`
+ *   still open the history popups, and no `display` is forced with `!important`
+ *   on a card `cdAutoHide()` shows or hides by writing an inline `display`.
+ *
+ * The live CPU trace is the one thing drawn from more than the current tick: it
+ * keeps the last readings of `#srv-fill-cpu` in memory for the session, so it is
+ * a picture of what the page already showed rather than a second history engine.
+ *
+ * The only numbers in this module are presentational: the 65 / 85 pair the
+ * legacy `setRing()` already uses to colour these three gauges, and the 20-100
+ * window plus the 75 °C notch the runtime itself draws the temperature arc in.
+ */
+import { clean, doc, installStyle, root, t } from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_MINIPC_SHOWCASE__";
+const STYLE_ID = "dm-minipc-showcase-style";
+const state = (root[KEY] ||= { installed: false, listeners: false, frame: 0, trace: [] });
+if (!Array.isArray(state.trace)) state.trace = [];
+
+const RING_RADIUS = 52;
+const RING_LENGTH = 2 * Math.PI * RING_RADIUS;
+/* Same pair as the legacy setRing(): above 85% the gauge is red, above 65%
+   amber, below that it keeps the colour configured on the card. */
+const WARN_LEVEL = 65;
+const ALERT_LEVEL = 85;
+const WARN_COLOUR = "#f59e0b";
+const ALERT_COLOUR = "#ef4444";
+
+/* Readings kept for the trace: about ten minutes of a dashboard that ticks
+   every few seconds, and short enough to stay a glance rather than a chart. */
+const TRACE_SAMPLES = 96;
+const TRACE_WIDTH = 300;
+const TRACE_HEIGHT = 56;
+
+/* The gauges follow the order of the cards in the hero, which is the order the
+   legacy markup writes the bars in. */
+const METRIC_BARS = Object.freeze(["srv-fill-cpu", "srv-fill-ram", "srv-fill-disk"]);
+
+const ICONS = Object.freeze({
+  cpu: '<rect x="8.4" y="8.4" width="7.2" height="7.2" rx="1.6"/><rect x="4.6" y="4.6" width="14.8" height="14.8" rx="3"/><path d="M9 2.6v2M15 2.6v2M9 19.4v2M15 19.4v2M2.6 9h2M2.6 15h2M19.4 9h2M19.4 15h2"/>',
+  ram: '<rect x="2.6" y="7" width="18.8" height="10" rx="2.2"/><path d="M6.6 17v3M12 17v3M17.4 17v3M6.8 10.4h2.6v3.2H6.8zM14.6 10.4h2.6v3.2h-2.6z"/>',
+  disk: '<circle cx="12" cy="12" r="8.8"/><circle cx="12" cy="12" r="2.6"/><path d="M17.4 17.4 14 14"/>',
+  bolt: '<path d="M13.2 2.8 5.6 13.4h5.3l-.9 7.8 8.4-10.6h-5.3l.1-7.8Z"/>',
+  clock: '<circle cx="12" cy="12" r="8.6"/><path d="M12 6.9V12l3.4 2"/>',
+  down: '<path d="M12 3.6v13M6.8 11.4 12 16.6l5.2-5.2M4.6 20.4h14.8"/>',
+  up: '<path d="M12 20.4v-13M6.8 12.6 12 7.4l5.2 5.2M4.6 3.6h14.8"/>',
+  wifi: '<path d="M2.6 8.8a14 14 0 0 1 18.8 0M5.8 12.4a9.4 9.4 0 0 1 12.4 0M9 16a4.8 4.8 0 0 1 6 0"/><circle cx="12" cy="19.4" r="1.1" fill="currentColor" stroke="none"/>',
+  grid: '<path d="M12 2.6 4 8.4V21h16V8.4L12 2.6Z"/><path d="M12.8 10.2 9.4 15.4h3l-.8 4 3.8-5.6h-2.8l.2-3.6Z"/>',
+  thermo: '<path d="M14 14.4V5.2a2 2 0 1 0-4 0v9.2a3.9 3.9 0 1 0 4 0Z"/>',
+});
+
+/* The telemetry tiles are static markup: their emoji is decoration, so it can be
+   swapped for a line icon keyed on the entity the tile opens in the history. */
+const TELEMETRY_ICONS = Object.freeze({
+  "dm.server_potenza_raspberry_server": "bolt",
+  "dm.server_uptime_home_assistant": "clock",
+  "dm.server_speedtest_download": "down",
+  "dm.server_speedtest_upload": "up",
+});
+
+const METRIC_ICONS = Object.freeze({
+  "dm.server_cpu": "cpu",
+  "dm.server_ram": "ram",
+  "dm.server_disco": "disk",
+});
+
+function icon(name, size = 20) {
+  const body = ICONS[name];
+  if (!body) return "";
+  return `<svg class="dm-srvx-ico" viewBox="0 0 24 24" width="${size}" height="${size}" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${body}</svg>`;
+}
+
+/** The `dm.*` entity a card opens in the history popup, "" when it opens none. */
+function cardEntity(node) {
+  return clean(node?.getAttribute?.("onclick")).match(/dm\.[a-z0-9_]+/)?.[0] || "";
+}
+
+/* ── readers ──────────────────────────────────────────────────────────── */
+
+/** Load of one gauge, read from the bar the legacy render loop writes. */
+export function metricLevel(barId, scope = doc) {
+  const width = Number.parseFloat(clean(scope?.getElementById?.(barId)?.style?.width));
+  if (!Number.isFinite(width)) return null;
+  return Math.max(0, Math.min(100, width));
+}
+
+/** Dash pair drawing `level` percent of a ring. */
+export function ringDash(level, circumference = RING_LENGTH) {
+  const value = Number.isFinite(level) ? Math.max(0, Math.min(100, level)) : 0;
+  const drawn = (value / 100) * circumference;
+  return `${drawn.toFixed(1)} ${(circumference - drawn).toFixed(1)}`;
+}
+
+/** Colour of a gauge: the card's own colour until the legacy thresholds bite. */
+export function ringColour(level, colour) {
+  if (Number.isFinite(level) && level > ALERT_LEVEL) return ALERT_COLOUR;
+  if (Number.isFinite(level) && level > WARN_LEVEL) return WARN_COLOUR;
+  return colour;
+}
+
+/**
+ * Fraction of the temperature ring the legacy runtime drew, 0 when it has not
+ * drawn one yet. The scale follows the arc instead of re-deriving the reading.
+ */
+export function tempFraction(scope = doc) {
+  const dash = clean(scope?.getElementById?.("srv-temp-circle")?.getAttribute?.("stroke-dasharray"));
+  const [drawn, gap] = dash.split(/[\s,]+/).map(Number);
+  if (!Number.isFinite(drawn) || !Number.isFinite(gap) || drawn + gap <= 0) return 0;
+  return Math.max(0, Math.min(1, drawn / (drawn + gap)));
+}
+
+/**
+ * Level of the CPU temperature, taken from the marker the legacy status text
+ * carries. Keeping the classification there means one owner for the thresholds.
+ */
+export function tempLevel(text) {
+  const value = clean(text);
+  if (value.includes("🔴")) return "hot";
+  if (value.includes("🟡")) return "warm";
+  if (value.includes("🟢")) return "ok";
+  return "";
+}
+
+/** The same wording without its marker, so the badge can draw its own dot. */
+export function tempWording(text) {
+  return clean(clean(text).replace(/^[🔴🟡🟢]\s*/u, ""));
+}
+
+/**
+ * The trace, as the two paths that draw it: the line and the area under it.
+ * A single reading is drawn flat across the band instead of as a lone dot.
+ */
+/** Height of one reading inside the band, as a share of the band. */
+export function traceOffset(value, height = TRACE_HEIGHT) {
+  const level = Number.isFinite(value) ? Math.max(0, Math.min(100, value)) : 0;
+  return (height - 3 - (level / 100) * (height - 6)) / height;
+}
+
+export function tracePaths(values, width = TRACE_WIDTH, height = TRACE_HEIGHT) {
+  const points = (values || []).filter((value) => Number.isFinite(value));
+  if (!points.length) return { line: "", area: "" };
+  const span = points.length > 1 ? width / (points.length - 1) : width;
+  const y = (value) => traceOffset(value, height) * height;
+  const line =
+    points.length === 1
+      ? `M0 ${y(points[0]).toFixed(1)} L${width} ${y(points[0]).toFixed(1)}`
+      : points.map((value, index) => `${index ? "L" : "M"}${(index * span).toFixed(1)} ${y(value).toFixed(1)}`).join(" ");
+  return { line, area: `${line} L${width} ${height} L0 ${height} Z` };
+}
+
+/** Connectivity, read from the badge class the render loop rewrites per tick. */
+export function networkState(scope = doc) {
+  const badge = scope?.getElementById?.("waw-net-badge");
+  if (badge?.classList?.contains("offline")) return "off";
+  if (badge?.classList?.contains("online")) return "on";
+  return "";
+}
+
+/**
+ * Keep the reading the page is showing. Sampling happens on every state event,
+ * page open or not, so the trace is already drawn when the section is opened.
+ */
+export function sampleCpu(scope = doc, samples = state.trace) {
+  const level = metricLevel("srv-fill-cpu", scope);
+  if (level === null) return samples;
+  samples.push(level);
+  while (samples.length > TRACE_SAMPLES) samples.shift();
+  return samples;
+}
+
+/* ── mount ────────────────────────────────────────────────────────────── */
+
+function ringMarkup() {
+  return `
+    <svg class="dm-srvx-ring" viewBox="0 0 120 120" aria-hidden="true">
+      <circle class="dm-srvx-ring-track" cx="60" cy="60" r="${RING_RADIUS}" fill="none" stroke-width="8"/>
+      <circle class="dm-srvx-ring-arc" cx="60" cy="60" r="${RING_RADIUS}" fill="none" stroke-width="8" stroke-linecap="round" stroke-dasharray="0 ${RING_LENGTH.toFixed(1)}"/>
+    </svg>`;
+}
+
+/**
+ * Turn one metric card into a ring gauge. The value nodes are moved into the
+ * middle of the ring, never copied, so the render loop keeps one target.
+ */
+function mountGauge(card) {
+  if (card.dataset.dmSrvxGauge) return;
+  card.dataset.dmSrvxGauge = "true";
+  const gauge = doc.createElement("div");
+  gauge.className = "dm-srvx-gauge";
+  gauge.innerHTML = `${ringMarkup()}<div class="dm-srvx-gauge-val"></div>`;
+  const value = card.querySelector(".srv-metric-val")?.parentElement;
+  card.prepend(gauge);
+  if (value) gauge.querySelector(".dm-srvx-gauge-val")?.append(value);
+  const glyph = card.querySelector(".srv-metric-icon");
+  const name = METRIC_ICONS[cardEntity(card)];
+  if (glyph && name) glyph.innerHTML = icon(name, 16);
+}
+
+/**
+ * The machine itself: an isometric chassis drawn once in the slot the hero
+ * already has. Only the LEDs and the fan move, and both stop when the badge
+ * says the machine is off the network.
+ */
+function mountChassis(page) {
+  const slot = page.querySelector(".srv-hero-icon");
+  if (!slot || slot.dataset.dmSrvxChassis) return;
+  slot.dataset.dmSrvxChassis = "true";
+  slot.innerHTML = `
+    <svg class="dm-srvx-box" viewBox="0 0 120 104" aria-hidden="true">
+      <defs>
+        <linearGradient id="dmSrvxTop" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0" style="stop-color:var(--srvx-case-top-a)"/>
+          <stop offset="1" style="stop-color:var(--srvx-case-top-b)"/>
+        </linearGradient>
+        <linearGradient id="dmSrvxLeft" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" style="stop-color:var(--srvx-case-left-a)"/>
+          <stop offset="1" style="stop-color:var(--srvx-case-left-b)"/>
+        </linearGradient>
+        <linearGradient id="dmSrvxRight" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" style="stop-color:var(--srvx-case-right-a)"/>
+          <stop offset="1" style="stop-color:var(--srvx-case-right-b)"/>
+        </linearGradient>
+      </defs>
+      <ellipse class="dm-srvx-box-glow" cx="60" cy="86" rx="40" ry="9"/>
+      <g class="dm-srvx-box-body">
+        <path d="M60 16 100 39 60 62 20 39Z" fill="url(#dmSrvxTop)"/>
+        <path d="M20 39 60 62v20L20 59Z" fill="url(#dmSrvxLeft)"/>
+        <path d="M100 39 60 62v20l40-23Z" fill="url(#dmSrvxRight)"/>
+        <path class="dm-srvx-box-edge" d="M60 16 100 39 60 62 20 39Z" fill="none" stroke-width="1.1" stroke-linejoin="round"/>
+        <path class="dm-srvx-box-edge dm-srvx-box-edge-soft" d="M20 39v20l40 23 40-23V39" fill="none" stroke-width="1.1" stroke-linejoin="round"/>
+      </g>
+      <g class="dm-srvx-vents" stroke-width="1.6" stroke-linecap="round">
+        <path d="M74 34.5 87 42M70 37 83 44.5M66 39.5 79 47"/>
+      </g>
+      <g transform="rotate(-29.7 45 39)">
+        <ellipse class="dm-srvx-fan-hole" cx="45" cy="39" rx="12.8" ry="12.8" stroke-width="1.2" transform="scale(1 .5)" transform-origin="45 39"/>
+        <g class="dm-srvx-fan" transform="scale(1 .5)" transform-origin="45 39">
+          <path d="M45 39c1.4-4.4 4.6-7.4 8.4-7.9.4 4.2-2.8 8.1-8.4 7.9Z" transform="rotate(0 45 39)"/>
+          <path d="M45 39c1.4-4.4 4.6-7.4 8.4-7.9.4 4.2-2.8 8.1-8.4 7.9Z" transform="rotate(72 45 39)"/>
+          <path d="M45 39c1.4-4.4 4.6-7.4 8.4-7.9.4 4.2-2.8 8.1-8.4 7.9Z" transform="rotate(144 45 39)"/>
+          <path d="M45 39c1.4-4.4 4.6-7.4 8.4-7.9.4 4.2-2.8 8.1-8.4 7.9Z" transform="rotate(216 45 39)"/>
+          <path d="M45 39c1.4-4.4 4.6-7.4 8.4-7.9.4 4.2-2.8 8.1-8.4 7.9Z" transform="rotate(288 45 39)"/>
+          <circle class="dm-srvx-fan-hub" cx="45" cy="39" r="2.2" stroke-width="1"/>
+        </g>
+      </g>
+      <g class="dm-srvx-front">
+        <path class="dm-srvx-strip" d="M25.5 47.5 54 63.8"/>
+        <circle class="dm-srvx-led dm-srvx-led-pwr" cx="28" cy="57" r="2.6"/>
+        <circle class="dm-srvx-led dm-srvx-led-act" cx="35.5" cy="61.4" r="2.6"/>
+        <path class="dm-srvx-port" d="M44 66.5 52 71" stroke-width="3.4" stroke-linecap="round"/>
+      </g>
+      <g class="dm-srvx-side" stroke-width="1.5" stroke-linecap="round">
+        <path d="M70 63.5v9M76 60v9M82 56.5v9M88 53v9"/>
+      </g>
+    </svg>`;
+}
+
+/**
+ * The band under the header: the readings this page has already shown, kept for
+ * the session so the machine has a shape over time and not just a number.
+ */
+function mountTrace(page) {
+  const hero = page.querySelector(".srv-hero");
+  const top = hero?.querySelector(".srv-hero-top");
+  if (!top) return null;
+  let trace = hero.querySelector(":scope > .dm-srvx-trace");
+  if (trace) return trace;
+  trace = doc.createElement("div");
+  trace.className = "dm-srvx-trace";
+  trace.dataset.dmSrvxTrace = "empty";
+  trace.innerHTML = `
+    <div class="dm-srvx-trace-head">
+      <span class="dm-srvx-trace-lbl">${t("Carico CPU · live", "CPU load · live")}</span>
+      <span class="dm-srvx-trace-peak"></span>
+    </div>
+    <div class="dm-srvx-trace-plot">
+      <svg class="dm-srvx-trace-svg" viewBox="0 0 ${TRACE_WIDTH} ${TRACE_HEIGHT}" preserveAspectRatio="none" aria-hidden="true">
+        <defs>
+          <linearGradient id="dmSrvxTraceFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stop-color="currentColor" stop-opacity=".42"/>
+            <stop offset="1" stop-color="currentColor" stop-opacity="0"/>
+          </linearGradient>
+        </defs>
+        <path class="dm-srvx-trace-mid" d="M0 ${(TRACE_HEIGHT / 2).toFixed(1)} H${TRACE_WIDTH}" fill="none"/>
+        <path class="dm-srvx-trace-area" d=""/>
+        <path class="dm-srvx-trace-line" d="" fill="none"/>
+      </svg>
+      <span class="dm-srvx-trace-dot"></span>
+    </div>`;
+  top.insertAdjacentElement("afterend", trace);
+  return trace;
+}
+
+/* Headings that give the page its three blocks. Each one is tied to the block
+   below it, so a block emptied by cdAutoHide() does not leave a title behind. */
+const GROUPS = Object.freeze([
+  { block: ".srv-temp-card", card: ".srv-temp-card", it: "Termica", en: "Thermal" },
+  { block: ".srv-tel-grid", card: ".srv-tel-card", it: "Telemetria", en: "Telemetry" },
+  { block: ".srv-status-grid", card: ".srv-status-card", it: "Rete e impianto", en: "Network & plant" },
+]);
+
+function mountHeadings(page) {
+  for (const group of GROUPS) {
+    const block = page.querySelector(group.block);
+    if (!block || block.previousElementSibling?.classList?.contains("dm-srvx-head")) continue;
+    const heading = doc.createElement("div");
+    heading.className = "dm-srvx-head";
+    heading.dataset.dmSrvxHead = group.block;
+    heading.innerHTML = `<span>${t(group.it, group.en)}</span>`;
+    block.insertAdjacentElement("beforebegin", heading);
+  }
+}
+
+/** Hide a heading whose whole block the auto-hide has taken off the page. */
+function syncHeadings(page) {
+  for (const group of GROUPS) {
+    const block = page.querySelector(group.block);
+    const heading = block?.previousElementSibling;
+    if (!heading?.classList?.contains("dm-srvx-head")) continue;
+    const cards = block.matches(group.card) ? [block] : [...block.querySelectorAll(group.card)];
+    const empty = cards.length > 0 && cards.every((card) => card.style.display === "none");
+    const display = empty ? "none" : "";
+    if (heading.style.display !== display) heading.style.display = display;
+  }
+}
+
+/** Aurora and sweep behind the chassis panel — decoration, not a reading. */
+function mountHeroEffect(page) {
+  const hero = page.querySelector(".srv-hero");
+  if (!hero || hero.dataset.dmSrvxFx) return;
+  hero.dataset.dmSrvxFx = "true";
+  const effect = doc.createElement("div");
+  effect.className = "dm-srvx-fx";
+  effect.setAttribute("aria-hidden", "true");
+  hero.prepend(effect);
+}
+
+/** Thermal scale and mirrored status badge next to the temperature ring. */
+function mountThermal(page) {
+  const card = page.querySelector(".srv-temp-card");
+  const info = card?.querySelector(".srv-temp-info");
+  if (!info || info.dataset.dmSrvxThermal) return null;
+  info.dataset.dmSrvxThermal = "true";
+  const badge = doc.createElement("div");
+  badge.className = "dm-srvx-temp-badge";
+  badge.innerHTML = '<span class="dm-srvx-temp-dot"></span><span class="dm-srvx-temp-txt"></span>';
+  info.querySelector(".srv-temp-status")?.insertAdjacentElement("afterend", badge);
+  const scale = doc.createElement("div");
+  scale.className = "dm-srvx-scale";
+  /* The scale spans the 20-100 °C window the legacy arc is drawn in, and the
+     notch marks the 75 °C the runtime calls "alta" in the status line. */
+  scale.innerHTML = `
+    <div class="dm-srvx-scale-track"><span class="dm-srvx-scale-limit"></span><span class="dm-srvx-scale-pin"></span></div>
+    <div class="dm-srvx-scale-ends"><span>20°</span><span class="dm-srvx-scale-mark">${t("limite 75°", "75° limit")}</span><span>100°</span></div>`;
+  info.append(scale);
+  return card;
+}
+
+function mountTelemetryIcons(page) {
+  for (const tile of page.querySelectorAll(".srv-tel-card")) {
+    const glyph = tile.querySelector(".srv-tel-icon");
+    const name = TELEMETRY_ICONS[cardEntity(tile)];
+    if (!glyph || !name || glyph.dataset.dmSrvxIcon) continue;
+    glyph.dataset.dmSrvxIcon = name;
+    glyph.innerHTML = icon(name, 19);
+  }
+}
+
+/** A leading icon for the two status rows, so they read as a pair of channels. */
+function mountStatusIcons(page) {
+  const names = ["wifi", "grid"];
+  const cards = [...page.querySelectorAll(".srv-status-card")];
+  cards.forEach((card, index) => {
+    if (card.dataset.dmSrvxIcon) return;
+    card.dataset.dmSrvxIcon = "true";
+    const slot = doc.createElement("div");
+    slot.className = "dm-srvx-status-ico";
+    slot.innerHTML = icon(names[index] || "wifi", 18);
+    card.prepend(slot);
+  });
+}
+
+/* ── render ───────────────────────────────────────────────────────────── */
+
+/** Draw the samples collected so far; an empty trace keeps the band hidden. */
+function renderTrace(trace) {
+  if (!trace) return;
+  const samples = state.trace;
+  const mode = samples.length ? "on" : "empty";
+  if (trace.dataset.dmSrvxTrace !== mode) trace.dataset.dmSrvxTrace = mode;
+  if (!samples.length) return;
+  const { line, area } = tracePaths(samples);
+  const linePath = trace.querySelector(".dm-srvx-trace-line");
+  const areaPath = trace.querySelector(".dm-srvx-trace-area");
+  if (linePath?.getAttribute("d") !== line) linePath?.setAttribute("d", line);
+  if (areaPath?.getAttribute("d") !== area) areaPath?.setAttribute("d", area);
+  const offset = `${(traceOffset(samples[samples.length - 1]) * 100).toFixed(1)}%`;
+  if (clean(trace.style.getPropertyValue("--dm-srvx-last")) !== offset) {
+    trace.style.setProperty("--dm-srvx-last", offset);
+  }
+  const peak = trace.querySelector(".dm-srvx-trace-peak");
+  const value = `${t("picco", "peak")} ${Math.round(Math.max(...samples))}%`;
+  if (peak && peak.textContent !== value) peak.textContent = value;
+}
+
+export function renderMinipcShowcase() {
+  const page = doc?.getElementById?.("page-server");
+  if (!page) return false;
+  page.classList.add("dm-srvx");
+  page.querySelector(".srv-hero")?.parentElement?.classList.add("dm-srvx-shell");
+  mountHeroEffect(page);
+  mountChassis(page);
+  mountTelemetryIcons(page);
+  mountStatusIcons(page);
+  mountHeadings(page);
+  syncHeadings(page);
+  renderTrace(mountTrace(page));
+  const thermal = mountThermal(page) || page.querySelector(".srv-temp-card");
+
+  const cards = [...page.querySelectorAll(".srv-hero-metrics .srv-metric")];
+  cards.forEach((card, index) => {
+    mountGauge(card);
+    const arc = card.querySelector(".dm-srvx-ring-arc");
+    if (!arc) return;
+    const level = metricLevel(METRIC_BARS[index] || "", doc);
+    const dash = ringDash(level ?? 0);
+    if (arc.getAttribute("stroke-dasharray") !== dash) arc.setAttribute("stroke-dasharray", dash);
+    // The bar carries the colour the markup configured for this metric.
+    const own = clean(card.querySelector(".srv-metric-fill")?.style?.background) || "currentColor";
+    const colour = ringColour(level, own);
+    if (arc.getAttribute("stroke") !== colour) arc.setAttribute("stroke", colour);
+    const loaded = level === null ? "" : level > ALERT_LEVEL ? "alert" : level > WARN_LEVEL ? "warn" : "ok";
+    if (card.dataset.dmSrvxLevel !== loaded) card.dataset.dmSrvxLevel = loaded;
+  });
+
+  if (thermal) {
+    const source = doc.getElementById("v-srv-temp-status");
+    const level = tempLevel(source?.textContent);
+    if (thermal.dataset.dmSrvxTemp !== level) thermal.dataset.dmSrvxTemp = level;
+    const wording = tempWording(source?.textContent);
+    const mirror = thermal.querySelector(".dm-srvx-temp-txt");
+    if (mirror && mirror.textContent !== wording) mirror.textContent = wording;
+    const pin = `${(tempFraction(doc) * 100).toFixed(1)}%`;
+    if (clean(thermal.style.getPropertyValue("--dm-srvx-temp")) !== pin) {
+      thermal.style.setProperty("--dm-srvx-temp", pin);
+    }
+  }
+
+  const net = networkState(doc);
+  if (page.dataset.dmSrvNet !== net) page.dataset.dmSrvNet = net;
+  return true;
+}
+
+export function scheduleMinipcShowcase() {
+  if (state.frame) return;
+  const run = () => {
+    state.frame = 0;
+    renderMinipcShowcase();
+  };
+  state.frame = root.requestAnimationFrame?.(run) || root.setTimeout?.(run, 0) || 0;
+}
+
+function pageVisible() {
+  return Boolean(doc?.getElementById("page-server")?.classList.contains("active"));
+}
+
+export function installMinipcShowcaseSection() {
+  if (!doc) return;
+  installStyle(STYLE_ID, minipcShowcaseCss());
+  if (!state.listeners) {
+    state.listeners = true;
+    for (const eventName of [
+      "dashboardmodern:legacy-ready",
+      "dashboardmodern:runtime-ready",
+      "pageshow",
+    ]) {
+      root.addEventListener?.(eventName, scheduleMinipcShowcase);
+    }
+    // The bars, the temperature arc and the badges repaint through the legacy
+    // render loop, so the gauges follow the same events instead of a timer.
+    root.addEventListener?.("dashboardmodern:state-changed", () => {
+      // Sampling is three DOM reads, so it runs on every tick; the repaint only
+      // happens while the page is the one on screen.
+      sampleCpu();
+      if (pageVisible()) scheduleMinipcShowcase();
+    });
+    doc.addEventListener(
+      "click",
+      (event) => {
+        if (event.target?.closest?.('[data-tab="server"],[data-page="server"]')) {
+          root.queueMicrotask?.(scheduleMinipcShowcase);
+        }
+      },
+      true,
+    );
+  }
+  state.installed = true;
+  sampleCpu();
+  renderMinipcShowcase();
+}
+
+/* ── styles ───────────────────────────────────────────────────────────── */
+
+function minipcShowcaseCss() {
+  return `
+#page-server.dm-srvx{
+  --srvx-surface:var(--card-bg,#fff);
+  --srvx-surface-2:var(--surface-2,#f8fafc);
+  --srvx-text:var(--text,#0f172a);
+  --srvx-dim:var(--text-dim,#64748b);
+  --srvx-r:26px;--srvx-r-s:20px;
+  --srvx-shadow:0 20px 38px -26px rgba(10,26,44,.55),0 2px 6px -3px rgba(10,26,44,.12);
+  --srvx-shadow-s:0 16px 30px -24px rgba(10,26,44,.6),0 2px 5px -3px rgba(10,26,44,.12);
+  --srvx-live:#10b981;--srvx-live-rgb:16,185,129;
+  /* the hero follows the theme: light surfaces on a light dashboard */
+  --srvx-hero-bg:linear-gradient(150deg,#fbfdff 0%,#edf3fa 55%,#e4ecf6 100%);
+  --srvx-hero-text:var(--srvx-text);
+  --srvx-hero-dim:var(--srvx-dim);
+  --srvx-hero-tile:#ffffff;
+  --srvx-hero-tile-shadow:0 12px 24px -18px rgba(10,26,44,.5);
+  --srvx-hero-line:rgba(15,23,42,.08);
+  --srvx-hero-shadow:0 24px 44px -30px rgba(10,26,44,.55),0 2px 6px -3px rgba(10,26,44,.1);
+  --srvx-hero-inset:inset 0 0 0 1px rgba(15,23,42,.05);
+  --srvx-track:rgba(15,23,42,.09);
+  --srvx-case-top-a:#eef3fa;--srvx-case-top-b:#c3d0e0;
+  --srvx-case-left-a:#a9b7ca;--srvx-case-left-b:#8b9bb1;
+  --srvx-case-right-a:#93a2b8;--srvx-case-right-b:#76869d;
+  --srvx-case-edge:rgba(255,255,255,.9);
+  --srvx-case-ink:rgba(15,23,42,.34);
+  --srvx-case-hole:rgba(15,23,42,.18);
+  --srvx-case-blade:rgba(15,23,42,.3);
+  --srvx-case-shadow:0 12px 16px rgba(15,32,56,.22);
+}
+#page-server.dm-srvx[data-dm-srv-net="off"]{--srvx-live:#ef4444;--srvx-live-rgb:239,68,68}
+#page-server.dm-srvx .dm-srvx-shell{display:grid;gap:14px}
+#page-server.dm-srvx .dm-srvx-ico{display:block;flex:0 0 auto}
+
+/* ── the chassis panel ────────────────────────────────────────────────── */
+#page-server.dm-srvx .srv-hero{
+  margin-bottom:0!important;padding:20px!important;border:0!important;
+  border-radius:var(--srvx-r)!important;
+  background:var(--srvx-hero-bg)!important;
+  box-shadow:var(--srvx-hero-shadow),var(--srvx-hero-inset)!important;
+  color:var(--srvx-hero-text)!important
+}
+#page-server.dm-srvx .srv-hero::before{
+  top:-46%!important;right:-12%!important;width:340px!important;height:340px!important;
+  background:radial-gradient(circle,rgba(var(--srvx-live-rgb),.14) 0%,transparent 68%)!important
+}
+#page-server.dm-srvx .srv-hero::after{
+  bottom:-34%!important;left:-8%!important;width:280px!important;height:280px!important;
+  background:radial-gradient(circle,rgba(56,189,248,.14) 0%,transparent 70%)!important
+}
+/* faint board traces plus a sweep that crosses the panel */
+#page-server.dm-srvx .dm-srvx-fx{
+  position:absolute;inset:0;z-index:1;pointer-events:none;overflow:hidden;
+  border-radius:inherit;opacity:.5;
+  background-image:
+    linear-gradient(var(--srvx-hero-line) 1px,transparent 1px),
+    linear-gradient(90deg,var(--srvx-hero-line) 1px,transparent 1px);
+  background-size:34px 34px,34px 34px;
+  -webkit-mask-image:radial-gradient(120% 90% at 78% 8%,#000 0%,transparent 72%);
+  mask-image:radial-gradient(120% 90% at 78% 8%,#000 0%,transparent 72%)
+}
+#page-server.dm-srvx .dm-srvx-fx::after{
+  content:"";position:absolute;top:0;bottom:0;width:34%;left:-40%;
+  background:linear-gradient(90deg,transparent,rgba(var(--srvx-live-rgb),.10),transparent);
+  animation:dmSrvxSweep 9s ease-in-out infinite
+}
+#page-server.dm-srvx .srv-hero-top{margin-bottom:20px!important;z-index:2}
+/* the machine stands on the panel instead of sitting in a chip */
+#page-server.dm-srvx .srv-hero-icon{
+  width:112px!important;height:100px!important;border:0!important;border-radius:0!important;
+  background:none!important;box-shadow:none!important;padding:0!important;overflow:visible!important
+}
+#page-server.dm-srvx .dm-srvx-box{width:100%;height:100%;display:block;overflow:visible}
+#page-server.dm-srvx .dm-srvx-box-body{filter:drop-shadow(var(--srvx-case-shadow))}
+#page-server.dm-srvx .dm-srvx-box-glow{
+  fill:rgba(var(--srvx-live-rgb),.20);filter:blur(7px);transition:fill .5s ease
+}
+#page-server.dm-srvx .dm-srvx-box-edge{stroke:var(--srvx-case-edge)}
+#page-server.dm-srvx .dm-srvx-box-edge-soft{opacity:.45}
+#page-server.dm-srvx .dm-srvx-vents{stroke:var(--srvx-case-ink)}
+#page-server.dm-srvx .dm-srvx-side{stroke:var(--srvx-case-ink);opacity:.6}
+#page-server.dm-srvx .dm-srvx-port{stroke:var(--srvx-case-ink);opacity:.55}
+#page-server.dm-srvx .dm-srvx-fan-hole{fill:var(--srvx-case-hole);stroke:var(--srvx-case-edge);opacity:.9}
+#page-server.dm-srvx .dm-srvx-fan-hub{fill:var(--srvx-case-hole);stroke:var(--srvx-case-edge)}
+#page-server.dm-srvx .dm-srvx-fan{
+  fill:var(--srvx-case-blade);transform-box:fill-box;transform-origin:center;
+  animation:dmSrvxSpin 3.4s linear infinite
+}
+#page-server.dm-srvx .dm-srvx-strip{
+  stroke:var(--srvx-live);stroke-width:2.4;stroke-linecap:round;opacity:.85;
+  filter:drop-shadow(0 0 5px rgba(var(--srvx-live-rgb),.8))
+}
+#page-server.dm-srvx .dm-srvx-led{fill:var(--srvx-live)}
+#page-server.dm-srvx .dm-srvx-led-pwr{filter:drop-shadow(0 0 5px rgba(var(--srvx-live-rgb),.95))}
+#page-server.dm-srvx .dm-srvx-led-act{fill:#60a5fa;animation:dmSrvxBlink 2.6s steps(1,end) infinite}
+#page-server.dm-srvx[data-dm-srv-net="off"] .dm-srvx-led-act{fill:#64748b;animation:none}
+#page-server.dm-srvx[data-dm-srv-net="off"] .dm-srvx-fan{animation:none}
+#page-server.dm-srvx .srv-hero-brand>div{min-width:0}
+#page-server.dm-srvx .srv-hero-title{color:var(--srvx-hero-text)!important;font-size:23px!important;letter-spacing:.06em!important}
+#page-server.dm-srvx .srv-hero-sub{color:var(--srvx-hero-dim)!important;letter-spacing:.14em!important}
+#page-server.dm-srvx .srv-hero-pill{
+  background:rgba(var(--srvx-live-rgb),.14)!important;
+  border:1px solid rgba(var(--srvx-live-rgb),.34)!important;
+  color:var(--srvx-live)!important;padding:8px 15px!important
+}
+#page-server.dm-srvx .srv-hero-dot{
+  background:var(--srvx-live)!important;
+  box-shadow:0 0 0 4px rgba(var(--srvx-live-rgb),.18)!important
+}
+
+/* ── the live CPU trace ───────────────────────────────────────────────── */
+#page-server.dm-srvx .dm-srvx-trace{position:relative;z-index:2;margin:0 0 16px;display:grid;gap:6px}
+#page-server.dm-srvx .dm-srvx-trace[data-dm-srvx-trace="empty"]{display:none}
+#page-server.dm-srvx .dm-srvx-trace-head{
+  display:flex;align-items:baseline;justify-content:space-between;gap:10px;
+  font-size:9.5px;font-weight:800;letter-spacing:.14em;text-transform:uppercase
+}
+#page-server.dm-srvx .dm-srvx-trace-lbl{color:var(--srvx-hero-dim)}
+#page-server.dm-srvx .dm-srvx-trace-peak{color:var(--srvx-live);letter-spacing:.1em}
+#page-server.dm-srvx .dm-srvx-trace-plot{position:relative}
+#page-server.dm-srvx .dm-srvx-trace-svg{
+  display:block;width:100%;height:46px;
+  border-bottom:1px solid var(--srvx-hero-line)
+}
+#page-server.dm-srvx .dm-srvx-trace-mid{
+  stroke:var(--srvx-hero-line);stroke-width:1;stroke-dasharray:3 5;vector-effect:non-scaling-stroke
+}
+#page-server.dm-srvx .dm-srvx-trace-dot{
+  position:absolute;right:0;top:var(--dm-srvx-last,50%);
+  width:8px;height:8px;margin:-4px -4px 0 0;border-radius:50%;background:var(--srvx-live);
+  box-shadow:0 0 0 3px rgba(var(--srvx-live-rgb),.22);
+  transition:top .6s cubic-bezier(.2,.8,.25,1)
+}
+#page-server.dm-srvx .dm-srvx-trace-svg{color:var(--srvx-live)}
+#page-server.dm-srvx .dm-srvx-trace-area{fill:url(#dmSrvxTraceFill)}
+#page-server.dm-srvx .dm-srvx-trace-line{
+  stroke:var(--srvx-live);stroke-width:2;stroke-linejoin:round;stroke-linecap:round;
+  vector-effect:non-scaling-stroke
+}
+
+/* ── section headings ─────────────────────────────────────────────────── */
+#page-server.dm-srvx .dm-srvx-head{
+  display:flex;align-items:center;gap:12px;margin:6px 2px -2px;
+  font-size:9.5px;font-weight:800;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--srvx-dim)
+}
+#page-server.dm-srvx .dm-srvx-head::after{
+  content:"";flex:1;height:1px;
+  background:linear-gradient(90deg,color-mix(in srgb,var(--srvx-dim) 32%,transparent),transparent)
+}
+
+/* ── the three ring gauges ────────────────────────────────────────────── */
+#page-server.dm-srvx .srv-hero-metrics{gap:14px!important}
+/* no !important on display: cdAutoHide() writes it inline on unmapped cards */
+#page-server.dm-srvx .srv-metric{
+  display:grid;grid-template-rows:auto auto;justify-items:center;gap:10px;
+  padding:16px 12px 14px!important;border-radius:var(--srvx-r-s)!important;
+  background:var(--srvx-hero-tile)!important;border:1px solid var(--srvx-hero-line)!important;
+  box-shadow:var(--srvx-hero-tile-shadow,none)!important;
+  transition:transform .3s cubic-bezier(.34,1.4,.5,1),background .3s ease,border-color .3s ease,box-shadow .3s ease!important
+}
+#page-server.dm-srvx .srv-metric:hover{
+  transform:translateY(-3px)!important;
+  box-shadow:0 18px 28px -20px rgba(10,26,44,.45)!important
+}
+#page-server.dm-srvx .dm-srvx-gauge{position:relative;width:104px;height:104px}
+#page-server.dm-srvx .dm-srvx-ring{width:100%;height:100%;transform:rotate(-90deg)}
+#page-server.dm-srvx .dm-srvx-ring-track{stroke:var(--srvx-track)}
+#page-server.dm-srvx .dm-srvx-ring-arc{transition:stroke-dasharray 1.1s cubic-bezier(.2,.8,.25,1),stroke .45s ease}
+#page-server.dm-srvx .dm-srvx-gauge-val{
+  position:absolute;inset:0;display:grid;place-content:center;text-align:center
+}
+#page-server.dm-srvx .srv-metric-val{
+  font-size:30px!important;font-weight:300!important;letter-spacing:-.04em!important;
+  color:var(--srvx-hero-text)!important;line-height:1!important
+}
+#page-server.dm-srvx .srv-metric-unit{
+  font-size:13px!important;font-weight:700!important;color:var(--srvx-hero-dim)!important;margin-left:2px!important
+}
+#page-server.dm-srvx .srv-metric-top{width:100%;justify-content:center!important;gap:7px}
+#page-server.dm-srvx .srv-metric-icon{order:-1}
+#page-server.dm-srvx .srv-metric-lbl{
+  font-size:10px!important;letter-spacing:.16em!important;color:var(--srvx-hero-dim)!important
+}
+#page-server.dm-srvx .srv-metric-icon{
+  display:grid!important;place-items:center!important;font-size:0!important;
+  color:var(--srvx-hero-dim)!important;opacity:.8!important
+}
+#page-server.dm-srvx .srv-metric[data-dm-srvx-level="alert"] .srv-metric-lbl{color:#dc2626!important}
+#page-server.dm-srvx .srv-metric[data-dm-srvx-level="alert"]{border-color:rgba(239,68,68,.35)!important}
+/* the bar stays: it is the value the rings read, so it is hidden, not removed */
+#page-server.dm-srvx .srv-metric-bar{display:none!important}
+
+/* ── CPU temperature ──────────────────────────────────────────────────── */
+#page-server.dm-srvx .srv-temp-card{
+  gap:24px!important;padding:20px 22px!important;margin-bottom:0!important;border:0!important;
+  border-radius:var(--srvx-r)!important;background:var(--srvx-surface)!important;
+  box-shadow:var(--srvx-shadow)!important
+}
+#page-server.dm-srvx .srv-temp-ring{width:116px!important;height:116px!important}
+#page-server.dm-srvx .srv-temp-ring svg{width:100%!important;height:100%!important}
+/* only the track: #srv-temp-circle keeps the stroke the legacy loop writes */
+#page-server.dm-srvx .srv-temp-ring circle:not([id]){stroke:var(--srvx-surface-2)!important;stroke-width:8!important}
+#page-server.dm-srvx #srv-temp-circle{stroke-width:8!important}
+#page-server.dm-srvx .srv-temp-num{font-size:30px!important;font-weight:300!important;letter-spacing:-.04em!important}
+#page-server.dm-srvx .srv-temp-unit{font-size:10px!important;letter-spacing:.12em!important;margin-top:2px!important}
+#page-server.dm-srvx .srv-temp-title{font-size:9.5px!important;letter-spacing:.18em!important;margin-bottom:8px!important}
+/* the legacy line stays the owner of the wording; the badge shows it */
+#page-server.dm-srvx .srv-temp-status{display:none!important}
+#page-server.dm-srvx .dm-srvx-temp-badge{
+  display:inline-flex;align-items:center;gap:8px;padding:6px 13px 6px 10px;border-radius:999px;
+  background:var(--srvx-surface-2);font-size:13px;font-weight:800;color:var(--srvx-text)
+}
+#page-server.dm-srvx .dm-srvx-temp-dot{width:9px;height:9px;border-radius:50%;background:#94a3b8}
+#page-server.dm-srvx [data-dm-srvx-temp="ok"] .dm-srvx-temp-dot{background:#10b981;box-shadow:0 0 0 4px rgba(16,185,129,.16)}
+#page-server.dm-srvx [data-dm-srvx-temp="warm"] .dm-srvx-temp-dot{background:#f59e0b;box-shadow:0 0 0 4px rgba(245,158,11,.18)}
+#page-server.dm-srvx [data-dm-srvx-temp="hot"] .dm-srvx-temp-dot{background:#ef4444;box-shadow:0 0 0 4px rgba(239,68,68,.2)}
+#page-server.dm-srvx .srv-temp-sublbl{margin-top:8px!important;font-size:10px!important;letter-spacing:.04em!important}
+#page-server.dm-srvx .dm-srvx-scale{margin-top:12px;display:grid;gap:5px}
+#page-server.dm-srvx .dm-srvx-scale-track{
+  position:relative;height:7px;border-radius:99px;
+  background:linear-gradient(90deg,#38bdf8 0%,#34d399 34%,#fbbf24 68%,#ef4444 100%);
+  opacity:.85
+}
+#page-server.dm-srvx .dm-srvx-scale-pin{
+  position:absolute;top:50%;left:var(--dm-srvx-temp,0%);width:14px;height:14px;margin:-7px 0 0 -7px;
+  border-radius:50%;background:var(--srvx-surface);border:3px solid var(--srvx-text);
+  box-shadow:0 4px 10px -3px rgba(10,26,44,.6);
+  transition:left 1.1s cubic-bezier(.2,.8,.25,1)
+}
+#page-server.dm-srvx .dm-srvx-scale-limit{
+  position:absolute;left:68.75%;top:-3px;bottom:-3px;width:2px;border-radius:2px;
+  background:var(--srvx-surface);opacity:.85
+}
+#page-server.dm-srvx .dm-srvx-scale-ends{
+  position:relative;display:flex;justify-content:space-between;font-size:9px;font-weight:800;
+  letter-spacing:.08em;color:var(--srvx-dim);text-transform:uppercase
+}
+#page-server.dm-srvx .dm-srvx-scale-mark{
+  position:absolute;left:68.75%;transform:translateX(-50%);white-space:nowrap;opacity:.75
+}
+
+/* ── telemetry ────────────────────────────────────────────────────────── */
+#page-server.dm-srvx .srv-tel-grid{grid-template-columns:repeat(4,1fr)!important;gap:12px!important;margin-bottom:0!important}
+#page-server.dm-srvx .srv-tel-card{
+  padding:16px 15px!important;border:0!important;border-radius:var(--srvx-r-s)!important;
+  background:var(--srvx-surface)!important;box-shadow:var(--srvx-shadow-s)!important;gap:10px!important
+}
+#page-server.dm-srvx .srv-tel-card::before{
+  width:120px!important;height:120px!important;
+  background:radial-gradient(circle at top right,rgba(var(--tc-rgb,14,165,233),.14) 0%,transparent 68%)!important
+}
+#page-server.dm-srvx .srv-tel-card:hover{transform:translateY(-4px)!important;box-shadow:0 24px 36px -22px rgba(10,26,44,.62)!important}
+#page-server.dm-srvx .srv-tel-icon{
+  width:32px!important;height:32px!important;border-radius:11px!important;font-size:0!important;
+  background:rgba(var(--tc-rgb,14,165,233),.13)!important;border:0!important;
+  color:rgb(var(--tc-rgb,14,165,233))!important
+}
+#page-server.dm-srvx .srv-tel-lbl{font-size:9.5px!important;letter-spacing:.12em!important}
+#page-server.dm-srvx .srv-tel-val{font-size:26px!important;letter-spacing:-.02em!important}
+#page-server.dm-srvx .srv-tel-sub{font-size:9.5px!important;color:var(--srvx-dim)!important}
+
+/* ── connectivity and inverter ────────────────────────────────────────── */
+#page-server.dm-srvx .srv-status-grid{gap:12px!important}
+#page-server.dm-srvx .srv-status-card{
+  padding:15px 17px!important;border:0!important;border-radius:var(--srvx-r-s)!important;
+  background:var(--srvx-surface)!important;box-shadow:var(--srvx-shadow-s)!important;gap:12px!important
+}
+#page-server.dm-srvx .srv-status-card:hover{transform:translateY(-3px)!important;box-shadow:0 22px 34px -22px rgba(10,26,44,.6)!important}
+#page-server.dm-srvx .dm-srvx-status-ico{
+  width:36px;height:36px;border-radius:13px;display:grid;place-items:center;flex:0 0 auto;
+  background:var(--srvx-surface-2);color:var(--srvx-dim)
+}
+#page-server.dm-srvx .srv-status-left{flex:1;min-width:0}
+#page-server.dm-srvx .srv-status-lbl{font-size:9.5px!important;letter-spacing:.12em!important}
+#page-server.dm-srvx .srv-status-val{font-size:19px!important}
+#page-server.dm-srvx .srv-status-badge{padding:7px 13px!important;border-radius:999px!important;border:0!important}
+#page-server.dm-srvx .srv-status-badge.online{background:rgba(16,185,129,.13)!important}
+#page-server.dm-srvx .srv-status-badge.offline{background:rgba(239,68,68,.13)!important}
+#page-server.dm-srvx .srv-status-indicator{width:7px;height:7px;border-radius:50%}
+#page-server.dm-srvx .srv-status-card:has(.srv-status-badge.online) .dm-srvx-status-ico{
+  background:rgba(16,185,129,.13);color:#059669
+}
+
+@keyframes dmSrvxSpin{to{transform:rotate(360deg)}}
+@keyframes dmSrvxSweep{0%{left:-40%}55%{left:106%}100%{left:106%}}
+@keyframes dmSrvxBlink{0%,44%{opacity:.25}50%,58%{opacity:1}64%,100%{opacity:.25}}
+
+/* ── responsive ───────────────────────────────────────────────────────── */
+@media(max-width:760px){
+  #page-server.dm-srvx .srv-tel-grid{grid-template-columns:repeat(2,1fr)!important}
+}
+@media(max-width:620px){
+  #page-server.dm-srvx{--srvx-r:22px;--srvx-r-s:17px}
+  #page-server.dm-srvx .srv-hero{padding:16px!important}
+  /* the legacy sheet stacks these two: the pill belongs next to the name and
+     the temperature ring next to its scale, on a phone as much as on a desk */
+  #page-server.dm-srvx .srv-hero-top{
+    flex-direction:row!important;align-items:center!important;gap:10px!important;margin-bottom:16px!important
+  }
+  #page-server.dm-srvx .srv-hero-pill{padding:6px 11px!important;font-size:10px!important;letter-spacing:.08em!important;flex-shrink:0!important}
+  #page-server.dm-srvx .srv-hero-brand{gap:11px!important;min-width:0!important}
+  /* the subtitle gives way instead of pushing the pill onto its own line */
+  #page-server.dm-srvx .srv-hero-title,
+  #page-server.dm-srvx .srv-hero-sub{
+    white-space:nowrap!important;overflow:hidden!important;text-overflow:ellipsis!important
+  }
+  #page-server.dm-srvx .srv-temp-card{
+    flex-direction:row!important;text-align:left!important;align-items:center!important
+  }
+  #page-server.dm-srvx .srv-temp-num{font-size:24px!important}
+  #page-server.dm-srvx .dm-srvx-temp-badge{font-size:12px!important;padding:5px 11px 5px 9px!important}
+  #page-server.dm-srvx .dm-srvx-scale-ends{font-size:8px!important}
+  #page-server.dm-srvx .srv-hero-metrics{gap:9px!important}
+  #page-server.dm-srvx .srv-metric{padding:13px 6px 11px!important}
+  #page-server.dm-srvx .dm-srvx-gauge{width:82px;height:82px}
+  #page-server.dm-srvx .srv-metric-val{font-size:23px!important}
+  #page-server.dm-srvx .srv-metric-unit{font-size:11px!important}
+  #page-server.dm-srvx .srv-hero-icon{width:78px!important;height:70px!important}
+  #page-server.dm-srvx .dm-srvx-trace{margin-bottom:13px}
+  #page-server.dm-srvx .dm-srvx-trace-svg{height:44px}
+  #page-server.dm-srvx .dm-srvx-head{letter-spacing:.14em}
+  #page-server.dm-srvx .srv-hero-title{font-size:19px!important}
+  #page-server.dm-srvx .srv-temp-card{gap:15px!important;padding:16px!important}
+  #page-server.dm-srvx .srv-temp-ring{width:92px!important;height:92px!important}
+  #page-server.dm-srvx .srv-tel-val{font-size:22px!important}
+  #page-server.dm-srvx .srv-status-grid{grid-template-columns:1fr!important}
+}
+
+/* ── dark theme ───────────────────────────────────────────────────────── */
+html[data-theme="dark"] #page-server.dm-srvx{
+  --srvx-shadow:0 22px 40px -26px rgba(0,0,0,.78),0 2px 6px -3px rgba(0,0,0,.5);
+  --srvx-shadow-s:0 16px 30px -24px rgba(0,0,0,.72),0 2px 5px -3px rgba(0,0,0,.45);
+  --srvx-live:#34d399;--srvx-live-rgb:52,211,153;
+  --srvx-hero-bg:linear-gradient(150deg,#1b2740 0%,#111a2c 54%,#0a111e 100%);
+  --srvx-hero-text:#f2f6ff;
+  --srvx-hero-dim:rgba(198,214,240,.74);
+  --srvx-hero-tile:rgba(255,255,255,.055);
+  --srvx-hero-tile-shadow:inset 0 1px 0 rgba(255,255,255,.07);
+  --srvx-hero-line:rgba(255,255,255,.10);
+  --srvx-hero-shadow:0 28px 48px -28px rgba(0,0,0,.85),0 2px 6px -3px rgba(0,0,0,.5);
+  --srvx-hero-inset:inset 0 1px 0 rgba(255,255,255,.06);
+  --srvx-track:rgba(255,255,255,.10);
+  --srvx-case-top-a:#6a80a8;--srvx-case-top-b:#2f3f5e;
+  --srvx-case-left-a:#2b3a56;--srvx-case-left-b:#141d31;
+  --srvx-case-right-a:#1b2540;--srvx-case-right-b:#0d1424;
+  --srvx-case-edge:rgba(224,239,255,.38);
+  --srvx-case-ink:rgba(190,220,255,.34);
+  --srvx-case-hole:rgba(6,12,24,.6);
+  --srvx-case-blade:rgba(198,224,255,.42);
+  --srvx-case-shadow:0 14px 18px rgba(4,10,20,.55)
+}
+html[data-theme="dark"] #page-server.dm-srvx[data-dm-srv-net="off"]{--srvx-live:#f87171;--srvx-live-rgb:248,113,113}
+html[data-theme="dark"] #page-server.dm-srvx .dm-srvx-scale-pin{border-color:#dbe6f7!important}
+html[data-theme="dark"] #page-server.dm-srvx .dm-srvx-status-ico{background:rgba(255,255,255,.06)}
+
+/* ── motion ───────────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion:reduce){
+  #page-server.dm-srvx *,#page-server.dm-srvx *::before,#page-server.dm-srvx *::after{
+    animation:none!important;transition:none!important
+  }
+}
+`;
+}
+
+if (doc?.readyState === "loading") {
+  doc.addEventListener("DOMContentLoaded", installMinipcShowcaseSection, { once: true });
+} else {
+  installMinipcShowcaseSection();
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/navigation-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/navigation-section.js
@@ -1,7 +1,7 @@
-import { doc, installStyle, root, t } from "./shared.js";
+import { clean, doc, installStyle, root, t } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_NAVIGATION_SECTION__";
-const state = (root[KEY] ||= { installed: false, scroller: null });
+const state = (root[KEY] ||= { installed: false, scroller: null, autoHide: 0, behaviour: false });
 
 /* The dock is sized on its content (`width:max-content`), so with every section
  * enabled the thirteen tabs are wider than the screen and the ones past the
@@ -291,10 +291,146 @@ function installScroller() {
   return true;
 }
 
+/* ── one behaviour for the bar, on every page ─────────────────────────────
+ *
+ * The dock is shown by a tap on its handle and hidden again by the same three
+ * things everywhere: choosing a section, tapping away from it, or leaving it
+ * alone. The vendored runtime already does this, but it listens on the bubble
+ * phase, and several redesigned pages stop propagation on their own cards — so
+ * on Elettrodomestici or Temperature a tap outside the dock never reached the
+ * handler that closes it, while on Home it did. Same gesture, different answer
+ * depending on which section was open.
+ *
+ * These listeners run in the capture phase, before any page can swallow them,
+ * and they are delegated rather than bound to the tabs that existed at load —
+ * a tab reordered or reinserted later behaves like all the others. The
+ * "barra fissa" preference still wins: when it is on, nothing auto-hides. */
+const AUTO_HIDE_MS = 4000;
+const TAB_HIDE_MS = 800;
+
+function navFixed() {
+  try {
+    return clean(root.localStorage?.getItem("cd_navbar_mode")) === "fixed";
+  } catch (_error) {
+    return false;
+  }
+}
+
+/* Touch layouts are the ones with a hideable dock. On a desktop the bar is
+ * revealed by the pointer and must never be closed from here. The marker class
+ * is the runtime's own answer to the same question; the media query is the
+ * fallback for a document that has not been marked yet. */
+function touchNavigation() {
+  if (doc?.documentElement?.classList.contains("dm-touch-navigation")) return true;
+  try {
+    return Boolean(root.matchMedia?.("(hover: none) and (pointer: coarse)")?.matches);
+  } catch (_error) {
+    return false;
+  }
+}
+
+function clearAutoHide() {
+  if (!state.autoHide) return;
+  root.clearTimeout?.(state.autoHide);
+  state.autoHide = 0;
+}
+
+export function hideNavigation() {
+  clearAutoHide();
+  if (navFixed()) return false;
+  const nav = navigationBar();
+  if (!nav) return false;
+  nav.classList.remove("visible");
+  doc.body?.classList.remove("nav-visible");
+  return true;
+}
+
+export function scheduleNavigationAutoHide(delay = AUTO_HIDE_MS) {
+  clearAutoHide();
+  if (navFixed() || !touchNavigation()) return false;
+  state.autoHide = root.setTimeout?.(() => {
+    state.autoHide = 0;
+    hideNavigation();
+  }, delay) || 0;
+  return Boolean(state.autoHide);
+}
+
+export function showNavigation() {
+  const nav = navigationBar();
+  if (!nav) return false;
+  nav.classList.add("visible");
+  doc.body?.classList.add("nav-visible");
+  scheduleNavigationAutoHide();
+  return true;
+}
+
+function installBarBehaviour() {
+  if (state.behaviour) return false;
+  state.behaviour = true;
+
+  doc.addEventListener(
+    "click",
+    (event) => {
+      if (!touchNavigation()) return;
+      const nav = navigationBar();
+      if (!nav) return;
+      const target = event.target;
+      if (target?.closest?.("#bottomNavHandle")) {
+        // The runtime binds its own toggle to the handle whenever it decided
+        // this is a touch layout, and it announces that by publishing
+        // cdApplyNavMode. Toggling here too would toggle twice on one tap and
+        // the dock would never open. Where it did not bind — a layout it
+        // decided was a desktop, and a handle that would otherwise do nothing —
+        // this is the toggle.
+        if (typeof root.cdApplyNavMode !== "function") {
+          if (nav.classList.contains("visible")) hideNavigation();
+          else showNavigation();
+        } else if (nav.classList.contains("visible")) {
+          scheduleNavigationAutoHide();
+        }
+        return;
+      }
+      if (target?.closest?.(".tab")) {
+        // Give the section time to come up, then get out of its way.
+        scheduleNavigationAutoHide(TAB_HIDE_MS);
+        return;
+      }
+      if (!nav.contains(target)) {
+        if (nav.classList.contains("visible")) hideNavigation();
+        return;
+      }
+      scheduleNavigationAutoHide();
+    },
+    true,
+  );
+
+  for (const eventName of ["pointerdown", "touchstart", "wheel", "keydown"]) {
+    doc.addEventListener(
+      eventName,
+      (event) => {
+        const nav = navigationBar();
+        if (nav?.classList.contains("visible") && nav.contains(event.target)) {
+          scheduleNavigationAutoHide();
+        }
+      },
+      { capture: true, passive: true },
+    );
+  }
+
+  // The bar sits over the page, so the last row of every section needs the same
+  // room underneath it — not only the sections that happened to reserve it.
+  installStyle(
+    "dm-navigation-room-style",
+    `body.nav-visible .page{padding-bottom:calc(76px + env(safe-area-inset-bottom,0px))!important}`,
+  );
+  return true;
+}
+
 export function installNavigationSection() {
   if (!doc || state.installed) return;
   state.installed = true;
   installStyles();
+  installBarBehaviour();
   if (!installScroller()) {
     doc.addEventListener("DOMContentLoaded", () => installScroller(), { once: true });
   }

--- a/custom_components/dashboardmodern/frontend/src/sections/personalization-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/personalization-section.js
@@ -447,12 +447,29 @@ function ensureEvAppearanceEditor() {
     if (home) {
       if (existing.parentElement !== home) home.prepend(existing);
       state.evHomeAttempts = 0;
-    } else if ((state.evHomeAttempts || 0) < 5) {
+    } else if ((state.evHomeAttempts || 0) < 20) {
       state.evHomeAttempts = (state.evHomeAttempts || 0) + 1;
       root.setTimeout?.(schedule, 120);
     }
     return;
   }
+  /* One place, every time.
+   *
+   * Brand and model belong to the vehicle, so the panel belongs inside the
+   * vehicle accordion, above that car's entities. It used to fall back to the
+   * top of the tab whenever the accordion had not been printed yet — and since
+   * that depends on how fast the editor paints, reopening the EV tab gave two
+   * different pages: the same panel above the visibility banner one time and
+   * inside the accordion the next. The panel is now built only once its own
+   * section exists; until then this comes back for it. */
+  if (!evAccordionBody()) {
+    if ((state.evHomeAttempts || 0) < 20) {
+      state.evHomeAttempts = (state.evHomeAttempts || 0) + 1;
+      root.setTimeout?.(schedule, 120);
+    }
+    return;
+  }
+  state.evHomeAttempts = 0;
   const { current, fallback } = evVisual();
   const visual = current || fallback || {};
   const panel = doc.createElement("section");
@@ -461,23 +478,10 @@ function ensureEvAppearanceEditor() {
   const brand = effectiveBrand(visual) || clean(visual.brand) || "Leapmotor";
   const model = effectiveModel(visual);
   panel.innerHTML = `<div class="ed-sec-title">🚘 ${t("Brand e modello auto", "Vehicle brand and model")}</div><div class="ed-intro">${t("Il logo viene associato automaticamente al marchio. Il modello sostituisce la vecchia icona auto generica.", "The logo is automatically associated with the brand. The model replaces the old generic car icon.")}</div><div class="dm-ev-appearance-grid"><button type="button" class="dm-brand-preview dm-visual-trigger" data-brand-preview aria-label="${t("Scegli brand auto", "Choose car brand")}">${carBrandVisual(brand, 56)}<span class="dm-ev-brand-copy"><b>${esc(brand)}</b>${model ? `<small>${esc(model)}</small>` : ""}</span></button><label class="dm-ev-appearance-field"><span>${t("Marchio", "Brand")}</span><select class="ed-input" data-brand>${CAR_BRANDS.map((item) => `<option value="${esc(item.name)}" ${item.name === brand ? "selected" : ""}>${esc(item.name)}</option>`).join("")}</select></label><label class="dm-ev-appearance-field"><span>${t("Modello elettrico / ibrido", "Electric / hybrid model")}</span><select class="ed-input" data-model>${modelOptions(brand, model)}</select></label></div><button type="button" class="ed-save-btn" data-save>💾 ${t("Salva brand e modello", "Save brand and model")}</button>`;
-  // Brand and model belong to the vehicle, so they live inside the vehicle
-  // accordion, above the entities of the same car — not floating at the top of
-  // the tab. The accordion is found by its own EV slots rather than by its
-  // wording, so a renamed section still gets the panel.
-  const home = evAccordionBody();
-  if (home) home.prepend(panel);
-  else if (!body.querySelector(".ed-acc-body")) {
-    // The editor has not printed its accordions yet. Park the panel where it
-    // has always been and come back for it on the next pass, so it ends up in
-    // the vehicle section instead of staying at the top of the tab.
-    body.prepend(panel);
-    root.setTimeout?.(schedule, 0);
-  } else {
-    const visibleEvBlock = [...body.querySelectorAll("details,.ed-acc,.ed-form")].find((node) => node !== panel && /auto elettric|electric car|profilo auto|car profile|vettur|vehicle/i.test(clean(node.textContent)));
-    if (visibleEvBlock?.parentElement) visibleEvBlock.insertAdjacentElement("afterend", panel);
-    else body.prepend(panel);
-  }
+  // The accordion is found by its own EV slots rather than by its wording, so a
+  // renamed section still gets the panel. It exists: the guard above returned
+  // early otherwise, which is what keeps this placement the only one.
+  evAccordionBody().prepend(panel);
   const brandSelect = panel.querySelector("[data-brand]");
   const modelSelect = panel.querySelector("[data-model]");
   const refreshPreview = () => {

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -42,6 +42,7 @@ import { installPoolIrrigationSceneSection } from "./pool-irrigation-scene-secti
 import { installEvSection } from "./ev-section.js";
 import { installEvShowcaseSection } from "./ev-showcase-section.js";
 import { installEditorSlotsSection } from "./editor-slots-section.js";
+import { installConfigUniformitySection } from "./config-uniformity-section.js";
 import { installSolarThermalDesignSection } from "./solar-thermal-design-section.js";
 import { installLegacySections, LEGACY_SECTION_KEYS } from "./legacy-sections-registry.js";
 import { allStates, clean, english, section, wrapFunction } from "./shared.js";
@@ -650,6 +651,9 @@ export function installSectionRuntime() {
     installEditorContractsSection();
     // Readable entity rows for every section tab of the editor.
     installEditorSlotsSection();
+    // One section per tab, one switch, one save — installed after the editors
+    // that print those parts, so it reconciles what they left behind.
+    installConfigUniformitySection();
     installReportEditorSection();
     installShutterSection();
     installShutterSceneSection();

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -43,6 +43,7 @@ import { installEvSection } from "./ev-section.js";
 import { installEvShowcaseSection } from "./ev-showcase-section.js";
 import { installEditorSlotsSection } from "./editor-slots-section.js";
 import { installSolarThermalDesignSection } from "./solar-thermal-design-section.js";
+import { installMinipcShowcaseSection } from "./minipc-showcase-section.js";
 import { installLegacySections, LEGACY_SECTION_KEYS } from "./legacy-sections-registry.js";
 import { allStates, clean, english, section, wrapFunction } from "./shared.js";
 
@@ -659,6 +660,9 @@ export function installSectionRuntime() {
     // already mounted, and re-renders itself on the same runtime events.
     installEvShowcaseSection();
     installSolarThermalDesignSection();
+    // The MiniPC skin owns the presentation of #page-server: it reads the bars,
+    // the temperature arc and the status badges the legacy render loop writes.
+    installMinipcShowcaseSection();
     installBeta27ReleaseStability();
 
     root[RUNTIME_KEY] = Object.freeze({
@@ -702,6 +706,7 @@ export function installSectionRuntime() {
         "ev",
         "ev-showcase",
         "solar-thermal-design",
+        "minipc-showcase",
         "beta27-release-stability",
       ]),
       registry: root.__DASHBOARDMODERN_SECTIONS__,

--- a/custom_components/dashboardmodern/frontend/src/sections/security-showcase-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/security-showcase-section.js
@@ -39,7 +39,7 @@ import {
 
 const KEY = "__DASHBOARDMODERN_SECURITY_SHOWCASE__";
 const STYLE_ID = "dm-security-showcase-style";
-const state = (root[KEY] ||= { installed: false, listeners: false });
+const state = (root[KEY] ||= { installed: false, listeners: false, requestingFrames: false });
 
 const OFFLINE_STATES = new Set(["", "unavailable", "unknown", "none", "null"]);
 
@@ -235,6 +235,23 @@ function ensureSkeleton(host, labels) {
   return true;
 }
 
+/* The frames belong to the live owner in live-ui-section.js: it holds the
+ * object URLs, the auth fallback and the refresh timer. This is the one call
+ * that asks it to paint, deferred so the wall is in the document first, and
+ * guarded so a wall the owner itself just asked to be built does not ask back. */
+function requestCameraFrames() {
+  if (state.requestingFrames) return;
+  state.requestingFrames = true;
+  root.setTimeout?.(() => {
+    state.requestingFrames = false;
+    try {
+      root.refreshCameras?.();
+    } catch (error) {
+      root.console?.warn?.("[DashboardModern] camera frames", error);
+    }
+  }, 0);
+}
+
 function cardsSignature(models) {
   return JSON.stringify(models.map((model) => [model.slug, model.entity, model.name, model.channel]));
 }
@@ -263,7 +280,11 @@ export function renderSecurity() {
   if (!shell || !grid) return false;
 
   const models = cameraModels();
-  syncCards(grid, models, labels);
+  // A rebuilt wall is a wall of empty <img> elements: whatever frame the live
+  // owner had already written is gone with the markup it lived in, and nothing
+  // in a camera's Home Assistant state changes to ask for another one. So the
+  // wall asks for it itself, right after it rebuilds.
+  if (syncCards(grid, models, labels) && models.length) requestCameraFrames();
 
   const states = allStates();
   let online = 0;

--- a/custom_components/dashboardmodern/frontend/src/sections/shared.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shared.js
@@ -203,15 +203,33 @@ export function lexicalGlobal(name) {
   return root[name] ?? null;
 }
 
+/* The live registry, without a copy of it.
+ *
+ * This used to build a fresh merged object on every call: spread the two hosted
+ * maps, then `Object.assign` `_RAW_STATES` and `STATES` on top. `STATES` is a
+ * Proxy whose target *is* `_RAW_STATES`, so the second assign copied the same
+ * entries again — through a trap that consults the override table on every
+ * key. On a house with a few thousand entities one call cost more than a
+ * millisecond, and the renderers call it per card, several of them per row,
+ * twice a second. That is the dashboard feeling slow.
+ *
+ * When the runtime is the only source — which is every hosted dashboard, since
+ * `__HASS__`/`hass` live in the parent document and not in this one — the
+ * registry is handed back as it is: no copy, no traps, and never one repaint
+ * behind. The merge stays for the surfaces that really do expose a second map,
+ * and it never merges `STATES` over its own target.
+ *
+ * The returned map is the runtime's own object. Callers read it; writing to it
+ * would write into the mirror of Home Assistant itself.
+ */
 export function allStates() {
-  // Hosted Home Assistant surfaces do not all expose the live registry through
-  // the same object at the same moment. Merge every supported source instead of
-  // making the period engine and the compatibility layer observe different
-  // universes on Chrome vs the HA mobile WebView.
-  const values = {
-    ...(root.__HASS__?.states || {}),
-    ...(root.hass?.states || {}),
-  };
+  const raw = lexicalGlobal("_RAW_STATES");
+  const registry = raw && typeof raw === "object" ? raw : lexicalGlobal("STATES");
+  const hosted = [root.__HASS__?.states, root.hass?.states].filter(
+    (value) => value && typeof value === "object",
+  );
+  if (!hosted.length && !globalThis.__DM_SLOW_STATES__) return registry && typeof registry === "object" ? registry : {};
+  const values = hosted.length ? Object.assign({}, ...hosted) : {};
   for (const name of ["_RAW_STATES", "STATES"]) {
     const lexical = lexicalGlobal(name);
     if (lexical && typeof lexical === "object") Object.assign(values, lexical);
@@ -236,6 +254,25 @@ export function writeJsonIfChanged(key, value, { sync = true } = {}) {
     root.cdSyncPush?.();
   }
   return true;
+}
+
+/* Start the dashboard over.
+ *
+ * Hosted, the document comes from an iframe `srcdoc`, so its URL is
+ * `about:srcdoc` and `location.reload()` replaces it with a blank page in the
+ * Home Assistant WebView — the plancia goes white and stays white, which is
+ * what resetting the configuration used to do. The host rebuilds the document
+ * when asked; standalone, an ordinary reload is still an ordinary reload. */
+export function reloadDashboard() {
+  try {
+    if (root.__DASHBOARDMODERN_RELOAD__?.()) return true;
+  } catch (_error) {}
+  try {
+    root.location?.reload?.();
+    return true;
+  } catch (_error) {
+    return false;
+  }
 }
 
 export function installStyle(id, css) {

--- a/custom_components/dashboardmodern/frontend/tests/beta3-ui-coherence.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta3-ui-coherence.test.js
@@ -10,7 +10,11 @@ test("EV appearance is strictly scoped to the EV editor and is not prepended glo
   const source = await read("src/sections/personalization-section.js");
   assert.match(source, /if \(activeTab !== "sez2"\)/);
   assert.match(source, /querySelectorAll\("\[data-ev-appearance\]"\).*remove/);
-  assert.match(source, /visibleEvBlock\.insertAdjacentElement\("afterend", panel\)/);
+  // One placement, so reopening the tab cannot give two different pages: the
+  // panel is built only once the vehicle accordion exists, and goes inside it.
+  assert.match(source, /evAccordionBody\(\)\.prepend\(panel\)/);
+  assert.doesNotMatch(source, /body\.prepend\(panel\)/);
+  assert.doesNotMatch(source, /visibleEvBlock/);
 });
 
 test("room and action icon previews are the picker buttons and palette buttons are hidden", async () => {

--- a/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
@@ -7,5 +7,5 @@ const manifest = JSON.parse(
 );
 
 test("the release manifest is versioned correctly", () => {
-  assert.equal(manifest.version, "1.0.0-beta.30.8");
+  assert.equal(manifest.version, "1.0.0-beta.31");
 });

--- a/custom_components/dashboardmodern/frontend/tests/beta31-real-device-fixes.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta31-real-device-fixes.test.js
@@ -1,0 +1,271 @@
+// DM-FIX-20260818A
+/* The Beta 31 round of real-device reports, one test per complaint.
+ *
+ * Everything here is either a pure function or a source contract: the parts
+ * that need a live document are covered by the e2e specs of the same round.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+
+/* ── the dashboard was slow ───────────────────────────────────────────────── */
+
+test("the live registry is handed over, not copied, when the runtime is the only source", async () => {
+  const previous = {
+    hass: globalThis.__HASS__,
+    publicHass: globalThis.hass,
+    states: globalThis.STATES,
+    raw: globalThis._RAW_STATES,
+  };
+  try {
+    delete globalThis.__HASS__;
+    delete globalThis.hass;
+    const registry = { "sensor.a": { state: "1" } };
+    globalThis._RAW_STATES = registry;
+    globalThis.STATES = registry;
+    const { allStates } = await import(`../src/sections/shared.js?fix=${Date.now()}`);
+
+    // The same object, so reading it is free and never a repaint behind.
+    assert.equal(allStates(), registry);
+    registry["sensor.b"] = { state: "2" };
+    assert.equal(allStates()["sensor.b"].state, "2");
+  } finally {
+    globalThis.__HASS__ = previous.hass;
+    globalThis.hass = previous.publicHass;
+    globalThis.STATES = previous.states;
+    globalThis._RAW_STATES = previous.raw;
+  }
+});
+
+test("the Tapparelle page has one skin, and it is not the Beta 7 one", async () => {
+  const beta7 = await read("../src/sections/beta7-regression-section.js");
+  // Beta 7 declared left/right/top on the panel and nothing else did, so its
+  // 9px inset survived every later redesign and detached the closed shutter
+  // from the opening.
+  assert.doesNotMatch(beta7, /#page-tapparelle[^\n]*\.tapp-(?:win|shutter|glass)/);
+
+  const skin = await read("../src/sections/shutter-section.js");
+  assert.match(skin, /\.tapp-shutter\{[^}]*z-index:3/);
+  // The panel is positioned by the vendored rule alone: top/left/right 0.
+  assert.doesNotMatch(skin, /\.tapp-shutter\{[^}]*\b(?:left|right|top):(?!0)/);
+});
+
+/* ── the cameras were black ───────────────────────────────────────────────── */
+
+test("a rebuilt camera wall asks for its frames, and the frames keep coming", async () => {
+  const wall = await read("../src/sections/security-showcase-section.js");
+  // Rebuilding drops every <img> that held a frame, and no camera state change
+  // follows to ask for another one.
+  assert.match(wall, /if \(syncCards\(grid, models, labels\) && models\.length\) requestCameraFrames\(\)/);
+  assert.match(wall, /function requestCameraFrames\(\)/);
+  assert.match(wall, /state\.requestingFrames/);
+
+  const live = await read("../src/sections/live-ui-section.js");
+  assert.match(live, /const CAMERA_REFRESH_MS = 4000/);
+  assert.match(live, /export function syncCameraTimer\(\)/);
+  // Only while the page is on screen and the tab is not hidden.
+  assert.match(live, /securityVisible\(\) && doc\?\.visibilityState !== "hidden"/);
+  assert.match(live, /state\.building/);
+});
+
+/* ── the reset left a white screen and half a configuration ───────────────── */
+
+test("a hosted dashboard is rebuilt by its host instead of reloading about:srcdoc", async () => {
+  const host = await read("../src/legacy/host.js");
+  assert.match(host, /export const HOST_MESSAGE_SOURCE = "dashboardmodern-host"/);
+  assert.match(host, /window\.__DASHBOARDMODERN_RELOAD__=function/);
+  assert.match(host, /const reboot = \(\) => \{/);
+  assert.match(host, /function lostItsDocument\(\)|const lostItsDocument = \(\)/);
+
+  const shared = await read("../src/sections/shared.js");
+  assert.match(shared, /export function reloadDashboard\(\)/);
+  assert.match(shared, /root\.__DASHBOARDMODERN_RELOAD__\?\.\(\)/);
+
+  for (const path of [
+    "../src/sections/config-persistence-section.js",
+    "../src/sections/entity-autodetect-section.js",
+  ]) {
+    const source = await read(path);
+    assert.match(source, /reloadDashboard\(\)/, path);
+    assert.doesNotMatch(source, /location\?\.reload\?\.\(\)/, path);
+  }
+});
+
+test("a light with no entity is not written back as a quick action", async () => {
+  const { legacyLights } = await import("../src/core/dashboard-store.js");
+  assert.deepEqual(
+    legacyLights([
+      { entities: ["light.salone"], name: "Salone" },
+      { entities: [], name: "Vuota" },
+      { entity: "switch.lampada", name: "" },
+      null,
+    ]),
+    { "light.salone": "Salone", "switch.lampada": "switch.lampada" },
+  );
+  // A section that is not an array used to throw here, and the exception took
+  // the whole bootstrap with it — the dashboard came back blank.
+  assert.deepEqual(legacyLights({ a: { entity: "light.x", name: "X" } }), { "light.x": "X" });
+  assert.deepEqual(legacyLights(undefined), {});
+  assert.deepEqual(legacyLights("nonsense"), {});
+});
+
+test("the reset empties the configuration held in memory too", async () => {
+  const { DashboardStore } = await import("../src/core/dashboard-store.js");
+  const store = new DashboardStore({
+    storage: {
+      values: new Map(),
+      getItem(key) {
+        return this.values.has(key) ? this.values.get(key) : null;
+      },
+      setItem(key, value) {
+        this.values.set(key, value);
+      },
+      removeItem(key) {
+        this.values.delete(key);
+      },
+    },
+  });
+  store.state.sections.lights = [{ entities: ["light.x"], name: "X" }];
+  store.state.visibility = { home: true };
+  const empty = store.reset();
+  assert.deepEqual(empty.sections, {});
+  assert.deepEqual(empty.visibility, {});
+  assert.deepEqual(store.getState().sections, {});
+
+  const persistence = await read("../src/sections/config-persistence-section.js");
+  assert.match(persistence, /DashboardModernModules\?\.store\?\.reset\?\.\(\)/);
+});
+
+/* ── the Report showed different icons from the appliances ────────────────── */
+
+test("a Report entry shows the icon of the appliance it is about", async () => {
+  const { reportIconForDevice } = await import("../src/core/energy-projection.js");
+  const washer = {
+    name: "Lavatrice",
+    device_type: "washing_machine",
+    visual_type: "asset",
+    visual_key: "washer",
+    // The card never draws this one, so the Report must not draw it either.
+    emoji_icon: "🏠",
+  };
+  assert.equal(reportIconForDevice(washer), "🧺");
+  assert.equal(
+    reportIconForDevice({ name: "Boiler", device_type: "water_heater", visual_type: "asset", visual_key: "boiler" }),
+    "🚿",
+  );
+  // An icon deliberately given to the Report entry still wins.
+  assert.equal(reportIconForDevice({ ...washer, report_icon: "⭐" }), "⭐");
+  // And a device with nothing but a loose emoji keeps it.
+  assert.equal(reportIconForDevice({ name: "Cosa", emoji_icon: "🛠️" }), "🛠️");
+
+  const modules = await read("../legacy/modules-entry.js");
+  assert.match(modules, /createIconField\(`dm-report-icon-\$\{fieldToken\}`, item\.report_icon \|\| reportIconForDevice\(item\)\)/);
+});
+
+/* ── two Home rows asked twice for the same thing ─────────────────────────── */
+
+test("the retired Home rows are declared once and never rendered", async () => {
+  const { RETIRED_EDITOR_SLOTS, isRetiredEditorSlot } = await import("../src/core/editor-slots.js");
+  assert.deepEqual(RETIRED_EDITOR_SLOTS, [
+    "dm.home_interruttore_antifurto",
+    "dm.home_script_apertura_cancello",
+  ]);
+  assert.equal(isRetiredEditorSlot("dm.home_meteo"), false);
+});
+
+/* ── the car has two photos ───────────────────────────────────────────────── */
+
+test("the hero shows the cable that is actually in", async () => {
+  const { activeVehiclePhoto } = await import("../src/sections/ev-section.js");
+  const both = { idle: "/local/auto.png", plugged: "/local/auto-cavo.png" };
+  assert.equal(activeVehiclePhoto(both, false), "/local/auto.png");
+  assert.equal(activeVehiclePhoto(both, true), "/local/auto-cavo.png");
+  // One photo is enough: it stays whatever the cable does.
+  const only = { idle: "/local/auto.png", plugged: "" };
+  assert.equal(activeVehiclePhoto(only, true), "/local/auto.png");
+  assert.equal(activeVehiclePhoto(only, false), "/local/auto.png");
+  assert.equal(activeVehiclePhoto({ idle: "", plugged: "" }, true), "");
+});
+
+test("the cable is read from the wallbox, and 'disconnected' is not 'connected'", async () => {
+  const { vehiclePlugged } = await import(`../src/sections/ev-section.js?fix=${Date.now()}`);
+  const previous = globalThis._RAW_STATES;
+  try {
+    const registry = {};
+    globalThis._RAW_STATES = registry;
+    const say = (state) => {
+      registry["dm.ev_stato_ricarica"] = { state };
+      return vehiclePlugged();
+    };
+    assert.equal(say("Charging"), true);
+    assert.equal(say("In ricarica"), true);
+    assert.equal(say("Connected"), true);
+    assert.equal(say("Disconnected"), false);
+    assert.equal(say("Scollegato"), false);
+    assert.equal(say("idle"), false);
+    assert.equal(say("available"), false);
+
+    // No usable text: a wallbox drawing power has a cable in it.
+    delete registry["dm.ev_stato_ricarica"];
+    registry["dm.ev_potenza_wallbox"] = { state: "0" };
+    assert.equal(vehiclePlugged(), false);
+    registry["dm.ev_potenza_wallbox"] = { state: "3200" };
+    assert.equal(vehiclePlugged(), true);
+  } finally {
+    globalThis._RAW_STATES = previous;
+  }
+});
+
+test("the second photo is part of the shared configuration", async () => {
+  const { CONFIG_KEYS } = await import("../src/sections/config-persistence-section.js");
+  assert.ok(CONFIG_KEYS.includes("cd_ev_image_plugged"));
+  const source = await read("../src/sections/ev-section.js");
+  assert.match(source, /export const EV_PHOTO_KEYS/);
+  assert.match(source, /export function ensureVehiclePhotoEditor\(\)/);
+  assert.match(source, /Cavo staccato/);
+  assert.match(source, /Cavo attaccato/);
+});
+
+/* ── the EV configuration came up two different ways ──────────────────────── */
+
+test("brand and model have one place in the EV tab", async () => {
+  const source = await read("../src/sections/personalization-section.js");
+  assert.match(source, /evAccordionBody\(\)\.prepend\(panel\)/);
+  assert.doesNotMatch(source, /body\.prepend\(panel\)/);
+  assert.doesNotMatch(source, /visibleEvBlock/);
+});
+
+/* ── the menu behaved differently depending on the section ────────────────── */
+
+test("the bottom bar answers the same gesture the same way on every page", async () => {
+  const source = await read("../src/sections/navigation-section.js");
+  assert.match(source, /export function hideNavigation\(\)/);
+  assert.match(source, /export function showNavigation\(\)/);
+  assert.match(source, /export function scheduleNavigationAutoHide\(/);
+  // Capture phase: a redesigned page that stops propagation on its own cards
+  // used to swallow the tap that closes the dock.
+  assert.match(source, /doc\.addEventListener\(\s*"click",[\s\S]*?\n\s*true,\s*\n\s*\);/);
+  // Delegated, so a tab reordered or reinserted later behaves like the others.
+  assert.match(source, /target\?\.closest\?\.\("\.tab"\)/);
+  // The "barra fissa" preference still wins.
+  assert.match(source, /function navFixed\(\)/);
+  assert.match(source, /if \(navFixed\(\)\) return false;/);
+  // One room reservation for the bar, on every page.
+  assert.match(source, /body\.nav-visible \.page\{padding-bottom/);
+});
+
+/* ── the lens was a lens in some sections and a row in others ─────────────── */
+
+test("every entity field in the editors is the same readable row", async () => {
+  const source = await read("../src/sections/editor-slots-section.js");
+  assert.match(source, /export function decorateEntityFields\(/);
+  // The lens becomes the row: same button, same handler, same target — so the
+  // pair the picker guard and the editors reconcile is left intact.
+  assert.match(source, /lens\.classList\.add\("dm-slot-chip"\)/);
+  assert.match(source, /lens\.insertAdjacentElement\("afterend", manual\)/);
+  assert.doesNotMatch(source, /lens\.remove\(\)/);
+  assert.match(source, /input\.classList\.add\("dm-chip-raw"\)/);
+  assert.match(source, /\[data-dm-entity-chip="true"\]:not\(\[data-dm-entity-raw="true"\]\)>\.dm-chip-raw\{display:none!important\}/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/beta31-real-device-fixes.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta31-real-device-fixes.test.js
@@ -7,6 +7,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { readFile } from "node:fs/promises";
+import vm from "node:vm";
 
 const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
 
@@ -268,4 +269,54 @@ test("every entity field in the editors is the same readable row", async () => {
   assert.doesNotMatch(source, /lens\.remove\(\)/);
   assert.match(source, /input\.classList\.add\("dm-chip-raw"\)/);
   assert.match(source, /\[data-dm-entity-chip="true"\]:not\(\[data-dm-entity-raw="true"\]\)>\.dm-chip-raw\{display:none!important\}/);
+});
+
+/* ── the same light was listed twice in LUCI ATTIVE ───────────────────────── */
+
+function legacyFunction(source, name) {
+  const start = source.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `${name} missing`);
+  const end = source.indexOf("\n}\n", start);
+  assert.notEqual(end, -1, `unterminated ${name}`);
+  return source.slice(start, end + 2);
+}
+
+test("a light configured in the Lights tab enters the monitoring list once", async () => {
+  const source = await read("../legacy/dashboard-runtime-it.js");
+  const context = vm.createContext({
+    /* What the runtime builds at boot: the keys of cd_luci. */
+    GRUPPI_MONITORAGGIO: { luci: ["light.sala_radio", "light.banco_radio"], win: [] },
+  });
+  vm.runInContext(legacyFunction(source, "cdGruppoMerge"), context);
+  /* What cd_gruppi_extra holds: synchronizeLightAlerts copies every cd_luci
+   * entity into it, so the two sources overlap completely. */
+  vm.runInContext(
+    `cdGruppoMerge('luci', ['light.sala_radio', 'light.banco_radio', 'light.autorilevata']);
+     cdGruppoMerge('luci', ['light.sala_radio']);
+     cdGruppoMerge('sconosciuto', ['light.x']);
+     cdGruppoMerge('win', 'binary_sensor.porta');`,
+    context,
+  );
+  assert.deepEqual(context.GRUPPI_MONITORAGGIO.luci, [
+    "light.sala_radio",
+    "light.banco_radio",
+    "light.autorilevata",
+  ]);
+  assert.deepEqual(context.GRUPPI_MONITORAGGIO.win, []);
+  assert.equal(context.GRUPPI_MONITORAGGIO.sconosciuto, undefined);
+});
+
+test("both runtimes merge the alert groups through the guarded path", async () => {
+  for (const file of ["../legacy/dashboard-runtime-it.js", "../legacy/dashboard-runtime-en.js"]) {
+    const source = await read(file);
+    // cd_gruppi_extra and the avvisi of config.js: the two sources that used to
+    // be concatenated as they were.
+    assert.equal((source.match(/cdGruppoMerge\((?:k|grp), ids\);/g) || []).length, 2, file);
+    assert.doesNotMatch(source, /GRUPPI_MONITORAGGIO\[(?:k|grp)\]\.push\(\.\.\.ids\)/, file);
+  }
+});
+
+test("the lights tab keeps feeding cd_gruppi_extra, which is why the merge must dedupe", async () => {
+  const source = await read("../src/sections/lights-alerts-section.js");
+  assert.match(source, /const next = \[\.\.\.new Set\(\[\.\.\.\(extras\.luci \|\| \[\]\), \.\.\.lights\]\)\]/);
 });

--- a/custom_components/dashboardmodern/frontend/tests/beta7-regressions.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta7-regressions.test.js
@@ -36,14 +36,18 @@ test("brand contract is claimed before load failure and after every vehicle rend
   assert.match(source, /guardAll\(\);\n\s*return result;/);
 });
 
-test("beta7 final polish owns quick actions, climate and stable shutters", async () => {
+test("beta7 final polish owns quick actions and climate, and no longer skins the shutters", async () => {
   const source = await readFile(regressionsUrl, "utf8");
   assert.match(source, /polishQuickActionCards/);
   assert.match(source, /dm-beta7-existing-action-icon/);
   assert.match(source, /dm-beta7-action-form-row/);
   assert.match(source, /aspect-ratio:auto/);
-  assert.match(source, /dmBeta7ShutterRoll/);
+  // The shutter repaint guard stays; the Beta 7 window skin does not. It was
+  // the only sheet declaring left/right/top on .tapp-shutter, so it detached
+  // the closed panel from the opening the current skin draws.
   assert.match(source, /__dmBeta7StableShutters/);
+  assert.doesNotMatch(source, /#page-tapparelle[^\n]*\.tapp-(?:win|shutter|glass)/);
+  assert.doesNotMatch(source, /dmBeta7ShutterRoll/);
   assert.doesNotMatch(source, /MutationObserver|setInterval\s*\(/);
 });
 

--- a/custom_components/dashboardmodern/frontend/tests/editor-slots-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/editor-slots-section.test.js
@@ -43,9 +43,44 @@ test("the row keeps the contracts the editor saves through", () => {
   assert.match(source, /wzPickEntity\?\.\(input\)/);
   // Hidden, never removed: the picker guard reconciles the input/lens pair.
   assert.match(source, /\.dm-slots:not\(\.dm-slots-raw\) \.dm-slot>div:has\(>\.ed-slot-in\)\{display:none!important\}/);
-  assert.doesNotMatch(source, /\.remove\(\)/);
+  // The only thing this section removes is a whole row the configuration has
+  // retired. A decorated field is hidden behind "Modifica manuale" instead.
+  assert.doesNotMatch(source, /input\.remove\(\)/);
+  assert.match(source, /const row = input\.closest\("\.ed-slot"\);\n\s*if \(!row\) continue;\n\s*row\.remove\(\);/);
   // The chip is appended last so the lens stays the input's next sibling.
   assert.match(source, /slot\.append\(chip\)/);
+});
+
+test("the two retired Home rows never reach the form", async () => {
+  const { dropRetiredSlots } = await loadSection();
+  const { RETIRED_EDITOR_SLOTS, isRetiredEditorSlot } = await import(
+    "../src/core/editor-slots.js"
+  );
+  assert.deepEqual(RETIRED_EDITOR_SLOTS, [
+    "dm.home_interruttore_antifurto",
+    "dm.home_script_apertura_cancello",
+  ]);
+  assert.equal(isRetiredEditorSlot("dm.home_meteo"), false);
+  assert.equal(isRetiredEditorSlot(" dm.home_script_apertura_cancello "), true);
+
+  const rows = new Map();
+  const makeInput = (ref, hasRow = true) => {
+    const row = { remove: () => rows.set(ref, "removed") };
+    if (hasRow) rows.set(ref, "present");
+    return { dataset: { ref }, closest: (selector) => (hasRow && selector === ".ed-slot" ? row : null) };
+  };
+  const inputs = [
+    makeInput("dm.home_meteo"),
+    makeInput("dm.home_interruttore_antifurto"),
+    makeInput("dm.home_script_apertura_cancello"),
+    // A retired ref with no row of its own belongs to another form: left alone.
+    makeInput("dm.home_interruttore_antifurto", false),
+  ];
+  assert.equal(dropRetiredSlots({ querySelectorAll: () => inputs }), 2);
+  assert.equal(rows.get("dm.home_meteo"), "present");
+  assert.equal(rows.get("dm.home_interruttore_antifurto"), "removed");
+  assert.equal(rows.get("dm.home_script_apertura_cancello"), "removed");
+  assert.equal(dropRetiredSlots(null), 0);
 });
 
 test("the loads editor keeps its own layout", () => {
@@ -55,7 +90,7 @@ test("the loads editor keeps its own layout", () => {
 });
 
 test("the section owns presentation only", () => {
-  const body = source.slice(source.indexOf("\nimport {"));
+  const body = source.slice(source.lastIndexOf("\nimport {"));
   for (const owned of ["edSetSlot", "edSaveSezione", "localStorage", "ENTITY_OVERRIDES"])
     assert.doesNotMatch(body, new RegExp(owned), owned);
   assert.doesNotMatch(body, /setInterval\s*\(/);

--- a/custom_components/dashboardmodern/frontend/tests/minipc-showcase-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/minipc-showcase-section.test.js
@@ -1,0 +1,201 @@
+// DM-FIX-20260818A
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(
+  new URL("../src/sections/minipc-showcase-section.js", import.meta.url),
+  "utf8",
+);
+
+async function loadSection() {
+  return import(`../src/sections/minipc-showcase-section.js?fix=${Date.now()}`);
+}
+
+function fakeDocument({ widths = {}, dash = "", netClasses = [] } = {}) {
+  return {
+    getElementById(id) {
+      if (id === "srv-temp-circle") {
+        return { getAttribute: (name) => (name === "stroke-dasharray" ? dash : null) };
+      }
+      if (id === "waw-net-badge") {
+        return { classList: { contains: (name) => netClasses.includes(name) } };
+      }
+      if (id in widths) return { style: { width: widths[id] } };
+      return null;
+    },
+  };
+}
+
+test("each gauge reads the load from the bar the render loop writes", async () => {
+  const { metricLevel } = await loadSection();
+  const scope = fakeDocument({
+    widths: { "srv-fill-cpu": "23.4%", "srv-fill-ram": "61%", "srv-fill-disk": "0%" },
+  });
+  assert.equal(metricLevel("srv-fill-cpu", scope), 23.4);
+  assert.equal(metricLevel("srv-fill-ram", scope), 61);
+  assert.equal(metricLevel("srv-fill-disk", scope), 0);
+  // Out of range widths are clamped rather than drawn past the ring.
+  assert.equal(metricLevel("srv-fill-cpu", fakeDocument({ widths: { "srv-fill-cpu": "140%" } })), 100);
+  assert.equal(metricLevel("srv-fill-cpu", fakeDocument({ widths: { "srv-fill-cpu": "-4%" } })), 0);
+  // Before the first render there is no width to read.
+  assert.equal(metricLevel("srv-fill-cpu", fakeDocument()), null);
+});
+
+test("the ring draws exactly the percentage it was given", async () => {
+  const { ringDash } = await loadSection();
+  const [drawn, gap] = ringDash(40, 100).split(" ").map(Number);
+  assert.equal(drawn, 40);
+  assert.equal(gap, 60);
+  assert.equal(ringDash(0, 100), "0.0 100.0");
+  assert.equal(ringDash(100, 100), "100.0 0.0");
+  // A missing reading draws an empty ring instead of a full one.
+  assert.equal(ringDash(null, 100), "0.0 100.0");
+  assert.equal(ringDash(Number.NaN, 100), "0.0 100.0");
+});
+
+test("the gauge keeps its own colour until the legacy thresholds bite", async () => {
+  const { ringColour } = await loadSection();
+  // Same 65 / 85 pair the legacy setRing() uses for these three gauges.
+  assert.equal(ringColour(20, "#06b6d4"), "#06b6d4");
+  assert.equal(ringColour(65, "#06b6d4"), "#06b6d4");
+  assert.equal(ringColour(66, "#06b6d4"), "#f59e0b");
+  assert.equal(ringColour(85, "#06b6d4"), "#f59e0b");
+  assert.equal(ringColour(86, "#06b6d4"), "#ef4444");
+  // No reading at all keeps the configured colour instead of raising an alarm.
+  assert.equal(ringColour(null, "#10b981"), "#10b981");
+});
+
+test("the thermal scale follows the arc the runtime drew, never a sensor", async () => {
+  const { tempFraction } = await loadSection();
+  assert.equal(tempFraction(fakeDocument({ dash: "50 50" })), 0.5);
+  assert.equal(tempFraction(fakeDocument({ dash: "90.5 135.7" })).toFixed(3), "0.400");
+  assert.equal(tempFraction(fakeDocument({ dash: "0 226" })), 0);
+  // Nothing drawn yet, or an unreadable value: the pin stays at the cold end.
+  assert.equal(tempFraction(fakeDocument()), 0);
+  assert.equal(tempFraction(fakeDocument({ dash: "0 0" })), 0);
+});
+
+test("the temperature badge takes its level and wording from the legacy line", async () => {
+  const { tempLevel, tempWording } = await loadSection();
+  assert.equal(tempLevel("🟢 Ottimale"), "ok");
+  assert.equal(tempLevel("🟡 Nella norma"), "warm");
+  assert.equal(tempLevel("🔴 Alta — Controllare"), "hot");
+  assert.equal(tempLevel("—"), "");
+  assert.equal(tempLevel(), "");
+  // The wording survives in both locales, minus the marker the dot replaces.
+  assert.equal(tempWording("🟢 Ottimale"), "Ottimale");
+  assert.equal(tempWording("🔴 High — Check it"), "High — Check it");
+  assert.equal(tempWording("—"), "—");
+});
+
+test("connectivity is mirrored from the badge class, not recomputed", async () => {
+  const { networkState } = await loadSection();
+  assert.equal(networkState(fakeDocument({ netClasses: ["srv-status-badge", "online"] })), "on");
+  assert.equal(networkState(fakeDocument({ netClasses: ["srv-status-badge", "offline"] })), "off");
+  // Before the first tick the badge carries neither class.
+  assert.equal(networkState(fakeDocument({ netClasses: ["srv-status-badge"] })), "");
+  assert.equal(networkState(fakeDocument()), "");
+});
+
+test("the trace keeps only the readings the page already showed", async () => {
+  const { sampleCpu } = await loadSection();
+  const samples = [];
+  const scope = fakeDocument({ widths: { "srv-fill-cpu": "12%" } });
+  sampleCpu(scope, samples);
+  sampleCpu(scope, samples);
+  assert.deepEqual(samples, [12, 12]);
+  // A tick with no width to read adds nothing rather than a zero.
+  sampleCpu(fakeDocument(), samples);
+  assert.equal(samples.length, 2);
+  // The window is bounded, so a long session cannot grow without end.
+  const long = [];
+  for (let index = 0; index < 400; index += 1) sampleCpu(scope, long);
+  assert.equal(long.length, 96);
+});
+
+test("the trace draws the samples as a line and the area under it", async () => {
+  const { tracePaths, traceOffset } = await loadSection();
+  const empty = tracePaths([]);
+  assert.equal(empty.line, "");
+  assert.equal(empty.area, "");
+  // A single reading is drawn flat across the band instead of as a lone dot.
+  const single = tracePaths([50], 100, 50);
+  assert.match(single.line, /^M0 [\d.]+ L100 [\d.]+$/);
+  const many = tracePaths([0, 100], 100, 50);
+  assert.match(many.line, /^M0\.0 /);
+  assert.match(many.line, /L100\.0 /);
+  // The area closes onto the baseline so the fill never leaks upwards.
+  assert.equal(many.area.endsWith("L100 50 L0 50 Z"), true);
+  // Higher load sits higher in the band, and the dot uses the same geometry.
+  assert.ok(traceOffset(90) < traceOffset(10));
+  assert.ok(traceOffset(100) >= 0 && traceOffset(0) <= 1);
+  assert.equal(traceOffset(Number.NaN), traceOffset(0));
+});
+
+test("the redesigned page keeps every legacy runtime hook", () => {
+  // The legacy render loop drives these: it writes the bar widths, the arc and
+  // its threshold colour, the status wording and the badge classes. Losing any
+  // of them freezes the page on its first paint.
+  for (const hook of [
+    "srv-fill-cpu",
+    "srv-fill-ram",
+    "srv-fill-disk",
+    "srv-temp-circle",
+    "v-srv-temp-status",
+    "waw-net-badge",
+    "srv-metric-val",
+    "srv-metric-fill",
+  ])
+    assert.ok(source.includes(hook), hook);
+  // The bar is hidden, never removed: it is the value the rings read.
+  assert.match(source, /\.srv-metric-bar\{display:none!important\}/);
+});
+
+test("the section owns presentation only and never reads Home Assistant state", () => {
+  const body = source.slice(source.indexOf("\nimport {"));
+  for (const owned of [
+    "STATES",
+    "getRawState",
+    "getDisplay",
+    "apriStorico\\(",
+    "apriSrvHistory\\(",
+    "dm\\.server_temperatura_cpu",
+    "localStorage",
+  ])
+    assert.doesNotMatch(body, new RegExp(owned), owned);
+  // Event-driven only: no polling, no observer.
+  assert.doesNotMatch(body, /setInterval\s*\(/);
+  assert.doesNotMatch(body, /MutationObserver/);
+});
+
+test("the value nodes are moved into the rings, never duplicated", () => {
+  const mount = source.slice(source.indexOf("function mountGauge"), source.indexOf("function mountChassis"));
+  // append() moves the node; cloneNode would leave two writers of one value.
+  assert.match(mount, /\.append\(value\)/);
+  assert.doesNotMatch(mount, /cloneNode/);
+  // Mounting twice must not build a second ring.
+  assert.match(mount, /if \(card\.dataset\.dmSrvxGauge\) return/);
+});
+
+test("nothing forces a display the auto-hide writes inline on a card", () => {
+  // cdAutoHide() shows and hides these cards by writing an inline display, so a
+  // display:none|flex marked !important would either strand a hidden card on
+  // the page or hide one the user mapped.
+  const styles = source.slice(source.indexOf("function minipcShowcaseCss"));
+  for (const card of [".srv-metric", ".srv-temp-card", ".srv-tel-card", ".srv-status-card"]) {
+    const pattern = new RegExp(`${card.replace(".", "\\.")}\\{[^}]*display:[^};]*!important`);
+    assert.doesNotMatch(styles, pattern, card);
+  }
+  // A block emptied by the auto-hide drops its heading too.
+  assert.match(source, /cards\.every\(\(card\) => card\.style\.display === "none"\)/);
+});
+
+test("the page dresses both locales and both themes", () => {
+  // Every string this module adds goes through the locale helper.
+  assert.match(source, /t\("Carico CPU · live", "CPU load · live"\)/);
+  assert.match(source, /t\(group\.it, group\.en\)/);
+  assert.match(source, /html\[data-theme="dark"\] #page-server\.dm-srvx/);
+  // Motion is decoration: it stops when the system asks for less of it.
+  assert.match(source, /prefers-reduced-motion:reduce[\s\S]*?animation:none!important/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/minipc-showcase-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/minipc-showcase-section.test.js
@@ -114,23 +114,55 @@ test("the trace keeps only the readings the page already showed", async () => {
   assert.equal(long.length, 96);
 });
 
-test("the trace draws the samples as a line and the area under it", async () => {
+test("the curve draws the samples as a spline and the area under it", async () => {
   const { tracePaths, traceOffset } = await loadSection();
   const empty = tracePaths([]);
   assert.equal(empty.line, "");
   assert.equal(empty.area, "");
   // A single reading is drawn flat across the band instead of as a lone dot.
   const single = tracePaths([50], 100, 50);
-  assert.match(single.line, /^M0 [\d.]+ L100 [\d.]+$/);
-  const many = tracePaths([0, 100], 100, 50);
+  assert.match(single.line, /^M0\.0 ([\d.]+) C[\d.]+ \1 [\d.]+ \1 100\.0 \1$/);
+  const many = tracePaths([0, 60, 100], 100, 50);
   assert.match(many.line, /^M0\.0 /);
-  assert.match(many.line, /L100\.0 /);
+  // One cubic segment per gap between readings: the curve is smooth.
+  assert.equal(many.line.match(/C/g)?.length, 2);
+  assert.match(many.line, /100\.0 [\d.]+$/);
   // The area closes onto the baseline so the fill never leaks upwards.
   assert.equal(many.area.endsWith("L100 50 L0 50 Z"), true);
   // Higher load sits higher in the band, and the dot uses the same geometry.
   assert.ok(traceOffset(90) < traceOffset(10));
   assert.ok(traceOffset(100) >= 0 && traceOffset(0) <= 1);
   assert.equal(traceOffset(Number.NaN), traceOffset(0));
+});
+
+test("a spike cannot bow the curve out of its band", async () => {
+  const { smoothPath } = await loadSection();
+  assert.equal(smoothPath([]), "");
+  const height = 50;
+  // Alternating floor and ceiling readings: the control points of a
+  // Catmull-Rom spline overshoot, so they are clamped inside the band.
+  const points = [0, 100, 0, 100].map((level, index) => ({
+    x: index * 10,
+    y: level ? 1 : height - 1,
+  }));
+  const numbers = smoothPath(points, height)
+    .split(/[\sC]+/)
+    .map(Number)
+    .filter((value) => Number.isFinite(value));
+  for (const value of numbers.filter((_, index) => index % 2 === 1)) {
+    assert.ok(value >= 1 && value <= height - 1, `${value} outside the band`);
+  }
+});
+
+test("a gauge past a legacy threshold says so on its row too", async () => {
+  const { ringLevelName } = await loadSection();
+  assert.equal(ringLevelName(12), "ok");
+  assert.equal(ringLevelName(65), "ok");
+  assert.equal(ringLevelName(70), "warn");
+  assert.equal(ringLevelName(85), "warn");
+  assert.equal(ringLevelName(92), "alert");
+  // No reading yet: the row stays neutral instead of claiming a level.
+  assert.equal(ringLevelName(null), "");
 });
 
 test("the redesigned page keeps every legacy runtime hook", () => {
@@ -169,24 +201,39 @@ test("the section owns presentation only and never reads Home Assistant state", 
   assert.doesNotMatch(body, /MutationObserver/);
 });
 
-test("the value nodes are moved into the rings, never duplicated", () => {
-  const mount = source.slice(source.indexOf("function mountGauge"), source.indexOf("function mountChassis"));
-  // append() moves the node; cloneNode would leave two writers of one value.
-  assert.match(mount, /\.append\(value\)/);
-  assert.doesNotMatch(mount, /cloneNode/);
-  // Mounting twice must not build a second ring.
+test("the dial is built once and copies no value node", () => {
+  const mount = source.slice(source.indexOf("function mountGauge"), source.indexOf("function mountCore"));
+  // Mounting twice must not build a second arc for the same card.
   assert.match(mount, /if \(card\.dataset\.dmSrvxGauge\) return/);
+  // The reading stays the node the render loop writes: nothing is cloned and no
+  // value is read out of the DOM to be printed somewhere else.
+  assert.doesNotMatch(mount, /cloneNode/);
+  assert.doesNotMatch(mount, /textContent/);
+  // Each card owns one radius of the dial, in the order the bars come in.
+  assert.match(source, /const RING_RADII = Object\.freeze\(\[86, 68, 50\]\)/);
+  assert.match(mount, /RING_RADII\[index\]/);
+});
+
+test("the machine is moved to the centre of the dial, not redrawn there", () => {
+  const mount = source.slice(source.indexOf("function mountCore"), source.indexOf("function mountTrace"));
+  // The hero slot itself travels into the dial: one drawing, one owner.
+  assert.match(mount, /core\.append\(slot\)/);
+  assert.doesNotMatch(mount, /cloneNode/);
+  assert.match(mount, /if \(slot\.parentElement !== core\)/);
 });
 
 test("nothing forces a display the auto-hide writes inline on a card", () => {
   // cdAutoHide() shows and hides these cards by writing an inline display, so a
-  // display:none|flex marked !important would either strand a hidden card on
-  // the page or hide one the user mapped.
+  // display marked !important would either strand a hidden card on the page or
+  // show one the user never mapped.
   const styles = source.slice(source.indexOf("function minipcShowcaseCss"));
   for (const card of [".srv-metric", ".srv-temp-card", ".srv-tel-card", ".srv-status-card"]) {
     const pattern = new RegExp(`${card.replace(".", "\\.")}\\{[^}]*display:[^};]*!important`);
     assert.doesNotMatch(styles, pattern, card);
   }
+  // The metric card carries its arc and its row into the same grid through
+  // display:contents, which the inline display:none still overrides.
+  assert.match(styles, /\.srv-metric\{\s*display:contents;/);
   // A block emptied by the auto-hide drops its heading too.
   assert.match(source, /cards\.every\(\(card\) => card\.style\.display === "none"\)/);
 });

--- a/custom_components/dashboardmodern/frontend/tests/minipc-showcase-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/minipc-showcase-section.test.js
@@ -42,28 +42,30 @@ test("each gauge reads the load from the bar the render loop writes", async () =
   assert.equal(metricLevel("srv-fill-cpu", fakeDocument()), null);
 });
 
-test("the ring draws exactly the percentage it was given", async () => {
-  const { ringDash } = await loadSection();
-  const [drawn, gap] = ringDash(40, 100).split(" ").map(Number);
-  assert.equal(drawn, 40);
-  assert.equal(gap, 60);
-  assert.equal(ringDash(0, 100), "0.0 100.0");
-  assert.equal(ringDash(100, 100), "100.0 0.0");
-  // A missing reading draws an empty ring instead of a full one.
-  assert.equal(ringDash(null, 100), "0.0 100.0");
-  assert.equal(ringDash(Number.NaN, 100), "0.0 100.0");
+test("a prism stands as tall as the load it carries", async () => {
+  const { barHeight } = await loadSection();
+  // 0% still leaves a base plate, 100% reaches the top of the scene.
+  assert.equal(barHeight(0, 100), 6);
+  assert.equal(barHeight(100, 100), 100);
+  assert.equal(barHeight(50, 100), 53);
+  // Out of range readings are clamped instead of growing out of the panel.
+  assert.equal(barHeight(140, 100), 100);
+  assert.equal(barHeight(-20, 100), 6);
+  // No reading yet: the base plate, not a full prism.
+  assert.equal(barHeight(null, 100), 6);
+  assert.equal(barHeight(Number.NaN, 100), 6);
 });
 
-test("the gauge keeps its own colour until the legacy thresholds bite", async () => {
-  const { ringColour } = await loadSection();
+test("a prism keeps its own colour until the legacy thresholds bite", async () => {
+  const { levelColour } = await loadSection();
   // Same 65 / 85 pair the legacy setRing() uses for these three gauges.
-  assert.equal(ringColour(20, "#06b6d4"), "#06b6d4");
-  assert.equal(ringColour(65, "#06b6d4"), "#06b6d4");
-  assert.equal(ringColour(66, "#06b6d4"), "#f59e0b");
-  assert.equal(ringColour(85, "#06b6d4"), "#f59e0b");
-  assert.equal(ringColour(86, "#06b6d4"), "#ef4444");
+  assert.equal(levelColour(20, "#06b6d4"), "#06b6d4");
+  assert.equal(levelColour(65, "#06b6d4"), "#06b6d4");
+  assert.equal(levelColour(66, "#06b6d4"), "#f59e0b");
+  assert.equal(levelColour(85, "#06b6d4"), "#f59e0b");
+  assert.equal(levelColour(86, "#06b6d4"), "#ef4444");
   // No reading at all keeps the configured colour instead of raising an alarm.
-  assert.equal(ringColour(null, "#10b981"), "#10b981");
+  assert.equal(levelColour(null, "#10b981"), "#10b981");
 });
 
 test("the thermal scale follows the arc the runtime drew, never a sensor", async () => {
@@ -154,15 +156,15 @@ test("a spike cannot bow the curve out of its band", async () => {
   }
 });
 
-test("a gauge past a legacy threshold says so on its row too", async () => {
-  const { ringLevelName } = await loadSection();
-  assert.equal(ringLevelName(12), "ok");
-  assert.equal(ringLevelName(65), "ok");
-  assert.equal(ringLevelName(70), "warn");
-  assert.equal(ringLevelName(85), "warn");
-  assert.equal(ringLevelName(92), "alert");
-  // No reading yet: the row stays neutral instead of claiming a level.
-  assert.equal(ringLevelName(null), "");
+test("a gauge past a legacy threshold says so on its label too", async () => {
+  const { levelName } = await loadSection();
+  assert.equal(levelName(12), "ok");
+  assert.equal(levelName(65), "ok");
+  assert.equal(levelName(70), "warn");
+  assert.equal(levelName(85), "warn");
+  assert.equal(levelName(92), "alert");
+  // No reading yet: the label stays neutral instead of claiming a level.
+  assert.equal(levelName(null), "");
 });
 
 test("the redesigned page keeps every legacy runtime hook", () => {
@@ -201,25 +203,26 @@ test("the section owns presentation only and never reads Home Assistant state", 
   assert.doesNotMatch(body, /MutationObserver/);
 });
 
-test("the dial is built once and copies no value node", () => {
-  const mount = source.slice(source.indexOf("function mountGauge"), source.indexOf("function mountCore"));
-  // Mounting twice must not build a second arc for the same card.
-  assert.match(mount, /if \(card\.dataset\.dmSrvxGauge\) return/);
+test("a prism is built once and copies no value node", () => {
+  const mount = source.slice(source.indexOf("function mountPrism"), source.indexOf("function mountScene"));
+  // Mounting twice must not stack a second prism on the same card.
+  assert.match(mount, /if \(card\.dataset\.dmSrvxPrism\) return/);
   // The reading stays the node the render loop writes: nothing is cloned and no
   // value is read out of the DOM to be printed somewhere else.
   assert.doesNotMatch(mount, /cloneNode/);
   assert.doesNotMatch(mount, /textContent/);
-  // Each card owns one radius of the dial, in the order the bars come in.
-  assert.match(source, /const RING_RADII = Object\.freeze\(\[86, 68, 50\]\)/);
-  assert.match(mount, /RING_RADII\[index\]/);
+  // Each prism knows which slot of the scene it stands in.
+  assert.match(mount, /--dm-srvx-slot/);
 });
 
-test("the machine is moved to the centre of the dial, not redrawn there", () => {
-  const mount = source.slice(source.indexOf("function mountCore"), source.indexOf("function mountTrace"));
-  // The hero slot itself travels into the dial: one drawing, one owner.
-  assert.match(mount, /core\.append\(slot\)/);
-  assert.doesNotMatch(mount, /cloneNode/);
-  assert.match(mount, /if \(slot\.parentElement !== core\)/);
+test("the machine is a box of six faces, and the old glyph slot is emptied", () => {
+  // One face list drives both the machine and the prisms.
+  assert.match(source, /const BOX_FACES = \["front", "back", "left", "right", "top", "bottom"\]/);
+  const mount = source.slice(source.indexOf("function mountScene"), source.indexOf("function mountTrace"));
+  // The legacy icon slot keeps existing — the runtime owns that markup — it is
+  // just emptied, never removed from the header.
+  assert.match(mount, /slot\.textContent = ""/);
+  assert.doesNotMatch(mount, /\.remove\(\)/);
 });
 
 test("nothing forces a display the auto-hide writes inline on a card", () => {
@@ -231,11 +234,10 @@ test("nothing forces a display the auto-hide writes inline on a card", () => {
     const pattern = new RegExp(`${card.replace(".", "\\.")}\\{[^}]*display:[^};]*!important`);
     assert.doesNotMatch(styles, pattern, card);
   }
-  // The metric card carries its arc and its row into the same grid through
-  // display:contents, which the inline display:none still overrides.
-  assert.match(styles, /\.srv-metric\{\s*display:contents;/);
-  // A block emptied by the auto-hide drops its heading too.
+  // A block emptied by the auto-hide drops its heading too, and the board is
+  // told so telemetry can take the whole row instead of leaving a hole.
   assert.match(source, /cards\.every\(\(card\) => card\.style\.display === "none"\)/);
+  assert.match(styles, /\[data-dm-srvx-thermal="off"\][\s\S]*?\.srv-tel-grid\{grid-column:1 \/ -1\}/);
 });
 
 test("the page dresses both locales and both themes", () => {

--- a/custom_components/dashboardmodern/frontend/tests/minipc-showcase-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/minipc-showcase-section.test.js
@@ -36,7 +36,10 @@ test("each gauge reads the load from the bar the render loop writes", async () =
   assert.equal(metricLevel("srv-fill-ram", scope), 61);
   assert.equal(metricLevel("srv-fill-disk", scope), 0);
   // Out of range widths are clamped rather than drawn past the ring.
-  assert.equal(metricLevel("srv-fill-cpu", fakeDocument({ widths: { "srv-fill-cpu": "140%" } })), 100);
+  assert.equal(
+    metricLevel("srv-fill-cpu", fakeDocument({ widths: { "srv-fill-cpu": "140%" } })),
+    100,
+  );
   assert.equal(metricLevel("srv-fill-cpu", fakeDocument({ widths: { "srv-fill-cpu": "-4%" } })), 0);
   // Before the first render there is no width to read.
   assert.equal(metricLevel("srv-fill-cpu", fakeDocument()), null);
@@ -198,13 +201,25 @@ test("the section owns presentation only and never reads Home Assistant state", 
     "localStorage",
   ])
     assert.doesNotMatch(body, new RegExp(owned), owned);
-  // Event-driven only: no polling, no observer.
+  // No polling.
   assert.doesNotMatch(body, /setInterval\s*\(/);
-  assert.doesNotMatch(body, /MutationObserver/);
+  // One observer, and only for the one thing that announces itself no other
+  // way: cdAutoHide() empties a block by writing an inline style on its cards
+  // and is called from inside the runtime, so there is no name to wrap and no
+  // event to hear. It is scoped to the page and to that attribute — never to
+  // the document, and never to what the cards say.
+  assert.equal(body.match(/new (?:root\.)?MutationObserver\s*\(/g)?.length ?? 0, 1);
+  assert.match(
+    body,
+    /observe\(page, \{ attributes: true, attributeFilter: \["style"\], subtree: true \}\)/,
+  );
 });
 
 test("a prism is built once and copies no value node", () => {
-  const mount = source.slice(source.indexOf("function mountPrism"), source.indexOf("function mountScene"));
+  const mount = source.slice(
+    source.indexOf("function mountPrism"),
+    source.indexOf("function mountScene"),
+  );
   // Mounting twice must not stack a second prism on the same card.
   assert.match(mount, /if \(card\.dataset\.dmSrvxPrism\) return/);
   // The reading stays the node the render loop writes: nothing is cloned and no
@@ -218,7 +233,10 @@ test("a prism is built once and copies no value node", () => {
 test("the machine is a box of six faces, and the old glyph slot is emptied", () => {
   // One face list drives both the machine and the prisms.
   assert.match(source, /const BOX_FACES = \["front", "back", "left", "right", "top", "bottom"\]/);
-  const mount = source.slice(source.indexOf("function mountScene"), source.indexOf("function mountTrace"));
+  const mount = source.slice(
+    source.indexOf("function mountScene"),
+    source.indexOf("function mountTrace"),
+  );
   // The legacy icon slot keeps existing — the runtime owns that markup — it is
   // just emptied, never removed from the header.
   assert.match(mount, /slot\.textContent = ""/);
@@ -237,7 +255,10 @@ test("nothing forces a display the auto-hide writes inline on a card", () => {
   // A block emptied by the auto-hide drops its heading too, and the board is
   // told so telemetry can take the whole row instead of leaving a hole.
   assert.match(source, /cards\.every\(\(card\) => card\.style\.display === "none"\)/);
-  assert.match(styles, /\[data-dm-srvx-thermal="off"\][\s\S]*?\.srv-tel-grid\{grid-column:1 \/ -1\}/);
+  assert.match(
+    styles,
+    /\[data-dm-srvx-thermal="off"\][\s\S]*?\.srv-tel-grid\{grid-column:1 \/ -1\}/,
+  );
 });
 
 test("the page dresses both locales and both themes", () => {

--- a/custom_components/dashboardmodern/frontend/tests/persistence-hotfix.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/persistence-hotfix.test.js
@@ -6,6 +6,7 @@ globalThis.addEventListener = () => {};
 const {
   applyRestoredValues,
   CONFIG_KEYS,
+  CONFIG_KEYS_REVISION,
   integrationUserDataKey,
   mergeLegacyMissingConfig,
   migrateLegacyUserData,
@@ -117,10 +118,10 @@ test("old incomplete cloud snapshot keeps local fields that were never synchroni
   assert.equal(merged.values.cd_avvisi_custom, local.cd_avvisi_custom);
 });
 
-test("revision-2 cloud absence is authoritative and is not filled from stale local data", () => {
+test("current-revision cloud absence is authoritative and is not filled from stale local data", () => {
   const remote = normalizeRemoteSnapshot({
     version: 1,
-    keys_revision: 2,
+    keys_revision: CONFIG_KEYS_REVISION,
     updated_at: 5000,
     values: { cd_sections: '{"energy":false}' },
   });
@@ -128,6 +129,22 @@ test("revision-2 cloud absence is authoritative and is not filled from stale loc
     cd_devices: '[{"name":"Stale"}]',
   });
   assert.equal(Object.hasOwn(merged.values, "cd_devices"), false);
+});
+
+test("a snapshot from before the second vehicle photo keeps the one on this device", () => {
+  assert.ok(CONFIG_KEYS.includes("cd_ev_image_plugged"));
+  const remote = normalizeRemoteSnapshot({
+    version: 1,
+    keys_revision: 2,
+    updated_at: 5000,
+    values: { cd_ev_image: '"/local/auto.png"' },
+  });
+  const merged = mergeLegacyMissingConfig(remote, {
+    cd_ev_image: '"/local/vecchia.png"',
+    cd_ev_image_plugged: '"/local/auto-cavo.png"',
+  });
+  assert.equal(merged.values.cd_ev_image, '"/local/auto.png"');
+  assert.equal(merged.values.cd_ev_image_plugged, '"/local/auto-cavo.png"');
 });
 
 test("store preserves a fresh legacy visibility write instead of overwriting it", () => {

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -215,10 +215,29 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // The Config auto-detection adds two more of the same shape: the pure matcher
   // and the section that installs it over the vendored `edAutoRileva`, reusing
   // that index instead of building a second one.
+  // Beta 31 adds exactly one owner: the Configuration answers the same three
+  // questions the same way on every tab — one section per tab, one visibility
+  // switch, one save at the end — by reconciling what the tab renderers leave
+  // behind. It renders no section content and saves nothing itself.
   // All facade/cycle/orphan/polling/global-observer checks stay active.
-  assert.ok(relative.length <= 102, `production graph unexpectedly grew to ${relative.length} modules`);
+  assert.ok(relative.length <= 103, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
-  assert.doesNotMatch(combined, /setInterval\s*\(/);
+
+  /* No polling, with one declared exception.
+   *
+   * A camera thumbnail is a still picture: nothing in Home Assistant pushes a
+   * new one and the entity state does not change when the view does, so the
+   * only way to keep the wall live is to ask again. That timer is armed by the
+   * Sicurezza page being on screen and disarmed the moment it is not — it is
+   * the one interval production is allowed, and it is named here so a second
+   * one cannot arrive unnoticed. */
+  const intervals = [...graph.entries()].filter(([, source]) =>
+    /setInterval\s*(?:\?\.)?\s*\(/.test(source),
+  );
+  assert.deepEqual(
+    intervals.map(([file]) => path.relative(frontendRoot, file).replaceAll("\\", "/")).sort(),
+    ["src/sections/live-ui-section.js"],
+  );
 
   const observers = [...graph.entries()].filter(([, source]) => /new\s+(?:root\.)?MutationObserver\s*\(/.test(source));
   // Beta17 contributes one page-scoped observer so delayed legacy writes on

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -249,8 +249,11 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // Beta17 contributes one page-scoped observer so delayed legacy writes on
   // #page-temp cannot resurrect the progress placeholder. Beta24 may add one
   // node-scoped SOC observer. Beta26 adds one #temp-grid-scoped observer. The
-  // loop below still rejects observers rooted at document/body/documentElement.
-  assert.ok(observers.length <= 5, `too many production observers: ${observers.length}`);
+  // configuration uniformity owns one more, scoped to the children of #ed-body,
+  // so the section switch and the save stay in place when a tab's own panels
+  // arrive late. The loop below still rejects observers rooted at
+  // document/body/documentElement.
+  assert.ok(observers.length <= 6, `too many production observers: ${observers.length}`);
   for (const [file, source] of observers) {
     assert.doesNotMatch(
       source,

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -215,8 +215,14 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // The Config auto-detection adds two more of the same shape: the pure matcher
   // and the section that installs it over the vendored `edAutoRileva`, reusing
   // that index instead of building a second one.
+  // The MiniPC redesign adds exactly one owner: the skin for #page-server. It
+  // turns the three load bars into ring gauges that read those same bars, moves
+  // the value nodes into the rings instead of copying them, mirrors the status
+  // wording the legacy loop writes and follows #waw-net-badge for connectivity.
+  // It reads no Home Assistant state, adds no polling and no observer, and never
+  // forces a display the auto-hide writes inline on an unmapped card.
   // All facade/cycle/orphan/polling/global-observer checks stay active.
-  assert.ok(relative.length <= 102, `production graph unexpectedly grew to ${relative.length} modules`);
+  assert.ok(relative.length <= 103, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
   assert.doesNotMatch(combined, /setInterval\s*\(/);
 

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -251,9 +251,11 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // node-scoped SOC observer. Beta26 adds one #temp-grid-scoped observer. The
   // configuration uniformity owns one more, scoped to the children of #ed-body,
   // so the section switch and the save stay in place when a tab's own panels
-  // arrive late. The loop below still rejects observers rooted at
-  // document/body/documentElement.
-  assert.ok(observers.length <= 6, `too many production observers: ${observers.length}`);
+  // arrive late. The MiniPC page owns one scoped to #page-server, so a heading
+  // follows the block the auto-hide empties — the auto-hide is called from
+  // inside the runtime, so there is no name to wrap. The loop below still
+  // rejects observers rooted at document/body/documentElement.
+  assert.ok(observers.length <= 7, `too many production observers: ${observers.length}`);
   for (const [file, source] of observers) {
     assert.doesNotMatch(
       source,

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-beta.30.8"
+  "version": "1.0.0-beta.31"
 }


### PR DESCRIPTION
## Cosa contiene

Questa PR porta alla release **1.0.0-beta.31**: la pagina MiniPC ridisegnata, il round di correzioni segnalate dal telefono, la Configurazione resa uniforme scheda per scheda, e le correzioni uscite dalla verifica finale.

---

## 1. Le undici segnalazioni

- **La Configurazione non era uniforme.** Un audit scheda per scheda contava: cinque schede senza nessun salvataggio (Temperatura, Tapparelle, Stanze, Luci, Avvisi), Sicurezza ed EV con due in posti diversi, otto diciture diverse per lo stesso gesto. Ora ogni scheda ha **un solo 💾 Salva sezione, sempre in fondo** — preme i salvataggi dei pannelli aperti, che restano i veri esecutori — il **banner della visibilità è su ogni sezione e sempre in apertura**, e una scheda contiene solo la propria sezione (prima ne portava tredici, dodici nascoste ma ancora nel documento).
- **La ricerca entità al posto della lente, ovunque.** Ogni campo entità è la stessa riga leggibile: dice quale entità è scelta, si tocca per aprire la ricerca, l'id da scrivere a mano resta dietro la matita. Lenti nude contate nell'audit: **48 → 0**.
- **Il reset lasciava lo schermo bianco.** Una configurazione di forma inattesa faceva fallire l'avvio con `value.map is not a function`. Il reset inoltre svuotava il disco ma non la memoria, così tornava indietro l'azione rapida «Luci» vuota, nata da una luce senza entità. Ora il reset svuota anche la memoria, la ricarica viene chiesta all'ospite (dentro `srcdoc` ricaricare dall'interno porta a una pagina vuota), e una luce senza entità non viene più scritta.
- **Le videocamere erano nere.** Ricostruire la parete buttava via i fotogrammi appena scaricati e il timer che li ricaricava era stato rimosso. Ora la parete li richiede appena si ricostruisce e un timer li aggiorna ogni quattro secondi, solo mentre Sicurezza è sullo schermo e la scheda del browser non è nascosta.
- **Due voci di troppo nel Config Home**: «Interruttore antifurto» e «Script apertura cancello» non vengono più disegnate.
- **Due foto dell'auto**: cavo staccato e cavo attaccato, affiancate e ciascuna con l'anteprima. La plancia mostra quella col cavo attaccato mentre l'auto è in ricarica. La seconda è facoltativa.
- **Il Config EV si apriva in due modi**: marchio e modello ora vengono costruiti solo quando la loro sezione esiste, e vanno lì.
- **Le icone del Report** seguono lo stesso ordine della scheda dell'elettrodomestico, quindi le due liste dicono la stessa cosa.
- **La tapparella non era allineata**: una pelle della Beta 7 disegnava una finestra alta 180 px ed era rimasta l'unica a dichiarare `left`, `right` e `top`. La pagina ha un solo proprietario: **9 px → 0 px** su tutti e quattro i lati.
- **Il rallentamento**: l'elenco entità veniva ricostruito da zero due volte al secondo, passando anche per il Proxy degli override. Con duemila entità la stessa sequenza è passata da **307 ms a 1 ms**.
- **Il menu in basso** ha un solo comportamento, in fase di cattura e delegato, quindi vale anche sulle pagine che fermano la propagazione del tocco.

## 2. Quattro difetti trovati durante la verifica

Tutti della stessa famiglia — qualcosa che arriva dopo la passata che avrebbe dovuto sistemarlo — corretti alla radice:

- la riga entità si rompeva in «Aggiungi luce», che fissa la propria griglia: id in chiaro e pulsante schiacciato in 58 px;
- la scheda EV poteva restare senza il pannello delle due foto, col vecchio campo singolo al suo posto;
- l'interruttore della sezione finiva sotto i pannelli che una scheda disegna per conto suo: la passata ora segue le modifiche della scheda (osservatore limitato ai figli di `#ed-body`) invece di un ritardo fisso;
- la matita «rinomina» spariva dalle righe di Visibilità ridisegnate dopo la passata che le marca.

## 3. MiniPC

La pagina è una scena in prospettiva (il mini PC come volume a sei facce, CPU/RAM/Disco come prismi che crescono con il carico, curva dal vivo del carico CPU) su una board a due colonne. Nessun valore è ricalcolato: il runtime legacy resta l'unico proprietario dei dati, le barre e l'arco termico restano in pagina e la scena li legge.

## Verifiche

- `npm run test:frontend` — **762 test verdi**.
- `npx playwright test` (desktop 1440×900 e mobile 390×844) — **282 test verdi, 0 falliti**.
- `npm run check:inline-syntax`, `npm run format:check`, `ruff check` / `ruff format --check` — ok.
- Confronto diretto con il ramo di partenza (Beta 30.8) servito in parallelo: la stessa configurazione che lì ferma l'avvio con `value.map is not a function` qui si carica senza errori, e il set di test Beta 31 passa 9 su 9 qui contro 3 su 9 lì.
- I test Python non sono stati eseguiti in locale (l'ambiente ha Python 3.11, le dipendenze richiedono ≥3.12); questa PR non tocca codice Python.

## Release

`manifest.json` è a `1.0.0-beta.31` e il CHANGELOG ha la voce corrispondente: al merge su `main` il workflow Release pubblica `v1.0.0-beta.31`.