### PR TITLE
1.0.0-rc.4: la tapparella ha la sua finestra, e la finestra si apre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.0.0-rc.4 — 2026-08-20
+
+L'ultima candidata prima della 1.0.
+
+### Aggiunto
+
+- **La tapparella ha la sua finestra, e la finestra si puo' aprire.** La card
+  mostrava un rettangolo con delle stecche che scendevano davanti a un cielo:
+  una tapparella senza infisso. Si guarda invece dalla stanza — che e' da dove
+  uno la guarda — e allora in primo piano c'e' sempre il telaio, con le sue due
+  ante e la maniglia, e la tapparella scende dietro perche' sta fuori. In Config
+  ogni tapparella prende un sensore di apertura, facoltativo: quando quel
+  contatto dice aperto le ante rientrano verso i loro cardini, si scopre il vano
+  e accanto allo stato compare «Finestra aperta». Senza sensore, o con un
+  sensore che non risponde, la card resta com'era: non si disegna un'apertura
+  che nessuno ha misurato.
+
+### Corretto
+
+- **Tapparelle tocca i bordi come tutte le altre pagine.** La casa del suo
+  contenuto ha sedici pixel di margine per lato — e' l'unica pagina che lo fa —
+  e l'intestazione, nascendo li' dentro, se li portava con se': restava una
+  striscia staccata dai bordi mentre ovunque altrove tocca i lati. Quel margine
+  distanzia le card dal bordo, non accorcia l'apertura della pagina.
+- **La barra in basso non si accende piu' di scatto.** Fa lo stesso mestiere
+  delle finestre — niente vetro smerigliato mentre e' ritirata — ed elencava a
+  mano cosa sfumare, con la sfocatura fuori dall'elenco: ricompariva accendendo
+  la sfocatura in un disegno solo, ed era il tremolio che si vedeva anche li'.
+- **L'intestazione che c'e' gia' si sposta invece di sdoppiarsi.** La casa puo'
+  cambiare mentre la pagina e' viva; cercarla solo fra i figli diretti
+  significava non trovarla e farne una seconda, lasciando la prima dov'era: due
+  nomi e due pulsanti Home sulla stessa pagina.
+- **Il contatto di una tapparella non sparisce piu' aprendo l'editor.** Il
+  modello canonico tiene solo i campi che conosce, e le tapparelle non avevano
+  un ramo proprio.
+
+### Resta aperto
+
+- **Fold8 aperto: lo scorrimento si ferma prima del fondo**, e riparte solo
+  ricaricando. Non e' stato riprodotto: con pagine lunghe e cinque misure tipo
+  Fold lo scorrimento arriva sempre in fondo, e nemmeno un ridisegno di stato,
+  uno di configurazione, un rientro nell'app o un cambio di misura lo rompono.
+  Le uniche regole che bloccherebbero l'altezza sono quelle del chiosco iOS, che
+  su Android non si attivano.
+
 ## 1.0.0-rc.3 — 2026-08-20
 
 Cinque cose viste sul telefono dopo la seconda release candidate.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.0.0--rc.3-0ea5e9" alt="Versione 1.0.0-rc.3">
+  <img src="https://img.shields.io/badge/version-1.0.0--rc.4-0ea5e9" alt="Versione 1.0.0-rc.4">
   <img src="https://img.shields.io/badge/HACS-custom-41BDF5" alt="HACS custom integration">
   <img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-18BCF2" alt="Home Assistant 2025.1+">
   <img src="https://img.shields.io/badge/UI-Italiano%20%7C%20English-16a34a" alt="Italiano e inglese">

--- a/custom_components/dashboardmodern/frontend/e2e/beta32-real-device-uniformity.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta32-real-device-uniformity.spec.js
@@ -302,15 +302,24 @@ test("every page opens with the same heading, once", async ({ page }, testInfo) 
           }
           return true;
         })(),
+        /* Larga quanto il blocco che apre, margine compreso.
+         *
+         * Si misurava contro il primo fratello, cioe' contro il contenuto
+         * dentro al margine: su Tapparelle, l'unica pagina il cui contenitore
+         * ha sedici pixel di margine per lato, quel confronto pretendeva che
+         * l'intestazione stesse dentro al margine — e sul telefono restava una
+         * striscia staccata dai bordi mentre su ogni altra pagina tocca i lati.
+         * Il margine distanzia le card dal bordo, non accorcia l'apertura della
+         * pagina. Quindi: mai piu' stretta di cio' che introduce, e mai piu'
+         * larga della casa che la contiene. */
         sameWidth: (() => {
           if (!mast) return false;
-          const sibling = [...mast.parentElement.children].find(
-            (node) => node !== mast && node.getClientRects().length,
-          );
-          if (!sibling) return true;
-          return (
-            Math.abs(mast.getBoundingClientRect().width - sibling.getBoundingClientRect().width) < 3
-          );
+          const mine = mast.getBoundingClientRect().width;
+          const casa = mast.parentElement.getBoundingClientRect().width;
+          const contenuto = [...mast.parentElement.children]
+            .filter((node) => node !== mast && node.getClientRects().length)
+            .reduce((top, node) => Math.max(top, node.getBoundingClientRect().width), 0);
+          return mine >= contenuto - 3 && mine <= casa + 3;
         })(),
         title: mast?.querySelector(".dm-page-mast-title")?.textContent?.trim() || "",
         subtitle: mast?.querySelector(".dm-page-mast-sub")?.textContent?.trim() || "",
@@ -498,4 +507,38 @@ test("un'intestazione annidata viene spostata, non duplicata", async ({ page }, 
     };
   });
   expect(dopo).toEqual({ intestazioni: 1, home: 1 });
