### PR TITLE
1.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.0.0-rc.2 — 2026-08-20
+
+Tutto quello che si è visto sul dispositivo dopo la prima release candidate.
+
+### Corretto
+
+- **Rientrare nell'app non lascia più la plancia a «CONNECTING…».** Su iPhone il
+  sistema butta via la pagina quando si passa ad altro, e al rientro il pannello
+  la ricostruisce da zero. Il runtime apre la presa verso Home Assistant una
+  volta sola e, se quel tentativo non va a buon fine, non ne prova altri:
+  restava la scritta del documento appena aperto, con i gradi a «--» e i
+  riquadri vuoti. Chiudere e riaprire l'app la sistemava, perché era un avvio
+  nuovo. Adesso la connessione viene richiesta di nuovo al rientro, al ritorno
+  della rete, e intanto a intervalli che si allargano; da connessi non resta
+  acceso nessun timer.
+- **Il cestino del Clima aggiorna l'elenco.** Cancellava davvero, ma la lista
+  restava ferma: la sezione appariva pulita solo uscendo e rientrando, e chi
+  continuava a premere si ritrovava a premere su righe che non esistevano più.
+  Il nome di scheda che il runtime usa dopo ogni eliminazione non corrisponde
+  più a niente da quando ce n'è una per sezione, e viene tradotto in quella
+  davvero aperta.
+- **Una sola entità non compare più su tutte le righe.** Il numero di una riga
+  dell'editor era il suo turno di arrivo invece della sua posizione: due righe
+  con lo stesso numero mostravano la stessa unità, sotto caldo e sotto freddo.
+- **Nascosta a mano vuol dire nascosta.** Nella mappa delle visibilità un
+  «no» poteva voler dire «non l'ho ancora configurata» oppure «non la voglio
+  vedere», e la passata che accende le sezioni configurate riscriveva tutte e
+  due: il MiniPC, che ha entità mappate, tornava su ogni volta. Ora la scelta
+  fatta di persona viene ricordata e viaggia con la configurazione.
+- **Il contatore totale dell'energia comanda sui campi di periodo.** Chi
+  riempiva il totale e anche giorno, mese e anno si ritrovava due verità che non
+  tornano. Ogni periodo si ricava dal totale con Recorder, e la maschera elenca
+  per nome le entità scavalcate offrendo di svuotarle.
+- **Le foto delle due auto non si scambiano più di casella.** La correzione di
+  un percorso storto finiva nella casella sbagliata, e da lì le due auto
+  mostravano la stessa immagine.
+- **Il telefono non paga più le finestre chiuse.** Dodici finestre nascoste
+  chiedevano ognuna di sfocare tutto quello che avevano dietro, a schermo
+  intero, e dentro due di esse girava una rotella di caricamento per sempre.
+- **Report leggibile**, intestazioni larghe quanto ciò che introducono, comandi
+  del campo entità scritti a parole, sonde del solare termico che dicono cosa
+  misurano, stanze delle luci adottate invece di restare nomi fantasma, riga
+  «aggiungi stanza» che non è più due quadratini, icone dei popup uguali a
+  quelle delle schede e in movimento quando l'elettrodomestico lavora.
+
 ## 1.0.0-rc.1 — 2026-08-19
 
 Prima release candidate della 1.0.0: la configurazione e le intestazioni delle

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.0.0--rc.1-0ea5e9" alt="Versione 1.0.0-rc.1">
+  <img src="https://img.shields.io/badge/version-1.0.0--rc.2-0ea5e9" alt="Versione 1.0.0-rc.2">
   <img src="https://img.shields.io/badge/HACS-custom-41BDF5" alt="HACS custom integration">
   <img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-18BCF2" alt="Home Assistant 2025.1+">
   <img src="https://img.shields.io/badge/UI-Italiano%20%7C%20English-16a34a" alt="Italiano e inglese">

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-rc.1","dashboardVersion":"1.0.0-rc.1","moduleVersion":14,"schemaVersion":4,"date":"2026-08-19T10:14:49+00:00","commit":"085f181d2e9a68fd8361504d4cc367d6952c8c61","assetHash":"23a0a57e69e9483a"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-rc.2","dashboardVersion":"1.0.0-rc.2","moduleVersion":14,"schemaVersion":4,"date":"2026-08-20T06:07:42+00:00","commit":"d367413ecd51776ec97c35ce381841e14b3987fa","assetHash":"0e0c2d9ff5af6894"});

--- a/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
@@ -7,5 +7,5 @@ const manifest = JSON.parse(
 );
 
 test("the release manifest is versioned correctly", () => {
-  assert.equal(manifest.version, "1.0.0-rc.1");
+  assert.equal(manifest.version, "1.0.0-rc.2");
 });

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-rc.1"
+  "version": "1.0.0-rc.2"
 }


### PR DESCRIPTION
Solo il numero di versione e le note: il codice è già su `main`, entrato con #163.

## Perché rc.2 e non rc.1

La rc.1 è stata ritirata poco dopo la pubblicazione, ma **il suo tag è rimasto** e punta al codice vecchio (`469ab2c`). Il workflow di pubblicazione si rifiuta esplicitamente di sovrascrivere un tag esistente:

```
Release tag v1.0.0-rc.1 already exists. Bump manifest.json instead of overwriting an existing release.
```

Da questo ambiente i tag non si possono né cancellare né spostare — git e API rispondono entrambi 403 — quindi questo giro esce come rc.2.

## Cosa cambia

- `manifest.json` → `1.0.0-rc.2`
- badge nel README
- `build-info.js` rigenerato
- la prova che fissa la versione, aggiornata
- voce di changelog con tutto quello che si è visto sul dispositivo dopo la prima release candidate

## Verifica

- unit: **786/786**
- formattazione: pulita
- il codice era già verde su `main`: 259/259 nella suite browser desktop + mobile, e tutti e 14 i check della CI su #163

Il merge di questa PR tocca `manifest.json` su `main`, che è ciò che fa partire la pubblicazione da sola.

---
_Generated by [Claude Code](https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT)_