### PR TITLE
1.0.0-rc.5: il catalogo delle entità davanti, e la finestra aperta che si vede

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.0.0-rc.5 — 2026-08-20
+
+Due cose viste sul telefono con la rc.4 installata.
+
+### Corretto
+
+- **Il catalogo delle entita' si apre davanti alla finestra che lo chiama.** La
+  finestra di modifica sta a 100040, il catalogo si apriva a 100000: si apriva
+  davvero, ma dietro. Chi premeva «Scegli entita'» vedeva la stessa schermata di
+  prima e concludeva che il pulsante non funzionasse. Non era un difetto del
+  campo nuovo: valeva per ogni finestra di modifica — tapparella, clima, azioni,
+  stanze — ed era li' da prima.
+- **Con la tapparella giu' si capisce che la finestra e' aperta.** Le ante
+  rientravano su un fondo dello stesso colore: la card diceva «Finestra aperta»
+  e mostrava una tapparella chiusa qualunque. Adesso l'anta aperta prende corpo
+  e getta ombra su quello che ha dietro — che sia la tapparella chiara o il
+  cielo — e attorno si vede lo spessore del muro. Da chiusa l'anta resta
+  trasparente, se no si perderebbe il vetro.
+
+### Resta aperto
+
+- **Fold8 aperto: lo scorrimento si ferma prima del fondo.** Invariato rispetto
+  alla rc.4: non riprodotto, con l'elenco di cosa e' stato escluso.
+
 ## 1.0.0-rc.4 — 2026-08-20
 
 L'ultima candidata prima della 1.0.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.0.0--rc.4-0ea5e9" alt="Versione 1.0.0-rc.4">
+  <img src="https://img.shields.io/badge/version-1.0.0--rc.5-0ea5e9" alt="Versione 1.0.0-rc.5">
   <img src="https://img.shields.io/badge/HACS-custom-41BDF5" alt="HACS custom integration">
   <img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-18BCF2" alt="Home Assistant 2025.1+">
   <img src="https://img.shields.io/badge/UI-Italiano%20%7C%20English-16a34a" alt="Italiano e inglese">

--- a/custom_components/dashboardmodern/frontend/e2e/beta32-real-device-uniformity.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/beta32-real-device-uniformity.spec.js
@@ -542,3 +542,36 @@ test("l'intestazione esce dal margine interno della sua casa", async ({ page }, 
   // E l'intestazione e' larga quanto la casa, margine compreso.
   expect(Math.abs(misura.scarto)).toBeLessThanOrEqual(3);
 });
+
+/* Il nome della plancia deve leggersi anche di notte.
+ *
+ * Il titolo in alto a sinistra e' un testo riempito da un gradiente, e il
+ * gradiente partiva da un blu notte scritto a mano. In tema chiaro si legge
+ * benissimo; in tema scuro quella prima parola finisce su un fondo dello stesso
+ * colore e sparisce — restava leggibile solo "Home". Il resto
+ * dell'intestazione seguiva gia' il tema: era solo quel capo a non farlo.
+ */
+test("il titolo della plancia segue il tema", async ({ page }, testInfo) => {
+  await boot(page, testInfo);
+  const colori = await page.evaluate(async () => {
+    const titolo = document.querySelector(".brand-text h1");
+    const radice = document.documentElement;
+    const precedente = radice.getAttribute("data-theme");
+    const leggi = async (tema) => {
+      radice.setAttribute("data-theme", tema);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      return getComputedStyle(titolo).backgroundImage;
+    };
+    const chiaro = await leggi("light");
+    const scuro = await leggi("dark");
+    if (precedente) radice.setAttribute("data-theme", precedente);
+    else radice.removeAttribute("data-theme");
+    return { chiaro, scuro };
+  });
+  // Il gradiente c'e' in tutti e due i temi...
+  expect(colori.chiaro).toMatch(/linear-gradient/);
+  expect(colori.scuro).toMatch(/linear-gradient/);
+  // ...ma non e' lo stesso: il capo scuro diventa chiaro quando il fondo si
+  // scurisce, altrimenti la prima parola sparisce.
+  expect(colori.scuro).not.toBe(colori.chiaro);
+});

