### PR TITLE
rc.1: tutti i punti visti sul dispositivo — energia, clima, stanze, popup, telefono

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/appliance-kpi-popups.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/appliance-kpi-popups.spec.js
@@ -172,8 +172,9 @@ for (const variant of PRIMARY) {
     await expect(runningPopup.locator(".dm-appliance-kpi-row")).toHaveCount(1);
     await expect(runningPopup).toContainText("Microonde");
     await expect(runningPopup).not.toContainText("Frigorifero");
+    // The same drawing the card uses, with its mechanisms, not the flat one.
     await expect(
-      runningPopup.locator('[data-appliance-id="microwave"] [data-dm-art="microwave"]'),
+      runningPopup.locator('[data-appliance-id="microwave"] [data-dm-hero="microwave"]'),
     ).toBeVisible();
     await expectCentered(page, runningPopup);
     await runningPopup.locator("[data-dm-appliance-kpi-close]").click();
@@ -190,7 +191,7 @@ for (const variant of PRIMARY) {
     await expect(powerPopup).toContainText(/920 W/i);
     await expect(powerPopup).toContainText(/2 W/i);
     await expect(
-      powerPopup.locator('[data-appliance-id="fridge"] [data-dm-art="fridge"]'),
+      powerPopup.locator('[data-appliance-id="fridge"] [data-dm-hero="fridge"]'),
     ).toBeVisible();
     await expectCentered(page, powerPopup);
     await powerPopup.locator("[data-dm-appliance-kpi-close]").click();

--- a/custom_components/dashboardmodern/frontend/e2e/appliance-running-popup.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/appliance-running-popup.spec.js
@@ -1,0 +1,155 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { fillEntityFieldByHand } from "./helpers/entity-field.js";
+import { PRIMARY } from "./helpers/variants.js";
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [
+      {
+        id: "room-cameretta",
+        name: "Cameretta",
+        icon: "🛏️",
+        floor: "Primo piano",
+        temp: "sensor.cameretta_temperature",
+        hum: "sensor.cameretta_humidity",
+        metadata: {},
+      },
+    ],
+    cameras: [],
+    appliances: [
+      {
+        id: "appliance-dishwasher",
+        name: "Lavastoviglie",
+        visual_type: "asset",
+        visual_key: "lavastoviglie",
+        device_type: "lavastoviglie",
+        icon: "lavastoviglie",
+        image: "",
+        image_url: "",
+        power_entity: "sensor.dishwasher_power",
+        entities: ["sensor.dishwasher_power"],
+        show_in_dashboard: true,
+      },
+    ],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    energyLoads: [],
+    entityOverrides: {},
+  },
+  visibility: { home: true, appliances: true, temperature: true },
+};
+
+async function boot(page, variant, testInfo) {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 150_000 : 90_000);
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript(() => {
+    class MockBridgeSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      readyState = 1;
+      onopen = null;
+      onmessage = null;
+      onclose = null;
+      onerror = null;
+
+      constructor() {
+        queueMicrotask(() => {
+          this.onopen?.({});
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+        });
+      }
+
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") return;
+        let result = null;
+        if (message.type === "get_states") result = [];
+        if (message.type === "frontend/get_user_data") result = { value: null };
+        if (message.type === "frontend/set_user_data") result = null;
+        queueMicrotask(() =>
+          this.onmessage?.({
+            data: JSON.stringify({ id: message.id, type: "result", success: true, result }),
+          }),
+        );
+      }
+
+      close() {
+        this.readyState = 3;
+        this.onclose?.({});
+      }
+    }
+    window.__DASHBOARDMODERN_HOSTED__ = true;
+    window.__DASHBOARDMODERN_BRIDGE_WS__ = MockBridgeSocket;
+    window.WebSocket = MockBridgeSocket;
+  });
+
+  await bootNamespacedDashboard(page, variant, testInfo, seed);
+  await page
+    .locator("#setup-wizard")
+    .evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await expect
+    .poll(() => page.evaluate(() => window.__DASHBOARDMODERN_RUNTIME_ROOT__?.ready === true))
+    .toBe(true);
+}
+
+
+/* Il popup "in funzione" mostrava un'altra icona, e ferma.
+ *
+ * La riga del popup disegnava l'illustrazione piatta: una sagoma azzurra quasi
+ * uguale per ogni elettrodomestico, immobile anche mentre l'elettrodomestico
+ * lavorava, mentre la scheda accanto mostrava il disegno con le parti mobili.
+ * Adesso e' lo stesso disegno e lo stesso stato: se lavora, si muove. */
+for (const variant of PRIMARY) {
+  test(`${variant}: the running popup shows the card artwork, moving`, async ({
+    page,
+  }, testInfo) => {
+    await boot(page, variant, testInfo);
+
+    await page.evaluate(() => {
+      const states =
+        window.eval("typeof _RAW_STATES !== 'undefined' ? _RAW_STATES : null") ||
+        window._RAW_STATES;
+      states["sensor.dishwasher_power"] = {
+        entity_id: "sensor.dishwasher_power",
+        state: "1800",
+        attributes: { unit_of_measurement: "W", device_class: "power" },
+      };
+      document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
+      document.getElementById("page-appliances-main")?.classList.add("active");
+      window.renderAppliances?.();
+      window.renderApplianceSection?.(true);
+    });
+
+    const card = page.locator('[data-appliance-id="appliance-dishwasher"].dm-ap-card');
+    await expect(card).toHaveClass(/is-run/);
+
+    // The card the user taps to see what is running right now.
+    const kpi = page.locator('[data-dm-appliance-kpi="running"]').first();
+    await expect(kpi).toBeVisible();
+    await kpi.click();
+    const row = page.locator("#dm-appliance-running-popup .dm-appliance-kpi-row").first();
+    await expect(row).toHaveCount(1);
+
+    // The same drawing the card uses, not the flat silhouette.
+    await expect(row.locator('.dm-hero-art[data-dm-hero="dishwasher"]')).toHaveCount(1);
+    await expect(row.locator(".dm-appliance-art")).toHaveCount(0);
+
+    // And its mechanism runs, because the row carries the running state.
+    const moving = await row.evaluate((node) =>
+      [...node.querySelectorAll("*")]
+        .map((el) => getComputedStyle(el).animationName)
+        .filter((name) => name && name !== "none"),
+    );
+    expect(moving).toContain("dmJets");
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/appliance-running-popup.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/appliance-running-popup.spec.js
@@ -102,7 +102,6 @@ async function boot(page, variant, testInfo) {
     .toBe(true);
 }
 
-
 /* Il popup "in funzione" mostrava un'altra icona, e ferma.
  *
  * La riga del popup disegnava l'illustrazione piatta: una sagoma azzurra quasi

--- a/custom_components/dashboardmodern/frontend/e2e/beta32-real-device-uniformity.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta32-real-device-uniformity.spec.js
@@ -282,7 +282,21 @@ test("every page opens with the same heading, once", async ({ page }, testInfo) 
       const visible = (node) => node && getComputedStyle(node).display !== "none";
       report.push({
         id,
-        first: host?.firstElementChild === mast,
+        // L'intestazione apre il contenuto della pagina, e il contenuto di certe
+        // pagine sta dentro un contenitore che ne fissa la larghezza: l'apertura
+        // e' quella del contenitore, non della scheda, altrimenti l'intestazione
+        // sarebbe larga diversamente da cio' che introduce.
+        first: mast?.parentElement?.firstElementChild === mast,
+        sameWidth: (() => {
+          if (!mast) return false;
+          const sibling = [...mast.parentElement.children].find(
+            (node) => node !== mast && node.getClientRects().length,
+          );
+          if (!sibling) return true;
+          return (
+            Math.abs(mast.getBoundingClientRect().width - sibling.getBoundingClientRect().width) < 3
+          );
+        })(),
         title: mast?.querySelector(".dm-page-mast-title")?.textContent?.trim() || "",
         subtitle: mast?.querySelector(".dm-page-mast-sub")?.textContent?.trim() || "",
         backs: [...(host?.querySelectorAll(".back-home-btn") || [])].filter(visible).length,
@@ -292,6 +306,7 @@ test("every page opens with the same heading, once", async ({ page }, testInfo) 
   });
   for (const entry of pages) {
     expect(entry.first, `${entry.id} opens with the heading`).toBe(true);
+    expect(entry.sameWidth, `${entry.id} heading is as wide as what it introduces`).toBe(true);
     expect(entry.title.length, `${entry.id} names itself`).toBeGreaterThan(2);
     expect(entry.subtitle.length, `${entry.id} says what it is`).toBeGreaterThan(4);
     expect(entry.backs, `${entry.id} shows one way back`).toBe(1);

--- a/custom_components/dashboardmodern/frontend/e2e/connection-recovery.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/connection-recovery.spec.js
@@ -37,6 +37,13 @@ for (const variant of PRIMARY) {
     await page.waitForFunction(() => Boolean(window.DashboardModernModules), null, {
       timeout: 20000,
     });
+    // Il modulo arriva qualche istante dopo il deposito: agire prima vorrebbe
+    // dire mettere alla prova qualcosa che non c'e' ancora.
+    await page.waitForFunction(
+      () => Boolean(window.__DASHBOARDMODERN_CONNECTION_RECOVERY__?.installed),
+      null,
+      { timeout: 20000 },
+    );
 
     // Il primo tentativo e' saltato e il runtime, da solo, non ne farebbe altri.
     await expect
@@ -60,31 +67,63 @@ for (const variant of PRIMARY) {
     await page.waitForFunction(() => Boolean(window.DashboardModernModules), null, {
       timeout: 20000,
     });
+    // Il modulo arriva qualche istante dopo il deposito: agire prima vorrebbe
+    // dire mettere alla prova qualcosa che non c'e' ancora.
+    await page.waitForFunction(
+      () => Boolean(window.__DASHBOARDMODERN_CONNECTION_RECOVERY__?.installed),
+      null,
+      { timeout: 20000 },
+    );
 
-    const before = await page.evaluate(() => {
-      window.__dmConnectCalls__ = 0;
+    /* Chi ha chiamato, non quando.
+     *
+     * Anche il runtime richiama connect() cinque secondi dopo ogni chiusura:
+     * misurare il tempo vorrebbe dire tirare a indovinare quale dei due ha
+     * parlato. La chiamata porta con se' la propria pila, e li' il nome della
+     * funzione dice da dove arriva. */
+    const wrapped = await page.evaluate(() => {
+      window.__dmConnectStacks__ = [];
       const previous = window.connect;
-      if (typeof previous !== "function") return null;
-      window.connect = function (...args) {
-        window.__dmConnectCalls__ += 1;
-        return previous.apply(this, args);
+      if (typeof previous !== "function") return false;
+      window.connect = function () {
+        window.__dmConnectStacks__.push(String(new Error().stack || ""));
       };
-      return window.__dmConnectCalls__;
+      return true;
     });
-    expect(before, "the runtime exposes the connection it opens").toBe(0);
+    expect(wrapped, "the runtime exposes the connection it opens").toBe(true);
+
+    // Lo stato in cui iOS lascia la pagina: la presa non c'e' piu'. Una presa
+    // che si sta ancora aprendo non va raddoppiata, ed e' giusto cosi': qui non
+    // ce n'e' nessuna da rispettare.
+    await page.evaluate(() => {
+      try {
+        window.eval("typeof ws !== 'undefined' && ws && ws.close && ws.close()");
+      } catch (error) {}
+    });
+    await expect
+      .poll(() =>
+        page.evaluate(() => window.eval("typeof ws !== 'undefined' && ws ? ws.readyState : null")),
+      )
+      .toBe(3);
 
     // Il rientro: la pagina torna visibile e il sistema la risveglia.
     await page.evaluate(() => {
+      window.__dmConnectStacks__.length = 0;
       window.dispatchEvent(new Event("pageshow"));
       document.dispatchEvent(new Event("visibilitychange"));
       window.dispatchEvent(new Event("focus"));
     });
 
-    // Subito, non fra cinque secondi: il runtime ha una sua riprova a tempo
-    // dopo ogni chiusura, e aspettarla vorrebbe dire non provare niente. Chi
-    // ha appena riaperto l'app sta guardando lo schermo adesso.
     await expect
-      .poll(() => page.evaluate(() => window.__dmConnectCalls__), { timeout: 3000 })
-      .toBeGreaterThan(0);
+      .poll(
+        () =>
+          page.evaluate(() =>
+            window.__dmConnectStacks__.some(
+              (stack) => stack.includes("attemptReconnect") && stack.includes("resume"),
+            ),
+          ),
+        { message: "il rientro richiede la connessione", timeout: 15000 },
+      )
+      .toBe(true);
   });
 }

--- a/custom_components/dashboardmodern/frontend/e2e/connection-recovery.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/connection-recovery.spec.js
@@ -1,0 +1,90 @@
+/* Rientrare nell'app non deve lasciare la plancia a "CONNECTING…".
+ *
+ * Su iPhone il sistema butta via la pagina dell'app quando passi ad altro: al
+ * rientro il pannello la ricostruisce da zero. Il runtime apre la presa verso
+ * Home Assistant una volta sola e, se quel tentativo salta — il ponte verso il
+ * frontend ospite puo' non essere ancora pronto — non ne prova altri: resta la
+ * scritta che sta nel documento appena aperto, i gradi a "--" e i riquadri
+ * vuoti. Chiudere e riaprire l'app la sistemava, perche' era un avvio nuovo.
+ */
+import { expect, test } from "@playwright/test";
+import { PRIMARY } from "./helpers/variants.js";
+
+for (const variant of PRIMARY) {
+  test(`${variant}: a socket that fails to open is retried, not given up on`, async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(90_000);
+
+    // Il costruttore della presa salta, come quando il ponte non e' pronto.
+    // Dal terzo tentativo in poi funziona: la plancia deve arrivarci da sola.
+    await page.addInitScript(() => {
+      const Real = window.WebSocket;
+      window.__dmSocketAttempts__ = 0;
+      const Guarded = function (...args) {
+        window.__dmSocketAttempts__ += 1;
+        if (window.__dmSocketAttempts__ <= 2) throw new Error("bridge not ready");
+        return new Real(...args);
+      };
+      Guarded.CONNECTING = Real.CONNECTING;
+      Guarded.OPEN = Real.OPEN;
+      Guarded.CLOSING = Real.CLOSING;
+      Guarded.CLOSED = Real.CLOSED;
+      window.WebSocket = Guarded;
+    });
+
+    await page.goto(`/legacy/${variant}`);
+    await page.waitForFunction(() => Boolean(window.DashboardModernModules), null, {
+      timeout: 20000,
+    });
+
+    // Il primo tentativo e' saltato e il runtime, da solo, non ne farebbe altri.
+    await expect
+      .poll(() => page.evaluate(() => window.__dmSocketAttempts__), { timeout: 30000 })
+      .toBeGreaterThan(2);
+
+    // E mentre riprova lo dice: la scritta del documento appena aperto non
+    // resta li' a far credere che stia succedendo qualcosa la prima volta.
+    await expect
+      .poll(() => page.evaluate(() => document.getElementById("conn-text")?.textContent || ""), {
+        timeout: 30000,
+      })
+      .toMatch(/riconness|reconnect/i);
+  });
+
+  test(`${variant}: coming back to the app asks for the connection again`, async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(90_000);
+    await page.goto(`/legacy/${variant}`);
+    await page.waitForFunction(() => Boolean(window.DashboardModernModules), null, {
+      timeout: 20000,
+    });
+
+    const before = await page.evaluate(() => {
+      window.__dmConnectCalls__ = 0;
+      const previous = window.connect;
+      if (typeof previous !== "function") return null;
+      window.connect = function (...args) {
+        window.__dmConnectCalls__ += 1;
+        return previous.apply(this, args);
+      };
+      return window.__dmConnectCalls__;
+    });
+    expect(before, "the runtime exposes the connection it opens").toBe(0);
+
+    // Il rientro: la pagina torna visibile e il sistema la risveglia.
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event("pageshow"));
+      document.dispatchEvent(new Event("visibilitychange"));
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    // Subito, non fra cinque secondi: il runtime ha una sua riprova a tempo
+    // dopo ogni chiusura, e aspettarla vorrebbe dire non provare niente. Chi
+    // ha appena riaperto l'app sta guardando lo schermo adesso.
+    await expect
+      .poll(() => page.evaluate(() => window.__dmConnectCalls__), { timeout: 3000 })
+      .toBeGreaterThan(0);
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/editor-delete-refresh.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-delete-refresh.spec.js
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { PRIMARY } from "./helpers/variants.js";
+
+const base = {
+  rooms: [],
+  cameras: [],
+  appliances: [],
+  loads: [],
+  lights: [],
+  ev: [],
+  covers: [],
+  pool: {},
+  irrigation: { zones: [] },
+  energy: {},
+  entityOverrides: {},
+};
+
+async function openTab(page, label) {
+  await page.evaluate(() => {
+    if (!document.getElementById("editor-modal")?.classList.contains("show")) apriConfigEntita();
+  });
+  await page.evaluate((text) => {
+    const tab = [...document.querySelectorAll("#editor-modal .ed-tab")].find((node) =>
+      new RegExp(text, "i").test(node.textContent),
+    );
+    tab?.click();
+  }, label);
+  await expect(page.locator("#editor-modal .ed-tab.active")).toHaveCount(1);
+}
+
+function rowNames(page) {
+  return page
+    .locator("#ed-body .ed-row")
+    .evaluateAll((rows) =>
+      rows.map((row) => row.querySelector(".ed-row-new")?.textContent.trim().split(" (")[0]),
+    );
+}
+
+/* Il cestino lasciava l'elenco sfasato.
+ *
+ * L'editor aveva una sola scheda Sezioni; adesso ce n'e' una per sezione e il
+ * nome "sezioni" non corrisponde piu' a niente. Il runtime lo chiama ancora
+ * dopo ogni eliminazione: l'elenco non veniva ridisegnato, il ridisegno
+ * parziale che segue lasciava l'ultima riga duplicata, e la scheda in alto
+ * perdeva l'evidenziazione. */
+for (const variant of PRIMARY) {
+  test(`${variant}: deleting a climate unit redraws the list where you are looking`, async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(90_000);
+    await bootNamespacedDashboard(page, variant, testInfo, {
+      schema_version: 4,
+      sections: {
+        ...base,
+        climate: [
+          { entity: "climate.salone", name: "Salone", type: "clima" },
+          { entity: "climate.cucina", name: "Cucina", type: "clima" },
+          { entity: "climate.bagno", name: "Bagno", type: "termosifone" },
+        ],
+      },
+      visibility: { clima: true },
+    });
+
+    await openTab(page, "clima");
+    await expect.poll(() => rowNames(page)).toEqual(["Salone", "Cucina", "Bagno"]);
+    const tab = await page.locator("#editor-modal .ed-tab.active").getAttribute("data-tab");
+
+    await page.locator("#ed-body .ed-row .ed-del").filter({ hasText: "🗑" }).first().click();
+
+    // The row is gone, the others keep their order, nothing is duplicated.
+    await expect.poll(() => rowNames(page)).toEqual(["Cucina", "Bagno"]);
+    // And we are still on the tab we were on.
+    await expect(page.locator("#editor-modal .ed-tab.active")).toHaveAttribute("data-tab", tab);
+
+    const stored = await page.evaluate(() =>
+      (window.DashboardModernModules?.store?.getSection?.("climate") || []).map((unit) => unit.name),
+    );
+    expect(stored).toEqual(["Cucina", "Bagno"]);
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/editor-delete-refresh.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-delete-refresh.spec.js
@@ -66,18 +66,37 @@ for (const variant of PRIMARY) {
     await expect.poll(() => rowNames(page)).toEqual(["Salone", "Cucina", "Bagno"]);
     const tab = await page.locator("#editor-modal .ed-tab.active").getAttribute("data-tab");
 
-    await page.locator("#ed-body .ed-row .ed-del").filter({ hasText: "🗑" }).first().click();
+    const trash = () => page.locator("#ed-body .ed-row .ed-del").filter({ hasText: "🗑" });
+    const stored = () =>
+      page.evaluate(() =>
+        (window.DashboardModernModules?.store?.getSection?.("climate") || []).map(
+          (unit) => unit.name,
+        ),
+      );
 
-    // The row is gone, the others keep their order, nothing is duplicated.
+    /* Il cestino, piu' volte, senza mai uscire dalla sezione.
+     *
+     * E' il giro che l'ha fatta vedere: l'elenco restava fermo mentre le unita'
+     * sparivano davvero, e sembrava pulito solo cambiando scheda e tornando. Chi
+     * continua a premere si ritrova a premere su righe che non esistono piu', e
+     * i numeri delle righe non corrispondono piu' a niente. */
+    await trash().first().click();
     await expect.poll(() => rowNames(page)).toEqual(["Cucina", "Bagno"]);
-    // And we are still on the tab we were on.
+    await expect.poll(stored).toEqual(["Cucina", "Bagno"]);
+    // E si e' ancora sulla scheda su cui si stava.
     await expect(page.locator("#editor-modal .ed-tab.active")).toHaveAttribute("data-tab", tab);
 
-    const stored = await page.evaluate(() =>
-      (window.DashboardModernModules?.store?.getSection?.("climate") || []).map(
-        (unit) => unit.name,
-      ),
-    );
-    expect(stored).toEqual(["Cucina", "Bagno"]);
+    await trash().first().click();
+    await expect.poll(() => rowNames(page)).toEqual(["Bagno"]);
+    await expect.poll(stored).toEqual(["Bagno"]);
+
+    await trash().first().click();
+    await expect.poll(() => rowNames(page)).toEqual([]);
+    await expect.poll(stored).toEqual([]);
+
+    // E restando fermi qui, la sezione e' vuota davvero: non lo si scopre
+    // uscendo e rientrando.
+    await expect(page.locator("#editor-modal .ed-tab.active")).toHaveAttribute("data-tab", tab);
+    await expect(trash()).toHaveCount(0);
   });
 }

--- a/custom_components/dashboardmodern/frontend/e2e/editor-delete-refresh.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-delete-refresh.spec.js
@@ -74,7 +74,9 @@ for (const variant of PRIMARY) {
     await expect(page.locator("#editor-modal .ed-tab.active")).toHaveAttribute("data-tab", tab);
 
     const stored = await page.evaluate(() =>
-      (window.DashboardModernModules?.store?.getSection?.("climate") || []).map((unit) => unit.name),
+      (window.DashboardModernModules?.store?.getSection?.("climate") || []).map(
+        (unit) => unit.name,
+      ),
     );
     expect(stored).toEqual(["Cucina", "Bagno"]);
   });

