### PR TITLE
In HACS il nome è «DashboardModern v2»

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Le entità restano entità Home Assistant: DashboardModern si occupa di presenta
    https://github.com/danigio15/dashboardmodern-v2
    ```
 
-4. Cerca **Dashboard Modern V2** e installa la versione più recente.
+4. Cerca **DashboardModern v2** e installa la versione più recente.
 5. **Riavvia Home Assistant.**
 6. **Impostazioni → Dispositivi e servizi → Aggiungi integrazione → Dashboard Modern V2**.
 7. Dai un nome alla plancia e conferma.


### PR DESCRIPTION
Il passo 4 dell'installazione diceva di cercare **Dashboard Modern V2**. Ma HACS elenca il repository con il nome dichiarato in `hacs.json`, che è **DashboardModern v2** — tutto attaccato, `v` minuscola.

Chi seguiva il README alla lettera cercava con gli spazi e non trovava niente, subito dopo aver aggiunto il repository.

Una riga:

```diff
-4. Cerca **Dashboard Modern V2** e installa la versione più recente.
+4. Cerca **DashboardModern v2** e installa la versione più recente.
```

Il passo 6 resta invariato: lì il nome con gli spazi è quello giusto, perché l'elenco delle integrazioni di Home Assistant usa `manifest.json`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuuN4rCvFRPFkiaBRgSBfQ