--- a/custom_components/dashboardmodern/frontend/e2e/shutter-window.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/shutter-window.spec.js
@@ -366,3 +366,44 @@ test("l'anta aperta si stacca da cio' che ha dietro", async ({ page }, testInfo)
   const chiusa = await misura();
   expect(chiusa.corpo, "l'anta chiusa lascia vedere il vetro").toBe(false);
 });
+
+/* Il nome della tapparella non cede il posto allo stato.
+ *
+ * Con due pastiglie accanto — "Aperta" e "Finestra aperta" — a cedere spazio
+ * era il nome, che finiva troncato: "Tapparella so…". Il nome e' il dato che
+ * identifica la scheda; lo stato e' un commento, e a andare a capo dev'essere
+ * lui.
+ */
+test("il nome resta intero anche con due pastiglie", async ({ page }, testInfo) => {
+  test.setTimeout(180_000);
+  await apriTapparelle(page, testInfo);
+  const nomi = await page.evaluate(() =>
+    [...document.querySelectorAll("#page-tapparelle .tapp-card[data-tapp]")].map((carta) => {
+      const nome = carta.querySelector(".tapp-name");
+      const pastiglie = [...carta.querySelectorAll(".tapp-head .tapp-state")];
+      const suo = nome.getBoundingClientRect();
+      return {
+        tapp: carta.getAttribute("data-tapp"),
+        pastiglie: pastiglie.length,
+        // Troncato vuol dire che il testo e' piu' largo della sua casella.
+        troncato: nome.scrollWidth > nome.clientWidth + 1,
+        /* E soprattutto: con due pastiglie il nome tiene la sua riga. La
+         * troncatura si vede solo a certe larghezze, mentre questo e' il
+         * contratto — lo stato va a capo, il nome no — e vale sempre. */
+        soloSuaRiga: pastiglie.every(
+          (pastiglia) => pastiglia.getBoundingClientRect().top >= suo.bottom - 1,
+        ),
+      };
+    }),
+  );
+  const conDue = nomi.find((voce) => voce.tapp === "cover.c1");
+  expect(conDue.pastiglie, "la prima ha due pastiglie").toBe(2);
+  expect(conDue.soloSuaRiga, "e il nome tiene la sua riga").toBe(true);
+  for (const voce of nomi) {
+    expect(voce.troncato, `${voce.tapp} mostra il nome per intero`).toBe(false);
+  }
+  // Con una pastiglia sola non si cambia niente: resta sulla riga del nome.
+  const conUna = nomi.find((voce) => voce.tapp === "cover.c2");
+  expect(conUna.pastiglie).toBe(1);
+  expect(conUna.soloSuaRiga, "con una pastiglia la riga resta una").toBe(false);
+});

--- a/custom_components/dashboardmodern/frontend/e2e/shutter-window.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/shutter-window.spec.js
@@ -274,3 +274,95 @@ test("il contatto si modifica anche dalla matita", async ({ page }, testInfo) =>
     )
     .toBe("binary_sensor.finestra_nuova");
 });