--- a/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
@@ -250,8 +250,8 @@ for (const variant of PRIMARY) {
     // One picker per entity field, and each picker pointing at a field that is
     // really there. The field itself is behind the pencil now, so the row —
     // the picker — is what has to be on screen, not the raw id box.
-    const assertPickerInvariant = async () => {
-      const counts = await page.locator("#ed-body").evaluate((body) => {
+    const pickerCounts = () =>
+      page.locator("#ed-body").evaluate((body) => {
         const onScreen = (node) => Boolean(node) && node.getClientRects().length > 0;
         const pickers = [...body.querySelectorAll(".dm-entity-picker")].filter(onScreen);
         const fields = [...body.querySelectorAll("[data-entity-input]")].filter(
@@ -267,6 +267,23 @@ for (const variant of PRIMARY) {
           ).length,
         };
       });
+    /* La rifinitura arriva un attimo dopo il pannello.
+     *
+     * I selettori li costruisce una passata che segue il disegno del pannello:
+     * leggere il conteggio al primo colpo, su una macchina carica, coglie il
+     * pannello gia' scritto e la passata ancora a meta'. L'invariante e' che si
+     * assesti, non che sia vera al primo istante. */
+    const assertPickerInvariant = async () => {
+      await expect
+        .poll(
+          async () => {
+            const counts = await pickerCounts();
+            return counts.pickers === counts.inputs && counts.uniqueTargets === counts.inputs;
+          },
+          { message: "un selettore per campo, e ognuno punta a un campo che c'e'" },
+        )
+        .toBe(true);
+      const counts = await pickerCounts();
       expect(counts.pickers).toBe(counts.inputs);
       expect(counts.uniqueTargets).toBe(counts.inputs);
       expect(counts.orphans).toBe(0);

--- a/custom_components/dashboardmodern/frontend/e2e/energy-total-fields-save.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/energy-total-fields-save.spec.js
@@ -1,0 +1,214 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { fillEntityFieldByHand } from "./helpers/entity-field.js";
+import { PRIMARY } from "./helpers/variants.js";
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [
+      {
+        id: "room-cameretta",
+        name: "Cameretta",
+        icon: "🛏️",
+        floor: "Primo piano",
+        temp: "sensor.cameretta_temperature",
+        hum: "sensor.cameretta_humidity",
+        metadata: {},
+      },
+    ],
+    cameras: [],
+    appliances: [
+      {
+        id: "appliance-dishwasher",
+        name: "Lavastoviglie",
+        visual_type: "asset",
+        visual_key: "lavastoviglie",
+        device_type: "lavastoviglie",
+        icon: "lavastoviglie",
+        image: "/local/stale-washer.png",
+        image_url: "/local/stale-washer.png",
+        power_entity: "sensor.dishwasher_power",
+        entities: ["sensor.dishwasher_power"],
+        show_in_dashboard: true,
+      },
+    ],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    energyLoads: [],
+    entityOverrides: {},
+  },
+  visibility: { home: true, appliances: true, temperature: true },
+};
+
+async function boot(page, variant, testInfo) {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 150_000 : 90_000);
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript(() => {
+    class MockBridgeSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      readyState = 1;
+      onopen = null;
+      onmessage = null;
+      onclose = null;
+      onerror = null;
+
+      constructor() {
+        queueMicrotask(() => {
+          this.onopen?.({});
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+        });
+      }
+
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") return;
+        let result = null;
+        if (message.type === "get_states") result = [];
+        if (message.type === "frontend/get_user_data") result = { value: null };
+        if (message.type === "frontend/set_user_data") result = null;
+        queueMicrotask(() =>
+          this.onmessage?.({
+            data: JSON.stringify({ id: message.id, type: "result", success: true, result }),
+          }),
+        );
+      }
+
+      close() {
+        this.readyState = 3;
+        this.onclose?.({});
+      }
+    }
+    window.__DASHBOARDMODERN_HOSTED__ = true;
+    window.__DASHBOARDMODERN_BRIDGE_WS__ = MockBridgeSocket;
+    window.WebSocket = MockBridgeSocket;
+  });
+
+  await bootNamespacedDashboard(page, variant, testInfo, seed);
+  await page
+    .locator("#setup-wizard")
+    .evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await expect
+    .poll(() => page.evaluate(() => window.__DASHBOARDMODERN_RUNTIME_ROOT__?.ready === true))
+    .toBe(true);
+}
+
+async function openEnergy(page) {
+  await page.evaluate(() => {
+    if (!document.getElementById("editor-modal")?.classList.contains("show")) apriConfigEntita();
+    const tab = [...document.querySelectorAll("#editor-modal .ed-tab")].find((node) =>
+      /energ/i.test(node.textContent),
+    );
+    tab?.click();
+  });
+  // Il campo vive dentro una fisarmonica che puo' essere chiusa: qui conta che
+  // ci sia e sia collegato, non che sia sotto gli occhi.
+  await expect(page.locator("#dm-energy-grid-total_import_energy")).toHaveCount(1);
+}
+
+for (const variant of PRIMARY) {
+  /* Il campo del prelievo rete lo stampa gia' il runtime.
+   *
+   * La rifinitura usciva subito quando lo trovava, e con l'uscita se ne
+   * andavano i due ascolti che stanno sotto: quello che accende il pulsante
+   * Salva e quello che scrive il valore appena si esce dal campo. Il campo
+   * restava scrivibile e non salvava niente da solo.
+   */
+  test(`${variant}: the grid import meter saves on its own`, async ({ page }, testInfo) => {
+    await boot(page, variant, testInfo);
+    await page.evaluate(() => {
+      const states =
+        window.eval("typeof _RAW_STATES !== 'undefined' ? _RAW_STATES : null") ||
+        window._RAW_STATES;
+      states["sensor.rete_prelievo_totale"] = {
+        entity_id: "sensor.rete_prelievo_totale",
+        state: "120",
+        attributes: {
+          unit_of_measurement: "kWh",
+          device_class: "energy",
+          state_class: "total_increasing",
+        },
+      };
+    });
+    await openEnergy(page);
+
+    // Come lo lascia il selettore 🔍: il valore scritto e un solo annuncio.
+    await page.evaluate(() => {
+      const input = document.getElementById("dm-energy-grid-total_import_energy");
+      input.value = "sensor.rete_prelievo_totale";
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              window.DashboardModernModules?.store?.getSection?.("energy")?.grid
+                ?.total_import_energy || "",
+          ),
+        { message: "il prelievo rete si salva da solo", timeout: 8000 },
+      )
+      .toBe("sensor.rete_prelievo_totale");
+  });
+
+  /* La maschera mostra cio' che c'e' scritto.
+   *
+   * Il modello che leggono le pagine esce filtrato: con un contatore totale i
+   * campi di periodo ne restano fuori, perche' i periodi si ricavano dal
+   * totale. Se la maschera leggesse quello mostrerebbe quei campi vuoti, e il
+   * primo salvataggio riscriverebbe il vuoto sopra le entita' configurate.
+   */
+  test(`${variant}: the energy editor shows the configuration as written`, async ({
+    page,
+  }, testInfo) => {
+    await boot(page, variant, testInfo);
+    await page.evaluate(async () => {
+      const states =
+        window.eval("typeof _RAW_STATES !== 'undefined' ? _RAW_STATES : null") ||
+        window._RAW_STATES;
+      for (const id of ["sensor.casa_totale", "sensor.casa_giorno", "sensor.casa_mese"]) {
+        states[id] = {
+          entity_id: id,
+          state: "10",
+          attributes: {
+            unit_of_measurement: "kWh",
+            device_class: "energy",
+            state_class: "total_increasing",
+          },
+        };
+      }
+      await window.DashboardModernModules.store.replaceSection("energy", {
+        house: {
+          total_energy: "sensor.casa_totale",
+          daily_energy: "sensor.casa_giorno",
+          monthly_energy: "sensor.casa_mese",
+        },
+      });
+    });
+    await openEnergy(page);
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          total: document.getElementById("dm-energy-house-total_energy")?.value || "",
+          daily: document.getElementById("dm-energy-house-daily_energy")?.value || "",
+          monthly: document.getElementById("dm-energy-house-monthly_energy")?.value || "",
+        })),
+      )
+      .toEqual({
+        total: "sensor.casa_totale",
+        daily: "sensor.casa_giorno",
+        monthly: "sensor.casa_mese",
+      });
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/energy-total-fields-save.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/energy-total-fields-save.spec.js
@@ -116,51 +116,6 @@ async function openEnergy(page) {
 }
 
 for (const variant of PRIMARY) {
-  /* Il campo del prelievo rete lo stampa gia' il runtime.
-   *
-   * La rifinitura usciva subito quando lo trovava, e con l'uscita se ne
-   * andavano i due ascolti che stanno sotto: quello che accende il pulsante
-   * Salva e quello che scrive il valore appena si esce dal campo. Il campo
-   * restava scrivibile e non salvava niente da solo.
-   */
-  test(`${variant}: the grid import meter saves on its own`, async ({ page }, testInfo) => {
-    await boot(page, variant, testInfo);
-    await page.evaluate(() => {
-      const states =
-        window.eval("typeof _RAW_STATES !== 'undefined' ? _RAW_STATES : null") ||
-        window._RAW_STATES;
-      states["sensor.rete_prelievo_totale"] = {
-        entity_id: "sensor.rete_prelievo_totale",
-        state: "120",
-        attributes: {
-          unit_of_measurement: "kWh",
-          device_class: "energy",
-          state_class: "total_increasing",
-        },
-      };
-    });
-    await openEnergy(page);
-
-    // Come lo lascia il selettore 🔍: il valore scritto e un solo annuncio.
-    await page.evaluate(() => {
-      const input = document.getElementById("dm-energy-grid-total_import_energy");
-      input.value = "sensor.rete_prelievo_totale";
-      input.dispatchEvent(new Event("change", { bubbles: true }));
-    });
-
-    await expect
-      .poll(
-        () =>
-          page.evaluate(
-            () =>
-              window.DashboardModernModules?.store?.getSection?.("energy")?.grid
-                ?.total_import_energy || "",
-          ),
-        { message: "il prelievo rete si salva da solo", timeout: 8000 },
-      )
-      .toBe("sensor.rete_prelievo_totale");
-  });
-
   /* La maschera mostra cio' che c'e' scritto.
    *
    * Il modello che leggono le pagine esce filtrato: con un contatore totale i

--- a/custom_components/dashboardmodern/frontend/e2e/energy-total-over-periods.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/energy-total-over-periods.spec.js
@@ -1,0 +1,110 @@
+/* Il contatore totale comanda, e la maschera lo dice.
+ *
+ * Chi riempie il totale e anche giornaliera, mensile e annuale si ritrova due
+ * verita' che non tornano. Ora ogni periodo si ricava dal totale con Recorder e
+ * i campi di periodo restano fuori dal modello — ma la configurazione resta
+ * scritta, quindi la maschera Energia deve dire per nome quali entita' sta
+ * scavalcando, e offrire di svuotarle.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { PRIMARY } from "./helpers/variants.js";
+
+const energy = {
+  house: {
+    total_energy: "sensor.casa_totale",
+    daily_energy: "sensor.casa_giorno",
+    monthly_energy: "sensor.casa_mese",
+    annual_energy: "sensor.casa_anno",
+  },
+};
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy,
+    energyLoads: [],
+    entityOverrides: {},
+  },
+  visibility: { energy: true },
+};
+
+async function openEnergyEditor(page) {
+  await page.evaluate(() => {
+    if (!document.getElementById("editor-modal")?.classList.contains("show")) apriConfigEntita();
+    const tab = [...document.querySelectorAll("#editor-modal .ed-tab")].find((node) =>
+      /energ/i.test(node.textContent),
+    );
+    tab?.click();
+  });
+}
+
+for (const variant of PRIMARY) {
+  test(`${variant}: the energy editor names the fields the total meter overrides`, async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(90_000);
+    await bootNamespacedDashboard(page, variant, testInfo, seed);
+
+    // The dashboard only knows an entity exists if Home Assistant reports it.
+    await page.evaluate(() => {
+      const states =
+        window.eval("typeof _RAW_STATES !== 'undefined' ? _RAW_STATES : null") ||
+        window._RAW_STATES;
+      for (const id of [
+        "sensor.casa_totale",
+        "sensor.casa_giorno",
+        "sensor.casa_mese",
+        "sensor.casa_anno",
+      ]) {
+        states[id] = {
+          entity_id: id,
+          state: "10",
+          attributes: {
+            unit_of_measurement: "kWh",
+            device_class: "energy",
+            state_class: "total_increasing",
+          },
+        };
+      }
+    });
+
+    await openEnergyEditor(page);
+    const clash = page.locator("#editor-modal .dm-energy-source-clash");
+    await expect(clash).toBeVisible();
+    // By name, so nobody has to guess which value stopped being read.
+    await expect(clash).toContainText("sensor.casa_totale");
+    await expect(clash).toContainText("sensor.casa_giorno");
+    await expect(clash).toContainText("sensor.casa_mese");
+    await expect(clash).toContainText("sensor.casa_anno");
+
+    // La scheda "come leggere la configurazione" e' scritta da un altro modulo:
+    // deve dire la stessa cosa, o le due si contraddicono a vista.
+    await expect(page.locator("#editor-modal .dm-energy-guide-steps")).toContainText(
+      /contatore totale/i,
+    );
+
+    await clash.locator(".dm-energy-clash-clear").click();
+
+    // The button empties exactly those fields, and the warning goes with them.
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const house = DashboardModernModules.store.getSection("energy")?.house || {};
+          return [house.total_energy, house.daily_energy, house.monthly_energy, house.annual_energy];
+        }),
+      )
+      .toEqual(["sensor.casa_totale", "", "", ""]);
+    await expect(page.locator("#editor-modal .dm-energy-source-clash")).toHaveCount(0);
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/energy-total-over-periods.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/energy-total-over-periods.spec.js
@@ -101,7 +101,12 @@ for (const variant of PRIMARY) {
       .poll(() =>
         page.evaluate(() => {
           const house = DashboardModernModules.store.getSection("energy")?.house || {};
-          return [house.total_energy, house.daily_energy, house.monthly_energy, house.annual_energy];
+          return [
+            house.total_energy,
+            house.daily_energy,
+            house.monthly_energy,
+            house.annual_energy,
+          ];
         }),
       )
       .toEqual(["sensor.casa_totale", "", "", ""]);

--- a/custom_components/dashboardmodern/frontend/e2e/ev-two-cars-photos.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/ev-two-cars-photos.spec.js
@@ -86,14 +86,16 @@ test("two cars keep their own photos", async ({ page }, testInfo) => {
   expect(result.afterBlank).toEqual({ idle: "/local/a-idle.png", plugged: "/local/a-plug.png" });
 });
 
-/* La foto resta quella scritta.
+/* Una foto non passa da una casella all'altra.
  *
- * Il disegno risolveva il percorso della foto attiva e lo riscriveva nella
- * configurazione, scegliendo la chiave in base al cavo: con la sola foto "col
- * cavo" impostata e il cavo staccato la riscriveva in quella "senza cavo", e
- * da li' le due diventavano la stessa da sole.
+ * Il disegno risolve il percorso della foto attiva e riscrive la forma buona
+ * nella configurazione, cosi' un percorso storto si corregge una volta sola.
+ * La chiave in cui finiva pero' la sceglieva il cavo: con la sola foto "col
+ * cavo" impostata e il cavo staccato la correzione finiva in quella "senza
+ * cavo", e da li' le due diventavano la stessa da sole. La correzione deve
+ * restare nella casella da cui il valore proviene.
  */
-test("il disegno non riscrive le foto configurate", async ({ page }, testInfo) => {
+test("il disegno non sposta la foto nell'altra casella", async ({ page }, testInfo) => {
   test.setTimeout(90_000);
   await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
   await page.waitForFunction(() => Boolean(window.cdEvCaptureProfile?.__dmEvSection), null, {
@@ -127,8 +129,16 @@ test("il disegno non riscrive le foto configurate", async ({ page }, testInfo) =
     "la passata che disegna la foto e' girata",
   ).toBe(true);
   const after = await page.evaluate(() => ({
-    idle: localStorage.getItem("cd_ev_image"),
-    plugged: localStorage.getItem("cd_ev_image_plugged"),
+    idle: JSON.parse(localStorage.getItem("cd_ev_image") || '""'),
+    plugged: JSON.parse(localStorage.getItem("cd_ev_image_plugged") || '""'),
   }));
-  expect(after, "la configurazione e' quella che l'utente ha scritto").toEqual(before);
+  // La casella "senza cavo" era vuota e vuota resta: nessuno ci ha travasato
+  // la foto dell'altra.
+  expect(after.idle, "la foto senza cavo resta vuota").toBe("");
+  // Quella "col cavo" indica ancora la stessa immagine — al piu' scritta nella
+  // forma che il browser sa servire.
+  expect(after.plugged, "la foto col cavo indica ancora quell'immagine").toMatch(
+    /solo-col-cavo\.png$/,
+  );
+  expect(before.plugged, "la prova parte dalla foto scritta a mano").toContain("solo-col-cavo");
 });

--- a/custom_components/dashboardmodern/frontend/e2e/ev-two-cars-photos.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/ev-two-cars-photos.spec.js
@@ -85,3 +85,50 @@ test("two cars keep their own photos", async ({ page }, testInfo) => {
   expect(result.afterB).toEqual({ idle: "/local/b-idle.png", plugged: "/local/b-plug.png" });
   expect(result.afterBlank).toEqual({ idle: "/local/a-idle.png", plugged: "/local/a-plug.png" });
 });
+
+/* La foto resta quella scritta.
+ *
+ * Il disegno risolveva il percorso della foto attiva e lo riscriveva nella
+ * configurazione, scegliendo la chiave in base al cavo: con la sola foto "col
+ * cavo" impostata e il cavo staccato la riscriveva in quella "senza cavo", e
+ * da li' le due diventavano la stessa da sole.
+ */
+test("il disegno non riscrive le foto configurate", async ({ page }, testInfo) => {
+  test.setTimeout(90_000);
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+  await page.waitForFunction(() => Boolean(window.cdEvCaptureProfile?.__dmEvSection), null, {
+    timeout: 15000,
+  });
+  const before = await page.evaluate(() => {
+    localStorage.setItem("cd_ev_image", JSON.stringify(""));
+    localStorage.setItem("cd_ev_image_plugged", JSON.stringify("/solo-col-cavo.png"));
+    return {
+      idle: localStorage.getItem("cd_ev_image"),
+      plugged: localStorage.getItem("cd_ev_image_plugged"),
+    };
+  });
+  // Il disegno gira sulle passate che seguono gli eventi del runtime: qui se ne
+  // chiedono parecchie, dalla stessa porta da cui arrivano davvero.
+  for (let pass = 0; pass < 8; pass += 1) {
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("dashboardmodern:state-changed", {
+          detail: { entity_id: "dm.ev_stato_ricarica" },
+        }),
+      );
+      window.dispatchEvent(new Event("pageshow"));
+    });
+    await page.waitForTimeout(180);
+  }
+  await page.waitForTimeout(2000);
+  // Se la passata non fosse mai girata questa prova non proverebbe niente.
+  expect(
+    await page.evaluate(() => Boolean(document.getElementById("lm-hero-card")?.dataset.evImage)),
+    "la passata che disegna la foto e' girata",
+  ).toBe(true);
+  const after = await page.evaluate(() => ({
+    idle: localStorage.getItem("cd_ev_image"),
+    plugged: localStorage.getItem("cd_ev_image_plugged"),
+  }));
+  expect(after, "la configurazione e' quella che l'utente ha scritto").toEqual(before);
+});

--- a/custom_components/dashboardmodern/frontend/e2e/ev-two-profiles.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/ev-two-profiles.spec.js
@@ -1,0 +1,96 @@
+/* Due auto configurate devono restare due.
+ *
+ * Si mappano le entita' della prima auto, le si salva come profilo, si rimappa
+ * per la seconda e si salva di nuovo: nella pagina Auto compaiono due schede
+ * fra cui scegliere. Il percorso passa da localStorage, dal negozio e da tre
+ * rifiniture diverse, e finora nessuna prova lo copriva dall'inizio alla fine.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { PRIMARY } from "./helpers/variants.js";
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  visibility: { ev: true },
+};
+
+for (const variant of PRIMARY) {
+  test(`${variant}: two saved car profiles both reach the Auto page`, async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(90_000);
+    await bootNamespacedDashboard(page, variant, testInfo, seed);
+    await page.evaluate(() => {
+      if (!document.getElementById("editor-modal")?.classList.contains("show")) apriConfigEntita();
+      const tab = [...document.querySelectorAll("#editor-modal .ed-tab")].find((node) =>
+        /\bEV\b/i.test(node.textContent),
+      );
+      tab?.click();
+    });
+    await expect(page.locator('#ed-body input[placeholder*="Nome auto"]')).toBeVisible();
+
+    const saveProfile = async (name, battery) => {
+      await page.evaluate((entity) => {
+        const input = document.querySelector(
+          '#ed-body .ed-slot-in[data-ref="dm.ev_batteria_auto"]',
+        );
+        if (!input) throw new Error("the battery slot is missing from the EV editor");
+        input.value = entity;
+        input.dispatchEvent(new Event("change", { bubbles: true }));
+      }, battery);
+      await page.locator('#ed-body input[placeholder*="Nome auto"]').fill(name);
+      await page.locator("#ed-body button", { hasText: "SALVA ATTUALE" }).first().click();
+    };
+
+    await saveProfile("Zoe", "sensor.zoe_soc");
+    await expect
+      .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem("cd_ev_cars") || "[]").length))
+      .toBe(1);
+
+    // The second save adds a profile; it does not overwrite the first.
+    await saveProfile("Tesla", "sensor.tesla_soc");
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          JSON.parse(localStorage.getItem("cd_ev_cars") || "[]").map((car) => [
+            car.name,
+            car.ov?.["dm.ev_batteria_auto"],
+          ]),
+        ),
+      )
+      .toEqual([
+        ["Zoe", "sensor.zoe_soc"],
+        ["Tesla", "sensor.tesla_soc"],
+      ]);
+
+    // And the Auto page offers both, not just the one saved last.
+    await page.evaluate(() => {
+      document.getElementById("editor-modal")?.classList.remove("show");
+      document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
+      document.getElementById("page-ev")?.classList.add("active");
+      window.cdEvCarsRefresh?.();
+      window.render?.();
+    });
+
+    const picker = page.locator("#ev-car-picker");
+    await expect(picker).toBeVisible();
+    await expect(picker).toHaveAttribute("data-profile-count", "2");
+    await expect(picker.locator(".dm-vehicle-profile-card")).toHaveCount(2);
+    await expect(picker).toContainText("Zoe");
+    await expect(picker).toContainText("Tesla");
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/ev-two-profiles.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/ev-two-profiles.spec.js
@@ -58,7 +58,9 @@ for (const variant of PRIMARY) {
 
     await saveProfile("Zoe", "sensor.zoe_soc");
     await expect
-      .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem("cd_ev_cars") || "[]").length))
+      .poll(() =>
+        page.evaluate(() => JSON.parse(localStorage.getItem("cd_ev_cars") || "[]").length),
+      )
       .toBe(1);
 
     // The second save adds a profile; it does not overwrite the first.

--- a/custom_components/dashboardmodern/frontend/e2e/idle-overlays-cost-nothing.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/idle-overlays-cost-nothing.spec.js
@@ -1,0 +1,60 @@
+/* Un telefono paga il vetro smerigliato anche quando non si vede.
+ *
+ * Sopra la Home stanno dodici finestre chiuse — meteo, clima, allarme,
+ * carichi, lavatrice, auto, dettagli, tastierino, storico, conferma e i due
+ * storici del server. Sono nascoste, ma restano larghe quanto lo schermo e
+ * ognuna chiedeva al browser di sfocare tutto quello che aveva dietro: dodici
+ * livelli a schermo intero che la GPU tiene in memoria e ricompone a ogni
+ * scorrimento. Dentro due di quelle finestre girava anche una rotella di
+ * caricamento, per sempre, senza che nessuno la stesse guardando.
+ */
+import { expect, test } from "@playwright/test";
+import { PRIMARY } from "./helpers/variants.js";
+
+function idleCost(page) {
+  return page.evaluate(() => {
+    const blurred = [];
+    const spinning = [];
+    for (const element of document.querySelectorAll("*")) {
+      const box = element.getBoundingClientRect();
+      if (!(box.width > 0 && box.height > 0)) continue;
+      const style = getComputedStyle(element);
+      const closed = element.closest(
+        ".modal-wrapper:not(.show),.clima-popup-overlay:not(.show),.hist-overlay:not(.show),#srv-hist-overlay:not(.show)",
+      );
+      if (!closed) continue;
+      const backdrop = style.backdropFilter || style.webkitBackdropFilter || "none";
+      if (backdrop && backdrop !== "none") blurred.push(element.id || element.className);
+      if (
+        style.animationName !== "none" &&
+        style.animationIterationCount === "infinite" &&
+        style.animationPlayState !== "paused"
+      ) {
+        spinning.push(element.id || element.className);
+      }
+    }
+    return { blurred, spinning };
+  });
+}
+
+for (const variant of PRIMARY) {
+  test(`${variant}: a closed overlay costs nothing to keep around`, async ({ page }, testInfo) => {
+    test.setTimeout(90_000);
+    await page.goto(`/legacy/${variant}`);
+    await page.waitForFunction(() => Boolean(document.getElementById("weather-modal")), null, {
+      timeout: 15000,
+    });
+
+    // Every overlay on the page is closed: none of them may blur or animate.
+    await expect.poll(() => idleCost(page)).toEqual({ blurred: [], spinning: [] });
+
+    // The frosted background is what makes a modal read as a modal: it comes
+    // back the moment one opens, which is the only time anybody sees it.
+    await page.evaluate(() => document.getElementById("weather-modal")?.classList.add("show"));
+    const backdrop = await page.evaluate(() => {
+      const style = getComputedStyle(document.getElementById("weather-modal"));
+      return style.backdropFilter || style.webkitBackdropFilter;
+    });
+    expect(backdrop).toMatch(/blur/);
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/lights-phantom-rooms.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/lights-phantom-rooms.spec.js
@@ -1,0 +1,75 @@
+/* Una stanza che c'e' solo sulle luci non e' una stanza fantasma.
+ *
+ * L'importazione dalle aree di Home Assistant assegna a ogni luce il nome della
+ * sua area e, separatamente, aggiunge quelle aree all'elenco delle stanze. Le
+ * due scritture non hanno lo stesso proprietario: l'elenco viene riscritto dal
+ * deposito a ogni salvataggio, l'assegnazione delle luci no. Bastava un
+ * salvataggio perche' le luci restassero a puntare a nomi che nella sezione
+ * Stanze non c'erano piu'.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { PRIMARY } from "./helpers/variants.js";
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [{ id: "room-salone", name: "Salone", icon: "mdi:sofa" }],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [
+      { id: "l1", name: "Piantana", entities: ["light.piantana"] },
+      { id: "l2", name: "Faretti", entities: ["light.faretti"] },
+    ],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  visibility: {},
+};
+
+for (const variant of PRIMARY) {
+  test(`${variant}: una stanza assegnata solo alle luci finisce nell'elenco`, async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(90_000);
+    await bootNamespacedDashboard(page, variant, testInfo, seed);
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "cd_luci",
+        JSON.stringify({ "light.piantana": "Piantana", "light.faretti": "Faretti" }),
+      );
+      // Quello che lascia l'importazione dalle aree: un nome, non un id.
+      localStorage.setItem(
+        "cd_luci_rooms",
+        JSON.stringify({ "light.piantana": "Mansarda", "light.faretti": "Salone" }),
+      );
+    });
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const store = window.DashboardModernModules?.store;
+            store?.dataContracts?.();
+            const rooms = store?.getSection?.("rooms") || [];
+            return rooms.map((room) => room.name).sort();
+          }),
+        { message: "la stanza delle luci compare fra le stanze", timeout: 20_000 },
+      )
+      .toEqual(["Mansarda", "Salone"]);
+
+    const assignment = await page.evaluate(() => {
+      try {
+        return JSON.parse(localStorage.getItem("cd_luci_rooms") || "{}")["light.piantana"];
+      } catch (error) {
+        return null;
+      }
+    });
+    expect(assignment, "la luce punta alla stanza per id").toMatch(/^room-/);
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/lights-phantom-rooms.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/lights-phantom-rooms.spec.js
@@ -50,13 +50,16 @@ for (const variant of PRIMARY) {
         JSON.stringify({ "light.piantana": "Mansarda", "light.faretti": "Salone" }),
       );
     });
+    // La passata sui contratti gira quando il runtime la sveglia: qui la si
+    // sveglia dalla stessa porta, invece di aspettare che passi da sola. Senza
+    // questo la prova dipendeva da quale evento capitasse entro venti secondi,
+    // e su una macchina lenta non ne capitava nessuno.
     await expect
       .poll(
         () =>
           page.evaluate(() => {
-            const store = window.DashboardModernModules?.store;
-            store?.dataContracts?.();
-            const rooms = store?.getSection?.("rooms") || [];
+            window.dispatchEvent(new Event("pageshow"));
+            const rooms = window.DashboardModernModules?.store?.getSection?.("rooms") || [];
             return rooms.map((room) => room.name).sort();
           }),
         { message: "la stanza delle luci compare fra le stanze", timeout: 20_000 },

--- a/custom_components/dashboardmodern/frontend/e2e/minipc-stays-hidden.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/minipc-stays-hidden.spec.js
@@ -1,0 +1,154 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { fillEntityFieldByHand } from "./helpers/entity-field.js";
+import { PRIMARY } from "./helpers/variants.js";
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [
+      {
+        id: "room-cameretta",
+        name: "Cameretta",
+        icon: "🛏️",
+        floor: "Primo piano",
+        temp: "sensor.cameretta_temperature",
+        hum: "sensor.cameretta_humidity",
+        metadata: {},
+      },
+    ],
+    cameras: [],
+    appliances: [
+      {
+        id: "appliance-dishwasher",
+        name: "Lavastoviglie",
+        visual_type: "asset",
+        visual_key: "lavastoviglie",
+        device_type: "lavastoviglie",
+        icon: "lavastoviglie",
+        image: "/local/stale-washer.png",
+        image_url: "/local/stale-washer.png",
+        power_entity: "sensor.dishwasher_power",
+        entities: ["sensor.dishwasher_power"],
+        show_in_dashboard: true,
+      },
+    ],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    energyLoads: [],
+    entityOverrides: {
+      "dm.server_cpu": "sensor.minipc_cpu",
+      "dm.server_ram": "sensor.minipc_ram",
+    },
+  },
+  visibility: { home: true, appliances: true, temperature: true },
+};
+
+async function boot(page, variant, testInfo) {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 150_000 : 90_000);
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript(() => {
+    class MockBridgeSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      readyState = 1;
+      onopen = null;
+      onmessage = null;
+      onclose = null;
+      onerror = null;
+
+      constructor() {
+        queueMicrotask(() => {
+          this.onopen?.({});
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+        });
+      }
+
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") return;
+        let result = null;
+        if (message.type === "get_states") result = [];
+        if (message.type === "frontend/get_user_data") result = { value: null };
+        if (message.type === "frontend/set_user_data") result = null;
+        queueMicrotask(() =>
+          this.onmessage?.({
+            data: JSON.stringify({ id: message.id, type: "result", success: true, result }),
+          }),
+        );
+      }
+
+      close() {
+        this.readyState = 3;
+        this.onclose?.({});
+      }
+    }
+    window.__DASHBOARDMODERN_HOSTED__ = true;
+    window.__DASHBOARDMODERN_BRIDGE_WS__ = MockBridgeSocket;
+    window.WebSocket = MockBridgeSocket;
+  });
+
+  await bootNamespacedDashboard(page, variant, testInfo, seed);
+  await page
+    .locator("#setup-wizard")
+    .evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await expect
+    .poll(() => page.evaluate(() => window.__DASHBOARDMODERN_RUNTIME_ROOT__?.ready === true))
+    .toBe(true);
+}
+
+/* Nascosta a mano vuol dire nascosta.
+ *
+ * Nella mappa delle visibilita' un `false` puo' voler dire due cose opposte:
+ * "non l'ho ancora configurata", che ci scrive la procedura iniziale, oppure
+ * "non la voglio vedere", che ci scrive chi preme il pulsante. La passata che
+ * accende le sezioni configurate le trattava allo stesso modo, e il MiniPC —
+ * che ha delle entita' mappate — tornava su ogni volta.
+ */
+for (const variant of PRIMARY) {
+  test(`${variant}: hiding the MiniPC keeps it hidden`, async ({ page }, testInfo) => {
+    await boot(page, variant, testInfo);
+
+    await page.evaluate(() => {
+      if (!document.getElementById("editor-modal")?.classList.contains("show")) apriConfigEntita();
+      const tab = [...document.querySelectorAll("#editor-modal .ed-tab")].find((node) =>
+        /minipc/i.test(node.textContent),
+      );
+      tab?.click();
+    });
+
+    const banner = page.locator('#ed-body button[data-key="server"]');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText(/visibile|visible/i);
+    await banner.click();
+    await expect(banner).toContainText(/nascosta|hidden/i);
+
+    // La passata che accende le sezioni configurate gira su ogni salvataggio e
+    // su ogni cambio di stato: qui la si sveglia dalle stesse porte.
+    await page.evaluate(() => {
+      window.DashboardModernModules?.store?.replaceSection?.("entityOverrides", {
+        "dm.server_cpu": "sensor.minipc_cpu",
+        "dm.server_ram": "sensor.minipc_ram",
+        "dm.server_disco": "sensor.minipc_disk",
+      });
+      document.dispatchEvent(new Event("submit", { bubbles: true }));
+      window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: {} }));
+    });
+
+    await expect
+      .poll(
+        () => page.evaluate(() => JSON.parse(localStorage.getItem("cd_sections") || "{}").server),
+        { message: "il MiniPC resta nascosto", timeout: 8000 },
+      )
+      .toBe(false);
+    await expect(page.locator('.tab[data-tab="server"]')).toBeHidden();
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/navbar-desktop-scroll.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/navbar-desktop-scroll.spec.js
@@ -153,3 +153,44 @@ test("the touch bar keeps the scrolling it already had", async ({ page }, testIn
   });
   expect(navOverflow).toBeGreaterThan(0);
 });
+
+/* La barra resta dove l'utente l'ha portata.
+ *
+ * Il dock riporta la sezione aperta sotto gli occhi ogni volta che il puntatore
+ * rientra sulla barra. Chi aveva appena scorso con le frecce se la vedeva
+ * scattare indietro proprio mentre tornava a cliccare, e il click cadeva
+ * sull'icona sbagliata. Chi guida vince, finché non cambia sezione.
+ */
+test("the dock stays where it was steered", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "desktop", "the arrows are the fine-pointer layout");
+  test.setTimeout(80_000);
+  await bootWithEverySectionVisible(page, testInfo, { width: 1180, height: 800 });
+  await pinDock(page);
+
+  expect((await portMetrics(page)).canScroll, "the bar overflows").toBe(true);
+
+  await page.locator(".dm-nav-arrow-next").click();
+  // Lo scorrimento e' animato: si legge quando si e' fermato, non appena parte.
+  const settledScroll = async () => {
+    let last = -1;
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      const current = (await portMetrics(page)).scrollLeft;
+      if (current === last) return current;
+      last = current;
+      await page.waitForTimeout(120);
+    }
+    return last;
+  };
+  const steered = await settledScroll();
+  expect(steered, "the arrow scrolled the bar").toBeGreaterThan(0);
+
+  // Rientrare col puntatore non riavvolge quello che l'utente ha scorso.
+  await page.locator(".dm-nav-scroll").hover();
+  await page.waitForTimeout(700);
+  expect(await settledScroll(), "the pointer does not rewind it").toBe(steered);
+
+  // Che il cambio di sezione riporti la barra sulla sezione aperta e' scritto
+  // nel modulo e commentato li'; non e' asserito qui perche' in questa scheda
+  // la sezione aperta e' gia' sotto gli occhi, e una prova che non puo'
+  // fallire non protegge niente.
+});

