### PR TITLE
Le animazioni sono informazione, e la potenza ha una casella per verso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,29 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   risalvata mentre non era lei in mostra tiene le sue foto, non quelle
   dell'altra.
 
+- **Da desktop le animazioni di elettrodomestici e avvisi non si vedevano.**
+  Tre rami CSS rispettavano «riduci il movimento» del sistema operativo
+  spegnendo tutto — il cestello che gira, il vapore, il led, la goccia
+  dell'allagamento. Su molti desktop Windows quell'impostazione è attiva senza
+  che nessuno l'abbia mai scelta, e Chrome la passa alle pagine: gli
+  elettrodomestici in funzione sembravano fermi, e gli avvisi pure. Ma questi
+  movimenti sono informazione, non decorazione — dicono che la macchina sta
+  lavorando adesso, che l'acqua sta gocciolando adesso — e adesso restano
+  accesi. Le transizioni puramente decorative continuano a rispettare
+  l'impostazione.
+
+- **Due sensori di potenza, uno per verso (#184).** Chi ha prelievo e
+  immissione — o carica e scarica — come due sensori separati, sempre
+  positivi, non aveva dove mettere il secondo: la casella della potenza è una,
+  e nel riquadro del verso opposto c'era soltanto il rimando «è una sola, si
+  imposta in…», che sembrava la spunta della sorgente unica ancora accesa. Il
+  secondo sensore adesso si dichiara lì — «Potenza immessa» per la rete,
+  «Potenza scaricata» per la batteria — e il numero col segno si ricava da
+  solo: prelievo meno immissione, scarica meno carica. Con la sorgente unica
+  con segno dichiarata le due caselle si spengono, perché sono due modi di
+  dire la stessa cosa. E togliere quella spunta riaccende le caselle dei due
+  versi, che era l'altra metà della segnalazione.
+
 ## 1.1.4
 
 ### Corretto

--- a/custom_components/dashboardmodern/frontend/e2e/due-potenze-una-per-verso.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/due-potenze-una-per-verso.spec.js
@@ -101,10 +101,26 @@ test("dalla coppia esce un solo numero, col segno del verso", async ({ page }, t
 
   await page.evaluate(() => {
     const stati = {
-      "sensor.prelievo_w": { entity_id: "sensor.prelievo_w", state: "1200", attributes: { unit_of_measurement: "W" } },
-      "sensor.immissione_w": { entity_id: "sensor.immissione_w", state: "300", attributes: { unit_of_measurement: "W" } },
-      "sensor.carica_w": { entity_id: "sensor.carica_w", state: "500", attributes: { unit_of_measurement: "W" } },
-      "sensor.scarica_w": { entity_id: "sensor.scarica_w", state: "0", attributes: { unit_of_measurement: "W" } },
+      "sensor.prelievo_w": {
+        entity_id: "sensor.prelievo_w",
+        state: "1200",
+        attributes: { unit_of_measurement: "W" },
+      },
+      "sensor.immissione_w": {
+        entity_id: "sensor.immissione_w",
+        state: "300",
+        attributes: { unit_of_measurement: "W" },
+      },
+      "sensor.carica_w": {
+        entity_id: "sensor.carica_w",
+        state: "500",
+        attributes: { unit_of_measurement: "W" },
+      },
+      "sensor.scarica_w": {
+        entity_id: "sensor.scarica_w",
+        state: "0",
+        attributes: { unit_of_measurement: "W" },
+      },
     };
     window.__HASS__ = { states: { ...(window.__HASS__?.states || {}), ...stati } };
     const raw = window.eval("typeof _RAW_STATES !== 'undefined' ? _RAW_STATES : null");

--- a/custom_components/dashboardmodern/frontend/e2e/due-potenze-una-per-verso.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/due-potenze-una-per-verso.spec.js
@@ -1,0 +1,127 @@
+/* Issue #184 — «non permette l'inserimento della seconda entità».
+ *
+ * Chi ha due sensori di potenza separati — prelievo e immissione, carica e
+ * scarica, sempre positivi — non aveva dove mettere il secondo: la casella
+ * della potenza e' una, e nel riquadro del verso opposto c'era soltanto il
+ * rimando «e' una sola, si imposta in...», che sembrava la spunta della
+ * sorgente unica ancora accesa. E togliere davvero quella spunta deve
+ * riaccendere le caselle dei due versi.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {
+      grid: { signed: { power: "sensor.rete_w", positive: "import" } },
+    },
+    entityOverrides: {},
+  },
+  visibility: { home: true, energy: true },
+};
+
+test("tolta la spunta le caselle si riaccendono, e il secondo sensore ha la sua", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(120_000);
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+  await page.evaluate(() => {
+    window.apriConfigEntita();
+    window.editorSwitch("energy");
+  });
+  await page.evaluate(() => {
+    document
+      .querySelector('[data-energy-signed="grid"]')
+      ?.closest("details.ed-acc")
+      ?.setAttribute("open", "");
+  });
+
+  const card = page.locator('[data-energy-signed="grid"]');
+  await expect(card).toHaveAttribute("data-state", "on");
+  // Con la sorgente unica dichiarata anche la casella del secondo sensore e' spenta.
+  await expect(page.locator("#dm-energy-grid-power").first()).toBeDisabled();
+  await expect(page.locator("#dm-energy-grid-power_export")).toBeDisabled();
+
+  // Si toglie la spunta, come nell'issue.
+  await card.locator('[data-energy-signed-toggle="grid"]').click();
+  await page.waitForTimeout(600);
+  await page.evaluate(() => {
+    document.querySelectorAll("#ed-body details.ed-acc").forEach((d) => d.setAttribute("open", ""));
+  });
+
+  // Le caselle dei due versi sono di nuovo scrivibili — non «come se la spunta
+  // fosse ancora presente».
+  await expect(page.locator("#dm-energy-grid-power").first()).toBeEnabled();
+  await expect(page.locator("#dm-energy-grid-power_export")).toBeEnabled();
+  await expect(page.locator("#dm-energy-grid-daily_import_energy")).toBeEnabled();
+  await expect(page.locator("#dm-energy-grid-daily_export_energy")).toBeEnabled();
+
+  // Il secondo sensore di potenza si scrive nella sua casella, nel riquadro
+  // dell'immissione: prima li' c'era soltanto il rimando.
+  await page.evaluate(() => {
+    const scrivi = (id, valore) => {
+      const input = document.getElementById(id);
+      input.value = valore;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    };
+    scrivi("dm-energy-grid-power", "sensor.prelievo_w");
+    scrivi("dm-energy-grid-power_export", "sensor.immissione_w");
+  });
+  await page.waitForTimeout(700);
+
+  const grid = await page.evaluate(
+    () => window.DashboardModernModules?.store?.getSection?.("energy")?.grid,
+  );
+  expect(grid.power).toBe("sensor.prelievo_w");
+  expect(grid.power_export).toBe("sensor.immissione_w");
+  expect(grid.signed).toBeUndefined();
+});
+
+test("dalla coppia esce un solo numero, col segno del verso", async ({ page }, testInfo) => {
+  const conCoppia = JSON.parse(JSON.stringify(seed));
+  conCoppia.sections.energy = {
+    grid: { power: "sensor.prelievo_w", power_export: "sensor.immissione_w" },
+    battery: { power: "sensor.carica_w", power_discharge: "sensor.scarica_w" },
+  };
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, conCoppia);
+
+  await page.evaluate(() => {
+    const stati = {
+      "sensor.prelievo_w": { entity_id: "sensor.prelievo_w", state: "1200", attributes: { unit_of_measurement: "W" } },
+      "sensor.immissione_w": { entity_id: "sensor.immissione_w", state: "300", attributes: { unit_of_measurement: "W" } },
+      "sensor.carica_w": { entity_id: "sensor.carica_w", state: "500", attributes: { unit_of_measurement: "W" } },
+      "sensor.scarica_w": { entity_id: "sensor.scarica_w", state: "0", attributes: { unit_of_measurement: "W" } },
+    };
+    window.__HASS__ = { states: { ...(window.__HASS__?.states || {}), ...stati } };
+    const raw = window.eval("typeof _RAW_STATES !== 'undefined' ? _RAW_STATES : null");
+    if (raw) Object.assign(raw, stati);
+    window.dispatchEvent(new CustomEvent("dashboardmodern:states-ready", { detail: {} }));
+  });
+
+  const lettura = (slot) =>
+    page.evaluate((riferimento) => {
+      const stato = window.eval(
+        `typeof STATES !== "undefined" ? STATES[${JSON.stringify(riferimento)}] : null`,
+      );
+      return stato ? String(stato.state) : null;
+    }, slot);
+
+  // Rete: prelievo 1200, immissione 300 → scambio +900 (verso il prelievo).
+  await expect.poll(() => lettura("dm.energy_potenza_scambio_rete")).toBe("900");
+  // Batteria: carica 500, scarica 0 → il runtime vuole positiva la scarica: -500.
+  await expect.poll(() => lettura("dm.energy_potenza_batteria")).toBe("-500");
+});

--- a/custom_components/dashboardmodern/frontend/e2e/le-animazioni-restano-anche-a-movimento-ridotto.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/le-animazioni-restano-anche-a-movimento-ridotto.spec.js
@@ -1,0 +1,46 @@
+/* «Continuo a non vedere animazioni da desktop con Chrome.»
+ *
+ * Su molti desktop Windows «Effetti animazione» e' disattivato a livello di
+ * sistema — spesso senza che nessuno l'abbia mai scelto — e Chrome lo passa
+ * alle pagine come prefers-reduced-motion: reduce. I rami CSS che rispettavano
+ * quell'impostazione spegnevano il cestello che gira, il vapore, il led, la
+ * goccia dell'allagamento: da desktop gli elettrodomestici in funzione
+ * sembravano fermi, e gli avvisi pure. Segnalato tre volte.
+ *
+ * Questi movimenti sono informazione, non decorazione: dicono che la macchina
+ * sta lavorando in questo momento. La prova emula esattamente quel desktop.
+ */
+import { expect, test } from "@playwright/test";
+import { bootConsolidatedDashboard } from "./helpers/consolidated-runtime.js";
+
+test.use({ contextOptions: { reducedMotion: "reduce" } });
+
+test("con movimento ridotto gli elettrodomestici in funzione si muovono lo stesso", async ({
+  page,
+}, testInfo) => {
+  await bootConsolidatedDashboard(page, "dashboard.html", testInfo);
+  const emulato = await page.evaluate(
+    () => window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+  expect(emulato, "la prova deve girare sul desktop che riduce il movimento").toBe(true);
+
+  await page.locator('.tab[data-tab="appliances-main"]').evaluate((button) => button.click());
+  const inFunzione = page.locator(
+    '#page-appliances-main .appl-main-view.active .appl-wide-card[data-appliance-state="running"]',
+  );
+  await expect(inFunzione).toHaveCount(1);
+
+  // Il frigo in funzione ha la luce interna che pulsa e il led che respira.
+  await expect
+    .poll(() =>
+      inFunzione.evaluate((card) => {
+        const luce = card.querySelector(".dmh-light");
+        const led = card.querySelector(".dmh-led");
+        return {
+          luce: luce ? getComputedStyle(luce).animationName : "manca",
+          led: led ? getComputedStyle(led).animationName : "manca",
+        };
+      }),
+    )
+    .toEqual({ luce: "dmGlowPulse", led: "dmDotBreathe" });
+});

--- a/custom_components/dashboardmodern/frontend/src/core/renderers.js
+++ b/custom_components/dashboardmodern/frontend/src/core/renderers.js
@@ -1,4 +1,4 @@
-import { SIGNED_GROUPS, SIGNED_MEASURES, signedSource } from "./signed-energy.js";
+import { POWER_PAIRS, SIGNED_GROUPS, SIGNED_MEASURES, signedSource } from "./signed-energy.js";
 // DM-FIX-20260812B
 import { getDeviceDisplayName, getDeviceVisual } from "./device-model.js";
 import { pick } from "./i18n.js";
@@ -136,6 +136,10 @@ const ENERGY_GROUPS = [
     "Rete · immissione",
     [
       ["power", "Potenza", "W", "sensor.rete_power"],
+      /* Chi ha due sensori di potenza separati — prelievo e immissione, sempre
+       * positivi — dichiara qui il secondo: il numero col segno si ricava da
+       * solo. Con la sorgente unica con segno questa casella si spegne. */
+      ["power_export", "Potenza immessa", "W", "sensor.rete_immissione_w"],
       ["daily_export_energy", "Energia immessa giornaliera", "kWh", "sensor.rete_immissione_oggi"],
       ["monthly_export_energy", "Energia immessa mensile", "kWh", "sensor.rete_immissione_mese"],
       ["annual_export_energy", "Energia immessa annuale", "kWh", "sensor.rete_immissione_anno"],
@@ -175,6 +179,8 @@ const ENERGY_GROUPS = [
     "Batteria · scarica",
     [
       ["power", "Potenza", "W", "sensor.batteria_power"],
+      // Il secondo sensore di chi ha carica e scarica separate, sempre positive.
+      ["power_discharge", "Potenza scaricata", "W", "sensor.batteria_scarica_w"],
       ["daily_discharged_energy", "Scaricata oggi", "kWh", "sensor.batteria_scaricata_oggi"],
       [
         "monthly_discharged_energy",
@@ -228,6 +234,7 @@ const ENERGY_EN = Object.freeze({
   "Potenza rete": "Grid power",
   "Potenza prelevata": "Import power",
   "Potenza immessa": "Export power",
+  "Potenza scaricata": "Discharge power",
   "Energia prelevata giornaliera": "Daily imported energy",
   "Energia immessa giornaliera": "Daily exported energy",
   "Energia prelevata mensile": "Monthly imported energy",
@@ -388,7 +395,14 @@ export function signedManagedFields(model = {}, group = "") {
   const source = signedSource(model, group);
   if (!definition || !source) return new Set();
   const fields = new Set();
-  if (source.entities.power) fields.add(definition.powerField);
+  if (source.entities.power) {
+    fields.add(definition.powerField);
+    /* Anche la casella del secondo sensore di potenza: la sorgente unica
+     * dichiara gia' tutti e due i versi, e lasciarla accesa vorrebbe dire due
+     * padroni sullo stesso numero. */
+    const pair = POWER_PAIRS[group];
+    if (pair) fields.add(pair.opposite);
+  }
   for (const period of definition.periods) {
     if (!source.entities[period.key]) continue;
     fields.add(period.positive);

--- a/custom_components/dashboardmodern/frontend/src/core/signed-energy.js
+++ b/custom_components/dashboardmodern/frontend/src/core/signed-energy.js
@@ -18,6 +18,46 @@
 /** Dominio riservato alle letture ricavate: non esiste in Home Assistant. */
 export const DERIVED_DOMAIN = "dm_derived";
 
+/* Due sensori di potenza, uno per verso — issue #184.
+ *
+ * La casella della potenza e' una per gruppo, perche' il modello ne tiene un
+ * numero solo, col segno a dire il verso. Molti impianti pero' pubblicano due
+ * sensori separati, sempre positivi: prelievo e immissione, carica e scarica.
+ * Chi li aveva non sapeva dove mettere il secondo — nel riquadro del verso
+ * opposto c'era soltanto il rimando «e' una sola, si imposta in...», che
+ * sembrava la spunta della sorgente unica ancora accesa.
+ *
+ * Qui si dichiara il secondo sensore, e il numero col segno si ricava:
+ * prelievo meno immissione per la rete, scarica meno carica per la batteria —
+ * i versi che il runtime considera positivi. La casella di sempre prende il
+ * verso del riquadro in cui sta: prelievo per la rete, carica per la
+ * batteria. La sorgente unica con segno, quando e' dichiarata, vince: sono
+ * due modi di dire la stessa cosa, e non possono valere insieme. */
+export const POWER_PAIRS = Object.freeze({
+  // La casella di sempre e' il prelievo (il verso positivo del runtime):
+  // il derivato e' power - power_export.
+  grid: Object.freeze({ opposite: "power_export", oppositeIsRuntimePositive: false }),
+  // La casella di sempre sta nel riquadro «carica», il runtime vuole positiva
+  // la scarica: il derivato e' power_discharge - power.
+  battery: Object.freeze({ opposite: "power_discharge", oppositeIsRuntimePositive: true }),
+});
+
+/** La coppia di potenze di un gruppo, se il secondo sensore e' dichiarato. */
+export function powerPairSource(energy = {}, group = "") {
+  const pair = POWER_PAIRS[group];
+  if (!pair) return null;
+  // La sorgente unica con segno vince: dichiara gia' tutti e due i versi.
+  if (signedSource(energy, group)) return null;
+  const opposite = clean(energy?.[group]?.[pair.opposite]);
+  if (!opposite) return null;
+  return {
+    group,
+    main: clean(energy?.[group]?.power),
+    opposite,
+    oppositeIsRuntimePositive: pair.oppositeIsRuntimePositive,
+  };
+}
+
 const clean = (value) => String(value ?? "").trim();
 
 /* Il verso che il runtime considera positivo.
@@ -149,6 +189,13 @@ export function applySignedSources(energy = {}) {
       target[period.negative] = derivedEntityId(group, period.negative);
     }
   }
+  for (const group of Object.keys(POWER_PAIRS)) {
+    if (!powerPairSource(energy, group)) continue;
+    own(group)[SIGNED_GROUPS[group].powerField] = derivedEntityId(
+      group,
+      SIGNED_GROUPS[group].powerField,
+    );
+  }
   return result;
 }
 
@@ -222,6 +269,24 @@ export function derivedEnergyStates(energy = {}, states = {}) {
       result[negativeId] = derivedState(negativeId, reading?.source, forNegative);
     }
   }
+  for (const group of Object.keys(POWER_PAIRS)) {
+    const pair = powerPairSource(energy, group);
+    if (!pair) continue;
+    const oppositeReading = readingFrom(states, pair.opposite);
+    /* Senza la casella principale il verso mancante vale zero: chi dichiara la
+     * sola immissione ha un impianto che non preleva mai da quel sensore. */
+    const mainReading = pair.main ? readingFrom(states, pair.main) : null;
+    const mainValue = pair.main ? mainReading?.value ?? null : 0;
+    const oppositeValue = oppositeReading?.value ?? null;
+    const id = derivedEntityId(group, SIGNED_GROUPS[group].powerField);
+    const value =
+      mainValue === null || oppositeValue === null
+        ? null
+        : pair.oppositeIsRuntimePositive
+          ? oppositeValue - mainValue
+          : mainValue - oppositeValue;
+    result[id] = derivedState(id, oppositeReading?.source || mainReading?.source, value);
+  }
   return result;
 }
 
@@ -232,6 +297,12 @@ export function signedSourceEntities(energy = {}) {
     const source = signedSource(energy, group);
     if (!source) continue;
     for (const entity of Object.values(source.entities)) ids.add(entity);
+  }
+  for (const group of Object.keys(POWER_PAIRS)) {
+    const pair = powerPairSource(energy, group);
+    if (!pair) continue;
+    if (pair.main) ids.add(pair.main);
+    ids.add(pair.opposite);
   }
   return [...ids];
 }

--- a/custom_components/dashboardmodern/frontend/src/core/signed-energy.js
+++ b/custom_components/dashboardmodern/frontend/src/core/signed-energy.js
@@ -276,7 +276,7 @@ export function derivedEnergyStates(energy = {}, states = {}) {
     /* Senza la casella principale il verso mancante vale zero: chi dichiara la
      * sola immissione ha un impianto che non preleva mai da quel sensore. */
     const mainReading = pair.main ? readingFrom(states, pair.main) : null;
-    const mainValue = pair.main ? mainReading?.value ?? null : 0;
+    const mainValue = pair.main ? (mainReading?.value ?? null) : 0;
     const oppositeValue = oppositeReading?.value ?? null;
     const id = derivedEntityId(group, SIGNED_GROUPS[group].powerField);
     const value =

--- a/custom_components/dashboardmodern/frontend/src/core/signed-energy.js
+++ b/custom_components/dashboardmodern/frontend/src/core/signed-energy.js
@@ -46,8 +46,14 @@ export const POWER_PAIRS = Object.freeze({
 export function powerPairSource(energy = {}, group = "") {
   const pair = POWER_PAIRS[group];
   if (!pair) return null;
-  // La sorgente unica con segno vince: dichiara gia' tutti e due i versi.
-  if (signedSource(energy, group)) return null;
+  /* La sorgente unica con segno vince solo se la potenza ce l'ha davvero.
+   *
+   * Una dichiarazione puo' esistere col solo verso scelto, o con i soli campi
+   * dei periodi: in quei momenti la sorgente con segno non produce nessuna
+   * potenza, e spegnere la coppia avrebbe lasciato passare il sensore del
+   * prelievo cosi' com'era — 1200 W al posto di 900. La coppia si fa da parte
+   * quando l'entita' di potenza con segno e' scritta, non prima. */
+  if (signedSource(energy, group)?.entities?.power) return null;
   const opposite = clean(energy?.[group]?.[pair.opposite]);
   if (!opposite) return null;
   return {
@@ -219,6 +225,22 @@ function readingFrom(states, entity) {
   return { source, value: numeric(raw) };
 }
 
+/* Una lettura di potenza portata in watt.
+ *
+ * I due sensori di una coppia possono dichiarare unita' diverse — 1200 W di
+ * prelievo e 0.3 kW di immissione — e sottrarre i numeri grezzi avrebbe
+ * prodotto 1199.7 spacciati per kW. Un'unita' che non si riconosce non si
+ * indovina: la lettura diventa muta, non un numero sbagliato. */
+const POWER_UNIT_FACTORS = Object.freeze({ w: 1, kw: 1000, mw: 1000000 });
+
+function watts(reading) {
+  if (!reading || reading.value === null || reading.value === undefined) return null;
+  const unit = clean(reading.source?.attributes?.unit_of_measurement).toLowerCase();
+  if (!unit) return reading.value; // senza unita' si assume il watt, come fa il runtime
+  const factor = POWER_UNIT_FACTORS[unit];
+  return factor === undefined ? null : reading.value * factor;
+}
+
 function derivedState(id, source, value, unit) {
   return {
     entity_id: id,
@@ -276,8 +298,8 @@ export function derivedEnergyStates(energy = {}, states = {}) {
     /* Senza la casella principale il verso mancante vale zero: chi dichiara la
      * sola immissione ha un impianto che non preleva mai da quel sensore. */
     const mainReading = pair.main ? readingFrom(states, pair.main) : null;
-    const mainValue = pair.main ? (mainReading?.value ?? null) : 0;
-    const oppositeValue = oppositeReading?.value ?? null;
+    const mainValue = pair.main ? watts(mainReading) : 0;
+    const oppositeValue = watts(oppositeReading);
     const id = derivedEntityId(group, SIGNED_GROUPS[group].powerField);
     const value =
       mainValue === null || oppositeValue === null
@@ -285,7 +307,9 @@ export function derivedEnergyStates(energy = {}, states = {}) {
         : pair.oppositeIsRuntimePositive
           ? oppositeValue - mainValue
           : mainValue - oppositeValue;
-    result[id] = derivedState(id, oppositeReading?.source || mainReading?.source, value);
+    /* L'unita' si dichiara, non si eredita: i due sensori possono usarne due
+     * diverse, e il numero qui sopra e' gia' stato portato in watt. */
+    result[id] = derivedState(id, oppositeReading?.source || mainReading?.source, value, "W");
   }
   return result;
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/appliance-layout-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/appliance-layout-section.js
@@ -357,9 +357,11 @@ function installStyles() {
         #dm-appliance-daily-popup .dm-appliance-daily-visual svg,#dm-appliance-daily-popup .dm-appliance-daily-visual ha-icon{width:46px!important;height:46px!important;max-width:46px!important;max-height:46px!important;--mdc-icon-size:46px}
       }
 
-      /* prefers-reduced-motion:reduce non spegne piu' questi disegni: dicono
-       * che la macchina lavora adesso, e su molti desktop quell'impostazione
-       * di sistema e' attiva a insaputa di chi guarda la plancia. */
+      /* A movimento ridotto si spegne la decorazione (la transizione della
+       * card), non i disegni di stato: quelli dicono che la macchina lavora
+       * adesso, e su molti desktop quell'impostazione di sistema e' attiva a
+       * insaputa di chi guarda la plancia. */
+      @media(prefers-reduced-motion:reduce){#page-appliances-main .appl-wide-card:not(.dm-ap-card),#appl-grid-overview .appl-wide-card:not(.dm-ap-card){transition:none!important}}
     `,
   );
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/appliance-layout-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/appliance-layout-section.js
@@ -357,7 +357,9 @@ function installStyles() {
         #dm-appliance-daily-popup .dm-appliance-daily-visual svg,#dm-appliance-daily-popup .dm-appliance-daily-visual ha-icon{width:46px!important;height:46px!important;max-width:46px!important;max-height:46px!important;--mdc-icon-size:46px}
       }
 
-      @media(prefers-reduced-motion:reduce){#page-appliances-main .appl-wide-card *,#appl-grid-overview .appl-wide-card *{animation:none!important;transition:none!important}}
+      /* prefers-reduced-motion:reduce non spegne piu' questi disegni: dicono
+       * che la macchina lavora adesso, e su molti desktop quell'impostazione
+       * di sistema e' attiva a insaputa di chi guarda la plancia. */
     `,
   );
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/appliance-showcase-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/appliance-showcase-section.js
@@ -1268,15 +1268,21 @@ function showcaseCss() {
 [data-theme="dark"] .dm-ap-badge.off{background:rgba(148,163,184,.14);color:#94a3b8}
 [data-theme="dark"] .dm-ap-badge.unavailable{background:rgba(239,68,68,.16);color:#fca5a5}
 [data-theme="dark"] .dm-appl-chips button.active{box-shadow:0 8px 18px rgba(14,165,233,.20)}
-/* Niente ramo a movimento ridotto per i disegni di stato.
+/* A movimento ridotto si spegne la decorazione, non l'informazione.
  *
  * «Ridotto» qui spegneva TUTTO — il cestello che gira, il vapore, il led — e
  * su Windows quell'impostazione e' spesso attiva senza che nessuno l'abbia
  * scelta per questa plancia: da desktop gli elettrodomestici in funzione
  * sembravano fermi, ed e' stato segnalato tre volte come animazioni "assenti".
- * Questi movimenti sono informazione, non decorazione: dicono che la macchina
- * sta lavorando adesso. Le transizioni decorative (hover, ombre) restano
- * governate dai loro rami. */
+ * Quei movimenti dicono che la macchina sta lavorando adesso, e restano.
+ * Quello che l'impostazione continua a spegnere e' il resto: il sollevamento
+ * al passaggio del mouse, il luccichio della barra, la ghiera che ruota. */
+@media (prefers-reduced-motion:reduce){
+.dm-appl-shell .dm-ap-card{transition:none}
+.dm-appl-shell .dm-ap-card:hover{transform:none;box-shadow:0 12px 30px rgba(15,23,42,.06)}
+.dm-appl-shell .dm-ap-bar.run i::after{animation:none;content:none}
+.dm-appl-shell .dm-ap-ring.indeterminate svg{animation:none}
+}
 @keyframes dmDotPulse{0%{box-shadow:0 0 0 0 rgba(34,197,94,.45)}70%{box-shadow:0 0 0 6px rgba(34,197,94,0)}100%{box-shadow:0 0 0 0 rgba(34,197,94,0)}}
 @keyframes dmDotBreathe{0%,100%{opacity:1}50%{opacity:.35}}
 @keyframes dmBarSheen{0%{transform:translateX(-100%)}55%,100%{transform:translateX(100%)}}

--- a/custom_components/dashboardmodern/frontend/src/sections/appliance-showcase-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/appliance-showcase-section.js
@@ -1268,10 +1268,15 @@ function showcaseCss() {
 [data-theme="dark"] .dm-ap-badge.off{background:rgba(148,163,184,.14);color:#94a3b8}
 [data-theme="dark"] .dm-ap-badge.unavailable{background:rgba(239,68,68,.16);color:#fca5a5}
 [data-theme="dark"] .dm-appl-chips button.active{box-shadow:0 8px 18px rgba(14,165,233,.20)}
-/* reduced motion */
-@media (prefers-reduced-motion:reduce){
-.dm-appl-shell *,.dm-appl-shell *::before,.dm-appl-shell *::after{animation:none!important;transition:none!important}
-}
+/* Niente ramo a movimento ridotto per i disegni di stato.
+ *
+ * «Ridotto» qui spegneva TUTTO — il cestello che gira, il vapore, il led — e
+ * su Windows quell'impostazione e' spesso attiva senza che nessuno l'abbia
+ * scelta per questa plancia: da desktop gli elettrodomestici in funzione
+ * sembravano fermi, ed e' stato segnalato tre volte come animazioni "assenti".
+ * Questi movimenti sono informazione, non decorazione: dicono che la macchina
+ * sta lavorando adesso. Le transizioni decorative (hover, ombre) restano
+ * governate dai loro rami. */
 @keyframes dmDotPulse{0%{box-shadow:0 0 0 0 rgba(34,197,94,.45)}70%{box-shadow:0 0 0 6px rgba(34,197,94,0)}100%{box-shadow:0 0 0 0 rgba(34,197,94,0)}}
 @keyframes dmDotBreathe{0%,100%{opacity:1}50%{opacity:.35}}
 @keyframes dmBarSheen{0%{transform:translateX(-100%)}55%,100%{transform:translateX(100%)}}

--- a/custom_components/dashboardmodern/frontend/src/sections/beta9-real-device-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta9-real-device-polish-section.js
@@ -785,10 +785,10 @@ function installStyles() {
         max-width:360px!important
       }
     }
-    @media(prefers-reduced-motion:reduce){
-      #page-home .g-icon-wrap[class*="dm-alert-"],
-      #page-home .g-icon-wrap .dm-alert-glyph{animation:none!important;transform:none!important}
-    }
+    /* Gli avvisi animati restano animati anche a movimento ridotto: il
+     * movimento e' il segnale — una perdita d'acqua che gocciola, una fiamma
+     * che trema — e su molti desktop quell'impostazione di sistema e' attiva
+     * senza che nessuno l'abbia scelta per questa plancia. */
   `);
 }
 

--- a/custom_components/dashboardmodern/frontend/tests/beta27-appliance-motion-cards.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta27-appliance-motion-cards.test.js
@@ -19,7 +19,11 @@ test("beta27 appliance cards expose running and standby visual states", () => {
   assert.match(source, /data-appliance-state=\\?"standby\\?"/);
   assert.match(source, /data-appliance-state=\\?"running\\?"/);
   assert.match(source, /dm-appliance-standby-breathe/);
-  assert.match(source, /prefers-reduced-motion:reduce/);
+  /* I disegni di stato non hanno piu' un ramo a movimento ridotto che li
+   * spegne: su molti desktop quell'impostazione e' attiva a insaputa di chi
+   * guarda, e "in funzione" senza movimento e' stato segnalato tre volte
+   * come animazioni assenti. */
+  assert.doesNotMatch(source, /prefers-reduced-motion:reduce\)\{#page-appliances-main \.appl-wide-card/);
 });
 
 test("beta27 gives appliance families distinct physical animations", () => {

--- a/custom_components/dashboardmodern/frontend/tests/beta27-appliance-motion-cards.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta27-appliance-motion-cards.test.js
@@ -19,11 +19,12 @@ test("beta27 appliance cards expose running and standby visual states", () => {
   assert.match(source, /data-appliance-state=\\?"standby\\?"/);
   assert.match(source, /data-appliance-state=\\?"running\\?"/);
   assert.match(source, /dm-appliance-standby-breathe/);
-  /* I disegni di stato non hanno piu' un ramo a movimento ridotto che li
-   * spegne: su molti desktop quell'impostazione e' attiva a insaputa di chi
-   * guarda, e "in funzione" senza movimento e' stato segnalato tre volte
-   * come animazioni assenti. */
-  assert.doesNotMatch(source, /prefers-reduced-motion:reduce\)\{#page-appliances-main \.appl-wide-card/);
+  /* Il ramo a movimento ridotto puo' spegnere la decorazione (transition),
+   * mai i disegni di stato: su molti desktop quell'impostazione e' attiva a
+   * insaputa di chi guarda, e "in funzione" senza movimento e' stato
+   * segnalato tre volte come animazioni assenti. */
+  const ridotti = source.match(/@media\(prefers-reduced-motion:reduce\)\{[^}]*\{[^}]*\}\}/g) || [];
+  for (const blocco of ridotti) assert.doesNotMatch(blocco, /animation/);
 });
 
 test("beta27 gives appliance families distinct physical animations", () => {

--- a/custom_components/dashboardmodern/frontend/tests/beta9-real-device-polish.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta9-real-device-polish.test.js
@@ -79,6 +79,10 @@ test("shutters are compact and alert animations follow the alert kind", async ()
   for (const kind of ["window", "leak", "flame", "motion", "temperature", "power", "light", "security"]) {
     assert.match(source, new RegExp(`\\.dm-alert-${kind} \\.dm-alert-glyph`));
   }
+  /* E nessun ramo a movimento ridotto le spegne: il movimento e' il segnale
+   * dell'avviso, e su molti desktop quell'impostazione di sistema e' attiva a
+   * insaputa di chi guarda la plancia. Da desktop gli avvisi parevano fermi. */
+  assert.doesNotMatch(source, /prefers-reduced-motion[\s\S]{0,200}dm-alert/);
 });
 
 test("add-light layout cannot collapse its entity field", async () => {

--- a/custom_components/dashboardmodern/frontend/tests/energia-entita-con-segno.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energia-entita-con-segno.test.js
@@ -6,6 +6,7 @@ import {
   derivedEntityId,
   derivedEnergyStates,
   isDerivedEntity,
+  powerPairSource,
   signedSource,
   signedSourceEntities,
   splitSignedReading,
@@ -183,6 +184,81 @@ import { migrateState } from "../src/core/migrations.js";
 function migrazioneDi(energy) {
   return migrateState({ schema_version: 4, sections: { energy }, visibility: {} }, {}).changes;
 }
+
+/* Due sensori di potenza, uno per verso — issue #184.
+ *
+ * Chi ha prelievo e immissione (o carica e scarica) come due sensori separati,
+ * sempre positivi, non aveva dove mettere il secondo: la casella della potenza
+ * e' una, e nel riquadro del verso opposto c'era soltanto il rimando. Il
+ * secondo sensore adesso si dichiara li', e il numero col segno si ricava. */
+test("il secondo sensore di potenza si dichiara, e il segno si ricava", () => {
+  const energy = { grid: { power: "sensor.prelievo_w", power_export: "sensor.immissione_w" } };
+  const pair = powerPairSource(energy, "grid");
+  assert.ok(pair, "la coppia non viene vista");
+  assert.equal(pair.main, "sensor.prelievo_w");
+  assert.equal(pair.opposite, "sensor.immissione_w");
+  const applied = applySignedSources(energy);
+  assert.equal(applied.grid.power, derivedEntityId("grid", "power"));
+  const states = {
+    "sensor.prelievo_w": stato(1200, "W"),
+    "sensor.immissione_w": stato(300, "W"),
+  };
+  const derived = derivedEnergyStates(energy, states);
+  assert.equal(derived[derivedEntityId("grid", "power")].state, "900");
+  assert.deepEqual(signedSourceEntities(energy).sort(), [
+    "sensor.immissione_w",
+    "sensor.prelievo_w",
+  ]);
+});
+
+test("per la batteria il runtime vuole positiva la scarica", () => {
+  const energy = { battery: { power: "sensor.carica_w", power_discharge: "sensor.scarica_w" } };
+  const derived = derivedEnergyStates(energy, {
+    "sensor.carica_w": stato(500, "W"),
+    "sensor.scarica_w": stato(0, "W"),
+  });
+  assert.equal(derived[derivedEntityId("battery", "power")].state, "-500", "in carica e' negativa");
+  const scarica = derivedEnergyStates(energy, {
+    "sensor.carica_w": stato(0, "W"),
+    "sensor.scarica_w": stato(800, "W"),
+  });
+  assert.equal(scarica[derivedEntityId("battery", "power")].state, "800");
+});
+
+test("senza la casella principale il verso mancante vale zero", () => {
+  const energy = { grid: { power_export: "sensor.immissione_w" } };
+  const derived = derivedEnergyStates(energy, { "sensor.immissione_w": stato(300, "W") });
+  assert.equal(derived[derivedEntityId("grid", "power")].state, "-300");
+});
+
+test("un sensore muto rende muto il derivato, non uno zero inventato", () => {
+  const energy = { grid: { power: "sensor.prelievo_w", power_export: "sensor.immissione_w" } };
+  const derived = derivedEnergyStates(energy, {
+    "sensor.prelievo_w": stato("unavailable", "W"),
+    "sensor.immissione_w": stato(300, "W"),
+  });
+  assert.equal(derived[derivedEntityId("grid", "power")].state, "unavailable");
+});
+
+test("la sorgente unica con segno vince sulla coppia", () => {
+  const energy = {
+    grid: {
+      power: "sensor.prelievo_w",
+      power_export: "sensor.immissione_w",
+      signed: { power: "sensor.rete_con_segno", positive: "import" },
+    },
+  };
+  assert.equal(powerPairSource(energy, "grid"), null, "due modi di dire la stessa cosa insieme");
+  const applied = applySignedSources(energy);
+  // Comanda la sorgente con segno: il derivato viene da lei.
+  assert.equal(applied.grid.power, "sensor.rete_con_segno");
+});
+
+test("senza il secondo sensore non cambia niente", () => {
+  const energy = { grid: { power: "sensor.rete_w" } };
+  assert.equal(powerPairSource(energy, "grid"), null);
+  assert.equal(applySignedSources(energy), energy);
+});
 
 test("un modello gia' migrato non si rimigra a ogni avvio", () => {
   const gia = {

--- a/custom_components/dashboardmodern/frontend/tests/energia-entita-con-segno.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energia-entita-con-segno.test.js
@@ -240,6 +240,46 @@ test("un sensore muto rende muto il derivato, non uno zero inventato", () => {
   assert.equal(derived[derivedEntityId("grid", "power")].state, "unavailable");
 });
 
+test("i due sensori possono usare unita' diverse: si sottraggono watt, non numeri", () => {
+  const energy = { grid: { power: "sensor.prelievo_w", power_export: "sensor.immissione_kw" } };
+  const derived = derivedEnergyStates(energy, {
+    "sensor.prelievo_w": stato(1200, "W"),
+    "sensor.immissione_kw": stato(0.3, "kW"),
+  });
+  const lettura = derived[derivedEntityId("grid", "power")];
+  assert.equal(lettura.state, "900", "0.3 kW sono 300 W, non 0.3");
+  assert.equal(lettura.attributes.unit_of_measurement, "W", "l'unita' si dichiara, non si eredita");
+});
+
+test("un'unita' che non si riconosce rende muta la lettura, non un numero sbagliato", () => {
+  const energy = { grid: { power: "sensor.prelievo_w", power_export: "sensor.strano" } };
+  const derived = derivedEnergyStates(energy, {
+    "sensor.prelievo_w": stato(1200, "W"),
+    "sensor.strano": stato(3, "hp"),
+  });
+  assert.equal(derived[derivedEntityId("grid", "power")].state, "unavailable");
+});
+
+test("una dichiarazione col solo verso non spegne la coppia", () => {
+  /* La scheda della sorgente unica salva subito il verso, prima che il
+   * sensore sia scritto: in quel momento non produce nessuna potenza, e la
+   * coppia deve continuare a lavorare — 900 W, non i 1200 grezzi del
+   * prelievo. */
+  const energy = {
+    grid: {
+      power: "sensor.prelievo_w",
+      power_export: "sensor.immissione_w",
+      signed: { positive: "import" },
+    },
+  };
+  assert.ok(powerPairSource(energy, "grid"), "la coppia si e' spenta per una dichiarazione vuota");
+  const derived = derivedEnergyStates(energy, {
+    "sensor.prelievo_w": stato(1200, "W"),
+    "sensor.immissione_w": stato(300, "W"),
+  });
+  assert.equal(derived[derivedEntityId("grid", "power")].state, "900");
+});
+
 test("la sorgente unica con segno vince sulla coppia", () => {
   const energy = {
     grid: {


### PR DESCRIPTION
Tre correzioni, tutte sull'ultima build segnalata.

## Da desktop le animazioni di elettrodomestici e avvisi non si vedevano

Tre rami CSS rispettavano «riduci il movimento» del sistema operativo spegnendo **tutto** — il cestello che gira, il vapore, il led, la goccia dell'allagamento. Su molti desktop Windows quell'impostazione è attiva senza che nessuno l'abbia mai scelta, e Chrome la passa alle pagine come `prefers-reduced-motion: reduce`: gli elettrodomestici in funzione sembravano fermi, e gli avvisi pure. Segnalato tre volte.

Questi movimenti sono informazione, non decorazione — dicono che la macchina sta lavorando *adesso* — e non si spengono più. Le transizioni puramente decorative (hover, ombre, popup) continuano a rispettare l'impostazione.

**Prova**: `e2e/le-animazioni-restano-anche-a-movimento-ridotto.spec.js` emula esattamente quel desktop (`reducedMotion: "reduce"`) e verifica che il frigo in funzione pulsi lo stesso.

## Due sensori di potenza, uno per verso (#184)

Chi ha prelievo e immissione — o carica e scarica — come due sensori separati, sempre positivi, non aveva dove mettere il secondo: la casella della potenza è una, e nel riquadro del verso opposto c'era soltanto il rimando «è una sola, si imposta in…», che sembrava la spunta della sorgente unica ancora accesa.

Il secondo sensore adesso si dichiara lì — **«Potenza immessa»** per la rete, **«Potenza scaricata»** per la batteria — e il numero col segno si ricava da solo col meccanismo delle letture derivate già esistente (`dm_derived`): prelievo − immissione, scarica − carica. La sorgente unica con segno, quando è dichiarata, vince e spegne le due caselle; toglierla le riaccende — che era l'altra metà della segnalazione.

**Prove**: 6 unit test nuovi in `energia-entita-con-segno.test.js` (derivazione, verso batteria, sensore muto ≠ zero, precedenza della sorgente con segno), più `e2e/due-potenze-una-per-verso.spec.js` che ripercorre l'issue: spunta tolta → caselle riaccese → due entità diverse salvate → `dm.energy_potenza_scambio_rete = 900` da 1200/300.

## Verifiche

1066 prove del frontend verdi, i18n a 1104 chiavi allineate, e2e nuovi e phase6 verdi su desktop e mobile. Changelog aggiornato sotto 1.1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT

---
_Generated by [Claude Code](https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT)_