+
+/* Il catalogo delle entita' deve stare davanti alla finestra che lo chiama.
+ *
+ * La finestra di modifica sta a 100040, il catalogo si apre a 100000 scritto a
+ * mano sull'elemento: si apriva davvero, ma dietro. Chi premeva "Scegli
+ * entita'" vedeva la stessa schermata di prima e concludeva che il pulsante non
+ * funzionasse — e valeva per tutte le finestre di modifica, non solo per il
+ * campo nuovo.
+ */
+test("il catalogo delle entita' si apre davanti, non dietro", async ({ page }, testInfo) => {
+  test.setTimeout(180_000);
+  await apriTapparelle(page, testInfo);
+  await apriSchedaTapparelle(page);
+
+  await aspetta(page, () => Boolean(document.querySelector("#ed-body .ed-row .dm-edit-existing")));
+  await page.evaluate(() => {
+    document.querySelector("#ed-body .ed-row .dm-edit-existing")?.click();
+  });
+  await aspetta(page, () =>
+    Boolean(document.querySelector("#dm-shutter-editor-modal form")?.elements?.contact),
+  );
+
+  const esito = await page.evaluate(async () => {
+    const form = document.querySelector("#dm-shutter-editor-modal form");
+    const riga = form.elements.contact.closest(".ed-form-row");
+    (riga.querySelector(".dm-entity-picker") || riga.querySelector("button"))?.click();
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    const catalogo = document.getElementById("cd-entpick");
+    if (!catalogo) return { aperto: false };
+    const centro = document.elementFromPoint(
+      Math.round(innerWidth / 2),
+      Math.round(innerHeight / 2),
+    );
+    return {
+      aperto: true,
+      // Aperto non basta: dev'essere anche quello che si tocca.
+      davanti: Boolean(centro?.closest("#cd-entpick")),
+    };
+  });
+  expect(esito.aperto, "il catalogo si apre").toBe(true);
+  expect(esito.davanti, "e sta davanti alla finestra di modifica").toBe(true);
+});
+
+/* Con la tapparella giu' la finestra aperta dev'essere comunque leggibile.
+ *
+ * Le ante rientravano su un fondo dello stesso colore: la card diceva "finestra
+ * aperta" e mostrava una tapparella chiusa qualunque. L'anta aperta deve
+ * prendere corpo e fare ombra, cosi' si stacca da cio' che ha dietro — che sia
+ * la tapparella chiara o il cielo.
+ */
+test("l'anta aperta si stacca da cio' che ha dietro", async ({ page }, testInfo) => {
+  test.setTimeout(180_000);
+  await apriTapparelle(page, testInfo);
+
+  const misura = () =>
+    page.evaluate(() => {
+      const carta = document.querySelector('#page-tapparelle .tapp-card[data-tapp="cover.c1"]');
+      const vano = carta.querySelector(".tapp-win");
+      const anta = vano.querySelector(".dm-tw-anta-sx");
+      const spalla = vano.querySelector(".dm-tw-spalla");
+      const stile = getComputedStyle(anta);
+      return {
+        stato: vano.dataset.dmInfissoStato,
+        // Da aperta l'anta ha un corpo suo, da chiusa lascia vedere il vetro.
+        corpo: stile.backgroundImage !== "none",
+        ombra: stile.boxShadow.split(",").length >= 2,
+        spessore: Number(getComputedStyle(spalla).opacity),
+      };
+    });
+
+  const aperta = await misura();
+  expect(aperta.stato).toBe("aperto");
+  expect(aperta.corpo, "l'anta aperta prende corpo").toBe(true);
+  expect(aperta.ombra, "e fa ombra su cio' che ha dietro").toBe(true);
+  expect(aperta.spessore, "e si vede lo spessore del muro").toBeGreaterThan(0.9);
+
+  // Chiusa torna trasparente: se no si perderebbe il vetro.
+  await page.evaluate(() => {
+    const raw = eval("_RAW_STATES");
+    raw["binary_sensor.finestra_camera"] = {
+      ...raw["binary_sensor.finestra_camera"],
+      state: "off",
+    };
+    window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: {} }));
+  });
+  await expect.poll(async () => (await misura()).stato, { timeout: 20_000 }).toBe("chiuso");
+  // Lo spessore si spegne sfumando: si aspetta che abbia finito, non che sia
+  // gia' finito.
+  await expect.poll(async () => (await misura()).spessore < 0.1, { timeout: 20_000 }).toBe(true);
+  const chiusa = await misura();
+  expect(chiusa.corpo, "l'anta chiusa lascia vedere il vetro").toBe(false);
+});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-rc.4","dashboardVersion":"1.0.0-rc.4","moduleVersion":14,"schemaVersion":4,"date":"2026-08-20T11:41:20+00:00","commit":"0b3f0cd15213416de02c07b326bb1b87be5dce3d","assetHash":"4be599af279fad22"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.0.0-rc.5","dashboardVersion":"1.0.0-rc.5","moduleVersion":14,"schemaVersion":4,"date":"2026-08-20T13:53:38+00:00","commit":"3750b5916f64fe35ece10c2b38d2a010e83db6e5","assetHash":"02d5fc2724585979"});