+});
+
+/* Il margine interno della casa non stringe l'intestazione.
+ *
+ * Tapparelle tiene il proprio contenuto in un blocco con sedici pixel di
+ * margine per lato — l'unica pagina che lo fa — e l'intestazione, nascendo li'
+ * dentro, li prendeva con se': sul telefono restava una striscia bianca
+ * staccata dai bordi mentre su ogni altra pagina tocca i lati. Il margine
+ * distanzia le card dal bordo, non accorcia l'apertura della pagina.
+ */
+test("l'intestazione esce dal margine interno della sua casa", async ({ page }, testInfo) => {
+  await boot(page, testInfo);
+  const misura = await page.evaluate(async () => {
+    document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
+    const host = document.getElementById("page-tapparelle");
+    host.classList.add("active");
+    window.dispatchEvent(
+      new CustomEvent("dashboardmodern:state-changed", { detail: { entity_id: "cover.t1" } }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    const mast = host.querySelector(".dm-page-mast");
+    if (!mast) return null;
+    const casa = mast.parentElement;
+    const stile = getComputedStyle(casa);
+    return {
+      margine: Math.round(Number.parseFloat(stile.paddingLeft) || 0),
+      scarto: Math.round(casa.getBoundingClientRect().width - mast.getBoundingClientRect().width),
+    };
+  });
+  expect(misura).not.toBeNull();
+  // La prova ha senso solo se quel margine c'e' davvero.
+  expect(misura.margine).toBeGreaterThan(0);
+  // E l'intestazione e' larga quanto la casa, margine compreso.
+  expect(Math.abs(misura.scarto)).toBeLessThanOrEqual(3);
 });

--- a/custom_components/dashboardmodern/frontend/e2e/popup-opening-does-not-stutter.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/popup-opening-does-not-stutter.spec.js
@@ -8,54 +8,80 @@
  * da 36ms a 23ms una volta curato.
  *
  * La cura e' far salire la sfocatura insieme alla dissolvenza invece che di
- * scatto: la stessa mezza dozzina di disegni che il browser fa comunque per
- * sfumare l'opacita' portano su anche lo sfondo, un pezzo per volta.
+ * scatto. Vale per ogni cosa che il modulo spegne da chiusa, non solo per le
+ * finestre: la barra in basso fa lo stesso mestiere ed era rimasta indietro —
+ * il tremolio si vedeva anche li'.
  *
  * Qui si controlla la cura, non la misura. Quanto dura un disegno dipende da
  * cosa sta facendo la macchina in quel momento — sullo stesso computer lo
  * stesso identico codice ha dato 23ms da solo e 90ms con la suite intorno — e
- * un numero cosi' non e' un contratto, e' il meteo. Il contratto e' che lo
- * sfondo sfocato sia fra le cose che sfumano: e' quello che spalma il lavoro
- * su tutta la dissolvenza invece di concentrarlo in un disegno solo.
+ * un numero cosi' non e' un contratto, e' il meteo.
  */
 import { expect, test } from "@playwright/test";
 import { PRIMARY } from "./helpers/variants.js";
 
+/* Cio' che viene spento da chiuso, e la classe che lo riapre. */
+const SPENTI = [
+  [".modal-wrapper", "show"],
+  [".clima-popup-overlay", "show"],
+  [".hist-overlay", "show"],
+  ["#srv-hist-overlay", "show"],
+  [".srv-history-overlay", "show"],
+  ["nav.tabs.bottom-nav-bar", "visible"],
+];
+
 for (const variant of PRIMARY) {
-  test(`${variant}: lo sfondo di una finestra sfuma invece di comparire di scatto`, async ({
-    page,
-  }) => {
+  test(`${variant}: niente si sfoca di scatto quando si apre`, async ({ page }) => {
     test.setTimeout(90_000);
     await page.goto(`/legacy/${variant}`);
     await page.waitForFunction(() => Boolean(document.getElementById("weather-modal")), null, {
       timeout: 15000,
     });
 
-    const transitions = await page.evaluate(() => {
-      const modal = document.getElementById("weather-modal");
-      const closed = getComputedStyle(modal).transitionProperty;
-      modal.classList.add("show");
-      const open = getComputedStyle(modal).transitionProperty;
-      modal.classList.remove("show");
-      return { closed, open };
-    });
+    const esito = await page.evaluate((spenti) => {
+      const colpevoli = [];
+      const visti = new Set();
+      let controllati = 0;
+      for (const [selector, className] of spenti) {
+        for (const element of document.querySelectorAll(selector)) {
+          if (visti.has(element)) continue;
+          visti.add(element);
+          controllati += 1;
+          const eraAperto = element.classList.contains(className);
+          element.classList.add(className);
+          const style = getComputedStyle(element);
+          const blur = style.backdropFilter || style.webkitBackdropFilter || "none";
+          const proprieta = style.transitionProperty;
+          const sfuma = /backdrop-filter/.test(proprieta) || /\ball\b/.test(proprieta);
+          if (!eraAperto) element.classList.remove(className);
+          if (blur !== "none" && !sfuma) {
+            colpevoli.push({
+              chi: (element.id || element.className || element.tagName).toString().slice(0, 34),
+              sfuma: proprieta.slice(0, 70),
+            });
+          }
+        }
+      }
+      return { colpevoli, controllati };
+    }, SPENTI);
 
-    // Chiusa e aperta: in tutti e due gli stati la sfocatura deve essere fra le
-    // proprieta' che sfumano, altrimenti scatta da una parte o dall'altra.
-    expect(transitions.closed).toMatch(/backdrop-filter/);
-    expect(transitions.open).toMatch(/backdrop-filter/);
+    // La prova deve avere qualcosa da provare.
+    expect(esito.controllati).toBeGreaterThan(8);
+    // Chi si sfoca da aperto deve sfumare anche la sfocatura: altrimenti la
+    // costruisce tutta in un disegno solo, ed e' li' che il telefono inciampa.
+    expect(esito.colpevoli).toEqual([]);
 
-    // E deve sfumare insieme alla dissolvenza, non su un tempo suo.
-    const durations = await page.evaluate(() => {
+    // E la sfocatura sale insieme alla dissolvenza, non su un tempo suo.
+    const tempi = await page.evaluate(() => {
       const modal = document.getElementById("weather-modal");
       modal.classList.add("show");
       const style = getComputedStyle(modal);
-      const properties = style.transitionProperty.split(",").map((value) => value.trim());
-      const times = style.transitionDuration.split(",").map((value) => value.trim());
+      const proprieta = style.transitionProperty.split(",").map((value) => value.trim());
+      const durate = style.transitionDuration.split(",").map((value) => value.trim());
       modal.classList.remove("show");
-      const at = (name) => times[properties.indexOf(name)] || "";
+      const at = (name) => durate[proprieta.indexOf(name)] || "";
       return { opacity: at("opacity"), backdrop: at("backdrop-filter") };
     });
-    expect(durations.backdrop).toBe(durations.opacity);
+    expect(tempi.backdrop).toBe(tempi.opacity);
   });
 }

--- a/custom_components/dashboardmodern/frontend/e2e/shutter-window.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/shutter-window.spec.js
@@ -65,7 +65,13 @@ async function apriTapparelle(page, testInfo) {
     globalThis.renderTapparelle?.();
     window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: {} }));
   });
-  await page.waitForTimeout(600);
+  await page.waitForFunction(
+    () =>
+      document.querySelectorAll("#page-tapparelle .tapp-card[data-tapp] .dm-tw-infisso").length >=
+      2,
+    null,
+    { timeout: 20_000 },
+  );
 }
 
 function carte(page) {
@@ -138,53 +144,82 @@ test("il contatto apre la finestra, e solo quella che ce l'ha", async ({ page },
   expect(lista.find((carta) => carta.tapp === "cover.c1").pastiglia).toBe("");
 });
 
+/* Aspetta che una cosa ci sia, invece di sperare che sia arrivata.
+ *
+ * Le attese a tempo fisso reggono finche' il motore e' quello di casa: su
+ * WebKit, che ci mette il doppio, la stessa prova cadeva perche' guardava
+ * troppo presto. Non era un difetto della plancia, era una prova che misurava
+ * la velocita' della macchina. */
+function aspetta(page, condizione, argomento) {
+  return page.waitForFunction(condizione, argomento, { timeout: 20_000 });
+}
+
+async function apriSchedaTapparelle(page) {
+  await page.evaluate(() => globalThis.apriConfigEntita?.());
+  await aspetta(page, () =>
+    Boolean(document.querySelector("#editor-modal .ed-tab[data-tab='tapp']")),
+  );
+  await page.evaluate(() => {
+    document.querySelector('#editor-modal .ed-tab[data-tab="tapp"]')?.click();
+  });
+  // Prima il campo che stampa il runtime, poi quello aggiunto dal modulo: il
+  // secondo arriva su un disegno successivo.
+  await aspetta(page, () => Boolean(document.getElementById("ed-tp-ent")));
+  await aspetta(page, () => Boolean(document.getElementById("ed-tp-contact")));
+}
+
 test("il sensore si configura dove si configura la tapparella", async ({ page }, testInfo) => {
   test.setTimeout(180_000);
   await apriTapparelle(page, testInfo);
-  const esito = await page.evaluate(async () => {
-    globalThis.apriConfigEntita?.();
-    await new Promise((resolve) => setTimeout(resolve, 800));
-    document.querySelector('#editor-modal .ed-tab[data-tab="tapp"]')?.click();
-    await new Promise((resolve) => setTimeout(resolve, 900));
-    const campo = document.getElementById("ed-tp-contact");
-    if (!campo) return { campo: false };
+  await apriSchedaTapparelle(page);
 
-    // Si compila come si compila a mano, e si aggiunge la tapparella.
+  // Il campo riceve il trattamento di tutti gli altri campi entita': la
+  // pastiglia che apre il catalogo, la matita e il cestino. Non si controlla la
+  // lente com'e' nata, perche' proprio quella decorazione la trasforma; si
+  // controlla che sia arrivata.
+  await aspetta(page, () =>
+    Boolean(document.getElementById("ed-tp-contact")?.closest('[data-dm-entity-chip="true"]')),
+  );
+  const pastiglia = await page.evaluate(() =>
+    Boolean(
+      document
+        .getElementById("ed-tp-contact")
+        ?.closest(".ed-form-row")
+        ?.querySelector(".dm-slot-chip"),
+    ),
+  );
+  expect(pastiglia, "il campo ha la pastiglia che apre il catalogo").toBe(true);
+
+  // Si compila come si compila a mano, e si aggiunge la tapparella.
+  await page.evaluate(() => {
     document.getElementById("ed-tp-name").value = "Bagno";
     document.getElementById("ed-tp-ent").value = "cover.c3";
-    campo.value = "binary_sensor.finestra_bagno";
+    document.getElementById("ed-tp-contact").value = "binary_sensor.finestra_bagno";
     globalThis.edTappAdd?.();
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    /* Si guarda dove il disegno va a leggere: il modello canonico se c'e' gia',
-     * altrimenti la copia in localStorage. Il modello si allinea con i suoi
-     * tempi, e chiedere solo a lui vorrebbe dire misurare la sincronizzazione
-     * invece del salvataggio. */
-    const canoniche = globalThis.DashboardModernModules?.store?.getSection?.("covers") || [];
-    const chiave = Object.keys(localStorage).find((name) => name.endsWith("cd_tapparelle"));
-    let copia = [];
-    try {
-      copia = JSON.parse(localStorage.getItem(chiave || "cd_tapparelle") || "[]");
-    } catch (_error) {}
-    const trova = (elenco) => elenco.find((item) => item?.entity === "cover.c3");
-    const nuova = trova(canoniche) || trova(copia) || null;
-    return {
-      campo: true,
-      // Il campo riceve il trattamento di tutti gli altri campi entita':
-      // la pastiglia che apre il catalogo, la matita e il cestino. Non si
-      // controlla la lente com'e' nata, perche' proprio quella decorazione la
-      // trasforma; si controlla che sia arrivata.
-      vestito: Boolean(campo.closest('[data-dm-entity-chip="true"]')),
-      pastiglia: Boolean(campo.closest(".ed-form-row")?.querySelector(".dm-slot-chip")),
-      contatto: nuova?.contact || "",
-      nome: nuova?.name || "",
-    };
   });
-  expect(esito.campo, "il campo esiste nella scheda Tapparelle").toBe(true);
-  expect(esito.vestito, "il campo e' vestito come gli altri campi entita'").toBe(true);
-  expect(esito.pastiglia, "e ha la pastiglia che apre il catalogo").toBe(true);
-  expect(esito.nome).toBe("Bagno");
+
+  /* Si guarda dove il disegno va a leggere: il modello canonico se c'e' gia',
+   * altrimenti la copia in localStorage. Il modello si allinea con i suoi
+   * tempi, e chiedere solo a lui vorrebbe dire misurare la sincronizzazione
+   * invece del salvataggio. */
+  const nuova = () =>
+    page.evaluate(() => {
+      const canoniche = globalThis.DashboardModernModules?.store?.getSection?.("covers") || [];
+      const chiave = Object.keys(localStorage).find((name) => name.endsWith("cd_tapparelle"));
+      let copia = [];
+      try {
+        copia = JSON.parse(localStorage.getItem(chiave || "cd_tapparelle") || "[]");
+      } catch (_error) {}
+      const trova = (elenco) => elenco.find((item) => item?.entity === "cover.c3");
+      const voce = trova(canoniche) || trova(copia) || null;
+      return { nome: voce?.name || "", contatto: voce?.contact || "" };
+    });
+
+  await expect.poll(async () => (await nuova()).nome, { timeout: 20_000 }).toBe("Bagno");
   // E quello che si e' scritto si ritrova dove il disegno lo va a leggere.
-  expect(esito.contatto).toBe("binary_sensor.finestra_bagno");
+  await expect
+    .poll(async () => (await nuova()).contatto, { timeout: 20_000 })
+    .toBe("binary_sensor.finestra_bagno");
 });
 
 /* La matita apre il suo editor, e il contatto dev'essere anche li'.
@@ -198,40 +233,44 @@ test("il sensore si configura dove si configura la tapparella", async ({ page },
 test("il contatto si modifica anche dalla matita", async ({ page }, testInfo) => {
   test.setTimeout(180_000);
   await apriTapparelle(page, testInfo);
-  const esito = await page.evaluate(async () => {
-    globalThis.apriConfigEntita?.();
-    await new Promise((resolve) => setTimeout(resolve, 800));
-    document.querySelector('#editor-modal .ed-tab[data-tab="tapp"]')?.click();
-    await new Promise((resolve) => setTimeout(resolve, 900));
+  await apriSchedaTapparelle(page);
 
-    // La matita della prima tapparella, quella che il contatto ce l'ha gia'.
-    const matita = document.querySelector("#ed-body .ed-row .dm-edit-existing");
-    matita?.click();
-    await new Promise((resolve) => setTimeout(resolve, 700));
+  // La matita della prima tapparella, quella che il contatto ce l'ha gia'.
+  await aspetta(page, () => Boolean(document.querySelector("#ed-body .ed-row .dm-edit-existing")));
+  await page.evaluate(() => {
+    document.querySelector("#ed-body .ed-row .dm-edit-existing")?.click();
+  });
+  await aspetta(page, () =>
+    Boolean(document.querySelector("#dm-shutter-editor-modal form")?.elements?.contact),
+  );
+
+  const partenza = await page.evaluate(
+    () => document.querySelector("#dm-shutter-editor-modal form").elements.contact.value,
+  );
+  // Ci arriva gia' compilato con quello che c'era.
+  expect(partenza).toBe("binary_sensor.finestra_camera");
+
+  await page.evaluate(() => {
     const form = document.querySelector("#dm-shutter-editor-modal form");
-    if (!form?.elements?.contact) return { campo: false };
-    const partenza = form.elements.contact.value;
-
     form.elements.contact.value = "binary_sensor.finestra_nuova";
     form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
-    await new Promise((resolve) => setTimeout(resolve, 700));
-
-    const leggi = () => {
-      const canoniche = globalThis.DashboardModernModules?.store?.getSection?.("covers") || [];
-      const chiave = Object.keys(localStorage).find((name) => name.endsWith("cd_tapparelle"));
-      let copia = [];
-      try {
-        copia = JSON.parse(localStorage.getItem(chiave || "cd_tapparelle") || "[]");
-      } catch (_error) {}
-      const trova = (elenco) => elenco.find((item) => item?.entity === "cover.c1");
-      return trova(canoniche)?.contact ?? trova(copia)?.contact ?? "";
-    };
-    return { campo: true, partenza, dopo: leggi() };
   });
 
-  expect(esito.campo, "la finestra di modifica ha il campo del contatto").toBe(true);
-  // Ci arriva gia' compilato con quello che c'era.
-  expect(esito.partenza).toBe("binary_sensor.finestra_camera");
   // E quello che si scrive si salva.
-  expect(esito.dopo).toBe("binary_sensor.finestra_nuova");
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(() => {
+          const canoniche = globalThis.DashboardModernModules?.store?.getSection?.("covers") || [];
+          const chiave = Object.keys(localStorage).find((name) => name.endsWith("cd_tapparelle"));
+          let copia = [];
+          try {
+            copia = JSON.parse(localStorage.getItem(chiave || "cd_tapparelle") || "[]");
+          } catch (_error) {}
+          const trova = (elenco) => elenco.find((item) => item?.entity === "cover.c1");
+          return trova(canoniche)?.contact ?? trova(copia)?.contact ?? "";
+        }),
+      { timeout: 20_000 },
+    )
+    .toBe("binary_sensor.finestra_nuova");
 });

--- a/custom_components/dashboardmodern/frontend/e2e/shutter-window.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/shutter-window.spec.js
@@ -186,3 +186,52 @@ test("il sensore si configura dove si configura la tapparella", async ({ page },
   // E quello che si e' scritto si ritrova dove il disegno lo va a leggere.
   expect(esito.contatto).toBe("binary_sensor.finestra_bagno");
 });
+
+/* La matita apre il suo editor, e il contatto dev'essere anche li'.
+ *
+ * Le matite delle righe sono intercettate in fase di cattura da un altro
+ * modulo, che apre la propria finestra di modifica: quella con nome, entita' e
+ * stanza. Il campo aggiunto al modulo di aggiunta non passa da li', quindi
+ * senza questo un contatto sbagliato non si poteva ne' correggere ne' togliere
+ * — si poteva solo cancellare la tapparella e rifarla.
+ */
+test("il contatto si modifica anche dalla matita", async ({ page }, testInfo) => {
+  test.setTimeout(180_000);
+  await apriTapparelle(page, testInfo);
+  const esito = await page.evaluate(async () => {
+    globalThis.apriConfigEntita?.();
+    await new Promise((resolve) => setTimeout(resolve, 800));
+    document.querySelector('#editor-modal .ed-tab[data-tab="tapp"]')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 900));
+
+    // La matita della prima tapparella, quella che il contatto ce l'ha gia'.
+    const matita = document.querySelector("#ed-body .ed-row .dm-edit-existing");
+    matita?.click();
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    const form = document.querySelector("#dm-shutter-editor-modal form");
+    if (!form?.elements?.contact) return { campo: false };
+    const partenza = form.elements.contact.value;
+
+    form.elements.contact.value = "binary_sensor.finestra_nuova";
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 700));
+
+    const leggi = () => {
+      const canoniche = globalThis.DashboardModernModules?.store?.getSection?.("covers") || [];
+      const chiave = Object.keys(localStorage).find((name) => name.endsWith("cd_tapparelle"));
+      let copia = [];
+      try {
+        copia = JSON.parse(localStorage.getItem(chiave || "cd_tapparelle") || "[]");
+      } catch (_error) {}
+      const trova = (elenco) => elenco.find((item) => item?.entity === "cover.c1");
+      return trova(canoniche)?.contact ?? trova(copia)?.contact ?? "";
+    };
+    return { campo: true, partenza, dopo: leggi() };
+  });
+
+  expect(esito.campo, "la finestra di modifica ha il campo del contatto").toBe(true);
+  // Ci arriva gia' compilato con quello che c'era.
+  expect(esito.partenza).toBe("binary_sensor.finestra_camera");
+  // E quello che si scrive si salva.
+  expect(esito.dopo).toBe("binary_sensor.finestra_nuova");
+});