--- a/custom_components/dashboardmodern/frontend/e2e/rooms-editor-add-row.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/rooms-editor-add-row.spec.js
@@ -1,0 +1,158 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+import { fillEntityFieldByHand } from "./helpers/entity-field.js";
+import { PRIMARY } from "./helpers/variants.js";
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [
+      {
+        id: "room-salone",
+        name: "Salone",
+        icon: "mdi:sofa",
+        floor: "Piano terra",
+        temp: "",
+        hum: "",
+        metadata: {},
+      },
+      {
+        id: "room-bagno",
+        name: "Bagno",
+        icon: "🚿",
+        floor: "Piano terra",
+        temp: "",
+        hum: "",
+        metadata: {},
+      },
+      {
+        id: "room-cameretta",
+        name: "Cameretta",
+        icon: "🛏️",
+        floor: "Primo piano",
+        temp: "sensor.cameretta_temperature",
+        hum: "sensor.cameretta_humidity",
+        metadata: {},
+      },
+    ],
+    cameras: [],
+    appliances: [
+      {
+        id: "appliance-dishwasher",
+        name: "Lavastoviglie",
+        visual_type: "asset",
+        visual_key: "lavastoviglie",
+        device_type: "lavastoviglie",
+        icon: "lavastoviglie",
+        image: "/local/stale-washer.png",
+        image_url: "/local/stale-washer.png",
+        power_entity: "sensor.dishwasher_power",
+        entities: ["sensor.dishwasher_power"],
+        show_in_dashboard: true,
+      },
+    ],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    energyLoads: [],
+    entityOverrides: {},
+  },
+  visibility: { home: true, appliances: true, temperature: true },
+};
+
+async function boot(page, variant, testInfo) {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 150_000 : 90_000);
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await page.addInitScript(() => {
+    class MockBridgeSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      readyState = 1;
+      onopen = null;
+      onmessage = null;
+      onclose = null;
+      onerror = null;
+
+      constructor() {
+        queueMicrotask(() => {
+          this.onopen?.({});
+          this.onmessage?.({ data: JSON.stringify({ type: "auth_ok" }) });
+        });
+      }
+
+      send(raw) {
+        const message = JSON.parse(raw);
+        if (message.type === "auth") return;
+        let result = null;
+        if (message.type === "get_states") result = [];
+        if (message.type === "frontend/get_user_data") result = { value: null };
+        if (message.type === "frontend/set_user_data") result = null;
+        queueMicrotask(() =>
+          this.onmessage?.({
+            data: JSON.stringify({ id: message.id, type: "result", success: true, result }),
+          }),
+        );
+      }
+
+      close() {
+        this.readyState = 3;
+        this.onclose?.({});
+      }
+    }
+    window.__DASHBOARDMODERN_HOSTED__ = true;
+    window.__DASHBOARDMODERN_BRIDGE_WS__ = MockBridgeSocket;
+    window.WebSocket = MockBridgeSocket;
+  });
+
+  await bootNamespacedDashboard(page, variant, testInfo, seed);
+  await page
+    .locator("#setup-wizard")
+    .evaluateAll((nodes) => nodes.forEach((node) => node.remove()));
+  await expect
+    .poll(() => page.evaluate(() => window.__DASHBOARDMODERN_RUNTIME_ROOT__?.ready === true))
+    .toBe(true);
+}
+
+
+
+/* I due campi della riga "aggiungi stanza" erano due quadratini.
+ *
+ * La riga nasce dal runtime come una fila flex; la rifinitura la trasforma in
+ * una griglia, e in una griglia il flex dei campi non vale piu' niente: un
+ * campo di testo vuoto tiene la sua larghezza naturale, cioe' zero, e restano
+ * due riquadri larghi quanto la loro cornice con il resto della riga vuoto. */
+for (const variant of PRIMARY) {
+  test(`${variant}: the add-room fields fill the row`, async ({ page }, testInfo) => {
+    await boot(page, variant, testInfo);
+    await page.evaluate(() => {
+      if (!document.getElementById("editor-modal")?.classList.contains("show")) apriConfigEntita();
+      editorSwitch("stanze");
+    });
+
+    const row = page.locator("#ed-body .dm-beta5-room-add-row");
+    await expect(row).toBeVisible();
+
+    const boxes = await row.evaluate((node) => {
+      const width = (el) => Math.round(el.getBoundingClientRect().width);
+      return {
+        row: width(node),
+        trigger: width(node.querySelector(".dm-beta5-room-icon-trigger")),
+        icon: width(node.querySelector("#ed-room-icon")),
+        name: width(node.querySelector("#ed-room-name")),
+      };
+    });
+
+    // The icon field is the fixed middle column, the name takes what is left.
+    expect(boxes.icon).toBeGreaterThan(100);
+    expect(boxes.name).toBeGreaterThan(boxes.row / 2);
+    // Nothing of the row is left unclaimed.
+    expect(boxes.trigger + boxes.icon + boxes.name).toBeGreaterThan(boxes.row - 40);
+  });
+}

--- a/custom_components/dashboardmodern/frontend/e2e/rooms-editor-add-row.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/rooms-editor-add-row.spec.js
@@ -140,18 +140,22 @@ for (const variant of PRIMARY) {
     await expect(row).toBeVisible();
 
     const boxes = await row.evaluate((node) => {
-      const width = (el) => Math.round(el.getBoundingClientRect().width);
+      const width = (el) =>
+        el && getComputedStyle(el).display !== "none"
+          ? Math.round(el.getBoundingClientRect().width)
+          : 0;
       return {
         row: width(node),
         trigger: width(node.querySelector(".dm-beta5-room-icon-trigger")),
+        // Su schermo stretto il campo dell'icona non c'e': si sceglie con il
+        // pulsante accanto, e la riga porta solo il nome.
         icon: width(node.querySelector("#ed-room-icon")),
         name: width(node.querySelector("#ed-room-name")),
       };
     });
 
-    // The icon field is the fixed middle column, the name takes what is left.
-    expect(boxes.icon).toBeGreaterThan(100);
-    expect(boxes.name).toBeGreaterThan(boxes.row / 2);
+    if (boxes.icon) expect(boxes.icon, "the icon field fills its column").toBeGreaterThan(100);
+    expect(boxes.name, "the name field takes what is left").toBeGreaterThan(boxes.row / 2);
     // Nothing of the row is left unclaimed.
     expect(boxes.trigger + boxes.icon + boxes.name).toBeGreaterThan(boxes.row - 40);
   });

--- a/custom_components/dashboardmodern/frontend/e2e/rooms-editor-add-row.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/rooms-editor-add-row.spec.js
@@ -120,8 +120,6 @@ async function boot(page, variant, testInfo) {
     .toBe(true);
 }
 
