### PR TITLE
Due frasi che la 1.0.0 ha smentito: dove sta il blocco di sostegno, e da quando contano i download

### DIFF
--- a/.github/SUPPORT_BADGES.md
+++ b/.github/SUPPORT_BADGES.md
@@ -1,5 +1,6 @@
-<!-- Blocco di sostegno riutilizzato in README.md e in coda alle note di ogni
-     release (vedi .github/workflows/release.yml → append_body).
+<!-- Blocco di sostegno riutilizzato in README.md e in testa alle note di ogni
+     release: `append_body` di action-gh-release mette questo corpo prima
+     dell'elenco generato, non dopo (vedi .github/workflows/release.yml).
      Sorgente unica: per cambiare il testo o il canale si modifica qui. -->
 
 ### Sostieni il progetto

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,9 +130,10 @@ jobs:
       - name: Generate build provenance from the selected HEAD
         run: python scripts/build_release.py --expected-commit "$GITHUB_SHA" --output dashboardmodern.zip
       # Le note automatiche di GitHub elencano cosa è cambiato; il blocco di
-      # sostegno viene accodato in fondo, così ogni nuovo aggiornamento lo mostra
+      # sostegno si unisce a quell'elenco, così ogni nuovo aggiornamento lo mostra
       # senza doverlo riscrivere a mano. La sorgente è una sola, condivisa con il
-      # README: .github/SUPPORT_BADGES.md.
+      # README: .github/SUPPORT_BADGES.md. `append_body` mette questo corpo prima
+      # delle note generate, quindi il blocco apre la release invece di chiuderla.
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:

--- a/README.md
+++ b/README.md
@@ -1156,7 +1156,7 @@ Grazie a chi ha già sostenuto DashboardModern nelle scorse settimane: è **davv
 
 Grazie a chi sostiene il progetto: è ciò che tiene DashboardModern gratuito e in sviluppo. 💙
 