--- a/custom_components/dashboardmodern/frontend/e2e/shutter-window.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/shutter-window.spec.js
@@ -1,0 +1,188 @@
+/* La tapparella sta fuori, l'infisso si vede da dentro.
+ *
+ * La card mostrava una tapparella senza finestra. Si guarda invece dalla stanza,
+ * e allora in primo piano c'e' sempre l'infisso — telaio, due ante, maniglia —
+ * con la tapparella che scende dietro. E un infisso puo' essere aperto: un
+ * contatto sull'anta lo dice, e le ante rientrano verso i loro cardini.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const SEED = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [
+      { id: "c1", name: "Camera", entity: "cover.c1", contact: "binary_sensor.finestra_camera" },
+      { id: "c2", name: "Salone", entity: "cover.c2" },
+    ],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  visibility: { home: true, tapparelle: true },
+};
+
+const STATES = [
+  {
+    entity_id: "cover.c1",
+    state: "open",
+    attributes: { friendly_name: "Camera", current_position: 100, supported_features: 15 },
+  },
+  {
+    entity_id: "cover.c2",
+    state: "closed",
+    attributes: { friendly_name: "Salone", current_position: 0, supported_features: 15 },
+  },
+  {
+    entity_id: "binary_sensor.finestra_camera",
+    state: "on",
+    attributes: { friendly_name: "Finestra camera", device_class: "window" },
+  },
+];
+
+async function apriTapparelle(page, testInfo) {
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, SEED);
+  await page.waitForFunction(
+    () => Boolean(document.getElementById("dm-shutter-window-style")),
+    null,
+    { timeout: 15000 },
+  );
+  await page.evaluate((states) => {
+    const raw = eval("_RAW_STATES");
+    for (const entry of states) raw[entry.entity_id] = entry;
+  }, STATES);
+  await page.evaluate(() => {
+    document.querySelectorAll(".page").forEach((node) => node.classList.remove("active"));
+    document.getElementById("page-tapparelle").classList.add("active");
+    globalThis.renderTapparelle?.();
+    window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: {} }));
+  });
+  await page.waitForTimeout(600);
+}
+
+function carte(page) {
+  return page.evaluate(() =>
+    [...document.querySelectorAll("#page-tapparelle .tapp-card[data-tapp]")].map((card) => {
+      const vano = card.querySelector(".tapp-win");
+      const anta = vano?.querySelector(".dm-tw-anta-sx");
+      return {
+        tapp: card.getAttribute("data-tapp"),
+        infisso: Boolean(vano?.querySelector(".dm-tw-infisso .dm-tw-telaio")),
+        ante: vano?.querySelectorAll(".dm-tw-anta").length || 0,
+        maniglia: Boolean(vano?.querySelector(".dm-tw-maniglia")),
+        stato: vano?.dataset.dmInfissoStato || "",
+        // L'anta aperta si stringe verso il suo cardine.
+        stretta: anta ? getComputedStyle(anta).transform !== "none" : false,
+        pastiglia: card.querySelector(".dm-tw-pill")?.textContent?.trim() || "",
+      };
+    }),
+  );
+}
+
+test("l'infisso sta in primo piano su ogni tapparella", async ({ page }, testInfo) => {
+  test.setTimeout(180_000);
+  await apriTapparelle(page, testInfo);
+  const lista = await carte(page);
+  expect(lista.length).toBe(2);
+  for (const carta of lista) {
+    expect(carta.infisso, `${carta.tapp} ha il telaio`).toBe(true);
+    expect(carta.ante, `${carta.tapp} ha due ante`).toBe(2);
+    expect(carta.maniglia, `${carta.tapp} ha la maniglia`).toBe(true);
+  }
+
+  // E l'infisso sta davanti alla tapparella, non dietro: e' la tapparella a
+  // stare fuori.
+  const ordine = await page.evaluate(() => {
+    const vano = document.querySelector("#page-tapparelle .tapp-win");
+    const z = (selector) => Number(getComputedStyle(vano.querySelector(selector)).zIndex) || 0;
+    return { infisso: z(".dm-tw-infisso"), tapparella: z(".tapp-shutter") };
+  });
+  expect(ordine.infisso).toBeGreaterThan(ordine.tapparella);
+});
+
+test("il contatto apre la finestra, e solo quella che ce l'ha", async ({ page }, testInfo) => {
+  test.setTimeout(180_000);
+  await apriTapparelle(page, testInfo);
+
+  let lista = await carte(page);
+  const conSensore = lista.find((carta) => carta.tapp === "cover.c1");
+  const senzaSensore = lista.find((carta) => carta.tapp === "cover.c2");
+  expect(conSensore.stato).toBe("aperto");
+  expect(conSensore.stretta, "l'anta rientra verso il cardine").toBe(true);
+  expect(conSensore.pastiglia).toBe("Finestra aperta");
+  // Chi non ha il contatto resta chiuso e non guadagna una pastiglia.
+  expect(senzaSensore.stato).toBe("chiuso");
+  expect(senzaSensore.pastiglia).toBe("");
+
+  // Si chiude la finestra: la card la segue.
+  await page.evaluate(() => {
+    const raw = eval("_RAW_STATES");
+    raw["binary_sensor.finestra_camera"] = {
+      ...raw["binary_sensor.finestra_camera"],
+      state: "off",
+    };
+    window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: {} }));
+  });
+  await expect
+    .poll(async () => (await carte(page)).find((carta) => carta.tapp === "cover.c1")?.stato)
+    .toBe("chiuso");
+  lista = await carte(page);
+  expect(lista.find((carta) => carta.tapp === "cover.c1").pastiglia).toBe("");
+});
+
+test("il sensore si configura dove si configura la tapparella", async ({ page }, testInfo) => {
+  test.setTimeout(180_000);
+  await apriTapparelle(page, testInfo);
+  const esito = await page.evaluate(async () => {
+    globalThis.apriConfigEntita?.();
+    await new Promise((resolve) => setTimeout(resolve, 800));
+    document.querySelector('#editor-modal .ed-tab[data-tab="tapp"]')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    const campo = document.getElementById("ed-tp-contact");
+    if (!campo) return { campo: false };
+
+    // Si compila come si compila a mano, e si aggiunge la tapparella.
+    document.getElementById("ed-tp-name").value = "Bagno";
+    document.getElementById("ed-tp-ent").value = "cover.c3";
+    campo.value = "binary_sensor.finestra_bagno";
+    globalThis.edTappAdd?.();
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    /* Si guarda dove il disegno va a leggere: il modello canonico se c'e' gia',
+     * altrimenti la copia in localStorage. Il modello si allinea con i suoi
+     * tempi, e chiedere solo a lui vorrebbe dire misurare la sincronizzazione
+     * invece del salvataggio. */
+    const canoniche = globalThis.DashboardModernModules?.store?.getSection?.("covers") || [];
+    const chiave = Object.keys(localStorage).find((name) => name.endsWith("cd_tapparelle"));
+    let copia = [];
+    try {
+      copia = JSON.parse(localStorage.getItem(chiave || "cd_tapparelle") || "[]");
+    } catch (_error) {}
+    const trova = (elenco) => elenco.find((item) => item?.entity === "cover.c3");
+    const nuova = trova(canoniche) || trova(copia) || null;
+    return {
+      campo: true,
+      // Il campo riceve il trattamento di tutti gli altri campi entita':
+      // la pastiglia che apre il catalogo, la matita e il cestino. Non si
+      // controlla la lente com'e' nata, perche' proprio quella decorazione la
+      // trasforma; si controlla che sia arrivata.
+      vestito: Boolean(campo.closest('[data-dm-entity-chip="true"]')),
+      pastiglia: Boolean(campo.closest(".ed-form-row")?.querySelector(".dm-slot-chip")),
+      contatto: nuova?.contact || "",
+      nome: nuova?.name || "",
+    };
+  });
+  expect(esito.campo, "il campo esiste nella scheda Tapparelle").toBe(true);
+  expect(esito.vestito, "il campo e' vestito come gli altri campi entita'").toBe(true);
+  expect(esito.pastiglia, "e ha la pastiglia che apre il catalogo").toBe(true);
+  expect(esito.nome).toBe("Bagno");
+  // E quello che si e' scritto si ritrova dove il disegno lo va a leggere.
+  expect(esito.contatto).toBe("binary_sensor.finestra_bagno");
+});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-rc.3","dashboardVersion":"1.0.0-rc.3","moduleVersion":14,"schemaVersion":4,"date":"2026-08-20T08:43:49+00:00","commit":"057fd14a2cc43e280f4bc7c2e8c33d0b9d00f9b7","assetHash":"47a0065790c96949"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-rc.4","dashboardVersion":"1.0.0-rc.4","moduleVersion":14,"schemaVersion":4,"date":"2026-08-20T11:41:20+00:00","commit":"0b3f0cd15213416de02c07b326bb1b87be5dce3d","assetHash":"4be599af279fad22"});