-
-
 /* I due campi della riga "aggiungi stanza" erano due quadratini.
  *
  * La riga nasce dal runtime come una fila flex; la rifinitura la trasforma in

--- a/custom_components/dashboardmodern/frontend/e2e/runtime-ui-safari.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/runtime-ui-safari.spec.js
@@ -211,6 +211,17 @@ for (const variant of PRIMARY) {
     expect(visualBox?.height ?? 0).toBeGreaterThanOrEqual(50);
     const image = visual.locator("img.dm-ap-img");
     await expect(image).toBeVisible();
+    /* Visibile non vuol dire disegnata.
+     *
+     * Un <img> ha il suo riquadro appena entra nella pagina, ma la fotografia
+     * arriva dopo: misurarla prima restituisce zero per zero, e su una macchina
+     * carica quel "dopo" arriva piu' tardi di quanto la prova aspettasse. */
+    await expect
+      .poll(() => image.evaluate((node) => node.complete && node.naturalWidth > 0), {
+        message: "la fotografia dell'elettrodomestico e' arrivata",
+        timeout: 15000,
+      })
+      .toBe(true);
     await expect(visual.locator(".dm-appliance-glyph")).toHaveCount(0);
     await expect(visual.locator(".dm-ap-hero-fallback")).toHaveCount(0);
     const imageMetrics = await image.evaluate((node) => {

--- a/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
+++ b/custom_components/dashboardmodern/frontend/src/core/dashboard-store.js
@@ -268,13 +268,33 @@ export class DashboardStore {
     if (!section) return Promise.resolve();
     return this.replaceSection(section, value);
   }
+  /* Le sezioni su cui la persona si e' espressa di persona.
+   *
+   * Nella mappa delle visibilita' un `false` puo' voler dire due cose opposte:
+   * "non l'ho ancora configurata", che ci scrive la procedura iniziale, oppure
+   * "non la voglio vedere", che ci scrive chi preme il pulsante. Questa e'
+   * l'unica cosa che le distingue, e senza di essa una sezione nascosta a mano
+   * tornava accesa alla prima entita' mappata. */
+  manualVisibility() {
+    try {
+      const raw = this.storage?.getItem?.("cd_sections_manual");
+      if (!raw) return {};
+      const value = JSON.parse(raw);
+      return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+    } catch (_error) {
+      return {};
+    }
+  }
   ensureSectionVisibleForData(section) {
+    const manual = this.manualVisibility();
+    const shouldShow = (key) =>
+      Boolean(key) && manual[key] !== true && this.state.visibility[key] !== true;
     if (section === "entityOverrides") {
       let changed = false;
       for (const [slot, entity] of Object.entries(this.state.sections.entityOverrides || {})) {
         if (!configured(entity)) continue;
         const mapped = sectionForEditorSlot(slot);
-        if (mapped && this.state.visibility[mapped] !== true) {
+        if (shouldShow(mapped)) {
           this.state.visibility[mapped] = true;
           changed = true;
         }
@@ -283,8 +303,7 @@ export class DashboardStore {
     }
     const key = VISIBILITY_SECTION[section] || section;
     const value = this.state.sections[section];
-    const hasData = hasConfiguredData(section, value);
-    if (hasData && this.state.visibility[key] !== true) {
+    if (hasConfiguredData(section, value) && shouldShow(key)) {
       this.state.visibility[key] = true;
       return true;
     }

--- a/custom_components/dashboardmodern/frontend/src/sections/appliance-showcase-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/appliance-showcase-section.js
@@ -354,7 +354,7 @@ export function buildCardMarkup(model, labels = copy()) {
           : `<button type="button" class="dm-ap-tool dm-ap-history" disabled aria-disabled="true" title="${esc(labels.history)}" aria-label="${esc(labels.history)}">${ICONS.chart}</button>`
       }
     </span>`;
-  return `<article class="appl-wide-card dm-ap-card is-${badgeClass} acc-${esc(model.accent)}${model.alarm ? " has-alarm" : ""}" data-appliance-id="${esc(model.id)}" data-idx="${model.index}" data-mode="${esc(model.mode)}" data-art="${esc(model.artworkType)}" role="button" tabindex="0" aria-label="${esc(model.name)} — ${esc(model.label)}">
+  return `<article class="appl-wide-card dm-ap-card dm-ap-mech is-${badgeClass} acc-${esc(model.accent)}${model.alarm ? " has-alarm" : ""}" data-appliance-id="${esc(model.id)}" data-idx="${model.index}" data-mode="${esc(model.mode)}" data-art="${esc(model.artworkType)}" role="button" tabindex="0" aria-label="${esc(model.name)} — ${esc(model.label)}">
     <div class="dm-ap-top">
       <span class="dm-ap-chip" aria-hidden="true">${applianceArtwork(model.artworkType, 30) || "🔌"}</span>
       <span class="dm-ap-headings"><span class="dm-ap-name appl-wide-name">${esc(model.name)}</span>${roomName ? `<span class="dm-ap-room">${esc(roomName)}</span>` : ""}</span>
@@ -1073,47 +1073,55 @@ function showcaseCss() {
 .dm-appl-shell .dm-ap-card.is-standby .dm-ap-hero.has-image{filter:none}
 .dm-appl-shell .dm-ap-card.is-unavailable .dm-ap-hero.has-image{filter:grayscale(.6) opacity(.7)}
 /* ── running animations (hero mechanisms) ───────────────────────────── */
-.dm-ap-card.is-run .dm-ap-hero{background:radial-gradient(120% 90% at 50% 8%,rgba(186,230,253,.85),rgba(224,242,254,.35) 62%,transparent)}
-.dm-ap-card.is-run.acc-heat .dm-ap-hero{background:radial-gradient(120% 90% at 50% 12%,rgba(254,215,170,.75),rgba(254,226,226,.35) 62%,transparent)}
+/* Le meccaniche si muovono ovunque compaia il disegno, non solo sulla scheda.
+ *
+ * Queste regole erano scritte su .dm-ap-card, e cosi' il disegno riportato
+ * altrove — nel popup "in funzione", che mostra gli stessi elettrodomestici —
+ * restava un'immagine ferma e per giunta diversa da quella della scheda. La
+ * classe .dm-ap-mech dice "qui dentro c'e' un disegno animabile": la porta la
+ * scheda, la porta la riga del popup, e lo stato .is-run/.is-standby decide se
+ * il meccanismo gira. */
+.dm-ap-mech.is-run .dm-ap-hero{background:radial-gradient(120% 90% at 50% 8%,rgba(186,230,253,.85),rgba(224,242,254,.35) 62%,transparent)}
+.dm-ap-mech.is-run.acc-heat .dm-ap-hero{background:radial-gradient(120% 90% at 50% 12%,rgba(254,215,170,.75),rgba(254,226,226,.35) 62%,transparent)}
 /* Idle mechanisms are hidden until the appliance actually runs. */
-.dm-ap-card:not(.is-run) .dmh-jets,.dm-ap-card:not(.is-run) .dmh-steam,.dm-ap-card:not(.is-run) [data-dm-hero="oven"] .dmh-ring{opacity:0}
-.dm-ap-card:not(.is-run) [data-dm-hero="oven"] .dmh-glow,.dm-ap-card:not(.is-run) [data-dm-hero="microwave"] .dmh-glow,.dm-ap-card:not(.is-run) [data-dm-hero="toaster"] .dmh-glow,.dm-ap-card:not(.is-run) .dmh-zone{opacity:.16;filter:saturate(.25)}
-.dm-ap-card.is-off .dmh-light,.dm-ap-card.is-unavailable .dmh-light{opacity:.35;filter:saturate(.4)}
-.dm-ap-card:not(.is-run) .dmh-led{opacity:.45}
-.dm-ap-card.is-standby .dmh-led{animation:dmDotBreathe 2.4s ease-in-out infinite}
+.dm-ap-mech:not(.is-run) .dmh-jets,.dm-ap-mech:not(.is-run) .dmh-steam,.dm-ap-mech:not(.is-run) [data-dm-hero="oven"] .dmh-ring{opacity:0}
+.dm-ap-mech:not(.is-run) [data-dm-hero="oven"] .dmh-glow,.dm-ap-mech:not(.is-run) [data-dm-hero="microwave"] .dmh-glow,.dm-ap-mech:not(.is-run) [data-dm-hero="toaster"] .dmh-glow,.dm-ap-mech:not(.is-run) .dmh-zone{opacity:.16;filter:saturate(.25)}
+.dm-ap-mech.is-off .dmh-light,.dm-ap-mech.is-unavailable .dmh-light{opacity:.35;filter:saturate(.4)}
+.dm-ap-mech:not(.is-run) .dmh-led{opacity:.45}
+.dm-ap-mech.is-standby .dmh-led{animation:dmDotBreathe 2.4s ease-in-out infinite}
 /* washer / dryer: drum + accent ring spin, gentle wobble */
-.dm-ap-card.is-run [data-dm-hero="washer"] .dmh-drum,.dm-ap-card.is-run [data-dm-hero="dryer"] .dmh-drum{transform-origin:120px 140px;animation:dmDrumSpin 1.6s linear infinite}
-.dm-ap-card.is-run [data-dm-hero="washer"] .dmh-ring,.dm-ap-card.is-run [data-dm-hero="dryer"] .dmh-ring{transform-origin:120px 140px;animation:dmDrumSpin 2.8s linear infinite}
-.dm-ap-card.is-run [data-dm-hero="washer"] svg,.dm-ap-card.is-run [data-dm-hero="dryer"] svg{animation:dmWobble .6s ease-in-out infinite}
+.dm-ap-mech.is-run [data-dm-hero="washer"] .dmh-drum,.dm-ap-mech.is-run [data-dm-hero="dryer"] .dmh-drum{transform-origin:120px 140px;animation:dmDrumSpin 1.6s linear infinite}
+.dm-ap-mech.is-run [data-dm-hero="washer"] .dmh-ring,.dm-ap-mech.is-run [data-dm-hero="dryer"] .dmh-ring{transform-origin:120px 140px;animation:dmDrumSpin 2.8s linear infinite}
+.dm-ap-mech.is-run [data-dm-hero="washer"] svg,.dm-ap-mech.is-run [data-dm-hero="dryer"] svg{animation:dmWobble .6s ease-in-out infinite}
 /* oven: convection fan + interior glow + external heat rings */
-.dm-ap-card.is-run [data-dm-hero="oven"] .dmh-fan{transform-origin:120px 132px;animation:dmDrumSpin 1.3s linear infinite}
-.dm-ap-card.is-run [data-dm-hero="oven"] .dmh-glow{animation:dmGlowPulse 2.2s ease-in-out infinite}
-.dm-ap-card.is-run [data-dm-hero="oven"] .dmh-ring{transform-origin:120px 128px;animation:dmHeatRings 2.4s ease-in-out infinite}
+.dm-ap-mech.is-run [data-dm-hero="oven"] .dmh-fan{transform-origin:120px 132px;animation:dmDrumSpin 1.3s linear infinite}
+.dm-ap-mech.is-run [data-dm-hero="oven"] .dmh-glow{animation:dmGlowPulse 2.2s ease-in-out infinite}
+.dm-ap-mech.is-run [data-dm-hero="oven"] .dmh-ring{transform-origin:120px 128px;animation:dmHeatRings 2.4s ease-in-out infinite}
 /* dishwasher: pumping jets */
-.dm-ap-card.is-run [data-dm-hero="dishwasher"] .dmh-jets{transform-origin:120px 178px;animation:dmJets 1.5s ease-in-out infinite}
+.dm-ap-mech.is-run [data-dm-hero="dishwasher"] .dmh-jets{transform-origin:120px 178px;animation:dmJets 1.5s ease-in-out infinite}
 /* microwave: glow + rotating plate hint */
-.dm-ap-card.is-run [data-dm-hero="microwave"] .dmh-glow{animation:dmGlowPulse 1.9s ease-in-out infinite}
-.dm-ap-card.is-run [data-dm-hero="microwave"] .dmh-plate{transform-origin:100px 146px;animation:dmPlate 2.6s ease-in-out infinite}
+.dm-ap-mech.is-run [data-dm-hero="microwave"] .dmh-glow{animation:dmGlowPulse 1.9s ease-in-out infinite}
+.dm-ap-mech.is-run [data-dm-hero="microwave"] .dmh-plate{transform-origin:100px 146px;animation:dmPlate 2.6s ease-in-out infinite}
 /* cold cabinets */
-.dm-ap-card.is-run .dmh-light{animation:dmGlowPulse 2.6s ease-in-out infinite}
-.dm-ap-card.is-run [data-dm-hero="freezer"] .dmh-frost,.dm-ap-card.is-standby [data-dm-hero="freezer"] .dmh-frost{animation:dmFrost 2.8s ease-in-out infinite}
+.dm-ap-mech.is-run .dmh-light{animation:dmGlowPulse 2.6s ease-in-out infinite}
+.dm-ap-mech.is-run [data-dm-hero="freezer"] .dmh-frost,.dm-ap-mech.is-standby [data-dm-hero="freezer"] .dmh-frost{animation:dmFrost 2.8s ease-in-out infinite}
 /* cooktop zones + toaster elements */
-.dm-ap-card.is-run .dmh-zone,.dm-ap-card.is-run [data-dm-hero="toaster"] .dmh-glow{animation:dmGlowPulse 1.8s ease-in-out infinite}
+.dm-ap-mech.is-run .dmh-zone,.dm-ap-mech.is-run [data-dm-hero="toaster"] .dmh-glow{animation:dmGlowPulse 1.8s ease-in-out infinite}
 /* steam / airflow wisps */
-.dm-ap-card.is-run .dmh-steam{animation:dmSteamRise 2.6s ease-in-out infinite}
+.dm-ap-mech.is-run .dmh-steam{animation:dmSteamRise 2.6s ease-in-out infinite}
 /* fan / robot / boiler / kettle / tv */
-.dm-ap-card.is-run [data-dm-hero="fan"] .dmh-fan{transform-origin:120px 102px;animation:dmDrumSpin 1s linear infinite}
-.dm-ap-card.is-run [data-dm-hero="robot-vacuum"] .dmh-ring{transform-origin:120px 126px;animation:dmDrumSpin 1.8s linear infinite}
-.dm-ap-card.is-run [data-dm-hero="robot-vacuum"] svg{animation:dmRover 2.4s ease-in-out infinite}
-.dm-ap-card.is-run [data-dm-hero="vacuum"] svg,.dm-ap-card.is-run [data-dm-hero="iron"] svg{animation:dmSway 1.9s ease-in-out infinite}
-.dm-ap-card.is-run .dmh-water{animation:dmWaterSway 2.2s ease-in-out infinite}
-.dm-ap-card.is-run [data-dm-hero="kettle"] .dmh-frost{animation:dmBubbleUp 1.7s ease-in infinite}
-.dm-ap-card.is-run [data-dm-hero="television"] .dmh-screen{animation:dmScreen 3.4s ease-in-out infinite}
-.dm-ap-card.is-run [data-dm-hero="coffee"] .dmh-jets{animation:dmJets 1.2s ease-in-out infinite}
-.dm-ap-card.is-run .dmh-led{animation:dmDotBreathe 1.4s ease-in-out infinite}
+.dm-ap-mech.is-run [data-dm-hero="fan"] .dmh-fan{transform-origin:120px 102px;animation:dmDrumSpin 1s linear infinite}
+.dm-ap-mech.is-run [data-dm-hero="robot-vacuum"] .dmh-ring{transform-origin:120px 126px;animation:dmDrumSpin 1.8s linear infinite}
+.dm-ap-mech.is-run [data-dm-hero="robot-vacuum"] svg{animation:dmRover 2.4s ease-in-out infinite}
+.dm-ap-mech.is-run [data-dm-hero="vacuum"] svg,.dm-ap-mech.is-run [data-dm-hero="iron"] svg{animation:dmSway 1.9s ease-in-out infinite}
+.dm-ap-mech.is-run .dmh-water{animation:dmWaterSway 2.2s ease-in-out infinite}
+.dm-ap-mech.is-run [data-dm-hero="kettle"] .dmh-frost{animation:dmBubbleUp 1.7s ease-in infinite}
+.dm-ap-mech.is-run [data-dm-hero="television"] .dmh-screen{animation:dmScreen 3.4s ease-in-out infinite}
+.dm-ap-mech.is-run [data-dm-hero="coffee"] .dmh-jets{animation:dmJets 1.2s ease-in-out infinite}
+.dm-ap-mech.is-run .dmh-led{animation:dmDotBreathe 1.4s ease-in-out infinite}
 /* custom photos: breathing + glow (mechanisms are inside the picture) */
-.dm-ap-card.is-run .dm-ap-hero>.dm-ap-img{animation:dmBreath 3.2s ease-in-out infinite}
-.dm-ap-card.is-run .dm-ap-hero.has-image .dm-ap-img{filter:drop-shadow(0 10px 22px rgba(14,165,233,.35))}
+.dm-ap-mech.is-run .dm-ap-hero>.dm-ap-img{animation:dmBreath 3.2s ease-in-out infinite}
+.dm-ap-mech.is-run .dm-ap-hero.has-image .dm-ap-img{filter:drop-shadow(0 10px 22px rgba(14,165,233,.35))}
 /* fx overlays */
 .dm-ap-fx{position:absolute;inset:0;pointer-events:none}
 .dm-ap-fx-heat{background:radial-gradient(65% 55% at 50% 62%,rgba(251,146,60,.42),rgba(239,68,68,.16) 55%,transparent 75%);animation:dmHeatPulse 2.2s ease-in-out infinite}

--- a/custom_components/dashboardmodern/frontend/src/sections/beta26-real-device-stability-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta26-real-device-stability-section.js
@@ -431,6 +431,34 @@ function objectHasValues(key) {
   );
 }
 
+/* Nascosta a mano vuol dire nascosta.
+ *
+ * Nella mappa delle visibilita' un `false` puo' voler dire due cose opposte:
+ * "questa sezione non l'ho ancora configurata", che ci scrive la procedura
+ * iniziale, oppure "questa sezione non la voglio vedere", che ci scrive chi
+ * preme il pulsante. La passata che accende le sezioni configurate le
+ * trattava allo stesso modo e riscriveva tutti e due: chi nascondeva il MiniPC
+ * — o qualunque altra sezione con delle entita' mappate — se lo ritrovava
+ * acceso poco dopo, ogni volta, senza capire perche'.
+ *
+ * Qui si tiene da parte la sola cosa che distingue i due casi: su quali
+ * sezioni la persona si e' espressa di persona. Su quelle non si torna. */
+const MANUAL_VISIBILITY_KEY = "cd_sections_manual";
+
+export function manualVisibilityChoices() {
+  const value = readJson(MANUAL_VISIBILITY_KEY, {});
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+export function rememberManualVisibility(key) {
+  const name = clean(key);
+  if (!name) return false;
+  const current = manualVisibilityChoices();
+  if (current[name] === true) return false;
+  writeJsonIfChanged(MANUAL_VISIBILITY_KEY, { ...current, [name]: true });
+  return true;
+}
+
 export function legacyVisibilityTargets() {
   const targets = new Set();
   if (listConfigured("cd_stanze", (room) => Boolean(clean(room?.temp) || clean(room?.hum))))
@@ -484,7 +512,10 @@ export function ensureConfiguredSectionsVisible({ sync = true, render = true } =
   const next = visibility && typeof visibility === "object" && !Array.isArray(visibility)
     ? { ...visibility }
     : {};
+  const manual = manualVisibilityChoices();
   for (const key of legacyVisibilityTargets()) {
+    // Su una sezione decisa a mano non si torna, in nessun senso.
+    if (manual[key] === true) continue;
     if (next[key] === true) continue;
     next[key] = true;
     changed = true;
@@ -1206,6 +1237,8 @@ export function installBeta26RealDeviceStability() {
         const manualVisibility =
           button?.matches?.("[data-key]") ||
           /sezione visibile|sezione nascosta|section visible|section hidden/.test(text);
+        if (manualVisibility && clean(button?.getAttribute?.("data-key")))
+          rememberManualVisibility(button.getAttribute("data-key"));
         if (
           button &&
           !manualVisibility &&

--- a/custom_components/dashboardmodern/frontend/src/sections/beta4-mobile-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta4-mobile-polish-section.js
@@ -545,6 +545,23 @@ function schedule() {
 
 function installStyles() {
   installStyle("dm-beta5-root-causes-style", `
+    /* Un telefono paga il vetro smerigliato anche quando non si vede.
+     *
+     * Sopra la Home stanno dodici finestre chiuse: meteo, clima, allarme,
+     * carichi, lavatrice, auto, dettagli, tastierino, storico, conferma e i due
+     * storici del server. Sono nascoste, ma restano larghe quanto lo schermo e
+     * ognuna chiede al browser di sfocare tutto quello che ha dietro. Su un
+     * computer non si nota; su un telefono sono dodici livelli a schermo intero
+     * che la GPU tiene in memoria e ricompone a ogni scorrimento, e la stessa
+     * cosa vale per la barra di navigazione mentre e' ritirata.
+     *
+     * Dentro due di quelle finestre girava anche una rotella di caricamento,
+     * per sempre, senza che nessuno la stesse guardando.
+     *
+     * Lo sfondo sfocato torna appena la finestra si apre, ed e' l'unico momento
+     * in cui qualcuno lo vede. */
+    .modal-wrapper:not(.show),.modal-wrapper:not(.show) *,.clima-popup-overlay:not(.show),.clima-popup-overlay:not(.show) *,.hist-overlay:not(.show),.hist-overlay:not(.show) *,#srv-hist-overlay:not(.show),#srv-hist-overlay:not(.show) *,nav.tabs.bottom-nav-bar:not(.visible){backdrop-filter:none!important;-webkit-backdrop-filter:none!important}
+    .modal-wrapper:not(.show) *,.clima-popup-overlay:not(.show) *,.hist-overlay:not(.show) *,#srv-hist-overlay:not(.show) *{animation-play-state:paused!important}
     .ed-tab[data-tab]>.dm-beta4-tab-icon{display:inline-grid!important;place-items:center!important;flex:0 0 auto!important;min-width:1.2em!important;margin-right:5px!important;visibility:visible!important;opacity:1!important}
     .ed-tab[data-tab]>.dm-beta4-tab-label{display:inline!important;white-space:nowrap!important}
 

--- a/custom_components/dashboardmodern/frontend/src/sections/beta4-mobile-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta4-mobile-polish-section.js
@@ -568,6 +568,15 @@ function installStyles() {
 
     #ed-body[data-dm-beta5-rooms="true"] .dm-beta5-room-add-row{display:grid!important;grid-template-columns:58px 138px minmax(0,1fr)!important;gap:10px!important;align-items:center!important;margin-bottom:10px!important}
     #ed-body[data-dm-beta5-rooms="true"] #ed-room-icon-preview{display:none!important}
+    /* I due campi devono riempire la loro colonna.
+     *
+     * La riga nasce dal runtime come una fila flex e i campi si allargavano con
+     * il loro flex. Qui sopra la riga diventa una griglia, e in una griglia quel
+     * flex non vale piu' niente: un campo di testo tiene la sua larghezza
+     * naturale, che senza testo dentro e' zero. Restavano due quadratini larghi
+     * quanto la loro cornice, con il resto della riga vuoto. La versione stretta
+     * lo aveva gia' risolto per il nome; ora vale anche a schermo largo. */
+    #ed-body[data-dm-beta5-rooms="true"] #ed-room-icon,#ed-body[data-dm-beta5-rooms="true"] #ed-room-name{box-sizing:border-box!important;width:100%!important;min-width:0!important;margin:0!important}
     #ed-body[data-dm-beta5-rooms="true"] .dm-beta5-room-icon-trigger{display:grid!important;place-items:center!important;width:58px!important;height:58px!important;min-width:58px!important;padding:0!important;border:1px solid color-mix(in srgb,var(--info-color,#0ea5e9) 24%,var(--divider-color,#dbe4ee))!important;border-radius:16px!important;background:color-mix(in srgb,var(--info-color,#0ea5e9) 8%,var(--card-background-color,#fff))!important;cursor:pointer!important;overflow:hidden!important}
 
     #ed-body[data-dm-beta5-alerts="true"]{display:grid!important;gap:14px!important}

--- a/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
@@ -52,6 +52,9 @@ export const CONFIG_KEYS = Object.freeze([
   "dm_schema_version",
   "cd_branding",
   "cd_sections",
+  // La scelta fatta a mano sulle sezioni viaggia con la configurazione: se
+  // resta su un solo dispositivo, gli altri se la riaccendono da soli.
+  "cd_sections_manual",
   "cd_section_names",
   "cd_stanze",
   "cd_floors",

--- a/custom_components/dashboardmodern/frontend/src/sections/connection-recovery-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/connection-recovery-section.js
@@ -1,0 +1,147 @@
+/* Rientrare nell'app non deve lasciare la plancia a "CONNECTING…".
+ *
+ * Su iPhone il sistema butta via la pagina dell'app quando passi ad altro: al
+ * rientro il pannello di Home Assistant la ricostruisce da zero. Il runtime
+ * apre la presa verso Home Assistant una volta sola, all'avvio, e se
+ * quell'unico tentativo non va a buon fine non ne prova altri:
+ *
+ *     try { ws = new WebSocket(...); } catch(e) { return; }
+ *
+ * Quel `return` e' un vicolo cieco. Sulla pagina appena ricostruita il ponte
+ * verso il frontend ospite puo' non essere ancora pronto, il costruttore della
+ * presa salta, e la plancia resta con la scritta che sta nel documento appena
+ * aperto — "CONNECTING…" — con i gradi a "--" e i riquadri vuoti. Chiudere e
+ * riaprire l'app la sistema, perche' e' un avvio nuovo in cui il ponte fa in
+ * tempo: e' esattamente cio' che raccontava chi l'ha segnalata.
+ *
+ * Qui non si apre nessuna presa: si richiama `connect()`, quello del runtime,
+ * quando la plancia non e' connessa — al rientro dall'altra app, al ritorno
+ * della rete, e intanto a intervalli che si allargano. Da connessi non resta
+ * acceso niente.
+ */
+import { doc, english, lexicalGlobal, root } from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_CONNECTION_RECOVERY__";
+const state = (root[KEY] ||= { installed: false, listeners: false, timer: 0, attempts: 0, lastTry: 0 });
+
+/** Prima riprova, e il tetto oltre il quale l'attesa non cresce piu'. */
+const FIRST_DELAY = 2000;
+const MAX_DELAY = 30000;
+/** Due tentativi non si accavallano mai piu' stretti di cosi'. */
+export const MIN_GAP_MS = 4000;
+/** Una presa che sta ancora aprendosi dopo tutto questo e' una presa ferma. */
+export const STALE_CONNECTING_MS = 8000;
+
+function legacyConnect() {
+  const candidate = root.connect ?? lexicalGlobal("connect");
+  return typeof candidate === "function" ? candidate : null;
+}
+
+/* Connessa vuol dire autenticata, non "la presa esiste".
+ *
+ * Il pallino prende la classe quando Home Assistant risponde `auth_ok` e la
+ * perde alla chiusura: e' l'unico segnale che dice se i dati arrivano davvero,
+ * ed e' scritto dal runtime, non da qui. */
+export function connectionUp(scope = doc) {
+  return Boolean(scope?.getElementById?.("live-dot")?.classList?.contains("connected"));
+}
+
+/** Lo stato della presa del runtime, `null` quando non ce n'e' una. */
+export function socketReadyState() {
+  const value = lexicalGlobal("ws")?.readyState;
+  return typeof value === "number" ? value : null;
+}
+
+/* Se valga la pena richiamare connect(), e perche'.
+ *
+ * Separata dal resto perche' e' l'unico punto dove si decide qualcosa: il
+ * contorno legge il documento e guarda l'orologio, questa no. */
+export function reconnectDecision({ up, readyState, sinceLastTry, connecting = 0 }) {
+  if (up) return { retry: false, reason: "connessa" };
+  if (readyState === connecting && sinceLastTry < STALE_CONNECTING_MS) {
+    return { retry: false, reason: "sta gia' provando" };
+  }
+  if (sinceLastTry < MIN_GAP_MS) return { retry: false, reason: "troppo presto" };
+  return { retry: true, reason: readyState == null ? "nessuna presa" : "presa ferma" };
+}
+
+/* La scritta dice cosa sta succedendo.
+ *
+ * Il documento nasce con "CONNECTING…" e nessuno la riscrive finche' la presa
+ * non si apre: chi guarda non ha modo di distinguere "sto provando adesso" da
+ * "sono fermo qui da dieci minuti". Da connessi non si tocca niente: quella
+ * scritta appartiene al runtime. */
+function announceRetry() {
+  const label = doc?.getElementById("conn-text");
+  if (!label || connectionUp()) return false;
+  const text = english() ? "Reconnecting…" : "Riconnessione…";
+  if (label.textContent !== text) label.textContent = text;
+  return true;
+}
+
+export function attemptReconnect({ force = false } = {}) {
+  const decision = reconnectDecision({
+    up: connectionUp(),
+    readyState: socketReadyState(),
+    sinceLastTry: Date.now() - state.lastTry,
+    connecting: root.WebSocket?.CONNECTING ?? 0,
+  });
+  if (!force && !decision.retry) return false;
+  const connect = legacyConnect();
+  if (!connect) return false;
+  state.lastTry = Date.now();
+  state.attempts += 1;
+  announceRetry();
+  try {
+    connect();
+  } catch (_error) {
+    return false;
+  }
+  return true;
+}
+
+/* Un solo timer, e solo mentre serve. */
+function watch(delay = FIRST_DELAY) {
+  if (!doc || state.timer) return false;
+  state.timer = root.setTimeout?.(() => {
+    state.timer = 0;
+    if (connectionUp()) {
+      state.attempts = 0;
+      return;
+    }
+    attemptReconnect();
+    watch(Math.min(MAX_DELAY, Math.max(FIRST_DELAY, delay * 2)));
+  }, Math.max(0, delay));
+  return Boolean(state.timer);
+}
+
+/* Il rientro azzera l'attesa: chi ha appena riaperto l'app la sta guardando. */
+function resume() {
+  if (connectionUp()) return false;
+  state.attempts = 0;
+  attemptReconnect();
+  watch(FIRST_DELAY);
+  return true;
+}
+
+export function installConnectionRecoverySection() {
+  if (!doc) return false;
+  if (!state.listeners) {
+    state.listeners = true;
+    doc.addEventListener("visibilitychange", () => {
+      if (doc.visibilityState === "visible") resume();
+    });
+    for (const event of ["pageshow", "focus", "online", "dashboardmodern:legacy-ready"]) {
+      root.addEventListener?.(event, resume);
+    }
+  }
+  watch(FIRST_DELAY);
+  state.installed = true;
+  return true;
+}
+
+if (doc?.readyState === "loading") {
+  doc.addEventListener("DOMContentLoaded", installConnectionRecoverySection, { once: true });
+} else if (doc) {
+  installConnectionRecoverySection();
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/connection-recovery-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/connection-recovery-section.js
@@ -56,12 +56,18 @@ export function socketReadyState() {
  *
  * Separata dal resto perche' e' l'unico punto dove si decide qualcosa: il
  * contorno legge il documento e guarda l'orologio, questa no. */
-export function reconnectDecision({ up, readyState, sinceLastTry, connecting = 0 }) {
+export function reconnectDecision({ up, readyState, sinceLastTry, connecting = 0, eager = false }) {
   if (up) return { retry: false, reason: "connessa" };
   if (readyState === connecting && sinceLastTry < STALE_CONNECTING_MS) {
     return { retry: false, reason: "sta gia' provando" };
   }
-  if (sinceLastTry < MIN_GAP_MS) return { retry: false, reason: "troppo presto" };
+  /* Chi ha appena riaperto l'app non aspetta il turno.
+   *
+   * La pausa fra due tentativi serve a non impilare prese mentre nessuno
+   * guarda. Al rientro qualcuno sta guardando lo schermo adesso: la prova si fa
+   * subito, e l'unico freno che resta e' quello che conta davvero — non
+   * aprirne una seconda sopra una che si sta ancora aprendo. */
+  if (!eager && sinceLastTry < MIN_GAP_MS) return { retry: false, reason: "troppo presto" };
   return { retry: true, reason: readyState == null ? "nessuna presa" : "presa ferma" };
 }
 
@@ -79,12 +85,13 @@ function announceRetry() {
   return true;
 }
 
-export function attemptReconnect({ force = false } = {}) {
+export function attemptReconnect({ force = false, eager = false } = {}) {
   const decision = reconnectDecision({
     up: connectionUp(),
     readyState: socketReadyState(),
     sinceLastTry: Date.now() - state.lastTry,
     connecting: root.WebSocket?.CONNECTING ?? 0,
+    eager,
   });
   if (!force && !decision.retry) return false;
   const connect = legacyConnect();
@@ -119,7 +126,7 @@ function watch(delay = FIRST_DELAY) {
 function resume() {
   if (connectionUp()) return false;
   state.attempts = 0;
-  attemptReconnect();
+  attemptReconnect({ eager: true });
   watch(FIRST_DELAY);
   return true;
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/data-contracts-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/data-contracts-section.js
@@ -269,6 +269,7 @@ function normalizeLegacyLightRooms() {
   if (!rooms.length) return false;
   const lights = readJson("cd_luci", {});
   const assignments = readJson("cd_luci_rooms", {});
+  const adopted = new Map();
   let changed = false;
   for (const [entity, name] of Object.entries(lights)) {
     const raw = clean(assignments[entity]);
@@ -285,7 +286,30 @@ function normalizeLegacyLightRooms() {
     if (resolved && assignments[entity] !== resolved.id) {
       assignments[entity] = resolved.id;
       changed = true;
+      continue;
     }
+    /* Una stanza che c'e' solo sulle luci non e' una stanza fantasma: e' una
+     * stanza che manca all'elenco.
+     *
+     * L'importazione dalle aree di Home Assistant assegna a ogni luce il nome
+     * della sua area e, separatamente, aggiunge quelle aree all'elenco delle
+     * stanze. Le due scritture non hanno lo stesso proprietario: l'elenco viene
+     * riscritto dal deposito a ogni salvataggio, l'assegnazione delle luci no.
+     * Bastava un salvataggio perche' l'elenco perdesse le aree e le luci
+     * restassero a puntare a nomi che nella sezione Stanze non c'erano piu'.
+     * Il nome viene adottato: era una stanza vera, torna nell'elenco. */
+    if (!resolved && raw) adopted.set(raw, (adopted.get(raw) || []).concat(entity));
+  }
+  if (adopted.size) {
+    const next = rooms.slice();
+    for (const [name, entities] of adopted) {
+      const id = `room-${slug(name) || next.length + 1}`;
+      if (next.some((room) => clean(room.id) === id)) continue;
+      next.push({ id, name, icon: "🏠" });
+      for (const entity of entities) assignments[entity] = id;
+      changed = true;
+    }
+    if (changed) dashboardStore()?.replaceSection?.("rooms", next);
   }
   if (!changed) return false;
   writeJsonIfChanged("cd_luci_rooms", assignments, { sync: false });

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-contracts-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-contracts-section.js
@@ -278,7 +278,7 @@ function normalizeEnergyGuide() {
     intro.innerHTML = `<strong>⚡ ${t("Come leggere la configurazione Energia", "How to read the Energy configuration")}</strong>
       <div class="dm-energy-guide-steps">
         <span><b>1 · ${t("Storico e mesi precedenti", "History and previous months")}</b><small>${t("usa il contatore totale kWh tramite Recorder", "use the total kWh meter through Recorder")}</small></span>
-        <span><b>2 · ${t("Giorno / Mese / Anno", "Day / Month / Year")}</b><small>${t("sono override facoltativi del singolo periodo", "are optional overrides for that period")}</small></span>
+        <span><b>2 · ${t("Giorno / Mese / Anno", "Day / Month / Year")}</b><small>${t("servono solo se non c'è un contatore totale: quando c'è, comanda lui", "only used when there is no total meter: when there is one, it wins")}</small></span>
         <span><b>3 · ${t("Consumo Casa", "Home consumption")}</b><small>${t("usa il bilancio Home Assistant quando Fotovoltaico e Rete sono completi; Casa resta fallback", "uses the Home Assistant balance when Solar and Grid are complete; Home remains the fallback")}</small></span>
       </div>`;
   }

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-crud-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-crud-section.js
@@ -336,7 +336,10 @@ function installStyles() {
       #editor-modal #ed-body:has(#ed-irr-ent) button{box-sizing:border-box!important;min-width:44px!important;min-height:44px!important;max-width:100%!important;white-space:normal!important}
       #editor-modal #ed-body:has(#ed-irr-ent) .ed-btn-add,#editor-modal #ed-body:has(#ed-irr-ent) .ed-save-btn{display:flex!important;align-items:center!important;justify-content:center!important;width:100%!important;max-width:100%!important;min-height:48px!important;margin:10px 0 0!important;padding:10px 12px!important}
 
-      #editor-modal [data-energy-panel="report"] .dm-report-row{display:grid!important;grid-template-columns:minmax(120px,.8fr) minmax(150px,1.25fr) minmax(110px,.6fr) minmax(220px,1.8fr) auto!important;gap:10px!important;align-items:end!important;padding:14px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:16px!important;background:var(--ha-card-background,var(--card-bg,#fff))!important}
+      /* La riga del Report la impagina report-editor-section, che e' quella che
+         le da' anche le aree: due griglie diverse sullo stesso elemento
+         lasciavano le colonne di una e le aree dell'altra, ed era quello che si
+         vedeva sballato. Qui resta solo cio' che non e' impaginazione. */
       #editor-modal [data-energy-panel="report"] .dm-report-row .dm-entity-field{min-width:0!important;margin:0!important}
       #editor-modal .dm-report-history-help{grid-column:1/-1;color:var(--secondary-text-color,#64748b);font-size:11px;line-height:1.4}
       #editor-modal .dm-report-row[data-history-valid="false"] .dm-report-history-help{color:var(--warning-color,#b45309);font-weight:800}

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-crud-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-crud-section.js
@@ -359,7 +359,48 @@ function installStyles() {
   );
 }
 
+/* "sezioni" non e' piu' una scheda.
+ *
+ * L'editor aveva una sola scheda Sezioni; adesso ce n'e' una per sezione, da
+ * sez0 a sez9, e il nome "sezioni" non corrisponde piu' a niente: editorSwitch
+ * lo riconosce come nome vecchio e non ridisegna nulla, mentre la barra in alto
+ * perde anche la scheda evidenziata.
+ *
+ * Ventiquattro punti del runtime lo chiamano ancora dopo aver aggiunto o
+ * eliminato qualcosa. Premendo il cestino su un'unita' clima l'elenco restava
+ * quello di prima, e il ridisegno parziale che segue lo lasciava sfasato: la
+ * riga eliminata spariva, l'ultima compariva due volte, e il contatore in alto
+ * diceva un numero che non tornava con nulla.
+ *
+ * Il nome vecchio viene tradotto nella scheda davvero aperta, cosi' l'elenco si
+ * ridisegna dove si sta guardando. */
+function retiredTabTarget() {
+  const active = clean(doc?.querySelector("#editor-modal .ed-tab.active")?.dataset?.tab);
+  if (active && active !== "sezioni") return active;
+  const first = clean(
+    doc?.querySelector('#editor-modal .ed-tab[data-tab^="sez"]')?.dataset?.tab,
+  );
+  return first && first !== "sezioni" ? first : "";
+}
+
+function installRetiredTabRepair() {
+  const current = root.editorSwitch;
+  if (typeof current !== "function" || current.__dmRetiredTabRepair) return false;
+  function editorSwitchOwner(tab, ...rest) {
+    if (clean(tab) === "sezioni") {
+      const target = retiredTabTarget();
+      if (target) return current.call(this, target, ...rest);
+    }
+    return current.call(this, tab, ...rest);
+  }
+  editorSwitchOwner.__dmRetiredTabRepair = true;
+  editorSwitchOwner.__dmRetiredTabOriginal = current;
+  root.editorSwitch = editorSwitchOwner;
+  return true;
+}
+
 function installWrappers() {
+  installRetiredTabRepair();
   wrapFunction("editorSwitch", "__dmCrudEditorSection", runContracts);
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-crud-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-crud-section.js
@@ -95,13 +95,34 @@ function editButton(kind, index) {
   return button;
 }
 
+/* Tutte le righe dell'elenco, comprese quelle gia' sistemate.
+ *
+ * Qui si escludevano le righe che avevano gia' il pulsante di modifica. Il
+ * seguito pero' numera le righe contando da capo su cio' che riceve: se una
+ * passata ne trova alcune gia' sistemate e altre no — cosa che accade ogni
+ * volta che il runtime ridisegna una parte dell'elenco — le nuove ripartono da
+ * zero e finiscono con lo stesso numero di righe che stanno piu' in alto. Chi
+ * dipinge le righe legge quel numero per sapere quale unita' mostrare, e due
+ * righe con lo stesso numero mostrano la stessa unita'. */
 function rowsBeforeForm(container, selector) {
   const field = container?.querySelector(selector);
   if (!container || !field) return [];
   return [...container.querySelectorAll(".ed-row")].filter((row) => {
-    if (row.contains(field) || row.querySelector("[data-dm-edit-kind]")) return false;
+    if (row.contains(field)) return false;
     return Boolean(row.querySelector(".ed-del")) && Boolean(row.compareDocumentPosition(field) & Node.DOCUMENT_POSITION_FOLLOWING);
   });
+}
+
+/* Che fare di ogni riga, e con quale numero.
+ *
+ * Il numero di una riga e' la sua posizione nell'elenco, non il suo turno di
+ * arrivo: una riga gia' sistemata ma numerata male va corretta, non lasciata
+ * com'e'. Separato dal documento perche' e' l'unica parte che decide. */
+export function editButtonPlan(rows = []) {
+  return rows.map((row, index) => ({
+    index,
+    action: !row?.hasButton ? "create" : row.index === index ? "keep" : "renumber",
+  }));
 }
 
 function ensureEditButtons() {
@@ -115,9 +136,22 @@ function ensureEditButtons() {
   ];
   definitions.forEach(([kind, container, selector]) => {
     if (!container?.querySelector(selector)) return;
-    rowsBeforeForm(container, selector).forEach((row, index) => {
-      const remove = [...row.querySelectorAll(".ed-del")].at(-1);
-      remove?.before(editButton(kind, index));
+    const rows = rowsBeforeForm(container, selector);
+    const existing = rows.map((row) => row.querySelector(`[data-dm-edit-kind="${kind}"]`));
+    const plan = editButtonPlan(
+      existing.map((button) => ({
+        hasButton: Boolean(button),
+        index: button ? Number.parseInt(button.dataset.dmEditIndex ?? "-1", 10) : -1,
+      })),
+    );
+    plan.forEach((step, position) => {
+      const row = rows[position];
+      if (step.action === "create") {
+        const remove = [...row.querySelectorAll(".ed-del")].at(-1);
+        remove?.before(editButton(kind, step.index));
+        return;
+      }
+      if (step.action === "renumber") existing[position].dataset.dmEditIndex = String(step.index);
     });
   });
   return Boolean(body.querySelector("[data-dm-edit-kind]"));

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
@@ -26,7 +26,7 @@
  * an entity already in `_RAW_STATES`.
  */
 import { isRetiredEditorSlot } from "../core/editor-slots.js";
-import { clean, doc, root, installStyle, t, wrapFunction } from "./shared.js";
+import { clean, doc, esc, installStyle, root, t, wrapFunction } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_EDITOR_SLOTS__";
 const STYLE_ID = "dm-editor-slots-style";
@@ -219,19 +219,41 @@ const FIELD_CAPTIONS = Object.freeze({
  * la cima. Il riferimento resta quello che e', cambia solo cio' che si legge.
  */
 const SLOT_LABELS = Object.freeze({
-  "dm.boiler_sonda_temperatura_1": ["Sonda pannello solare (°C)", "Solar collector probe (°C)"],
-  "dm.boiler_sonda_temperatura_2": ["Sonda accumulo basso (°C)", "Tank bottom probe (°C)"],
-  "dm.boiler_sonda_temperatura_3": ["Sonda accumulo alto (°C)", "Tank top probe (°C)"],
+  "dm.boiler_sonda_temperatura_1": [
+    "Sonda pannello solare (°C)",
+    "Solar collector probe (°C)",
+    "Sonda temperatura 1 (°C)",
+  ],
+  "dm.boiler_sonda_temperatura_2": [
+    "Sonda accumulo basso (°C)",
+    "Tank bottom probe (°C)",
+    "Sonda temperatura 2 (°C)",
+  ],
+  "dm.boiler_sonda_temperatura_3": [
+    "Sonda accumulo alto (°C)",
+    "Tank top probe (°C)",
+    "Sonda temperatura 3 (°C)",
+  ],
 });
 
-/* L'etichetta di una riga che l'utente puo' rinominare resta sua: qui si
- * riscrive solo il testo che il runtime stampa da se'. */
+/* L'etichetta di una riga che l'utente ha rinominato resta sua.
+ *
+ * Queste righe si possono rinominare, quindi il nome sta in un campo e non in
+ * un testo: si riscrive solo finche' porta ancora il nome di fabbrica, quello
+ * che il runtime stampa da se'. Chi l'ha cambiato se lo tiene. */
 function relabelSlot(slot, input) {
   const known = SLOT_LABELS[clean(input?.dataset?.ref)];
   if (!known) return;
   const label = slot.querySelector(".ed-slot-lbl");
-  if (!label || label.querySelector("input,select,textarea")) return;
+  if (!label) return;
   const text = t(known[0], known[1]);
+  const field = label.querySelector("input,textarea");
+  if (field) {
+    if (clean(field.value) !== clean(known[2])) return;
+    if (field.value !== text) field.value = text;
+    return;
+  }
+  if (label.querySelector("select")) return;
   if (clean(label.textContent) !== text) label.textContent = text;
 }
 
@@ -334,11 +356,11 @@ const CHIP_LAYOUT = Object.freeze([
 ]);
 const MANUAL_LAYOUT = Object.freeze([
   ["order", "2"],
-  ["flex", "0 0 36px"],
+  ["flex", "0 0 auto"],
   ["grid-column", "auto"],
-  ["width", "36px"],
+  ["width", "auto"],
   ["min-width", "36px"],
-  ["max-width", "36px"],
+  ["max-width", "none"],
   ["height", "36px"],
 ]);
 const CAPTION_LAYOUT = Object.freeze([
@@ -384,6 +406,9 @@ function paintFieldChip(host) {
   // identical content would quietly cost the user the value being typed.
   const mapped = value ? "mapped" : "empty";
   if (host.dataset.dmSlot !== mapped) host.dataset.dmSlot = mapped;
+  // Non si toglie quello che non c'e'.
+  const clearButton = host.querySelector(":scope > .dm-chip-clear");
+  if (clearButton) clearButton.hidden = !value;
   const name = chip.querySelector("[data-chip-name]");
   const id = chip.querySelector("[data-chip-id]");
   if (!name || !id) return;
@@ -427,12 +452,32 @@ function decorateField(input) {
   lens.classList.add("dm-slot-chip");
   lens.innerHTML = chipMarkup();
 
+  /* La matita da sola non diceva a cosa serviva.
+   *
+   * Chi arrivava su un campo gia' compilato non aveva modo di sapere che quel
+   * pulsante apre l'id da scrivere a mano, ne' come si toglie un'entita'
+   * sbagliata. Adesso i due comandi sono scritti: si modifica a mano, oppure si
+   * svuota il campo. Il secondo compare solo quando c'e' qualcosa da togliere. */
   const manual = doc.createElement("button");
   manual.type = "button";
   manual.className = "dm-chip-manual";
-  manual.textContent = "✏️";
+  manual.innerHTML = `<span aria-hidden="true">✏️</span><span class="dm-chip-manual-tx">${esc(t("Modifica", "Edit"))}</span>`;
   manual.setAttribute("aria-label", t("Modifica manuale", "Edit by hand"));
   manual.setAttribute("aria-pressed", "false");
+
+  const clearField = doc.createElement("button");
+  clearField.type = "button";
+  clearField.className = "dm-chip-clear";
+  clearField.innerHTML = `<span aria-hidden="true">🗑</span><span class="dm-chip-manual-tx">${esc(t("Elimina", "Remove"))}</span>`;
+  clearField.setAttribute("aria-label", t("Togli l'entità da questo campo", "Remove the entity from this field"));
+  clearField.addEventListener("click", (event) => {
+    event.preventDefault();
+    if (!clean(input.value)) return;
+    input.value = "";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    paintFieldChip(host);
+  });
   manual.addEventListener("click", (event) => {
     event.preventDefault();
     const on = host.dataset.dmEntityRaw !== "true";
@@ -443,6 +488,7 @@ function decorateField(input) {
   // After the lens, never between the field and the lens: that pair is a
   // contract every other owner of these forms reconciles.
   lens.insertAdjacentElement("afterend", manual);
+  manual.insertAdjacentElement("afterend", clearField);
 
   // After the form's own change handlers, never during them.
   input.addEventListener("change", () => {
@@ -613,6 +659,30 @@ function installStyles() {
    in the dark editor, the same as the label itself. */
 #editor-modal[data-dm-editor-theme="dark"] .dm-chip-caption{
   color:var(--text-dim,#92a4c2)!important
+}
+/* I due comandi del campo, scritti. La matita da sola non diceva a cosa
+   serviva, e non c'era modo di capire come si toglie un'entita' sbagliata. */
+[data-dm-entity-chip="true"] .dm-chip-manual,
+[data-dm-entity-chip="true"] .dm-chip-clear{
+  display:inline-flex!important;align-items:center!important;gap:5px!important;
+  padding:0 10px!important;border-radius:999px!important;
+  font-size:11.5px!important;font-weight:800!important;line-height:1!important;
+  white-space:nowrap!important;cursor:pointer!important
+}
+[data-dm-entity-chip="true"] .dm-chip-clear{
+  order:2!important;flex:0 0 auto!important;height:36px!important;
+  border:1px solid var(--divider-color,#dbe4ee)!important;background:transparent!important;
+  color:var(--secondary-text-color,#64748b)!important
+}
+[data-dm-entity-chip="true"] .dm-chip-clear[hidden]{display:none!important}
+[data-dm-entity-chip="true"] .dm-chip-clear:hover{
+  border-color:var(--error-color,#dc2626)!important;color:var(--error-color,#dc2626)!important
+}
+/* Il testo resta anche stretto: e' sul telefono che la matita da sola non si
+   capiva, quindi nasconderlo li' sarebbe stato togliere proprio la risposta. */
+@media(max-width:520px){
+  [data-dm-entity-chip="true"] .dm-chip-manual,
+  [data-dm-entity-chip="true"] .dm-chip-clear{padding:0 8px!important;font-size:11px!important}
 }
 [data-dm-entity-chip="true"] .dm-chip-manual{
   order:2!important;flex:0 0 36px!important;width:36px!important;min-width:36px!important;

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
@@ -427,9 +427,17 @@ function decorateField(input) {
     }
     root.requestAnimationFrame(() => paintFieldChip(host));
   });
-  pin(host, CARD_LAYOUT);
-  pin(lens, CHIP_LAYOUT);
-  pin(manual, MANUAL_LAYOUT);
+  /* La riga del Report si impagina da sola: ha la sua etichetta con la matita,
+   * il quadratino dell'icona e, in fondo, il pulsante che apre la voce per
+   * intero. Farne una card qui significava una cornice dentro la cornice e una
+   * seconda matita a capo, e siccome questa impaginazione si scrive
+   * sull'elemento nessun foglio di stile poteva rimediare. La card serve dove
+   * il campo e' nudo, non dove la riga lo veste gia'. */
+  if (!input.closest(".dm-report-row")) {
+    pin(host, CARD_LAYOUT);
+    pin(lens, CHIP_LAYOUT);
+    pin(manual, MANUAL_LAYOUT);
+  }
   ensureFieldCaption(host, input);
   paintFieldChip(host);
   return true;

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
@@ -209,7 +209,84 @@ const FIELD_CAPTIONS = Object.freeze({
   "luce-add-ent": ["Entità luce", "Light entity"],
   "ed-st-temp": ["Sensore temperatura", "Temperature sensor"],
   "ed-st-hum": ["Sensore umidità", "Humidity sensor"],
+  "wz-qa-ent": ["Entità da comandare", "Entity to control"],
+  "ed-qa-ent": ["Entità da comandare", "Entity to control"],
+  "wz-dev-sw": ["Interruttore del dispositivo", "Device switch"],
+  "wz-dev-pw": ["Potenza istantanea (W)", "Instant power (W)"],
+  "wz-dev-sv": ["Stato o programma", "State or programme"],
+  "wz-rep-ent": ["Contatore energia (kWh)", "Energy meter (kWh)"],
+  "ed-rep2-ent": ["Contatore energia (kWh)", "Energy meter (kWh)"],
+  "ed-lu-ent": ["Entità luce", "Light entity"],
 });
+
+/* Un esempio deve insegnare qualcosa.
+ *
+ * I campi entita' suggerivano "dm.core_054 / dm.core_023 / scene.x". Quei
+ * codici sono i nomi interni degli slot di questa dashboard, non entita' che
+ * qualcuno abbia davvero in casa: chi configurava leggeva una sigla e non
+ * poteva sapere cosa scriverci, e nel campo delle Azioni la sigla finiva anche
+ * come didascalia della riga. Ogni campo dice adesso che cosa vuole, con un
+ * esempio scritto come Home Assistant scrive le sue entita'. */
+const PLACEHOLDERS = Object.freeze({
+  "wz-qa-ent": [
+    "Entità da comandare, es. switch.luce_salone",
+    "Entity to control, e.g. switch.luce_salone",
+  ],
+  "ed-qa-ent": [
+    "Interruttore, luce o scena da comandare — i popup non ne hanno bisogno",
+    "Switch, light or scene to control — popups do not need one",
+  ],
+  "wz-dev-sw": [
+    "Facoltativo: interruttore, es. switch.lavatrice",
+    "Optional: switch, e.g. switch.lavatrice",
+  ],
+  "wz-dev-pw": [
+    "Facoltativo: potenza in W, es. sensor.lavatrice_potenza",
+    "Optional: power in W, e.g. sensor.lavatrice_potenza",
+  ],
+  "wz-dev-sv": [
+    "Facoltativo: stato o programma, es. sensor.lavatrice_stato",
+    "Optional: state or programme, e.g. sensor.lavatrice_stato",
+  ],
+  "wz-rep-ent": [
+    "Contatore in kWh, es. sensor.lavatrice_energia",
+    "kWh meter, e.g. sensor.lavatrice_energia",
+  ],
+  "ed-rep2-ent": [
+    "Contatore in kWh, es. sensor.lavatrice_energia",
+    "kWh meter, e.g. sensor.lavatrice_energia",
+  ],
+  "ed-lu-ent": ["Entità luce, es. light.salone", "Light entity, e.g. light.salone"],
+});
+
+const GENERIC_PLACEHOLDER = Object.freeze([
+  "Scegli con 🔍, oppure scrivi l'entità: dominio.nome",
+  "Pick with 🔍, or type the entity: domain.name",
+]);
+
+const PLACEHOLDER_SELECTOR = [
+  'input[placeholder*="dm.core_"]',
+  ...Object.keys(PLACEHOLDERS).map((id) => `#${id}[placeholder]`),
+].join(",");
+
+function rewritePlaceholder(input) {
+  const known = PLACEHOLDERS[input.id];
+  const current = input.getAttribute("placeholder") || "";
+  if (!known && !current.includes("dm.core_")) return false;
+  const text = known ? t(known[0], known[1]) : t(GENERIC_PLACEHOLDER[0], GENERIC_PLACEHOLDER[1]);
+  if (current === text) return false;
+  input.setAttribute("placeholder", text);
+  return true;
+}
+
+export function clarifyEntityPlaceholders(scope = doc) {
+  if (!scope?.querySelectorAll) return 0;
+  let count = 0;
+  for (const input of scope.querySelectorAll(PLACEHOLDER_SELECTOR)) {
+    if (rewritePlaceholder(input)) count += 1;
+  }
+  return count;
+}
 
 /* Nomi che dicono cosa misura la sonda, non in che ordine e' stata scritta.
  *
@@ -537,6 +614,7 @@ export function decorateEntityFields(scope = doc?.getElementById("ed-body")) {
 
 export function decorateEditorSlots(scope = doc?.getElementById("ed-body")) {
   if (!scope) return 0;
+  clarifyEntityPlaceholders();
   dropRetiredSlots(scope);
   let count = 0;
   for (const body of scope.querySelectorAll(".ed-acc-body")) if (decorateBody(body)) count += 1;

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
@@ -61,6 +61,7 @@ function decorate(slot) {
   if (!isSlotRow(slot)) return false;
   const input = slot.querySelector(".ed-slot-in[data-ref]");
   slot.classList.add("dm-slot");
+  relabelSlot(slot, input);
   let chip = slot.querySelector(":scope > .dm-slot-chip");
   if (!chip) {
     chip = doc.createElement("button");
@@ -209,6 +210,30 @@ const FIELD_CAPTIONS = Object.freeze({
   "ed-st-temp": ["Sensore temperatura", "Temperature sensor"],
   "ed-st-hum": ["Sensore umidità", "Humidity sensor"],
 });
+
+/* Nomi che dicono cosa misura la sonda, non in che ordine e' stata scritta.
+ *
+ * Il solare termico chiedeva "Sonda temperatura 1, 2, 3" e chi configura non ha
+ * modo di indovinare quale va dove. Dal disegno della pagina si sa: la prima
+ * alimenta la lettura del pannello, la seconda il fondo dell'accumulo, la terza
+ * la cima. Il riferimento resta quello che e', cambia solo cio' che si legge.
+ */
+const SLOT_LABELS = Object.freeze({
+  "dm.boiler_sonda_temperatura_1": ["Sonda pannello solare (°C)", "Solar collector probe (°C)"],
+  "dm.boiler_sonda_temperatura_2": ["Sonda accumulo basso (°C)", "Tank bottom probe (°C)"],
+  "dm.boiler_sonda_temperatura_3": ["Sonda accumulo alto (°C)", "Tank top probe (°C)"],
+});
+
+/* L'etichetta di una riga che l'utente puo' rinominare resta sua: qui si
+ * riscrive solo il testo che il runtime stampa da se'. */
+function relabelSlot(slot, input) {
+  const known = SLOT_LABELS[clean(input?.dataset?.ref)];
+  if (!known) return;
+  const label = slot.querySelector(".ed-slot-lbl");
+  if (!label || label.querySelector("input,select,textarea")) return;
+  const text = t(known[0], known[1]);
+  if (clean(label.textContent) !== text) label.textContent = text;
+}
 
 function fieldAlreadyLabelled(input) {
   if (!input) return true;

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-guidance-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-guidance-section.js
@@ -1,4 +1,16 @@
-import { clean, doc, english, installStyle, root, section, t, wrapFunction } from "./shared.js";
+import {
+  clean,
+  dashboardStore,
+  doc,
+  energyPeriodConflicts,
+  english,
+  esc,
+  installStyle,
+  root,
+  section,
+  t,
+  wrapFunction,
+} from "./shared.js";
 
 globalThis.__DM_20260815C__ = true;
 const KEY = "__DASHBOARDMODERN_ENERGY_GUIDANCE_SECTION__";
@@ -39,6 +51,97 @@ function contractCard(group, title, icon) {
   </article>`;
 }
 
+const CLASH_LABELS = Object.freeze({
+  "house:total_energy": ["Casa", "Home"],
+  "solar:total_energy": ["Fotovoltaico", "Solar"],
+  "grid:total_import_energy": ["Rete prelevata", "Grid import"],
+  "grid:total_export_energy": ["Rete immessa", "Grid export"],
+  "battery:total_charged_energy": ["Batteria caricata", "Battery charged"],
+  "battery:total_discharged_energy": ["Batteria scaricata", "Battery discharged"],
+});
+
+const PERIOD_ORDER = Object.freeze(["daily", "monthly", "annual"]);
+
+function periodLabel(key) {
+  if (key.startsWith("daily")) return t("Giornaliera", "Daily");
+  if (key.startsWith("monthly")) return t("Mensile", "Monthly");
+  return t("Annuale", "Annual");
+}
+
+/* La configurazione com'e' stata scritta, non come viene letta.
+ *
+ * section("energy") passa dal filtro che toglie i campi di periodo quando c'e'
+ * un totale: leggerla qui mostrerebbe una maschera gia' pulita e non ci sarebbe
+ * piu' niente da segnalare. L'avviso deve nascere dai valori grezzi. */
+function configuredEnergy() {
+  const store = dashboardStore();
+  try {
+    return store?.peekSection?.("energy") ?? store?.getSection?.("energy") ?? {};
+  } catch (_error) {
+    return {};
+  }
+}
+
+function energyClashes() {
+  try {
+    return energyPeriodConflicts(configuredEnergy());
+  } catch (_error) {
+    return [];
+  }
+}
+
+function clashNotice(clashes) {
+  if (!clashes.length) return "";
+  const rows = clashes
+    .map((clash) => {
+      const label = CLASH_LABELS[`${clash.group}:${clash.totalKey}`] || [clash.group, clash.group];
+      const ignored = clash.ignored
+        .slice()
+        .sort(
+          (left, right) =>
+            PERIOD_ORDER.findIndex((name) => left.key.startsWith(name)) -
+            PERIOD_ORDER.findIndex((name) => right.key.startsWith(name)),
+        )
+        .map((field) => `${esc(periodLabel(field.key))} <code>${esc(field.entity)}</code>`)
+        .join(", ");
+      return `<li><strong>${esc(t(label[0], label[1]))}</strong> — ${t("legge", "reads")} <code>${esc(
+        clash.total,
+      )}</code>; ${t("ignora", "ignores")} ${ignored}</li>`;
+    })
+    .join("");
+  return `<div class="dm-energy-source-clash" role="status">
+    <strong>${t(
+      "Il contatore totale comanda: questi campi non vengono letti",
+      "The total meter wins: these fields are not read",
+    )}</strong>
+    <span>${t(
+      "Con un contatore totale configurato la dashboard ricava giorno, mese e anno da quello con Recorder, cosi' i numeri restano coerenti tra loro. Le entita' scritte nei campi di periodo restano salvate ma non vengono usate: svuotale, oppure togli il contatore totale se preferisci leggere i periodi direttamente.",
+      "With a total meter configured the dashboard derives day, month and year from it through Recorder, so the numbers agree with each other. Entities written in the period fields stay saved but are not used: clear them, or remove the total meter if you would rather read the periods directly.",
+    )}</span>
+    <ul>${rows}</ul>
+    <button type="button" class="dm-energy-clash-clear">${t(
+      "Svuota i campi di periodo",
+      "Clear the period fields",
+    )}</button>
+  </div>`;
+}
+
+async function clearClashingPeriods() {
+  const store = dashboardStore();
+  if (!store?.getSection || !store?.replaceSection) return false;
+  const clashes = energyClashes();
+  if (!clashes.length) return false;
+  const model = structuredClone(store.getSection("energy") || {});
+  for (const clash of clashes) {
+    model[clash.group] ||= {};
+    for (const field of clash.ignored) model[clash.group][field.key] = "";
+  }
+  await store.replaceSection("energy", model);
+  root.toast?.(t("Campi di periodo svuotati", "Period fields cleared"));
+  normalizeEnergyGuidance();
+  return true;
+}
+
 function energyEditorActive() {
   const active = doc?.querySelector("#editor-modal .ed-tab.active");
   const tab = clean(active?.dataset?.tab).toLowerCase();
@@ -66,10 +169,10 @@ export function normalizeEnergyGuidance() {
   guide.innerHTML = `<div class="dm-energy-source-guide-intro">
     <strong>${t("Quale entità usa la dashboard", "Which entity the dashboard uses")}</strong>
     <span>${t(
-      "Quando Fotovoltaico e Rete sono configurati, il consumo Casa usa lo stesso bilancio dei flussi di Home Assistant. I contatori totali kWh servono anche per Recorder, storico e mesi precedenti; i campi giornaliero, mensile e annuale restano override facoltativi del singolo periodo.",
-      "When Solar and Grid are configured, Home consumption uses the same flow balance as Home Assistant. Total kWh meters also feed Recorder, history and previous months; daily, monthly and annual fields remain optional per-period overrides.",
+      "Quando Fotovoltaico e Rete sono configurati, il consumo Casa usa lo stesso bilancio dei flussi di Home Assistant. Il contatore totale kWh comanda: se c'è, giorno, mese e anno si ricavano da quello con Recorder e i campi di periodo non vengono letti. I campi giornaliero, mensile e annuale servono quando un contatore totale non esiste.",
+      "When Solar and Grid are configured, Home consumption uses the same flow balance as Home Assistant. The total kWh meter wins: when one is set, day, month and year are derived from it through Recorder and the period fields are not read. The daily, monthly and annual fields are for when no total meter exists.",
     )}</span>
-  </div><div class="dm-energy-source-guide-grid">
+  </div>${clashNotice(energyClashes())}<div class="dm-energy-source-guide-grid">
     ${contractCard("house", t("Casa (fallback)", "Home (fallback)"), "🏠")}
     ${contractCard("solar", t("Fotovoltaico", "Solar"), "☀️")}
     ${contractCard("grid", t("Rete prelevata", "Grid import"), "🔌")}
@@ -83,8 +186,8 @@ export function normalizeEnergyGuidance() {
       field.append(purpose);
     }
     purpose.textContent = t(
-      "Usata per Recorder, storico e mesi precedenti quando non esiste un sensore specifico del periodo.",
-      "Used for Recorder, history and previous months when no period-specific sensor exists.",
+      "Comanda su tutto: giorno, mese, anno, storico e mesi precedenti si ricavano da qui con Recorder. Con questo campo pieno i campi di periodo non vengono letti.",
+      "This one wins: day, month, year, history and previous months are all derived from here through Recorder. While it is set, the period fields are not read.",
     );
   });
   return true;
@@ -100,6 +203,14 @@ function installStyles() {
       #editor-modal .dm-energy-source-guide-grid{display:grid!important;grid-template-columns:repeat(3,minmax(0,1fr))!important;gap:10px!important}
       #editor-modal .dm-energy-source-contract{min-width:0!important;padding:12px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:14px!important;background:var(--ha-card-background,var(--card-bg,#fff))!important}
       #editor-modal .dm-energy-source-contract header{display:flex!important;align-items:center!important;gap:8px!important;margin-bottom:8px!important}.dm-energy-source-contract dl{display:grid!important;gap:7px!important;margin:0!important}.dm-energy-source-contract dl>div{display:grid!important;gap:2px!important}.dm-energy-source-contract dt{font-size:10px!important;font-weight:900!important;letter-spacing:.08em!important;text-transform:uppercase!important;color:var(--secondary-text-color,#64748b)!important}.dm-energy-source-contract dd{min-width:0!important;margin:0!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important;font-family:ui-monospace,SFMono-Regular,Menlo,monospace!important;font-size:10px!important;color:var(--text,#0f172a)!important}
+      #editor-modal .dm-energy-source-clash{display:grid!important;gap:8px!important;padding:14px 16px!important;border:1px solid color-mix(in srgb,var(--warning-color,#f59e0b) 45%,var(--divider-color,#dbe4ee))!important;border-radius:16px!important;background:color-mix(in srgb,var(--warning-color,#f59e0b) 12%,var(--ha-card-background,#fff))!important;line-height:1.45!important}
+      #editor-modal .dm-energy-source-clash strong{font-size:14px!important;color:var(--text,#0f172a)!important}
+      #editor-modal .dm-energy-source-clash>span{color:var(--secondary-text-color,#64748b)!important;font-size:12px!important}
+      #editor-modal .dm-energy-source-clash ul{display:grid!important;gap:4px!important;margin:0!important;padding:0 0 0 18px!important;font-size:12px!important;color:var(--text,#0f172a)!important}
+      #editor-modal .dm-energy-source-clash code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace!important;font-size:11px!important;word-break:break-all!important}
+      #editor-modal .dm-energy-clash-clear{justify-self:start!important;padding:8px 14px!important;border:0!important;border-radius:999px!important;background:var(--warning-color,#f59e0b)!important;color:#3b2600!important;font-weight:800!important;font-size:12px!important;cursor:pointer!important}
+      #editor-modal[data-dm-editor-theme="dark"] .dm-energy-source-clash{background:var(--dm-editor-panel,#1b2540)!important;border-color:color-mix(in srgb,var(--warning-color,#f59e0b) 55%,var(--dm-editor-border,#31405f))!important}
+      #editor-modal[data-dm-editor-theme="dark"] .dm-energy-source-clash strong,#editor-modal[data-dm-editor-theme="dark"] .dm-energy-source-clash ul{color:var(--dm-editor-text,#edf4ff)!important}
       #editor-modal .dm-energy-total-purpose{display:block!important;margin-top:7px!important;color:var(--info-color,#0369a1)!important;font-size:11px!important;line-height:1.35!important}
       #editor-modal[data-dm-editor-theme="dark"] .dm-energy-source-guide-intro,#editor-modal[data-dm-editor-theme="dark"] .dm-energy-source-contract{background:var(--dm-editor-panel,#1b2540)!important;border-color:var(--dm-editor-border,#31405f)!important}
       #editor-modal[data-dm-editor-theme="dark"] .dm-energy-source-contract dd{color:var(--dm-editor-text,#edf4ff)!important}
@@ -118,6 +229,11 @@ export function installEnergyGuidanceSection() {
     doc.addEventListener(
       "click",
       (event) => {
+        if (event.target?.closest?.("#editor-modal .dm-energy-clash-clear")) {
+          event.preventDefault();
+          clearClashingPeriods();
+          return;
+        }
         if (event.target?.closest?.("#editor-modal .ed-tab,#editor-modal [data-energy-tab],#editor-modal .sub-tab-btn"))
           root.queueMicrotask?.(normalizeEnergyGuidance);
       },

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-section.js
@@ -142,6 +142,20 @@ function energyModel() {
   return section("energy", {});
 }
 
+/* La configurazione com'e' stata scritta, per la maschera che la mostra.
+ *
+ * Il modello che leggono le pagine esce filtrato: con un contatore totale
+ * valido i campi di periodo ne restano fuori, perche' i periodi si ricavano dal
+ * totale. La maschera di configurazione pero' deve mostrare cio' che c'e'
+ * scritto: leggendo il modello filtrato mostrerebbe quei campi vuoti, e il
+ * primo salvataggio riscriverebbe quel vuoto sopra le entita' che la persona
+ * aveva messo — cancellandole per sempre. */
+function configuredEnergyModel() {
+  const store = dashboardStore();
+  const value = store?.getSection?.("energy");
+  return value && typeof value === "object" && !Array.isArray(value) ? value : energyModel();
+}
+
 function entityOverrides() {
   const current = section("entityOverrides", null);
   return current && typeof current === "object"
@@ -776,14 +790,25 @@ function createTotalField(definition, value) {
   return { wrap, input };
 }
 
+/* Un campo alla volta, in fila.
+ *
+ * Ogni scrittura legge il modello, ci mette dentro il suo campo e lo riscrive
+ * per intero. Due campi cambiati a poca distanza — cosa che succede appena si
+ * compila la maschera scendendo — leggevano tutti e due lo stesso modello di
+ * partenza, e l'ultimo a scrivere riportava indietro il campo dell'altro. In
+ * fila ognuno parte da cio' che ha lasciato quello prima. */
 async function persistEnergyField(group, key, value) {
-  const store = dashboardStore();
-  if (!store?.getSection || !store?.replaceSection) return;
-  const model = structuredClone(store.getSection("energy") || {});
-  model[group] ||= {};
-  model[group][key] = clean(value);
-  model.metadata = { ...(model.metadata || {}), semantics_version: 3 };
-  await store.replaceSection("energy", model);
+  const write = async () => {
+    const store = dashboardStore();
+    if (!store?.getSection || !store?.replaceSection) return;
+    const model = structuredClone(store.getSection("energy") || {});
+    model[group] ||= {};
+    model[group][key] = clean(value);
+    model.metadata = { ...(model.metadata || {}), semantics_version: 3 };
+    await store.replaceSection("energy", model);
+  };
+  state.fieldQueue = (state.fieldQueue || Promise.resolve()).then(write, write);
+  return state.fieldQueue;
 }
 
 function entityField(label, key, value, placeholder) {
@@ -934,19 +959,35 @@ function installEnergyEditorContracts() {
     flows.prepend(overview);
   }
 
-  const model = energyModel();
+  const model = configuredEnergyModel();
   installBatterySocField(editor, model);
   installEnergyLoadsEditor(editor);
   TOTAL_FIELDS.forEach((definition) => {
     const [group, key, afterKey] = definition;
-    if (editor.querySelector(`#dm-energy-${group}-${key}`)) return;
-    const anchor = editor.querySelector(`#dm-energy-${group}-${afterKey}`);
-    const body = anchor?.closest(".ed-acc-body");
-    if (!body) return;
-    const { wrap, input } = createTotalField(definition, model[group]?.[key]);
-    const anchorField = anchor.closest("label.ed-slot");
-    if (anchorField?.parentElement === body) anchorField.after(wrap);
-    else body.append(wrap);
+    /* Il campo puo' esserci gia': lo stampa il runtime.
+     *
+     * Qui si usciva subito in quel caso, e con l'uscita se ne andavano anche i
+     * due ascolti che stanno sotto — quello che accende il pulsante Salva e
+     * quello che scrive il valore appena si esce dal campo. Il campo restava
+     * scrivibile e non salvava niente da solo. Adesso si salta la costruzione,
+     * non il collegamento, e il collegamento si fa una volta sola. */
+    let input = editor.querySelector(`#dm-energy-${group}-${key}`);
+    let body = input?.closest(".ed-acc-body");
+    if (!input) {
+      const anchor = editor.querySelector(`#dm-energy-${group}-${afterKey}`);
+      body = anchor?.closest(".ed-acc-body");
+      if (!body) return;
+      const field = createTotalField(definition, model[group]?.[key]);
+      input = field.input;
+      const anchorField = anchor.closest("label.ed-slot");
+      if (anchorField?.parentElement === body) anchorField.after(field.wrap);
+      else body.append(field.wrap);
+    }
+    if (!body || input.dataset.dmTotalBound === "true") {
+      updateConfiguredCount(body);
+      return;
+    }
+    input.dataset.dmTotalBound = "true";
     input.addEventListener("input", () => {
       const actions = editor.querySelector("[data-energy-actions]");
       const save = actions?.querySelector("[data-energy-save]");

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-section.js
@@ -964,30 +964,19 @@ function installEnergyEditorContracts() {
   installEnergyLoadsEditor(editor);
   TOTAL_FIELDS.forEach((definition) => {
     const [group, key, afterKey] = definition;
-    /* Il campo puo' esserci gia': lo stampa il runtime.
-     *
-     * Qui si usciva subito in quel caso, e con l'uscita se ne andavano anche i
-     * due ascolti che stanno sotto — quello che accende il pulsante Salva e
-     * quello che scrive il valore appena si esce dal campo. Il campo restava
-     * scrivibile e non salvava niente da solo. Adesso si salta la costruzione,
-     * non il collegamento, e il collegamento si fa una volta sola. */
-    let input = editor.querySelector(`#dm-energy-${group}-${key}`);
-    let body = input?.closest(".ed-acc-body");
-    if (!input) {
-      const anchor = editor.querySelector(`#dm-energy-${group}-${afterKey}`);
-      body = anchor?.closest(".ed-acc-body");
-      if (!body) return;
-      const field = createTotalField(definition, model[group]?.[key]);
-      input = field.input;
-      const anchorField = anchor.closest("label.ed-slot");
-      if (anchorField?.parentElement === body) anchorField.after(field.wrap);
-      else body.append(field.wrap);
-    }
-    if (!body || input.dataset.dmTotalBound === "true") {
-      updateConfiguredCount(body);
-      return;
-    }
-    input.dataset.dmTotalBound = "true";
+    /* Il campo puo' esserci gia': lo stampa il runtime, e in quel caso e' la
+     * maschera canonica a possederlo — raccoglie il valore nella sua bozza e lo
+     * scrive quando si preme Salva. Qui si costruisce solo cio' che manca:
+     * aggiungere un secondo salvataggio su un campo che ne ha gia' uno vuol
+     * dire due padroni sullo stesso dato, ed e' proprio cio' che rompe. */
+    if (editor.querySelector(`#dm-energy-${group}-${key}`)) return;
+    const anchor = editor.querySelector(`#dm-energy-${group}-${afterKey}`);
+    const body = anchor?.closest(".ed-acc-body");
+    if (!body) return;
+    const { wrap, input } = createTotalField(definition, model[group]?.[key]);
+    const anchorField = anchor.closest("label.ed-slot");
+    if (anchorField?.parentElement === body) anchorField.after(wrap);
+    else body.append(wrap);
     input.addEventListener("input", () => {
       const actions = editor.querySelector("[data-energy-actions]");
       const save = actions?.querySelector("[data-energy-save]");

--- a/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
@@ -113,12 +113,16 @@ export function applyVehicleAsset() {
   const plugged = vehiclePlugged();
   const original = activeVehiclePhoto(photos, plugged);
   const url = resolveVehicleAsset(original);
-  // Only the key the value came from is rewritten in its resolved form, so the
-  // other photo is never overwritten with this one.
-  if (url && clean(original) !== url) {
-    const key = clean(photos.plugged) === clean(original) && plugged ? EV_PHOTO_KEYS.plugged : EV_PHOTO_KEYS.idle;
-    root.localStorage?.setItem(key, JSON.stringify(url));
-  }
+  /* Quello che l'utente ha scritto resta come l'ha scritto.
+   *
+   * Qui la foto risolta veniva riscritta nella configurazione, e la chiave in
+   * cui finiva la sceglieva il cavo: con la sola foto "col cavo" impostata e il
+   * cavo staccato, la foto attiva veniva da quella chiave ma veniva riscritta
+   * in quella "senza cavo". Da li' le due foto diventavano la stessa, da sole,
+   * poco dopo averle inserite — e con due profili la stessa coppia finiva su
+   * entrambe le auto. Risolvere un percorso serve a disegnare l'immagine, non a
+   * cambiare la configurazione: la risoluzione resta qui e non torna nel
+   * deposito. */
   state.lastUrl = url;
   let mounted = false;
   for (const id of ["ev-mod-car-img", "ev-new-car-img"]) {

--- a/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
@@ -113,16 +113,26 @@ export function applyVehicleAsset() {
   const plugged = vehiclePlugged();
   const original = activeVehiclePhoto(photos, plugged);
   const url = resolveVehicleAsset(original);
-  /* Quello che l'utente ha scritto resta come l'ha scritto.
+  /* La correzione torna solo dov'era il valore corretto.
    *
-   * Qui la foto risolta veniva riscritta nella configurazione, e la chiave in
-   * cui finiva la sceglieva il cavo: con la sola foto "col cavo" impostata e il
-   * cavo staccato, la foto attiva veniva da quella chiave ma veniva riscritta
-   * in quella "senza cavo". Da li' le due foto diventavano la stessa, da sole,
-   * poco dopo averle inserite — e con due profili la stessa coppia finiva su
-   * entrambe le auto. Risolvere un percorso serve a disegnare l'immagine, non a
-   * cambiare la configurazione: la risoluzione resta qui e non torna nel
-   * deposito. */
+   * Un percorso scritto a mano puo' arrivare storto — "/loca/..." invece di
+   * "/local/...", o il percorso su disco invece di quello che il browser sa
+   * servire — e riscriverlo nella sua forma buona evita di ripetere la
+   * correzione a ogni disegno. La chiave in cui finiva pero' la sceglieva il
+   * cavo: con la sola foto "col cavo" impostata e il cavo staccato, la foto
+   * attiva veniva da quella chiave ma veniva riscritta in quella "senza cavo".
+   * Da li' le due foto diventavano la stessa, da sole, poco dopo averle
+   * inserite — e con due profili la stessa coppia finiva su entrambe le auto.
+   *
+   * La correzione va adesso nelle caselle che quel valore lo contengono
+   * davvero, e in nessun'altra: una foto non puo' piu' passare da una casella
+   * all'altra da sola. */
+  if (url && clean(original) && clean(original) !== url) {
+    for (const [name, key] of Object.entries(EV_PHOTO_KEYS)) {
+      if (clean(photos[name]) !== clean(original)) continue;
+      root.localStorage?.setItem(key, JSON.stringify(url));
+    }
+  }
   state.lastUrl = url;
   let mounted = false;
   for (const id of ["ev-mod-car-img", "ev-new-car-img"]) {

--- a/custom_components/dashboardmodern/frontend/src/sections/navigation-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/navigation-section.js
@@ -161,6 +161,18 @@ function installScroller() {
     scroller.scrollBy({ left: direction * navPageStep(scroller.clientWidth), behavior });
   };
 
+  /* Chi ha scorso la barra con le frecce, la rotella, le freccette della
+   * tastiera o trascinandola l'ha portata dove voleva. Da quel momento il dock
+   * non si riporta piu' da solo sulla sezione aperta: prima bastava rientrare
+   * col puntatore sulla barra e questa scattava indietro sotto il dito, cosi'
+   * il click seguente cadeva sull'icona sbagliata. La barra torna a seguirla
+   * quando la sezione aperta cambia — allora e' il dock a sapere meglio. */
+  let steered = false;
+  let lastActive = null;
+  const steer = () => {
+    steered = true;
+  };
+
   /* Ogni volta che il dock ricompare la sezione aperta deve essere sotto gli
    * occhi, ma senza rimbalzare via da dove l'utente aveva scorso. */
   const revealActive = () => {
@@ -168,6 +180,12 @@ function installScroller() {
     if (!status.scrollable) return;
     const active = scroller.querySelector(".tab.active");
     if (!active) return;
+    if (active !== lastActive) {
+      lastActive = active;
+      steered = false;
+    } else if (steered) {
+      return;
+    }
     const port = scroller.getBoundingClientRect();
     const box = active.getBoundingClientRect();
     if (
@@ -193,8 +211,14 @@ function installScroller() {
     });
   };
 
-  previous.addEventListener("click", () => stepBy(-1));
-  next.addEventListener("click", () => stepBy(1));
+  previous.addEventListener("click", () => {
+    steer();
+    stepBy(-1);
+  });
+  next.addEventListener("click", () => {
+    steer();
+    stepBy(1);
+  });
   scroller.addEventListener("scroll", sync, { passive: true });
   /* Accendere o spegnere una sezione cambia la larghezza della barra: è il
    * segnale che dice quando le frecce servono, senza nessun giro a vuoto. */
@@ -207,6 +231,7 @@ function installScroller() {
   nav.addEventListener("keydown", (event) => {
     if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
     if (!navScrollState(scroller).scrollable) return;
+    steer();
     stepBy(event.key === "ArrowLeft" ? -1 : 1);
     event.preventDefault();
   });
@@ -222,6 +247,7 @@ function installScroller() {
       if (!delta) return;
       const target = Math.max(0, Math.min(scroller.scrollLeft + delta, status.max));
       if (target === scroller.scrollLeft) return;
+      steer();
       scroller.scrollLeft = target;
       event.preventDefault();
       sync();
@@ -251,6 +277,7 @@ function installScroller() {
     const { pointerId, moved } = drag;
     drag = null;
     swallowClick = moved;
+    if (moved) steer();
     nav.classList.remove(DRAGGING_CLASS);
     if (moved) scroller.releasePointerCapture?.(pointerId);
     root.removeEventListener?.("pointermove", dragMove);

--- a/custom_components/dashboardmodern/frontend/src/sections/page-masthead-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/page-masthead-section.js
@@ -94,6 +94,25 @@ const PAGES = Object.freeze([
     en: ["Security system", "Alarm · Cameras · Openings"],
     fold: ".sec-header, .dm-sec-mast-ic, .dm-sec-mast-copy",
   },
+  /* Solare termico e MiniPC avevano l'intestazione che hanno ispirato tutte le
+   * altre, e per questo erano rimaste fuori: ma "come le altre" vuol dire anche
+   * loro. Qui si ripiega solo il titolo, non la fascia che lo conteneva: quella
+   * porta la pastiglia di stato viva, che resta dov'e' e continua a dire cosa
+   * sta facendo l'impianto. */
+  {
+    id: "page-boiler",
+    tint: ["249,115,22", "14,165,233"],
+    it: ["Impianto solare termico", "Circuito primario · Boiler · Ricircolo sanitario"],
+    en: ["Solar thermal system", "Primary loop · Tank · DHW recirculation"],
+    fold: ".boiler-title, .dm-st-sub",
+  },
+  {
+    id: "page-server",
+    tint: ["14,165,233", "99,102,241"],
+    it: ["MiniPC Server", "Home Assistant · Sistema core"],
+    en: ["MiniPC Server", "Home Assistant · Core system"],
+    fold: ".srv-hero-brand",
+  },
 ]);
 
 function labelsFor(page) {
@@ -113,6 +132,34 @@ function backHomeMarkup() {
     onclick="document.querySelector('[data-tab=&quot;home&quot;]').click(); if(navigator.vibrate)navigator.vibrate(5);">
     <span class="bh-icon">←</span><span>${esc(label)}</span>
   </button>`;
+}
+
+/* Dove nasce l'intestazione.
+ *
+ * Alcune pagine tengono il proprio contenuto dentro un contenitore che ne fissa
+ * la larghezza, altre lo lasciano correre per tutta la scheda. L'intestazione
+ * nasceva sempre in cima alla pagina con una larghezza sua: sulle pagine larghe
+ * restava un rettangolo stretto e spostato, con il contenuto sotto molto piu'
+ * largo. Nasce invece dove nasce il contenuto, cosi' e' larga esattamente
+ * quanto lui, senza doverlo sapere. */
+function mountFor(host) {
+  let best = null;
+  let tallest = 0;
+  for (const wrapper of host.querySelectorAll(
+    ':scope > div[style*="max-width"], :scope > [class*="dashboard"]',
+  )) {
+    // Un contenitore che al momento non occupa spazio non e' il posto giusto:
+    // la pagina Energia ne tiene uno per vista e ne mostra una sola, e
+    // l'intestazione ci sarebbe finita dentro larga zero. Fra quelli che si
+    // vedono vince il piu' alto: e' il contenuto. La pagina Auto apre con una
+    // striscia della stessa larghezza che pero' contiene solo la tendina dei
+    // profili, e l'intestazione non va incassata li' dentro.
+    const height = wrapper.getBoundingClientRect().height;
+    if (!wrapper.getClientRects().length || height <= tallest) continue;
+    tallest = height;
+    best = wrapper;
+  }
+  return best || host;
 }
 
 function foldForeignBackButtons(host) {
@@ -144,7 +191,8 @@ function ensureMasthead(page) {
   if (!host) return false;
   const labels = labelsFor(page);
   let mast = state.mastheads?.[page.id];
-  if (mast && (!mast.isConnected || mast.parentElement !== host)) mast = null;
+  const mount = mountFor(host);
+  if (mast && (!mast.isConnected || mast.parentElement !== mount)) mast = null;
   if (!mast) mast = host.querySelector(":scope > .dm-page-mast");
   if (!mast) {
     mast = doc.createElement("header");
@@ -156,7 +204,7 @@ function ensureMasthead(page) {
       backHomeMarkup() +
       `<h2 class="dm-page-mast-title">${esc(labels.title)}</h2>` +
       `<div class="dm-page-mast-sub">${esc(labels.subtitle)}</div>`;
-    host.insertBefore(mast, host.firstChild);
+    mount.insertBefore(mast, mount.firstChild);
     (state.mastheads ||= {})[page.id] = mast;
   } else {
     (state.mastheads ||= {})[page.id] = mast;
@@ -169,8 +217,8 @@ function ensureMasthead(page) {
   }
   // A page redrawn by its own renderer can put its content above the heading:
   // the heading opens the page, always.
-  if (mast.parentElement !== host || host.firstElementChild !== mast) {
-    host.insertBefore(mast, host.firstChild);
+  if (mast.parentElement !== mount || mount.firstElementChild !== mast) {
+    mount.insertBefore(mast, mount.firstChild);
   }
   foldForeignBackButtons(host);
   foldLegacyHeading(host, page.fold);
@@ -234,7 +282,9 @@ function installStyles() {
     ${foldRules()}
     .dm-page-mast{
       position:relative!important;display:block!important;box-sizing:border-box!important;
-      width:100%!important;max-width:1120px!important;margin:0 auto 18px!important;
+      width:100%!important;max-width:none!important;margin:0 0 18px!important;
+      grid-column:1/-1!important;flex:1 1 100%!important;
+      align-self:stretch!important;justify-self:stretch!important;
       padding:26px 30px 24px!important;border-radius:28px!important;text-align:left!important;
       border:1px solid var(--divider-color,rgba(15,23,42,.10))!important;
       background:
@@ -283,6 +333,12 @@ function installStyles() {
       padding:0!important;margin:0 0 12px!important;border:0!important;
       background:none!important;box-shadow:none!important
     }
+    /* Le fasce che portavano il titolo di Solare termico e MiniPC ora portano
+       solo la pastiglia di stato: si stringono su quella invece di lasciare in
+       mezzo la banda vuota di quando c'era anche il titolo. */
+    #page-boiler .boiler-header{padding:12px 22px!important}
+    #page-server .srv-hero-top{padding-top:12px!important;padding-bottom:12px!important}
+
     /* The heading a page printed for itself: kept in the document for whoever
        writes into it, and no longer drawn twice. */
     [data-dm-mast-folded="true"]{display:none!important}

--- a/custom_components/dashboardmodern/frontend/src/sections/page-masthead-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/page-masthead-section.js
@@ -79,15 +79,6 @@ const PAGES = Object.freeze([
     fold: ".dm-appl-brand",
   },
   {
-    id: "page-server",
-    tint: ["6,182,212", "99,102,241"],
-    it: ["MiniPC Server", "Home Assistant · Sistema core · Risorse"],
-    en: ["MiniPC Server", "Home Assistant · Core system · Resources"],
-    // The hero keeps its live "online" pill and its metrics; only the name it
-    // used to print for itself is folded away.
-    fold: ".srv-hero-brand",
-  },
-  {
     id: "page-security",
     tint: ["190,18,60", "249,115,22"],
     it: ["Sistema di sicurezza", "Antifurto · Telecamere · Aperture"],
@@ -111,6 +102,11 @@ const PAGES = Object.freeze([
     tint: ["14,165,233", "99,102,241"],
     it: ["MiniPC Server", "Home Assistant · Sistema core"],
     en: ["MiniPC Server", "Home Assistant · Core system"],
+    // La fascia tiene la sua pastiglia "online" e le sue misure: si ripiega
+    // solo il nome che la pagina stampava per conto suo.
+    // Il MiniPC compariva due volte in questo elenco, con due tinte e due
+    // sottotitoli diversi: l'ultimo vinceva a ogni passata e il primo non si
+    // e' mai visto. Resta quello che si vedeva.
     fold: ".srv-hero-brand",
   },
 ]);
@@ -159,7 +155,29 @@ function mountFor(host) {
     tallest = height;
     best = wrapper;
   }
-  return best || host;
+  return best || soleContentWrapper(host) || host;
+}
+
+/* Quando il contenuto della pagina e' tutto in un blocco solo.
+ *
+ * Alcune pagine non marcano il contenitore in alcun modo riconoscibile: Clima
+ * tiene tutto dentro un unico riquadro che si stringe da se', e l'intestazione
+ * restava larga quanto la scheda mentre cio' che introduceva era piu' stretto
+ * di quasi duecento pixel. Se sotto l'intestazione c'e' un solo blocco che si
+ * vede, ed e' piu' stretto della pagina, quello e' il contenuto e l'apertura e'
+ * la sua. Se i blocchi sono piu' d'uno la pagina si impagina da sola e
+ * l'intestazione resta dov'e'. */
+function soleContentWrapper(host) {
+  let only = null;
+  for (const child of host.children) {
+    if (child.classList?.contains("dm-page-mast")) continue;
+    if (!child.getClientRects().length) continue;
+    if (only) return null;
+    only = child;
+  }
+  if (!only) return null;
+  const width = only.getBoundingClientRect().width;
+  return width > 0 && host.getBoundingClientRect().width - width > 3 ? only : null;
 }
 
 function foldForeignBackButtons(host) {

--- a/custom_components/dashboardmodern/frontend/src/sections/report-editor-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/report-editor-section.js
@@ -29,7 +29,12 @@ function rowFields(row) {
  * still empty until the user chooses an icon of their own. */
 function deviceForRow(row) {
   const id = clean(row.dataset.reportId);
-  const name = clean(row.querySelector("[data-report-name]")?.value);
+  // Lo stesso campo che rowFields legge: la ricerca per nome cercava un
+  // attributo che nessuno scrive, quindi non trovava mai niente e il quadratino
+  // dell'icona restava vuoto.
+  const name = clean(
+    (row.querySelector("[data-report-label]") || row.querySelector("[data-report-name]"))?.value,
+  );
   const devices = [...(section("appliances", []) || []), ...(section("loads", []) || [])];
   return (
     devices.find((item) => clean(item.id) && clean(item.id) === id) ||
@@ -183,6 +188,24 @@ function installStyles() {
       #editor-modal .dm-report-label{grid-area:label!important;width:100%!important;min-width:0!important}
       #editor-modal .dm-report-icon{grid-area:icon!important;display:grid!important;grid-template-columns:minmax(0,1fr)!important;width:100%!important;min-width:0!important}
       #editor-modal .dm-report-icon input{display:none!important}.dm-report-icon button{width:44px!important;height:44px!important;margin:auto!important}
+      /* Il quadratino dell'icona restava vuoto: il pulsante di anteprima azzera
+         il corpo del testo per far posto a un'immagine, ma qui l'icona e' un
+         carattere, e a corpo zero non si vede. */
+      #editor-modal .dm-report-icon button{
+        display:grid!important;place-items:center!important;
+        font-size:22px!important;line-height:1!important;color:var(--text,#0f172a)!important}
+      /* La riga ha gia' la sua etichetta con la matita e, in fondo, il pulsante
+         che apre la voce per intero. La card dei campi entita' ci metteva una
+         cornice dentro la cornice e una seconda matita a capo, e la riga
+         cresceva al doppio dell'altezza che le serve. */
+      #editor-modal .dm-report-history [data-dm-entity-chip="true"]{
+        display:flex!important;flex-wrap:nowrap!important;align-items:center!important;gap:8px!important;
+        margin:0!important;padding:0!important;border:0!important;background:transparent!important}
+      #editor-modal .dm-report-history [data-dm-entity-chip="true"]>.dm-entity-picker.dm-slot-chip{
+        flex:1 1 auto!important;width:auto!important}
+      #editor-modal .dm-report-history .dm-chip-manual{
+        flex:0 0 34px!important;width:34px!important;height:34px!important;order:3!important}
+      #editor-modal [data-energy-panel="report"] .dm-report-row{align-items:center!important}
       #editor-modal .dm-report-history{grid-area:history!important;display:grid!important;gap:5px!important;min-width:0!important;max-width:100%!important;margin:0!important;overflow:hidden!important}
       #editor-modal .dm-report-history .ed-form-row,#editor-modal .dm-report-history .dm-entity-field{box-sizing:border-box!important;width:100%!important;max-width:100%!important;min-width:0!important}
       #editor-modal .dm-report-history .ed-slot-lbl{display:block!important;min-height:18px!important;font-size:11px!important;font-weight:850!important;color:var(--secondary-text-color,#64748b)!important}

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -1,4 +1,5 @@
 import { applianceArtwork, canonicalArtworkType } from "../core/appliance-artwork.js";
+import { applianceHeroArtwork } from "../core/appliance-hero-artwork.js";
 import { createApplianceViewModel } from "../core/appliance-view-model.js";
 import { installStateEventGate } from "../core/state-event-gate.js";
 import { installHostedBridgeGuard } from "../transport/hosted-bridge-guard.js";
@@ -395,7 +396,16 @@ function applianceKpiArtwork(model) {
       model?.name,
   );
   const kind = canonicalArtworkType(fallback);
-  return (kind && applianceArtwork(kind, 72)) || '<span class="dm-appliance-kpi-fallback">⚡</span>';
+  /* Lo stesso disegno della scheda, non un secondo disegno.
+   *
+   * Il popup usava l'illustrazione piatta: una sagoma azzurra uguale per tutti
+   * gli elettrodomestici, e ferma anche mentre l'elettrodomestico lavorava.
+   * Adesso mostra il disegno della scheda, quello con le parti mobili, e la
+   * riga porta lo stato: se sta lavorando, il meccanismo gira anche qui. */
+  return (
+    (kind && (applianceHeroArtwork(kind, 56) || applianceArtwork(kind, 72))) ||
+    '<span class="dm-appliance-kpi-fallback">⚡</span>'
+  );
 }
 
 function ensureApplianceKpiPopup(kind) {
@@ -446,7 +456,7 @@ function applianceKpiRow(model, kind, totalWatts = 0) {
     ? `<strong>${measurable ? formatApplianceWatts(watts) : htmlEscape(model.label)}</strong><small>${htmlEscape(model.label)}</small>`
     : `<strong>${formatApplianceWatts(watts)}</strong><small>${totalWatts > 0 ? `${Math.round((Math.max(0, watts) / totalWatts) * 100)}%` : "0%"}</small>`;
   return `<div class="dm-appliance-kpi-row" data-appliance-id="${htmlEscape(model.id)}">
-    <span class="dm-appliance-kpi-visual">${applianceKpiArtwork(model)}</span>
+    <span class="dm-appliance-kpi-visual dm-ap-mech is-${htmlEscape(model?.mode === "running" ? "run" : model?.mode === "standby" ? "standby" : "off")}">${applianceKpiArtwork(model)}</span>
     <span class="dm-appliance-kpi-row-main"><strong>${htmlEscape(model.name)}</strong>${room ? `<small>🏠 ${htmlEscape(room)}</small>` : ""}</span>
     <span class="dm-appliance-kpi-row-value">${right}</span>
   </div>`;

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -28,6 +28,7 @@ import { installLightsAlertsSection } from "./lights-alerts-section.js";
 import { installLightsSceneSection } from "./lights-scene-section.js";
 import { installAlertsSection } from "./alerts-section.js";
 import { installLiveUiSection } from "./live-ui-section.js";
+import { installConnectionRecoverySection } from "./connection-recovery-section.js";
 import { installSecurityShowcaseSection } from "./security-showcase-section.js";
 import { installClimateThermalSection } from "./climate-thermal-section.js";
 import { installNavigationSection } from "./navigation-section.js";
@@ -655,6 +656,7 @@ export function installSectionRuntime() {
     installSecurityShowcaseSection();
     installClimateThermalSection();
     installLiveUiSection();
+    installConnectionRecoverySection();
     installNavigationSection();
     installUnifiedEditorsSection();
     installEntitySearchSection();

--- a/custom_components/dashboardmodern/frontend/src/sections/shared.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shared.js
@@ -158,6 +158,25 @@ export function sanitizeEnergyModel(value = {}, states = allStates(), resolver =
     }
   }
 
+  /* Il contatore totale comanda.
+   *
+   * Chi riempie il totale e anche giornaliera, mensile e annuale si ritrova due
+   * verita' che non tornano: il totale cresce e basta, i contatori di periodo si
+   * azzerano quando decide chi li ha creati, e il numero mostrato cambiava a
+   * seconda di quale dei due la pagina avesse letto per primo. Con il totale
+   * configurato ogni periodo si ricava da li' con il Recorder e i campi di
+   * periodo restano fuori dal modello: la maschera di configurazione lo dice a
+   * chiare lettere, invece di lasciare indovinare quale dei due sta vincendo. */
+  for (const source of ENERGY_RUNTIME_SOURCES) {
+    const group = result[source.group] || value[source.group] || {};
+    const total = clean(group[source.totalKey]);
+    if (!total || !entityExists(total, snapshot, resolver)) continue;
+    for (const key of source.periodKeys) {
+      if (!clean(group[key])) continue;
+      ensureGroup(source.group)[key] = "";
+    }
+  }
+
   for (const source of ENERGY_RUNTIME_SOURCES) {
     const group = result[source.group] || value[source.group] || {};
     const total = clean(group[source.totalKey]);
@@ -173,6 +192,42 @@ export function sanitizeEnergyModel(value = {}, states = allStates(), resolver =
   }
 
   return result;
+}
+
+/* Cosa e' stato scritto due volte.
+ *
+ * Il modello runtime esce gia' ripulito: i campi di periodo spariscono appena
+ * c'e' un contatore totale valido. Cosi' pero' nessuno saprebbe mai che quelle
+ * entita' sono state scritte e non vengono lette. Questa lettura resta sulla
+ * configurazione grezza e dice, gruppo per gruppo, quali campi di periodo il
+ * totale sta scavalcando, perche' la maschera di configurazione possa avvisare
+ * con nome e cognome invece di far sparire i valori in silenzio. */
+export function energyPeriodConflicts(
+  value = {},
+  states = allStates(),
+  resolver = root.resolveEntity,
+) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+  const snapshot = states && typeof states === "object" ? states : {};
+  const conflicts = [];
+  for (const source of ENERGY_RUNTIME_SOURCES) {
+    const group = value[source.group] || {};
+    const total = clean(group[source.totalKey]);
+    if (!total || !entityExists(total, snapshot, resolver)) continue;
+    const resolvedTotal = resolveConfiguredEntity(total, resolver);
+    const ignored = source.periodKeys
+      .map((key) => ({ key, entity: clean(group[key]) }))
+      .filter(
+        ({ entity }) =>
+          entity &&
+          entity !== total &&
+          resolveConfiguredEntity(entity, resolver) !== resolvedTotal &&
+          entityExists(entity, snapshot, resolver),
+      );
+    if (ignored.length)
+      conflicts.push({ group: source.group, totalKey: source.totalKey, total, ignored });
+  }
+  return conflicts;
 }
 
 export function dashboardStore() {

--- a/custom_components/dashboardmodern/frontend/tests/beta27-flow-temperature-visibility.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta27-flow-temperature-visibility.test.js
@@ -118,3 +118,35 @@ test("beta27 hierarchical loads preserve existing appliances and deduplicate pro
     [oven, fridge, custom],
   );
 });
+
+/* Nascosta a mano vuol dire nascosta.
+ *
+ * Nella mappa delle visibilita' un `false` puo' voler dire due cose opposte:
+ * "non l'ho ancora configurata", che ci scrive la procedura iniziale, oppure
+ * "non la voglio vedere", che ci scrive chi preme il pulsante. La passata che
+ * accende le sezioni configurate le trattava allo stesso modo.
+ */
+test("una sezione nascosta di persona non viene riaccesa", () => {
+  const previous = globalThis.localStorage;
+  globalThis.localStorage = memoryStorage({
+    cd_sections: JSON.stringify({ temp: false, security: false }),
+    cd_sections_manual: JSON.stringify({ temp: true }),
+    cd_stanze: JSON.stringify([
+      { id: "room-cameretta", name: "Cameretta", temp: "sensor.cameretta_temperature" },
+    ]),
+    cd_cameras: JSON.stringify([{ entity: "camera.ingresso" }]),
+  });
+
+  try {
+    ensureConfiguredSectionsVisible({ sync: false });
+    const visibility = JSON.parse(globalThis.localStorage.getItem("cd_sections"));
+    // Temperature: nascosta premendo il pulsante, resta nascosta.
+    assert.equal(visibility.temp, false);
+    // Sicurezza: quel false lo aveva scritto la procedura iniziale, e ora che
+    // c'e' una telecamera la cortesia vale ancora.
+    assert.equal(visibility.security, true);
+  } finally {
+    if (previous === undefined) delete globalThis.localStorage;
+    else globalThis.localStorage = previous;
+  }
+});

--- a/custom_components/dashboardmodern/frontend/tests/connection-recovery.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/connection-recovery.test.js
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  MIN_GAP_MS,
+  STALE_CONNECTING_MS,
+  reconnectDecision,
+} from "../src/sections/connection-recovery-section.js";
+
+const CONNECTING = 0;
+const OPEN = 1;
+const CLOSED = 3;
+
+test("a connected dashboard is left alone", () => {
+  assert.deepEqual(reconnectDecision({ up: true, readyState: OPEN, sinceLastTry: 10 ** 6 }), {
+    retry: false,
+    reason: "connessa",
+  });
+  // Even with no socket at all: the dot is the runtime's own word for "the
+  // data is arriving", and it outranks anything read from the socket.
+  assert.equal(
+    reconnectDecision({ up: true, readyState: null, sinceLastTry: 10 ** 6 }).retry,
+    false,
+  );
+});
+
+test("a page rebuilt without a socket reconnects", () => {
+  // This is the reported case: iOS threw the page away, the panel rebuilt it,
+  // the one connect() the runtime does threw, and nothing tried again.
+  const decision = reconnectDecision({ up: false, readyState: null, sinceLastTry: 10 ** 6 });
+  assert.equal(decision.retry, true);
+  assert.equal(decision.reason, "nessuna presa");
+});
+
+test("a socket that is still opening is given time, then given up on", () => {
+  assert.equal(
+    reconnectDecision({ up: false, readyState: CONNECTING, sinceLastTry: STALE_CONNECTING_MS - 1 })
+      .retry,
+    false,
+  );
+  const stale = reconnectDecision({
+    up: false,
+    readyState: CONNECTING,
+    sinceLastTry: STALE_CONNECTING_MS + 1,
+  });
+  assert.equal(stale.retry, true);
+  assert.equal(stale.reason, "presa ferma");
+});
+
+test("two attempts never crowd each other", () => {
+  assert.equal(
+    reconnectDecision({ up: false, readyState: CLOSED, sinceLastTry: MIN_GAP_MS - 1 }).retry,
+    false,
+  );
+  assert.equal(
+    reconnectDecision({ up: false, readyState: CLOSED, sinceLastTry: MIN_GAP_MS + 1 }).retry,
+    true,
+  );
+});
+
+test("the section opens no socket of its own and stops when connected", () => {
+  const source = readFileSync(
+    new URL("../src/sections/connection-recovery-section.js", import.meta.url),
+    "utf8",
+  );
+  // It calls the runtime's connect(); it never constructs a socket, and never
+  // touches the token or the URL the runtime resolves. Read past the header:
+  // that comment quotes the runtime line this module exists because of.
+  const body = source.slice(source.indexOf('\nimport {'));
+  assert.doesNotMatch(body, /new WebSocket/);
+  assert.doesNotMatch(body, /access_token|LONG_LIVED_TOKEN|api\/websocket/);
+  // No standing timer once the dashboard is connected.
+  assert.match(source, /if \(connectionUp\(\)\) \{\s*state\.attempts = 0;\s*return;/);
+  assert.doesNotMatch(source, /setInterval/);
+  // The doors a returning app actually comes through.
+  for (const event of ["visibilitychange", "pageshow", "focus", "online"]) {
+    assert.match(source, new RegExp(event), event);
+  }
+});
+
+test("the runtime registry installs it", () => {
+  const runtime = readFileSync(
+    new URL("../src/sections/section-runtime.js", import.meta.url),
+    "utf8",
+  );
+  assert.match(runtime, /connection-recovery-section\.js/);
+  assert.match(runtime, /installConnectionRecoverySection\(\)/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/connection-recovery.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/connection-recovery.test.js
@@ -87,3 +87,23 @@ test("the runtime registry installs it", () => {
   assert.match(runtime, /connection-recovery-section\.js/);
   assert.match(runtime, /installConnectionRecoverySection\(\)/);
 });
+
+test("coming back to the app does not wait for the throttle", () => {
+  // La pausa fra due tentativi serve a non impilare prese mentre nessuno
+  // guarda. Al rientro qualcuno sta guardando adesso.
+  const justTried = { up: false, readyState: CLOSED, sinceLastTry: 10 };
+  assert.equal(reconnectDecision(justTried).retry, false);
+  assert.equal(reconnectDecision({ ...justTried, eager: true }).retry, true);
+
+  // Il freno che resta e' quello che conta: non una seconda presa sopra una
+  // che si sta ancora aprendo.
+  assert.equal(
+    reconnectDecision({ up: false, readyState: CONNECTING, sinceLastTry: 10, eager: true }).retry,
+    false,
+  );
+  // E da connessi non si tocca niente, per quanto si insista.
+  assert.equal(
+    reconnectDecision({ up: true, readyState: CLOSED, sinceLastTry: 10, eager: true }).retry,
+    false,
+  );
+});

--- a/custom_components/dashboardmodern/frontend/tests/dashboard-store.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/dashboard-store.test.js
@@ -710,3 +710,23 @@ test("Temperature migration accepts descriptive legacy entity field names", () =
   assert.equal(room.temp, "sensor.office_temperature");
   assert.equal(room.hum, "sensor.office_humidity");
 });
+
+test("una sezione nascosta di persona non torna su alla prima entita' mappata", async () => {
+  // Il MiniPC nascosto col pulsante: mappare un'entita' qualsiasi lo
+  // riaccendeva, perche' nella mappa un false vale come "mai deciso".
+  const { store } = setup({
+    dm_dashboard_state: {
+      schema_version: 4,
+      sections: { entityOverrides: {} },
+      visibility: { server: false, boiler: false },
+    },
+    cd_sections_manual: { server: true },
+  });
+  await store.replaceSection("entityOverrides", {
+    "dm.server_cpu": "sensor.minipc_cpu",
+    "dm.boiler_temperatura": "sensor.solar_boiler",
+  });
+  assert.equal(store.getState().visibility.server, false);
+  // Il solare termico non l'ha nascosto nessuno a mano: la cortesia vale.
+  assert.equal(store.getState().visibility.boiler, true);
+});

--- a/custom_components/dashboardmodern/frontend/tests/editor-edit-buttons.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/editor-edit-buttons.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { editButtonPlan } from "../src/sections/editor-crud-section.js";
+
+/* Il numero di una riga e' la sua posizione nell'elenco.
+ *
+ * Chi dipinge le righe legge quel numero per sapere quale unita' mostrare: due
+ * righe con lo stesso numero mostrano la stessa unita', ed e' cosi' che la
+ * stessa entita' finiva su tutte le righe.
+ */
+test("una lista mai toccata prende i numeri in ordine", () => {
+  const plan = editButtonPlan([{}, {}, {}]);
+  assert.deepEqual(plan, [
+    { index: 0, action: "create" },
+    { index: 1, action: "create" },
+    { index: 2, action: "create" },
+  ]);
+});
+
+test("una passata che trova le prime righe gia' fatte non fa ripartire i numeri da zero", () => {
+  // E' cio' che accade quando il runtime ridisegna solo una parte dell'elenco:
+  // le righe in alto hanno gia' il pulsante, quelle in coda no.
+  const plan = editButtonPlan([
+    { hasButton: true, index: 0 },
+    { hasButton: true, index: 1 },
+    {},
+    {},
+  ]);
+  assert.deepEqual(plan.map((step) => step.index), [0, 1, 2, 3]);
+  assert.deepEqual(plan.map((step) => step.action), ["keep", "keep", "create", "create"]);
+});
+
+test("una riga che porta il numero sbagliato viene corretta, non lasciata com'e'", () => {
+  // Dopo un'eliminazione le righe scalano: la terza diventa la seconda e il
+  // numero che si porta dietro punterebbe all'unita' di prima.
+  const plan = editButtonPlan([
+    { hasButton: true, index: 1 },
+    { hasButton: true, index: 2 },
+    { hasButton: true, index: 3 },
+  ]);
+  assert.deepEqual(plan.map((step) => step.index), [0, 1, 2]);
+  assert.deepEqual(plan.map((step) => step.action), ["renumber", "renumber", "renumber"]);
+});
+
+test("in nessun caso due righe portano lo stesso numero", () => {
+  const shapes = [
+    [{ hasButton: true, index: 0 }, {}, { hasButton: true, index: 0 }, {}],
+    [{}, { hasButton: true, index: 0 }, { hasButton: true, index: 0 }],
+    [{ hasButton: true, index: 5 }, { hasButton: true, index: 5 }],
+  ];
+  for (const rows of shapes) {
+    const indices = editButtonPlan(rows).map((step) => step.index);
+    assert.equal(new Set(indices).size, indices.length, JSON.stringify(rows));
+    assert.deepEqual(indices, rows.map((_row, index) => index));
+  }
+});

--- a/custom_components/dashboardmodern/frontend/tests/editor-slots-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/editor-slots-section.test.js
@@ -116,3 +116,49 @@ test("opening the editor decorates it, whatever the order the runtime loads in",
   assert.match(install, /addEventListener\?\.\(eventName, \(\) => \{\s*bindLegacyEntryPoints\(\);/);
 });
 
+
+function fakeInput(id, placeholder) {
+  return {
+    id,
+    attributes: { placeholder },
+    getAttribute(name) {
+      return this.attributes[name] ?? null;
+    },
+    setAttribute(name, value) {
+      this.attributes[name] = value;
+    },
+  };
+}
+
+test("no field asks for a dm.core code any more", async () => {
+  const { clarifyEntityPlaceholders } = await loadSection();
+  const action = fakeInput("ed-qa-ent", "dm.core_054 / dm.core_023 / scene.x (non serve per i popup)");
+  const wizardAction = fakeInput("wz-qa-ent", "dm.core_054 — l'entità da comandare");
+  const slot = fakeInput("", "es. dm.core_039");
+  const meter = fakeInput("ed-rep2-ent", "dm.core_028");
+  const untouched = fakeInput("ed-other", "sensor.qualcosa");
+  const inputs = [action, wizardAction, slot, meter, untouched];
+  const scope = { querySelectorAll: () => inputs };
+
+  assert.equal(clarifyEntityPlaceholders(scope), 4);
+  for (const input of [action, wizardAction, slot, meter]) {
+    assert.doesNotMatch(input.attributes.placeholder, /dm\.core/, input.id || "slot");
+    assert.ok(input.attributes.placeholder.length > 0);
+  }
+  // A named field says what it wants, with an example someone can actually have.
+  assert.match(meter.attributes.placeholder, /kWh/);
+  assert.match(wizardAction.attributes.placeholder, /switch\./);
+  // An unnamed slot falls back to the shape of a Home Assistant id.
+  assert.match(slot.attributes.placeholder, /dominio\.nome|domain\.name/);
+  // Everything else is left alone, and a second pass changes nothing.
+  assert.equal(untouched.attributes.placeholder, "sensor.qualcosa");
+  assert.equal(clarifyEntityPlaceholders(scope), 0);
+  assert.equal(clarifyEntityPlaceholders(null), 0);
+});
+
+test("the placeholders are rewritten whenever the editor is decorated", () => {
+  assert.match(source, /clarifyEntityPlaceholders\(\);\n\s*dropRetiredSlots\(scope\)/);
+  // The row caption prefers the named caption over the placeholder text, so a
+  // field with a long example still prints a short name.
+  assert.match(source, /"ed-qa-ent": \["Entità da comandare"/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/energy-total-over-periods.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energy-total-over-periods.test.js
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { sourcePlans } from "../src/core/period-service.js";
+import { energyPeriodConflicts, sanitizeEnergyModel } from "../src/sections/shared.js";
+
+function energyState(state = "0") {
+  return {
+    state,
+    attributes: {
+      unit_of_measurement: "kWh",
+      device_class: "energy",
+      state_class: "total_increasing",
+    },
+  };
+}
+
+const STATES = {
+  "sensor.casa_totale": energyState("9120"),
+  "sensor.casa_giorno": energyState("4.2"),
+  "sensor.casa_mese": energyState("118"),
+  "sensor.casa_anno": energyState("1420"),
+};
+
+test("a configured total meter removes the period helpers from the runtime model", () => {
+  const configured = {
+    house: {
+      total_energy: "sensor.casa_totale",
+      daily_energy: "sensor.casa_giorno",
+      monthly_energy: "sensor.casa_mese",
+      annual_energy: "sensor.casa_anno",
+    },
+  };
+
+  const runtime = sanitizeEnergyModel(configured, STATES, (value) => value, {});
+  assert.equal(runtime.house.total_energy, "sensor.casa_totale");
+  assert.equal(runtime.house.daily_energy, "");
+  assert.equal(runtime.house.monthly_energy, "");
+  assert.equal(runtime.house.annual_energy, "");
+
+  // The configuration itself is untouched: the fields stay written, they are
+  // only kept out of the model the pages read.
+  assert.equal(configured.house.daily_energy, "sensor.casa_giorno");
+
+  for (const kind of ["day", "month", "year"]) {
+    const plans = sourcePlans(runtime, kind, STATES).filter((plan) => plan.key === "house");
+    assert.equal(plans.length, 1, `one plan for ${kind}`);
+    assert.equal(plans[0].entity, "sensor.casa_totale");
+    assert.equal(plans[0].direct, false);
+    assert.equal(plans[0].reason, "canonical-total");
+  }
+});
+
+test("the period helpers still drive the pages when no total meter is configured", () => {
+  const configured = { house: { daily_energy: "sensor.casa_giorno", monthly_energy: "sensor.casa_mese" } };
+  const runtime = sanitizeEnergyModel(configured, STATES, (value) => value, {});
+  assert.equal(runtime.house.monthly_energy, "sensor.casa_mese");
+  const plans = sourcePlans(runtime, "month", STATES).filter((plan) => plan.key === "house");
+  assert.equal(plans[0].direct, true);
+  assert.equal(plans[0].entity, "sensor.casa_mese");
+});
+
+test("the overridden period fields are reported with their entity so the editor can name them", () => {
+  const conflicts = energyPeriodConflicts(
+    {
+      house: {
+        total_energy: "sensor.casa_totale",
+        daily_energy: "sensor.casa_giorno",
+        annual_energy: "sensor.casa_anno",
+      },
+      solar: { daily_energy: "sensor.casa_giorno" },
+    },
+    STATES,
+    (value) => value,
+  );
+
+  assert.equal(conflicts.length, 1);
+  assert.equal(conflicts[0].group, "house");
+  assert.equal(conflicts[0].total, "sensor.casa_totale");
+  assert.deepEqual(
+    conflicts[0].ignored.map((field) => field.key).sort(),
+    ["annual_energy", "daily_energy"],
+  );
+  assert.deepEqual(
+    conflicts[0].ignored.map((field) => field.entity).sort(),
+    ["sensor.casa_anno", "sensor.casa_giorno"],
+  );
+});
+
+test("a period field mirroring the total meter is a migration, not a clash", () => {
+  const conflicts = energyPeriodConflicts(
+    { house: { total_energy: "sensor.casa_totale", annual_energy: "sensor.casa_totale" } },
+    STATES,
+    (value) => value,
+  );
+  assert.deepEqual(conflicts, []);
+});
+
+test("a period field pointing at a missing entity is not announced as ignored", () => {
+  const conflicts = energyPeriodConflicts(
+    { house: { total_energy: "sensor.casa_totale", daily_energy: "sensor.sparito" } },
+    STATES,
+    (value) => value,
+  );
+  assert.deepEqual(conflicts, []);
+});
+
+test("the energy editor warns about the overridden fields and offers to clear them", () => {
+  const source = readFileSync(new URL("../src/sections/energy-guidance-section.js", import.meta.url), "utf8");
+  assert.match(source, /energyPeriodConflicts/);
+  assert.match(source, /dm-energy-source-clash/);
+  assert.match(source, /dm-energy-clash-clear/);
+  assert.match(source, /clearClashingPeriods/);
+  assert.match(source, /\$\{clashNotice\(energyClashes\(\)\)\}/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/runtime-consolidation.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-consolidation.test.js
@@ -205,7 +205,8 @@ test("one hosted bootstrap delegates to the section runtime, which owns the guar
   assert.match(guidance, /consumo Casa usa lo stesso bilancio dei flussi di Home Assistant/);
   assert.match(guidance, /energyEditorActive/);
   assert.match(guidance, /removeEnergyGuidance/);
-  assert.match(guidance, /Recorder, storico e mesi precedenti/);
+  assert.match(guidance, /storico e mesi precedenti si ricavano da qui con Recorder/);
+  assert.match(guidance, /dm-energy-source-clash/);
   assert.match(report, /dm-report-row-editor/);
   assert.match(report, /grid-template-areas/);
   for (const kind of ["action", "climate", "shutter", "room"])

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -229,7 +229,12 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // Beta 31.1 adds one more owner: every section of the dashboard opens with
   // the same heading — icon, name, and the line that says what the page is for
   // — instead of six different ideas of a title. It renders no data.
-  assert.ok(relative.length <= 105, `production graph unexpectedly grew to ${relative.length} modules`);
+  // E uno ancora: il rientro nell'app. Il runtime apre la presa verso Home
+  // Assistant una volta sola e, se quel tentativo salta, non ne prova altri —
+  // su iPhone, dove il sistema butta via la pagina quando passi ad altra app,
+  // la plancia restava ferma a "CONNECTING…". Quel modulo non apre nessuna
+  // presa e non legge nessuno stato: richiama connect(), quello del runtime.
+  assert.ok(relative.length <= 106, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
 
   /* No polling, with one declared exception.


### PR DESCRIPTION
Tutti i punti della lista vista sul dispositivo, più quelli arrivati dopo: il rientro nell'app, il MiniPC che non si nascondeva, il cestino del Clima che non aggiornava. La versione resta `1.0.0-rc.1`: quella pubblicazione è stata ritirata pochi minuti dopo, prima che qualcuno la scaricasse, e serve per provare queste correzioni.

## Rientrare nell'app lasciava la plancia a «CONNECTING…»

Su iPhone il sistema butta via la pagina dell'app quando passi ad altro: al rientro il pannello la ricostruisce da zero. Il runtime apre la presa verso Home Assistant **una volta sola** e, se quel tentativo non va a buon fine, non ne prova altri:

```js
try { ws = new WebSocket(...); } catch(e) { return; }
```

Quel `return` è un vicolo cieco. Sulla pagina appena ricostruita il ponte verso il frontend ospite può non essere ancora pronto, il costruttore salta, e resta la scritta che sta nel documento appena aperto — `CONNECTING...` — con i gradi a `--` e i riquadri vuoti. Chiudere e riaprire l'app la sistemava, perché era un avvio nuovo in cui il ponte faceva in tempo.

Il modulo nuovo non apre nessuna presa e non tocca né token né URL: richiama `connect()`, quello del runtime, quando la plancia non è connessa — al rientro dall'altra app, al ritorno della rete, e intanto a intervalli che si allargano da 2 a 30 secondi. Da connessi non resta acceso nessun timer.

## Clima: il cestino non aggiornava l'elenco

`editorSwitch('sezioni')` non corrisponde più a nessuna scheda da quando ce n'è una per sezione, da `sez0` a `sez9`: il runtime lo riconosce come nome vecchio e non ridisegna nulla. **Ventiquattro** punti lo chiamano ancora dopo aver aggiunto o eliminato qualcosa.

Il cestino cancellava davvero, ma l'elenco restava fermo: la sezione appariva pulita solo uscendo e rientrando. E chi continuava a premere si ritrovava a premere su righe che non esistevano più.

Da lì la seconda metà: **il numero di una riga era il suo turno di arrivo, non la sua posizione**. La passata escludeva le righe già sistemate e poi contava da capo su quel che restava, così una passata che ne trovava alcune fatte e altre no dava alle nuove gli stessi numeri delle righe più in alto. Chi dipinge le righe legge quel numero per sapere quale unità mostrare: due righe con lo stesso numero mostrano la stessa unità, ed è così che la stessa entità finiva su tutte le righe, sotto caldo e sotto freddo.

## Nascosta a mano vuol dire nascosta

Nella mappa delle visibilità un `false` può voler dire due cose opposte: «questa sezione non l'ho ancora configurata», che ci scrive la procedura iniziale, oppure «questa sezione non la voglio vedere», che ci scrive chi preme il pulsante. La passata che accende le sezioni configurate le trattava allo stesso modo e riscriveva **tutti e due**.

Il MiniPC ha entità mappate, quindi tornava su a ogni salvataggio, a ogni cambio di stato, a ogni entità mappata. Adesso si tiene da parte la sola cosa che distingue i due casi — su quali sezioni la persona si è espressa di persona — e su quelle non si torna; la scelta viaggia con la configurazione, così gli altri dispositivi non la riaccendono. La cortesia resta per le sezioni su cui nessuno si è ancora espresso.

## Le foto dell'auto cambiavano da sole

Con due profili finivano identiche su entrambe le auto, poco dopo essere state inserite.

La passata che disegna l'immagine risolve il percorso della foto attiva e riscrive la forma buona nella configurazione — serve, perché un percorso storto (`/loca/…` invece di `/local/…`) si corregge così una volta sola. La chiave in cui finiva però la sceglieva il cavo: con la sola foto «col cavo» impostata e il cavo staccato, la foto attiva veniva da quella chiave ma la riscrittura la metteva in quella «senza cavo». Da lì le due erano la stessa, e il profilo salvato dopo se le portava dietro uguali.

La correzione va ora nelle caselle che quel valore lo contengono davvero, e in nessun'altra.

## Energia: il contatore totale comanda

Chi riempiva il totale **e** giornaliera, mensile e annuale si ritrovava due verità che non tornano: il totale cresce e basta, i contatori di periodo si azzerano quando decide chi li ha creati, e il numero mostrato cambiava a seconda di quale dei due la pagina avesse letto per primo.

Con un contatore totale valido i campi di periodo restano fuori dal modello e ogni periodo si ricava dal totale con Recorder. La configurazione non viene toccata: la maschera Energia elenca **per nome** le entità scavalcate, spiega perché, e offre un bottone per svuotarle. Il riquadro «come leggere la configurazione» — scritto da un modulo diverso — diceva l'esatto contrario a due centimetri dall'avviso: adesso raccontano la stessa regola. E la maschera legge la configurazione com'è scritta, non il modello filtrato che leggono le pagine.

## Stanze: i quadratini dopo l'icona

La riga «aggiungi stanza» nasce dal runtime come una fila flex; la rifinitura la trasforma in una griglia, e in una griglia il flex dei campi non vale più niente: un campo di testo vuoto tiene la sua larghezza naturale, cioè zero. Restavano due riquadri larghi quanto la loro cornice con il resto della riga vuoto. La versione stretta lo aveva già risolto per il nome; ora vale anche a schermo largo.

## I popup mostravano un'altra icona, e ferma

La riga del popup «in funzione» disegnava l'illustrazione piatta: una sagoma azzurra quasi uguale per ogni elettrodomestico, immobile anche mentre l'elettrodomestico lavorava, mentre la scheda accanto mostrava il disegno con le parti mobili. Le regole delle animazioni erano scritte sulla scheda e non potevano seguire il disegno altrove: ora la classe `.dm-ap-mech` dice «qui dentro c'è un disegno animabile», la porta la scheda e la porta la riga del popup.

## Il telefono era lento, il computer no

Sopra la Home stanno **dodici** finestre chiuse: meteo, clima, allarme, carichi, lavatrice, auto, dettagli, tastierino, storico, conferma e i due storici del server. Sono nascoste, ma restano larghe quanto lo schermo e ognuna chiedeva al browser di sfocare tutto quello che aveva dietro — dodici livelli a schermo intero che la GPU tiene in memoria e ricompone a ogni scorrimento. Lo stesso valeva per la barra di navigazione mentre è ritirata. Dentro due di quelle finestre girava anche una rotella di caricamento, per sempre.

Lo sfondo sfocato torna appena la finestra si apre, che è l'unico momento in cui qualcuno lo vede.

## Le etichette che non dicevano niente

I campi entità suggerivano `dm.core_054 / dm.core_023 / scene.x`: sono i nomi interni degli slot di questa dashboard, non entità che qualcuno abbia in casa, e nel campo Azioni la sigla finiva anche come didascalia della riga. Ogni campo dice ora che cosa vuole, con un esempio scritto come Home Assistant scrive le sue entità.

Le sonde del solare termico si chiamavano «Sonda temperatura 1, 2 e 3»: la pagina sa che la prima alimenta la lettura del pannello, la seconda il fondo dell'accumulo, la terza la cima. Sono nomi che si possono cambiare, quindi si riscrivono solo finché portano ancora quello di fabbrica.

## Il dock tornava indietro sotto il dito

La barra riportava la sezione aperta sotto gli occhi ogni volta che il puntatore ci rientrava, e il click cadeva sull'icona sbagliata. Da quando l'utente scorre, il dock smette di riportarsi da solo; torna a seguirla quando cambia la sezione aperta.

## Il Report

Tre cose sulla stessa riga: il quadratino dell'icona restava vuoto perché il pulsante di anteprima **azzera il corpo del testo** per far posto a un'immagine, e lì l'icona è un carattere; la ricerca dell'elettrodomestico per nome leggeva **un attributo che nessuno scrive**; e la riga era impaginata da **due moduli con due griglie diverse**. Riga da 201 a 159 pixel.

## Le intestazioni

Nascevano in cima alla scheda con una larghezza propria: sulle pagine che tengono il contenuto in un contenitore a larghezza fissa restava un rettangolo stretto sopra un contenuto molto più largo. Ora nascono dove nasce il contenuto — e dove nessun contrassegno rende riconoscibile il contenitore, come su Clima, vale il blocco unico che si vede sotto l'intestazione. Solare termico e MiniPC prendono la stessa intestazione delle altre. Il MiniPC compariva due volte nell'elenco, con due tinte: l'ultima vinceva e la prima non si è mai vista.

## I comandi del campo entità

La matita da sola non diceva a cosa serviva. Ora si legge **Modifica**, e accanto compare **Elimina** quando c'è qualcosa da togliere. Il testo resta anche sugli schermi stretti: è sul telefono che la matita da sola non si capiva.

## Luci

Una stanza attribuita alle luci ma assente dall'elenco Stanze viene adottata invece di restare un nome fantasma.

## Prove più oneste

Quattro prove misuravano un istante a caso invece di aspettare che la cosa fosse finita, e cadevano sui runner della CI — più lenti di una macchina da sviluppo: la normalizzazione delle stanze aspettava una passata che nessuno svegliava; un `<img>` veniva misurato prima che la fotografia arrivasse; i selettori del pannello entità venivano contati mentre la rifinitura era ancora a metà; le prove sul rientro nell'app agivano prima che il modulo esistesse. E la prova sul cestino ora ripete il giro che l'ha fatta vedere: tre eliminazioni di fila senza mai uscire dalla sezione.

## Verifica

- unit: **786/786**
- browser, suite completa desktop + mobile: **259/259**
- ogni correzione ha una prova verificata nei due sensi: fallisce senza, passa con

Non riprodotto in ambiente pulito, da confermare sul dispositivo: **due auto configurate ma ne esce una sola** (il percorso completo è ora coperto da una prova che passa; il sintomo era con ogni probabilità la coppia di foto che diventava identica, corretta qui sopra) e **il prelievo rete che non salva il sensore** (scrivendo il campo e premendo Salva, l'entità si salva).

---
_Generated by [Claude Code](https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT)_