--- a/custom_components/dashboardmodern/frontend/src/sections/beta27-release-stability-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta27-release-stability-section.js
@@ -10,6 +10,19 @@ function installReleaseStyles() {
   installStyle(
     "dm-beta27-release-stability-style",
     `
+      /* Il nome della plancia deve leggersi anche di notte.
+       *
+       * Il titolo in alto a sinistra e' un testo riempito da un gradiente, e il
+       * gradiente partiva da un blu notte scritto a mano. In tema chiaro si
+       * legge benissimo; in tema scuro quella prima parola finisce su un fondo
+       * dello stesso colore e sparisce — restava leggibile solo "Home". Tutto
+       * il resto dell'intestazione, sottotitolo e pastiglia della connessione,
+       * seguiva gia' il tema: era solo quel capo del gradiente a non farlo. */
+      .brand-text h1{
+        background:linear-gradient(135deg,var(--text,#0f172a),var(--green,#16a34a))!important;
+        -webkit-background-clip:text!important;background-clip:text!important;
+        -webkit-text-fill-color:transparent!important}
+
       /* Keep the animated appliance design compact on desktop/tablet as well as
          phones. The main artwork remains the single large visual owner; the
          header copy is text-only so cards never grow into a second poster.

--- a/custom_components/dashboardmodern/frontend/src/sections/shutter-window-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shutter-window-section.js
@@ -180,14 +180,33 @@ function installStyles() {
       content:""!important;position:absolute!important;left:-9px!important;top:7px!important;width:12px!important;height:5px!important;
       border-radius:3px!important;background:linear-gradient(180deg,#cbd5e1,#8fa0b3)!important}
 
-    /* Aperta: le ante rientrano verso il loro cardine e si vede il vano. */
+    /* Aperta: le ante rientrano verso il cardine e fanno ombra su cio' che
+       hanno dietro.
+     *
+     * Con la tapparella alzata bastava vedere il cielo scoperto. Con la
+     * tapparella giu' no: le ante rientravano su un fondo dello stesso colore e
+     * non si capiva piu' niente — la card diceva "finestra aperta" e mostrava
+     * una tapparella chiusa qualunque.
+     *
+     * Adesso l'anta aperta resta un'anta: prende corpo, si stacca dal fondo, e
+     * getta ombra su quello che ha dietro. E' l'ombra a dire che li' c'e' un
+     * buco, e funziona sia sulla tapparella chiara sia sul cielo — senza
+     * coprire ne' l'una ne' l'altro. Da chiusa l'anta resta trasparente, se no
+     * si perderebbe il vetro. */
     html body #page-tapparelle#page-tapparelle .tapp-win[data-dm-infisso-stato="aperto"] .dm-tw-anta{
-      transform:scaleX(.34)!important;filter:brightness(.92)!important}
+      transform:scaleX(.28)!important;
+      background:linear-gradient(135deg,#f7fafc,#dbe3ec)!important;
+      box-shadow:inset 0 0 0 1px #b6c2d1,6px 0 14px -4px rgba(15,23,42,.55)!important}
+    html body #page-tapparelle#page-tapparelle .tapp-win[data-dm-infisso-stato="aperto"] .dm-tw-anta-dx{
+      box-shadow:inset 0 0 0 1px #b6c2d1,-6px 0 14px -4px rgba(15,23,42,.55)!important}
+    /* Lo spessore del muro attorno al buco. */
     html body #page-tapparelle#page-tapparelle .dm-tw-spalla{
       position:absolute!important;top:8px!important;bottom:8px!important;left:8px!important;right:8px!important;
       border-radius:7px!important;z-index:6!important;opacity:0!important;transition:opacity .9s ease!important;
       pointer-events:none!important;
-      background:linear-gradient(90deg,rgba(15,23,42,.34),rgba(15,23,42,0) 24%,rgba(15,23,42,0) 76%,rgba(15,23,42,.34))!important}
+      background:linear-gradient(90deg,rgba(15,23,42,.62) 0,rgba(15,23,42,.22) 9%,rgba(15,23,42,0) 22%,
+                 rgba(15,23,42,0) 78%,rgba(15,23,42,.22) 91%,rgba(15,23,42,.62) 100%),
+                 linear-gradient(180deg,rgba(15,23,42,.30),rgba(15,23,42,0) 26%)!important}
     html body #page-tapparelle#page-tapparelle .tapp-win[data-dm-infisso-stato="aperto"] .dm-tw-spalla{opacity:1!important}
 
     /* La pastiglia dell'infisso vive accanto a quella della tapparella, e la

--- a/custom_components/dashboardmodern/frontend/src/sections/shutter-window-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shutter-window-section.js
@@ -95,10 +95,20 @@ function ensurePill(card, aperto) {
   const head = card.querySelector(".tapp-head");
   if (!head) return;
   let pill = head.querySelector(".dm-tw-pill");
+  /* Due pastiglie sulla stessa riga mangiano il nome.
+   *
+   * Il nome e' il dato che identifica la scheda; lo stato e' un commento. Con
+   * due pastiglie accanto — "Aperta" e "Finestra aperta" — a cedere spazio era
+   * il nome, che finiva troncato: "Tapparella so…". A cedere deve essere lo
+   * stato, che va a capo sotto e resta leggibile per intero. Il segno sta qui
+   * perche' e' questo modulo ad aggiungere la seconda pastiglia: chi crea
+   * l'affollamento se ne occupa. */
   if (!aperto) {
     if (pill) pill.remove();
+    if (head.dataset.dmTwPills) delete head.dataset.dmTwPills;
     return;
   }
+  if (head.dataset.dmTwPills !== "due") head.dataset.dmTwPills = "due";
   if (!pill) {
     pill = doc.createElement("span");
     pill.className = "tapp-state dm-tw-pill";
@@ -208,6 +218,12 @@ function installStyles() {
                  rgba(15,23,42,0) 78%,rgba(15,23,42,.22) 91%,rgba(15,23,42,.62) 100%),
                  linear-gradient(180deg,rgba(15,23,42,.30),rgba(15,23,42,0) 26%)!important}
     html body #page-tapparelle#page-tapparelle .tapp-win[data-dm-infisso-stato="aperto"] .dm-tw-spalla{opacity:1!important}
+
+    /* Con due pastiglie il nome tiene la sua riga e lo stato va a capo. */
+    html body #page-tapparelle#page-tapparelle .tapp-head[data-dm-tw-pills="due"]{
+      flex-wrap:wrap!important;justify-content:flex-start!important;row-gap:8px!important}
+    html body #page-tapparelle#page-tapparelle .tapp-head[data-dm-tw-pills="due"]>.dm-tapp-title{
+      flex:1 1 100%!important;min-width:0!important}
 
     /* La pastiglia dell'infisso vive accanto a quella della tapparella, e la
        forma la da' gia' chi possiede .tapp-state: qui si cambia solo il colore. */

--- a/custom_components/dashboardmodern/frontend/src/sections/unified-editors-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/unified-editors-section.js
@@ -332,7 +332,16 @@ function installStyles() {
   if (doc?.getElementById("dm-unified-editor-visual-style")) return;
   const style = doc.createElement("style");
   style.id = "dm-unified-editor-visual-style";
-  style.textContent = `.dm-unified-icon-row{display:grid!important;grid-template-columns:72px minmax(0,1fr)!important;gap:12px!important;align-items:center!important}.dm-unified-icon-preview{display:grid!important;place-items:center!important;width:72px!important;height:72px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:18px!important;background:var(--secondary-background-color,#eef3f8)!important;font-size:34px!important;overflow:hidden!important}.dm-unified-icon-preview ha-icon{--mdc-icon-size:36px!important}.dm-canonical-icon input{opacity:.78!important}.dm-editor-header-icon ha-icon{--mdc-icon-size:28px!important}`;
+  style.textContent = `.dm-unified-icon-row{display:grid!important;grid-template-columns:72px minmax(0,1fr)!important;gap:12px!important;align-items:center!important}.dm-unified-icon-preview{display:grid!important;place-items:center!important;width:72px!important;height:72px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:18px!important;background:var(--secondary-background-color,#eef3f8)!important;font-size:34px!important;overflow:hidden!important}.dm-unified-icon-preview ha-icon{--mdc-icon-size:36px!important}.dm-canonical-icon input{opacity:.78!important}.dm-editor-header-icon ha-icon{--mdc-icon-size:28px!important}
+/* Il catalogo delle entita' deve stare sopra la finestra che lo chiama.
+ *
+ * La finestra di modifica sta a 100040, il catalogo si apre a 100000 scritto a
+ * mano sull'elemento: si apriva davvero, ma dietro. Chi premeva "Scegli entita'"
+ * vedeva la stessa schermata di prima e concludeva che il pulsante non
+ * funzionasse — e valeva per tutte le finestre di modifica, non solo per una.
+ * La regola sta qui perche' e' qui che nasce la finestra: chi crea l'ostacolo
+ * si occupa di lasciare passare. */
+#cd-entpick{z-index:100060!important}`;
   doc.head.append(style);
 }
 

--- a/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta30-version-contract.test.js
@@ -7,5 +7,5 @@ const manifest = JSON.parse(
 );
 
 test("the release manifest is versioned correctly", () => {
-  assert.equal(manifest.version, "1.0.0-rc.4");
+  assert.equal(manifest.version, "1.0.0-rc.5");
 });

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.0.0-rc.4"
+  "version": "1.0.0-rc.5"
 }


### PR DESCRIPTION
Due cose viste sul telefono con la rc.4 installata.

## Il catalogo delle entità si apriva dietro

Premendo «Scegli entità» nella finestra di modifica non succedeva niente. In
realtà il catalogo **si apriva davvero**: la finestra di modifica sta a
`z-index:100040`, il catalogo a `100000` scritto a mano sull'elemento. Si
apriva dietro, quindi si vedeva la stessa schermata di prima e la conclusione
naturale era che il pulsante fosse rotto.

**Non è un difetto del campo nuovo.** Vale per ogni finestra di modifica —
tapparella, clima, azioni, stanze — ed era lì da prima che questa funzione
esistesse: il campo del sensore l'ha solo reso evidente, perché è il primo che
si compila per forza dal catalogo.

La regola sta in `unified-editors-section.js` perché è lì che nasce la finestra:
chi crea l'ostacolo si occupa di lasciar passare.

## Con la tapparella giù non si capiva che la finestra fosse aperta

Le ante rientravano verso i loro cardini su un fondo dello stesso colore: la
card diceva «Finestra aperta» e mostrava una tapparella chiusa qualunque.

Ho provato tre strade e ne ho scartate due, perché coprivano il vano con
un'apertura scura e così **cancellavano il cielo** quando la tapparella è
alzata — cioè rompevano quello che già funzionava. Quella scelta è diversa:
l'anta aperta **resta un'anta**, prende corpo e getta ombra su quello che ha
dietro, che sia la tapparella chiara o il cielo. È l'ombra a dire che lì c'è un
buco, senza coprire né l'una né l'altro. Attorno si vede lo spessore del muro.

Da chiusa l'anta torna trasparente, se no si perderebbe il vetro.

Niente animazione: questa pagina ha già tolto ogni animazione a riposo per il
telefono, e non la si rimette per un dettaglio.

## Prove

| | prova |
|---|---|
| Catalogo davanti | Si apre **e** è quello che si tocca al centro dello schermo — aperto non basta |
| Anta leggibile | Da aperta ha corpo e ombra e si vede lo spessore; da chiusa torna trasparente |

Tutte e due verificate rosse senza la correzione. 796 test unitari, 12 prove
browser su questa funzione.

## Resta aperto

**Fold8 aperto: lo scorrimento si ferma prima del fondo.** Invariato rispetto
alla rc.4, con l'elenco di cosa è stato escluso nel changelog.


---
_Generated by [Claude Code](https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT)_