-> Lo stesso blocco compare in coda alle note di **ogni nuovo aggiornamento**: la sorgente è unica, [`.github/SUPPORT_BADGES.md`](.github/SUPPORT_BADGES.md), e il workflow `Release` la accoda alle note generate automaticamente. Per cambiare il testo o aggiungere un canale si modifica lì e in questa sezione.
+> Lo stesso blocco apre le note di **ogni nuovo aggiornamento**, sopra l'elenco di cosa è cambiato: la sorgente è unica, [`.github/SUPPORT_BADGES.md`](.github/SUPPORT_BADGES.md), e il workflow `Release` la unisce alle note generate automaticamente. Per cambiare il testo o aggiungere un canale si modifica lì e in questa sezione.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1118,11 +1118,13 @@ Ogni release pubblica un pacchetto `dashboardmodern.zip` ed è quello che HACS s
 | Dove guardare | Cosa dice |
 | --- | --- |
 | [Pagina Releases](https://github.com/danigio15/dashboardmodern-v2/releases) | il numero di download di `dashboardmodern.zip` è indicato sotto ogni release, versione per versione |
-| Badge **Download totali** | somma di tutti i download di tutti i pacchetti pubblicati |
+| Badge **Download totali** | somma dei download di tutti i pacchetti presenti sulla pagina |
 | Badge **Download ultima release** | quante persone hanno già la versione più recente |
 | [Insights → Traffic](https://github.com/danigio15/dashboardmodern-v2/graphs/traffic) | visite e cloni della repository (visibile al proprietario) |
 
 > I download della release contano il pacchetto scaricato da HACS o a mano. Non contano gli aggiornamenti già presenti nella cache di HACS né le installazioni copiate da un backup, quindi il numero reale di impianti è **almeno** quello mostrato.
+
+> **Il conteggio parte dalla 1.0.0.** GitHub tiene i download attaccati alla release che li ha serviti: ripulendo la pagina dalle versioni precedenti alla 1.0 sono spariti anche i loro contatori. Quello che si vede qui è quindi la diffusione della **1.0 in poi**, non la storia del progetto — che invece resta nei commit e in [`docs/CHANGELOG_PRE_1.0.md`](docs/CHANGELOG_PRE_1.0.md).
 
 ---
 

--- a/docs/RELEASE_1_0.md
+++ b/docs/RELEASE_1_0.md
@@ -82,7 +82,7 @@ quella.** Le pubblicazioni precedenti — 46 release (`v0.15.25`, 43 beta, rc.2 
 | Le pagine `releases/tag/v0.15.x` e i loro pacchetti scaricabili | Il **codice**: ogni commit resta nella cronologia di `main` |
 | I link diretti a una vecchia release citati in una issue | Le **note**: archiviate in [`CHANGELOG_PRE_1.0.md`](CHANGELOG_PRE_1.0.md) e nel JSON che lo script salva prima di cancellare |
 | Il download di una versione precedente da HACS (*Redownload → versione specifica*) | Le **installazioni esistenti**: chi è già su una beta continua a funzionare e vede l'aggiornamento alla 1.0 |
-| I contatori di download delle vecchie release | Il contatore della 1.0 e quelli futuri |
+| I contatori di download delle vecchie release — il totale **riparte da zero** | Il contatore della 1.0 e quelli futuri |
 
 > Chi è fermo su una `v0.15.x` o su una beta **non viene toccato**: HACS legge le
 > release per proporre aggiornamenti, non per far funzionare quello che è già


### PR DESCRIPTION
## Cosa fa

Pubblicare la 1.0.0 e ripulire la pagina delle release ha smentito due affermazioni della documentazione. Questa PR le corregge. **Nessuna modifica al codice della plancia**, solo testo.

---

## 1. Il blocco di sostegno apre le note, non le chiude

La v1.0.0 è la prima release a portare il blocco di sostegno automatico, e si è visto che finisce **in testa** alle note, sopra «What's Changed» — non in fondo come la documentazione diceva in tre punti.

Il motivo è `append_body` di `action-gh-release`: mette il corpo personalizzato **prima** dell'elenco generato.

| File | Diceva | Dice |
| --- | --- | --- |
| `README.md` | «compare in coda alle note» | «apre le note, sopra l'elenco di cosa è cambiato» |
| `.github/SUPPORT_BADGES.md` | «in coda alle note di ogni release» | «in testa», con il perché |
| `.github/workflows/release.yml` | «viene accodato in fondo» | spiega che `append_body` lo mette prima |

Ho corretto la descrizione invece della posizione: in testa il blocco si vede di più, ed è quello che serve a un invito a sostenere il progetto. Se si preferisce averlo davvero in fondo serve un passaggio in più nel workflow — le note vanno generate via API e concatenate a mano — e si può fare in una PR a parte.

## 2. Il contatore dei download riparte dalla 1.0.0

GitHub tiene i download attaccati alla release che li ha serviti. Ripulendo la pagina dalle 49 release precedenti alla 1.0 sono spariti anche i loro contatori: il badge **Download totali** non è più la storia del progetto, è la diffusione della **1.0 in poi**.

Era una conseguenza prevedibile della pulizia, ma il README prometteva «somma di tutti i download di tutti i pacchetti pubblicati», che adesso non è più vero. Meglio dirlo che lasciare un numero che sembra piccolo senza spiegare perché.

- `README.md` → la riga della tabella è ora «somma dei download di tutti i pacchetti **presenti sulla pagina**», e un riquadro spiega da quando parte il conteggio, rimandando all'archivio pre-1.0 per la storia.
- `docs/RELEASE_1_0.md` → nella tabella «cosa si perde» il contatore dei download è marcato come **riparte da zero**.

## Verifiche

```
npm run test:frontend   800 pass / 0 fail
```

`prettier --check` segnala i due file Markdown, ma i file `.md` non rientrano nello scope di `npm run format:check` del repository (che copre `src/core`, i test elencati, gli e2e e `playwright.config.js`): la CI non li controlla e il resto della documentazione segue la stessa formattazione.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuuN4rCvFRPFkiaBRgSBfQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuuN4rCvFRPFkiaBRgSBfQ)_