--- a/custom_components/dashboardmodern/frontend/src/core/device-model.js
+++ b/custom_components/dashboardmodern/frontend/src/core/device-model.js
@@ -28,6 +28,8 @@ export function canonicalClimateType(value) {
  * a device can never silently fall back to `generico` just because a second
  * editor happened to know fewer appliance types.
  */
+import { contactEntity } from "./shutter-window.js";
+
 export const APPLIANCE_CATALOG = Object.freeze([
   { key: "lavatrice", it: "Lavatrice", en: "Washing machine" },
   { key: "lavastoviglie", it: "Lavastoviglie", en: "Dishwasher" },
@@ -323,6 +325,17 @@ export function normalizeDevice(input = {}, section, context = {}) {
   }
   if (input.stream || input.stream_url || input.url)
     base.stream = String(input.stream || input.stream_url || input.url);
+  /* Il contatto dell'infisso di una tapparella.
+   *
+   * Il modello tiene solo i campi che conosce, ed e' giusto cosi': e' quello che
+   * impedisce a una configurazione scritta a mano di portarsi dietro spazzatura.
+   * Ma vuol dire anche che un campo nuovo, se non lo si dichiara qui, sparisce
+   * alla prima normalizzazione — e il contatto spariva appena si apriva
+   * l'editor, lasciando la finestra sempre chiusa. */
+  if (section === "covers") {
+    const contact = contactEntity(input);
+    if (contact) base.contact = contact;
+  }
   if (input.threshold_run != null) base.metadata.threshold_run = +input.threshold_run;
   if (input.threshold_standby != null) base.metadata.threshold_standby = +input.threshold_standby;
   if (section === "ev") {

--- a/custom_components/dashboardmodern/frontend/src/core/shutter-window.js
+++ b/custom_components/dashboardmodern/frontend/src/core/shutter-window.js
@@ -1,0 +1,58 @@
+/* Quando l'infisso dietro la tapparella e' aperto.
+ *
+ * La tapparella sta fuori; l'infisso — telaio, ante, maniglia — sta dentro, ed
+ * e' quello che si vede dalla stanza. Un contatto sull'anta dice se e' aperta,
+ * e la card lo disegna. Qui non c'e' DOM: solo la lettura del contatto, cosi'
+ * la regola si puo' provare senza aprire un browser.
+ */
+
+const clean = (value) => String(value ?? "").trim();
+
+/* I nomi che il contatto puo' avere nella configurazione della tapparella.
+ * `contact` e' quello che scrive l'editor; gli altri esistono perche' chi
+ * arriva da una configurazione scritta a mano puo' aver usato i suoi. */
+export const CONTACT_KEYS = Object.freeze([
+  "contact",
+  "contact_entity",
+  "window_entity",
+  "opening_entity",
+]);
+
+export function contactEntity(cover = {}) {
+  for (const key of CONTACT_KEYS) {
+    const value = clean(cover[key]);
+    if (value) return value;
+  }
+  return "";
+}
+
+/* Aperto, chiuso, o non lo sappiamo.
+ *
+ * Un contatto porta e finestra in Home Assistant sta a `on` quando e' aperto e
+ * `off` quando e' chiuso — al contrario di quasi tutto il resto, ed e' il motivo
+ * per cui vale la pena scriverlo una volta sola qui. Un sensore che non risponde
+ * non e' una finestra chiusa: e' una finestra di cui non sappiamo niente, e la
+ * card in quel caso non inventa nulla. */
+const APERTO = /^(on|open|opening|aperto|aperta|true|detected)$/i;
+const CHIUSO = /^(off|closed|closing|chiuso|chiusa|false|clear)$/i;
+
+export function windowOpenFromState(state) {
+  const value = clean(state);
+  if (APERTO.test(value)) return true;
+  if (CHIUSO.test(value)) return false;
+  return null;
+}
+
+/** Il contatto di questa tapparella e cosa sta dicendo adesso. */
+export function shutterWindowModel(cover = {}, states = {}, resolve = (value) => value) {
+  const reference = contactEntity(cover);
+  if (!reference) return { entity: "", open: null, configured: false };
+  let entity = reference;
+  try {
+    entity = clean(resolve(reference)) || reference;
+  } catch (_error) {
+    entity = reference;
+  }
+  const snapshot = states?.[entity] || states?.[reference] || null;
+  return { entity, open: windowOpenFromState(snapshot?.state), configured: true };
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/beta4-mobile-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta4-mobile-polish-section.js
@@ -577,6 +577,14 @@ function installStyles() {
      * aggiungiamo, con gli stessi 0.4s della dissolvenza. */
     .modal-wrapper{transition:visibility 0s .4s,opacity .4s ease,backdrop-filter .4s ease,-webkit-backdrop-filter .4s ease!important}
     .modal-wrapper.show{transition:opacity .4s ease,backdrop-filter .4s ease,-webkit-backdrop-filter .4s ease!important}
+    /* E la stessa cosa vale per la barra in basso.
+     *
+     * Anche lei non tiene il vetro smerigliato mentre e' ritirata, e anche lei
+     * elenca a mano cosa sfumare — movimento, posizione, opacita', ombra — con
+     * la sfocatura fuori dall'elenco. Ricompare con un tocco, e in quel tocco la
+     * sfocatura si accendeva di colpo: il tremolio si vedeva sulla barra come si
+     * vedeva sulle finestre. Sale insieme alla dissolvenza, come la' . */
+    nav.tabs.bottom-nav-bar{transition:transform .4s cubic-bezier(0.175,0.885,0.32,1.275),bottom .4s cubic-bezier(0.175,0.885,0.32,1.275),opacity .3s ease,box-shadow .4s ease,backdrop-filter .3s ease,-webkit-backdrop-filter .3s ease!important}
     .ed-tab[data-tab]>.dm-beta4-tab-icon{display:inline-grid!important;place-items:center!important;flex:0 0 auto!important;min-width:1.2em!important;margin-right:5px!important;visibility:visible!important;opacity:1!important}
     .ed-tab[data-tab]>.dm-beta4-tab-label{display:inline!important;white-space:nowrap!important}
 

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-crud-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-crud-section.js
@@ -1,7 +1,9 @@
 // DM-FIX-20260812B
+import { contactEntity } from "../core/shutter-window.js";
 import { canonicalClimateType } from "../core/device-model.js";
 import {
   clean,
+  dashboardStore,
   doc,
   english,
   installStyle,
@@ -214,6 +216,7 @@ function beginEdit(kind, index) {
     setField("ed-tp-name", item.name || "");
     setField("ed-tp-ent", item.entity || "");
     setField("ed-tp-room", item.room || item.room_id || "");
+    setField("ed-tp-contact", contactEntity(item));
   } else if (kind === "room") {
     setField("ed-room-name", item.name || "");
     setField("ed-room-icon", item.icon || "🏠");
@@ -232,11 +235,29 @@ function finishEdit(kind) {
 }
 
 function installAddWrappers() {
-  const wrap = (name, kind, saveEdit) => {
+  /* `suAggiunta` serve a posare accanto a una voce nuova i campi che il runtime
+   * non conosce.
+   *
+   * Si chiama PRIMA e restituisce cosa fare DOPO, perche' aggiungendo una voce
+   * il runtime ridisegna la scheda: un campo letto dopo e' un campo gia'
+   * svuotato. Sta dentro a questo involucro e non in un secondo perche'
+   * l'involucro e' uno solo — un secondo si impilerebbe a ogni apertura
+   * dell'editor, visto che la guardia riconosce solo il proprio. */
+  const wrap = (name, kind, saveEdit, suAggiunta) => {
     const current = root[name];
     if (typeof current !== "function" || current.__dmEditableSection) return;
     function editableOwner(...args) {
-      if (state.editing?.kind !== kind) return current.apply(this, args);
+      if (state.editing?.kind !== kind) {
+        let poi = null;
+        try {
+          poi = suAggiunta?.() || null;
+        } catch (_error) {}
+        const result = current.apply(this, args);
+        try {
+          poi?.();
+        } catch (_error) {}
+        return result;
+      }
       saveEdit(state.editing.index);
       finishEdit(kind);
     }
@@ -284,6 +305,21 @@ function installAddWrappers() {
     root.buildDeviceCards?.();
   });
 
+  /* La copia in localStorage e il modello canonico devono dire la stessa cosa.
+   *
+   * Il runtime scrive solo la copia; il modello la rilegge per conto suo, con i
+   * suoi tempi. Fra le due cose c'e' una finestra in cui il disegno legge il
+   * modello e trova una versione vecchia — e con il contatto dell'infisso quella
+   * finestra si vedeva: la tapparella appena aggiunta restava senza. Scrivendo
+   * in tutte e due nello stesso momento la finestra non c'e' piu'. */
+  const salvaTapparelle = (list) => {
+    writeJsonIfChanged("cd_tapparelle", list);
+    try {
+      dashboardStore()?.replaceSection?.("covers", list)?.catch?.(() => {});
+    } catch (_error) {}
+    root.renderTapparelle?.();
+  };
+
   wrap("edTappAdd", "shutter", (index) => {
     const list = listFor("shutter");
     list[index] = {
@@ -291,9 +327,29 @@ function installAddWrappers() {
       name: clean(doc.getElementById("ed-tp-name")?.value),
       entity: clean(doc.getElementById("ed-tp-ent")?.value),
       room: clean(doc.getElementById("ed-tp-room")?.value),
+      // Il contatto dell'infisso: la card lo legge per sapere se la finestra
+      // dietro la tapparella e' aperta.
+      contact: clean(doc.getElementById("ed-tp-contact")?.value),
     };
-    writeJsonIfChanged("cd_tapparelle", list);
-    root.renderTapparelle?.();
+    salvaTapparelle(list);
+  },
+  /* Il contatto sopravvive anche a una tapparella appena aggiunta: l'elenco lo
+   * scrive il runtime, che di questo campo non sa niente, e la voce nasce senza.
+   * Qui la si ritrova dalla sua entita' e le si posa accanto il contatto. */
+  () => {
+    const contact = clean(doc.getElementById("ed-tp-contact")?.value);
+    const entity = clean(doc.getElementById("ed-tp-ent")?.value);
+    if (!contact || !entity) return null;
+    return () => {
+      const list = listFor("shutter");
+      let index = -1;
+      list.forEach((item, position) => {
+        if (clean(item?.entity) === entity) index = position;
+      });
+      if (index < 0 || clean(list[index].contact) === contact) return;
+      list[index] = { ...list[index], contact };
+      salvaTapparelle(list);
+    };
   });
 
   wrap("edStanzaRoomAdd", "room", (index) => {

--- a/custom_components/dashboardmodern/frontend/src/sections/page-masthead-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/page-masthead-section.js
@@ -195,6 +195,7 @@ function mountFor(host) {
  * misura del contenuto e la porta con se'. Se il contenuto e' largo quanto la
  * pagina non c'e' niente da imporre e il limite si toglie. */
 function alignToContent(host, mast, mount) {
+  escapeMountPadding(mast, mount);
   const content = mount === host ? tallestWrapper(host) : null;
   // Si copia il limite che il contenuto si e' dato, non la sua larghezza di
   // adesso: la larghezza include gia' il margine interno della pagina e
@@ -213,6 +214,33 @@ function alignToContent(host, mast, mount) {
   }
   if (mast.style.getPropertyValue("--dm-mast-room")) {
     mast.style.removeProperty("--dm-mast-room");
+  }
+}
+
+/* Il margine interno della casa non e' dell'intestazione.
+ *
+ * Tapparelle tiene il proprio contenuto in un blocco con sedici pixel di
+ * margine per lato — l'unica pagina che lo fa — e l'intestazione, che nasce li'
+ * dentro, li prendeva con se': sul telefono restava una striscia bianca
+ * staccata dai bordi mentre su tutte le altre pagine tocca i lati. Il margine
+ * serve a distanziare le card dal bordo, non ad accorciare l'apertura della
+ * pagina, quindi l'intestazione ne esce e resta larga quanto la casa. */
+function escapeMountPadding(mast, mount) {
+  const style = mount === mast.parentElement ? root.getComputedStyle?.(mount) : null;
+  const left = Number.parseFloat(style?.paddingLeft || "0") || 0;
+  const right = Number.parseFloat(style?.paddingRight || "0") || 0;
+  const bleed = Math.min(left, right);
+  if (bleed > 0) {
+    const value = `${Math.round(bleed)}px`;
+    if (mast.style.getPropertyValue("--dm-mast-bleed") !== value) {
+      mast.style.setProperty("--dm-mast-bleed", value);
+      mast.style.setProperty("--dm-mast-side", `-${Math.round(bleed)}px`);
+    }
+    return;
+  }
+  if (mast.style.getPropertyValue("--dm-mast-bleed")) {
+    mast.style.removeProperty("--dm-mast-bleed");
+    mast.style.removeProperty("--dm-mast-side");
   }
 }
 
@@ -370,7 +398,9 @@ function installStyles() {
     ${foldRules()}
     .dm-page-mast{
       position:relative!important;display:block!important;box-sizing:border-box!important;
-      width:100%!important;max-width:var(--dm-mast-room,none)!important;margin:0 auto 18px!important;
+      width:calc(100% + 2 * var(--dm-mast-bleed,0px))!important;
+      max-width:var(--dm-mast-room,none)!important;
+      margin:0 0 18px!important;margin-inline:var(--dm-mast-side,auto)!important;
       grid-column:1/-1!important;flex:1 1 100%!important;
       align-self:stretch!important;justify-self:stretch!important;
       padding:26px 30px 24px!important;border-radius:28px!important;text-align:left!important;

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -41,6 +41,7 @@ import { installReportEditorSection } from "./report-editor-section.js";
 import { installShutterSection } from "./shutter-section.js";
 import { installPageMastheadSection } from "./page-masthead-section.js";
 import { installShutterSceneSection } from "./shutter-scene-section.js";
+import { installShutterWindowSection } from "./shutter-window-section.js";
 import { installPoolIrrigationSceneSection } from "./pool-irrigation-scene-section.js";
 import { installEvSection } from "./ev-section.js";
 import { installEvShowcaseSection } from "./ev-showcase-section.js";
@@ -671,6 +672,7 @@ export function installSectionRuntime() {
     installReportEditorSection();
     installShutterSection();
     installShutterSceneSection();
+    installShutterWindowSection();
     installPageMastheadSection();
     installPoolIrrigationSceneSection();
     installEvSection();

--- a/custom_components/dashboardmodern/frontend/src/sections/shutter-window-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shutter-window-section.js
@@ -1,0 +1,231 @@
+/* La tapparella sta fuori, l'infisso si vede da dentro.
+ *
+ * La card mostrava un rettangolo azzurro con delle stecche che scendevano
+ * davanti: una tapparella senza finestra. Si guarda invece dalla stanza — che e'
+ * da dove uno guarda una tapparella — e allora in primo piano c'e' sempre
+ * l'infisso, con il suo telaio, le due ante e la maniglia; dietro il vetro
+ * scende la tapparella; dietro ancora c'e' il fuori.
+ *
+ * E un infisso puo' essere aperto. Un contatto sull'anta lo dice, e quando lo
+ * dice le ante rientrano verso i loro cardini e scoprono il vano.
+ *
+ * Il movimento delle ante e' uno `scaleX`, non un `rotateY`. Sono la stessa
+ * cosa sullo schermo — l'anta si stringe verso il cardine e torna — ma la
+ * rotazione aprirebbe un contesto tridimensionale su ogni card, ed e'
+ * esattamente quello che aveva ucciso WebKit sulle icone degli avvisi.
+ *
+ * Niente qui scrive dati: la posizione della tapparella resta di chi la
+ * disegnava, il contatto si legge e basta.
+ */
+import { shutterWindowModel } from "../core/shutter-window.js";
+import { allStates, clean, dashboardStore, doc, installStyle, readJson, root, t } from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_SHUTTER_WINDOW__";
+const STYLE_ID = "dm-shutter-window-style";
+const state = (root[KEY] ||= { installed: false, frame: 0 });
+
+/* Le tapparelle configurate: dal modello canonico, con la copia in
+ * localStorage come rete di sicurezza per la plancia ospitata, che puo'
+ * disegnare prima che il modello esista. */
+function covers() {
+  try {
+    const stored = dashboardStore()?.getSection?.("covers");
+    if (Array.isArray(stored) && stored.length) return stored;
+  } catch (_error) {}
+  const legacy = readJson("cd_tapparelle", []);
+  return Array.isArray(legacy) ? legacy : [];
+}
+
+function coverForCard(card) {
+  const entity = clean(card.getAttribute("data-tapp"));
+  if (!entity) return null;
+  return covers().find((item) => clean(item?.entity) === entity) || null;
+}
+
+/* I pezzi che si aggiungono al vano, una volta sola.
+ *
+ * Il runtime ridisegna tutta la griglia a ogni cambio di stato, quindi questa
+ * passata gira di continuo: costruisce solo dove non ha ancora costruito, e
+ * riconosce il proprio lavoro dal segno che lascia. */
+function build(windowNode) {
+  if (windowNode.dataset.dmInfisso === "true") return false;
+  windowNode.dataset.dmInfisso = "true";
+
+  /* Solo cio' che manca.
+   *
+   * Il vano ha gia' un padrone: cielo, colline, sole, cassonetto e guide sono
+   * disegnati dal modulo della scena, e le stecche sono uno sfondo ripetuto
+   * sulla tapparella stessa. Rifarli qui vorrebbe dire due padroni sullo stesso
+   * pixel, che e' il difetto che questa plancia ha passato mesi a togliersi.
+   * Quello che davvero non c'era e' l'infisso: il telaio, le due ante, la
+   * maniglia. */
+  const spalla = doc.createElement("div");
+  spalla.className = "dm-tw-spalla";
+  const infisso = doc.createElement("div");
+  infisso.className = "dm-tw-infisso";
+  infisso.innerHTML =
+    '<div class="dm-tw-anta dm-tw-anta-sx"></div>' +
+    '<div class="dm-tw-anta dm-tw-anta-dx"><span class="dm-tw-maniglia"></span></div>' +
+    '<div class="dm-tw-telaio"></div>';
+  windowNode.append(spalla, infisso);
+  return true;
+}
+
+/** Cosa dice il contatto di questa card, adesso. */
+export function paintCard(card, states = allStates()) {
+  const windowNode = card.querySelector(".tapp-win");
+  if (!windowNode) return false;
+  build(windowNode);
+  const cover = coverForCard(card);
+  const model = shutterWindowModel(cover || {}, states, root.resolveEntity || ((value) => value));
+  // Aperto solo quando il contatto lo dice: un sensore che non risponde non e'
+  // una finestra chiusa, ma il disegno di riposo e' quello, e non si inventa
+  // un'apertura che nessuno ha misurato.
+  const aperto = model.open === true ? "aperto" : "chiuso";
+  if (windowNode.dataset.dmInfissoStato !== aperto) windowNode.dataset.dmInfissoStato = aperto;
+  ensurePill(card, model.open === true);
+  return true;
+}
+
+/* La pastiglia "Finestra aperta" accanto a quella della tapparella.
+ *
+ * Sta accanto, non al posto: la tapparella continua a dire a che punto e', e
+ * l'infisso aggiunge la sua riga solo quando c'e' qualcosa da aggiungere. */
+function ensurePill(card, aperto) {
+  const head = card.querySelector(".tapp-head");
+  if (!head) return;
+  let pill = head.querySelector(".dm-tw-pill");
+  if (!aperto) {
+    if (pill) pill.remove();
+    return;
+  }
+  if (!pill) {
+    pill = doc.createElement("span");
+    pill.className = "tapp-state dm-tw-pill";
+    head.append(pill);
+  }
+  const label = t("Finestra aperta", "Window open");
+  if (pill.textContent !== label) pill.textContent = label;
+}
+
+export function paintShutterWindows(scope = doc?.getElementById("page-tapparelle")) {
+  if (!scope?.querySelectorAll) return 0;
+  const states = allStates();
+  let painted = 0;
+  for (const card of scope.querySelectorAll(".tapp-card[data-tapp]")) {
+    if (paintCard(card, states)) painted += 1;
+  }
+  return painted;
+}
+
+/* ── il campo in Config ─────────────────────────────────────────────────── */
+
+/* Il contatto si configura dove si configura la tapparella.
+ *
+ * Il modulo delle righe di sezione veste da solo i campi che chiedono
+ * un'entita' — pastiglia, matita, cestino — e li riconosce dalla lente accanto
+ * all'input. Qui basta quindi stampare la stessa coppia che stampa il runtime,
+ * e il resto arriva. */
+export function ensureContactField(body = doc?.getElementById("ed-body")) {
+  const room = body?.querySelector?.("#ed-tp-room");
+  if (!room) return false;
+  if (body.querySelector("#ed-tp-contact")) return false;
+  const holder = doc.createElement("label");
+  holder.className = "ed-slot dm-tw-contact-slot";
+  holder.innerHTML =
+    `<span class="ed-slot-lbl">${t("Sensore apertura infisso", "Window contact sensor")}</span>` +
+    '<span class="ed-form-row">' +
+    '<input id="ed-tp-contact" class="ed-input mono" autocomplete="off" data-entity-input="true"' +
+    ' placeholder="binary_sensor.finestra_camera">' +
+    `<button type="button" class="dm-entity-picker" data-entity-target="ed-tp-contact"` +
+    ` aria-label="${t("Seleziona entità", "Choose entity")}">🔍</button>` +
+    "</span>";
+  room.closest("label, .ed-slot, div")?.after?.(holder) || room.after(holder);
+  return true;
+}
+
+function schedule() {
+  if (state.frame) return;
+  const run = () => {
+    state.frame = 0;
+    paintShutterWindows();
+    ensureContactField();
+  };
+  state.frame = root.requestAnimationFrame?.(run) || root.setTimeout?.(run, 0) || 0;
+}
+
+function installStyles() {
+  installStyle(
+    STYLE_ID,
+    `
+    /* L'infisso, sempre in primo piano: sta sopra le guide del vano, che sono
+       l'ultimo strato che disegna il modulo della scena. */
+    html body #page-tapparelle#page-tapparelle .dm-tw-infisso{
+      position:absolute!important;inset:0!important;z-index:7!important;pointer-events:none!important}
+    html body #page-tapparelle#page-tapparelle .dm-tw-telaio{
+      position:absolute!important;inset:0!important;border:8px solid #e8edf3!important;border-radius:13px!important;
+      box-shadow:inset 0 0 0 1px #b6c2d1,inset 0 2px 5px rgba(15,23,42,.16)!important}
+    html body #page-tapparelle#page-tapparelle .dm-tw-anta{
+      position:absolute!important;top:8px!important;bottom:8px!important;width:calc(50% - 8px)!important;
+      border:6px solid #e8edf3!important;border-radius:7px!important;background:transparent!important;
+      box-shadow:inset 0 0 0 1px #b6c2d1!important;
+      transition:transform 1s cubic-bezier(.3,.7,.2,1),filter 1s ease!important}
+    html body #page-tapparelle#page-tapparelle .dm-tw-anta-sx{left:8px!important;transform-origin:left center!important}
+    html body #page-tapparelle#page-tapparelle .dm-tw-anta-dx{right:8px!important;transform-origin:right center!important}
+    html body #page-tapparelle#page-tapparelle .dm-tw-maniglia{
+      position:absolute!important;left:-9px!important;top:50%!important;width:7px!important;height:22px!important;
+      border-radius:3px!important;background:linear-gradient(180deg,#cbd5e1,#94a3b8)!important;
+      transform:translateY(-50%)!important;box-shadow:0 1px 2px rgba(15,23,42,.3)!important}
+    html body #page-tapparelle#page-tapparelle .dm-tw-maniglia::after{
+      content:""!important;position:absolute!important;left:-9px!important;top:7px!important;width:12px!important;height:5px!important;
+      border-radius:3px!important;background:linear-gradient(180deg,#cbd5e1,#8fa0b3)!important}
+
+    /* Aperta: le ante rientrano verso il loro cardine e si vede il vano. */
+    html body #page-tapparelle#page-tapparelle .tapp-win[data-dm-infisso-stato="aperto"] .dm-tw-anta{
+      transform:scaleX(.34)!important;filter:brightness(.92)!important}
+    html body #page-tapparelle#page-tapparelle .dm-tw-spalla{
+      position:absolute!important;top:8px!important;bottom:8px!important;left:8px!important;right:8px!important;
+      border-radius:7px!important;z-index:6!important;opacity:0!important;transition:opacity .9s ease!important;
+      pointer-events:none!important;
+      background:linear-gradient(90deg,rgba(15,23,42,.34),rgba(15,23,42,0) 24%,rgba(15,23,42,0) 76%,rgba(15,23,42,.34))!important}
+    html body #page-tapparelle#page-tapparelle .tapp-win[data-dm-infisso-stato="aperto"] .dm-tw-spalla{opacity:1!important}
+
+    /* La pastiglia dell'infisso vive accanto a quella della tapparella, e la
+       forma la da' gia' chi possiede .tapp-state: qui si cambia solo il colore. */
+    html body #page-tapparelle#page-tapparelle .dm-tw-pill{
+      background:rgba(245,158,11,.18)!important;border-color:rgba(245,158,11,.34)!important;color:#b45309!important}
+
+    #ed-body .dm-tw-contact-slot{display:block!important;margin-top:10px!important}
+  `,
+  );
+}
+
+export function installShutterWindowSection() {
+  if (!doc || state.installed) return;
+  state.installed = true;
+  installStyles();
+  for (const eventName of [
+    "dashboardmodern:legacy-ready",
+    "dashboardmodern:runtime-ready",
+    "dashboardmodern:state-changed",
+    "pageshow",
+  ]) {
+    root.addEventListener?.(eventName, schedule);
+  }
+  doc.addEventListener(
+    "click",
+    (event) => {
+      if (event.target?.closest?.("[data-tab],[data-page],.ed-tab,.tapp-btn")) {
+        root.setTimeout?.(schedule, 0);
+      }
+    },
+    true,
+  );
+  schedule();
+}
+
+if (doc?.readyState === "loading") {
+  doc.addEventListener("DOMContentLoaded", installShutterWindowSection, { once: true });
+} else {
+  installShutterWindowSection();
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/shutter-window-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shutter-window-section.js
@@ -208,6 +208,10 @@ export function installShutterWindowSection() {
     "dashboardmodern:legacy-ready",
     "dashboardmodern:runtime-ready",
     "dashboardmodern:state-changed",
+    // Quando arriva una configurazione condivisa il modulo della scena rifa' la
+    // griglia da capo con innerHTML, e con lei sparisce ogni infisso: senza
+    // questo, le card restavano senza finestra fino al primo cambio di stato.
+    "dashboardmodern:persistence-restored",
     "pageshow",
   ]) {
     root.addEventListener?.(eventName, schedule);

--- a/custom_components/dashboardmodern/frontend/src/sections/unified-editors-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/unified-editors-section.js
@@ -1,4 +1,5 @@
 // DM-FIX-20260813E
+import { contactEntity } from "../core/shutter-window.js";
 import { canonicalClimateType } from "../core/device-model.js";
 import {
   clean,
@@ -262,10 +263,14 @@ function openShutterEditor(item, index) {
     t("Modifica tapparella", "Edit shutter"),
     `<label class="ed-slot"><span class="ed-slot-lbl">${t("Nome", "Name")}</span><input class="ed-input" name="name" value="${esc(item.name)}" required></label>
      <label class="ed-slot"><span class="ed-slot-lbl">${t("Entità Home Assistant", "Home Assistant entity")}</span><span class="ed-form-row"><input class="ed-input mono" name="entity" value="${esc(item.entity)}" required><button type="button" class="dm-entity-picker" data-pick>🔍</button></span></label>
-     <label class="ed-slot"><span class="ed-slot-lbl">${t("Stanza", "Room")}</span><select class="ed-input" name="room">${roomsOptions(item.room || item.room_id)}</select></label>`,
+     <label class="ed-slot"><span class="ed-slot-lbl">${t("Stanza", "Room")}</span><select class="ed-input" name="room">${roomsOptions(item.room || item.room_id)}</select></label>
+     <label class="ed-slot"><span class="ed-slot-lbl">${t("Sensore apertura infisso", "Window contact sensor")}</span><span class="ed-form-row"><input class="ed-input mono" name="contact" value="${esc(contactEntity(item))}" placeholder="binary_sensor.finestra_camera"><button type="button" class="dm-entity-picker" data-pick-contact>🔍</button></span><small>${t("Se lo compili, la card mostra la finestra aperta quando il contatto lo dice.", "Fill it in and the card shows the window open when the contact says so.")}</small></label>`,
     "🪟",
   );
   form.querySelector("[data-pick]").addEventListener("click", () => root.wzPickEntity?.(form.elements.entity));
+  form
+    .querySelector("[data-pick-contact]")
+    ?.addEventListener("click", () => root.wzPickEntity?.(form.elements.contact));
   form.addEventListener("submit", (event) => {
     event.preventDefault();
     const list = listFor("shutter");
@@ -274,6 +279,9 @@ function openShutterEditor(item, index) {
       name: clean(form.elements.name.value),
       entity: clean(form.elements.entity.value),
       room: clean(form.elements.room.value),
+      // Svuotare il campo toglie il sensore: e' il modo per dire "questa
+      // tapparella non ha un infisso da guardare".
+      contact: clean(form.elements.contact?.value),
     };
     if (!list[index].name || !/^cover\./i.test(list[index].entity)) {
       form.querySelector("[data-error]").textContent = t("Inserisci un nome e un'entità cover.* valida.", "Enter a name and a valid cover.* entity.");

--- a/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
@@ -7,5 +7,5 @@ const manifest = JSON.parse(
 );
 
 test("the release manifest is versioned correctly", () => {
-  assert.equal(manifest.version, "1.0.0-rc.3");
+  assert.equal(manifest.version, "1.0.0-rc.4");
 });

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -234,7 +234,13 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // su iPhone, dove il sistema butta via la pagina quando passi ad altra app,
   // la plancia restava ferma a "CONNECTING…". Quel modulo non apre nessuna
   // presa e non legge nessuno stato: richiama connect(), quello del runtime.
-  assert.ok(relative.length <= 106, `production graph unexpectedly grew to ${relative.length} modules`);
+  // E due, insieme: la finestra dietro la tapparella. La card mostrava una
+  // tapparella senza infisso; adesso in primo piano c'e' il telaio con le sue
+  // ante, e un contatto sull'anta dice se sono aperte. La lettura del contatto
+  // sta in un modulo puro perche' si possa provare senza browser, il disegno in
+  // un modulo di sezione che non scrive dati: la posizione della tapparella
+  // resta di chi la disegnava.
+  assert.ok(relative.length <= 108, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
 
   /* No polling, with one declared exception.

--- a/custom_components/dashboardmodern/frontend/tests/shutter-window.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/shutter-window.test.js
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CONTACT_KEYS,
+  contactEntity,
+  shutterWindowModel,
+  windowOpenFromState,
+} from "../src/core/shutter-window.js";
+
+test("un contatto porta e finestra sta a on quando e' aperto", () => {
+  // Al contrario di quasi tutto il resto in Home Assistant, ed e' il motivo per
+  // cui questa lettura sta scritta una volta sola.
+  for (const aperto of ["on", "open", "Aperto", "APERTA", "true", "detected"]) {
+    assert.equal(windowOpenFromState(aperto), true, aperto);
+  }
+  for (const chiuso of ["off", "closed", "Chiusa", "false", "clear"]) {
+    assert.equal(windowOpenFromState(chiuso), false, chiuso);
+  }
+});
+
+test("un sensore che non risponde non e' una finestra chiusa", () => {
+  // "unavailable" vuol dire che non lo sappiamo. Chi disegna decidera' cosa
+  // mostrare, ma non deve poterlo confondere con un "chiuso" misurato.
+  for (const muto of ["unavailable", "unknown", "", null, undefined, "boh"]) {
+    assert.equal(windowOpenFromState(muto), null, String(muto));
+  }
+});
+
+test("il contatto si legge dal nome che la configurazione ha usato", () => {
+  assert.equal(contactEntity({ contact: "binary_sensor.a" }), "binary_sensor.a");
+  // Chi ha scritto la configurazione a mano puo' aver usato uno degli altri.
+  assert.equal(contactEntity({ window_entity: "binary_sensor.b" }), "binary_sensor.b");
+  assert.equal(contactEntity({ opening_entity: "binary_sensor.c" }), "binary_sensor.c");
+  // L'ordine e' quello dichiarato: vince il primo che c'e'.
+  assert.equal(
+    contactEntity({ opening_entity: "binary_sensor.c", contact: "binary_sensor.a" }),
+    "binary_sensor.a",
+  );
+  assert.equal(contactEntity({}), "");
+  assert.equal(contactEntity({ contact: "   " }), "");
+  assert.ok(CONTACT_KEYS.includes("contact"));
+});
+
+test("una tapparella senza contatto non ha una finestra da mostrare", () => {
+  const senza = shutterWindowModel({ entity: "cover.a" }, {});
+  assert.deepEqual(senza, { entity: "", open: null, configured: false });
+});
+
+test("il contatto passa per la risoluzione delle entita'", () => {
+  // La configurazione puo' puntare a un riferimento della plancia invece che a
+  // un'entita' vera: chi lo traduce e' il runtime, e la lettura lo interpella.
+  const states = { "binary_sensor.vero": { state: "on" } };
+  const model = shutterWindowModel({ contact: "dm.finestra" }, states, (value) =>
+    value === "dm.finestra" ? "binary_sensor.vero" : value,
+  );
+  assert.deepEqual(model, { entity: "binary_sensor.vero", open: true, configured: true });
+
+  // Se la traduzione esplode, resta il riferimento cosi' com'e'.
+  const rotto = shutterWindowModel({ contact: "binary_sensor.vero" }, states, () => {
+    throw new Error("no");
+  });
+  assert.equal(rotto.open, true);
+});
+
+test("un contatto configurato ma spento dice chiuso, non nulla", () => {
+  const states = { "binary_sensor.a": { state: "off" } };
+  assert.deepEqual(shutterWindowModel({ contact: "binary_sensor.a" }, states), {
+    entity: "binary_sensor.a",
+    open: false,
+    configured: true,
+  });
+  // Configurato ma assente da Home Assistant: non lo sappiamo.
+  assert.deepEqual(shutterWindowModel({ contact: "binary_sensor.mai" }, states), {
+    entity: "binary_sensor.mai",
+    open: null,
+    configured: true,
+  });
+});
+
+test("il contatto sopravvive alla normalizzazione della tapparella", async () => {
+  // Il modello canonico tiene solo i campi che conosce, ed e' quello che
+  // impedisce a una configurazione scritta a mano di portarsi dietro
+  // spazzatura. Ma vuol dire anche che un campo nuovo, se non lo si dichiara,
+  // sparisce alla prima normalizzazione: il contatto spariva appena si apriva
+  // l'editor, e la finestra restava sempre chiusa.
+  const { normalizeDevice } = await import("../src/core/device-model.js");
+  const tapparella = normalizeDevice(
+    { id: "c1", name: "Camera", entity: "cover.c1", contact: "binary_sensor.finestra" },
+    "covers",
+  );
+  assert.equal(tapparella.contact, "binary_sensor.finestra");
+  assert.equal(contactEntity(tapparella), "binary_sensor.finestra");
+
+  // Una tapparella senza contatto non guadagna un campo vuoto.
+  const senza = normalizeDevice({ id: "c2", entity: "cover.c2" }, "covers");
+  assert.equal("contact" in senza, false);
+
+  // E il campo resta delle tapparelle: un elettrodomestico non lo prende.
+  const appliance = normalizeDevice({ id: "a1", contact: "binary_sensor.x" }, "appliances");
+  assert.equal("contact" in appliance, false);
+});

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-rc.3"
+  "version": "1.0.0-rc.4"
 }


### PR DESCRIPTION
L'ultima candidata prima della 1.0.

## La tapparella ha la sua finestra

La card mostrava un rettangolo con delle stecche che scendevano davanti a un
cielo: una tapparella senza infisso. Si guarda invece dalla stanza — che è da
dove uno la guarda — e allora in primo piano c'è **sempre** il telaio, con le
sue due ante e la maniglia; la tapparella scende dietro, perché sta fuori.

In Config ogni tapparella prende un **sensore di apertura**, facoltativo. Quando
quel contatto dice aperto, le ante rientrano verso i loro cardini, si scopre il
vano, e accanto allo stato della tapparella compare «Finestra aperta». Senza
sensore, o con un sensore che non risponde, la card resta com'era: non si
disegna un'apertura che nessuno ha misurato.

Il movimento delle ante è uno `scaleX`, non un `rotateY`. Sullo schermo sono la
stessa cosa — l'anta si stringe verso il cardine e torna — ma la rotazione
aprirebbe un contesto tridimensionale su ogni card, ed è quello che aveva già
ucciso WebKit sulle icone degli avvisi.

**Il disegno aggiunge solo ciò che mancava.** Cielo, colline, sole, cassonetto e
guide li disegna già il modulo della scena, e le stecche sono uno sfondo
ripetuto sulla tapparella stessa: la prima versione li rifaceva, cioè metteva
due padroni sullo stesso pixel. È stata ridotta al solo infisso.

Due difetti veri sono usciti strada facendo:

- il modello canonico tiene solo i campi che conosce, e le tapparelle non
  avevano un ramo proprio: **il contatto spariva alla prima normalizzazione**,
  cioè appena si apriva l'editor, e la finestra restava sempre chiusa;
- aggiungendo una tapparella il runtime ridisegna la scheda, quindi un campo
  letto dopo l'aggiunta è un campo già svuotato. Ora si legge prima e si scrive
  dopo, in tutte e due le copie nello stesso momento, così fra la copia e il
  modello non resta una finestra in cui il disegno legge una versione vecchia.

## Tapparelle tocca i bordi come le altre

La casa del suo contenuto ha `padding: 0 16px` — è l'unica pagina che ce l'ha —
e l'intestazione, nascendo lì dentro, se li portava con sé. Restava una striscia
staccata dai bordi mentre su ogni altra pagina tocca i lati. Quel margine
distanzia le card dal bordo, non accorcia l'apertura della pagina.

## La barra in basso non si accende più di scatto

Fa lo stesso mestiere delle finestre — niente vetro smerigliato mentre è
ritirata — ed elencava a mano cosa sfumare, con la sfocatura fuori dall'elenco.
Ricompariva accendendo `blur(35px)` in un disegno solo: era il tremolio che si
vedeva anche lì.

La prova non controlla più una finestra a mano: passa in rassegna **tutto** ciò
che il modulo spegne da chiuso e chiede che chi si sfoca da aperto sfumi anche
la sfocatura. Quattordici elementi, e la barra era l'unico rimasto scoperto.

## L'intestazione si sposta invece di sdoppiarsi

La casa può cambiare mentre la pagina è viva. Cercarla solo fra i figli diretti
significava non trovarla quando sta dentro a un contenitore, e farne una seconda
lasciando la prima dov'era: **due nomi e due pulsanti Home** sulla stessa
pagina. Segnalato in revisione su #165 e verificato.

## Prove

| | prova |
|---|---|
| Infisso e sensore | `shutter-window.spec.js` (3 prove) + `shutter-window.test.js` (7 prove pure) |
| Contatto nella normalizzazione | verifica che sopravviva, che non nasca vuoto, e che resti delle tapparelle |
| Bordi di Tapparelle | `beta32-real-device-uniformity` — rossa senza, con 32 pixel di scarto |
| Sfocatura di scatto | `popup-opening-does-not-stutter` — rassegna di 14 elementi |
| Intestazione doppia | rossa senza, con due intestazioni e due Home |

796 test unitari verdi.

## Resta aperto

**Fold8 aperto: lo scorrimento si ferma prima del fondo**, e riparte solo
ricaricando. Non l'ho riprodotto. Escluso: l'impaginazione (cinque misure tipo
Fold, pagine lunghe — lo scorrimento arriva sempre in fondo), il ridisegno di
stato, il ridisegno di configurazione con sei funzioni di disegno chiamate a
mano, il rientro nell'app, il cambio di misura in piegatura, e qualcosa che
copra la pagina mangiandosi il tocco. Le uniche regole che bloccherebbero
l'altezza sono quelle del chiosco iOS, che su Android non si attivano.

È scritto anche nel changelog, così chi installa la rc.4 lo sa.


---
_Generated by [Claude Code](https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT)_