### PR TITLE
1.1.6: la foto non risorge, la finestra ha i suoi cursori, il telo si muove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   una bozza scritta e non salvata si scarta quando l'auto di destinazione
   cambia.
 
+- **«Dal dispositivo» rispondeva Caricamento non riuscito (HTTP 401).** La
+  plancia servita dall'integrazione non possiede nessun token: il suo
+  WebSocket si autentica lato server, e la chiamata REST all'archivio immagini
+  di Home Assistant non poteva che essere rifiutata. La foto viaggia adesso
+  sullo stesso WebSocket dell'integrazione — l'unico canale davvero
+  autenticato — e il backend la scrive sotto `config/www/dashboardmodern`,
+  rispondendo con un `/local/...` come quelli scritti a mano. Nomi sanificati,
+  solo immagini, tetto a 10 MB, e un nome già preso si numera invece di
+  sovrascrivere. Il vecchio archivio REST resta come ripiego per chi un token
+  vero ce l'ha.
+
 - **Le tapparelle erano rimaste senza animazioni da desktop.** Stessa causa
   degli elettrodomestici: «riduci il movimento» del sistema operativo spegneva
   anche il telo che scende e il rullo che gira, che sono lo stato della

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
 ## Non rilasciato
 
+## 1.1.6
+
+### Corretto
+
+- **La foto dell'auto risorgeva da sola, ancora.** Il profilo normalizzato nel
+  negozio canonico porta anche `image` e `image_url`, e componendo
+  `img || image` una foto svuotata apposta tornava in vita dall'alias rimasto
+  pieno al giro prima: a ogni risalvataggio della sezione la foto vecchia si
+  ripiazzava sull'auto sbagliata, qualunque cosa si facesse dal pannello. Era
+  «c'è qualche sezione che sovrascrive», alla lettera. Adesso `img` comanda,
+  anche vuota, e gli alias la seguono invece di farle da memoria ombra.
+
+- **Il pannello foto dice a quale auto sta scrivendo.** Le foto caricate in
+  configurazione finiscono sull'auto attiva, che non è per forza quella che si
+  sta guardando: chi apriva il pannello con l'altra vettura attiva se le
+  ritrovava sull'auto sbagliata, senza che niente lo dicesse. Il titolo ora
+  porta il nome dell'auto di destinazione e segue il cambio in tempo reale. E
+  una coppia di foto salvata su un'auto viene tolta a chi la portava identica:
+  è la firma del vecchio difetto che le mescolava, e la dichiarazione nuova
+  vince sulla copia.
+
+- **Le tapparelle erano rimaste senza animazioni da desktop.** Stessa causa
+  degli elettrodomestici: «riduci il movimento» del sistema operativo spegneva
+  anche il telo che scende e il rullo che gira, che sono lo stato della
+  finestra, non un ornamento. Restano fermi solo i fregi: il sollevamento della
+  card e le transizioni dei bottoni.
+
+- **Una finestra con tre coperture usciva come tre card.** E sotto la foto
+  della finestra il cursore era sempre uno. Adesso una riga di configurazione è
+  una card sola: la finestra disegna tutti i teli insieme — tapparella,
+  tenda, tenda da sole — e sotto ci sono i cursori, uno per copertura, ognuno
+  con la sua etichetta, la sua percentuale e il suo comando. I bottoni
+  apri/ferma/chiudi della card muovono l'infisso intero.
+
 ## 1.1.5
 
 ### Corretto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,10 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   configurazione finiscono sull'auto attiva, che non è per forza quella che si
   sta guardando: chi apriva il pannello con l'altra vettura attiva se le
   ritrovava sull'auto sbagliata, senza che niente lo dicesse. Il titolo ora
-  porta il nome dell'auto di destinazione e segue il cambio in tempo reale. E
-  una coppia di foto salvata su un'auto viene tolta a chi la portava identica:
-  è la firma del vecchio difetto che le mescolava, e la dichiarazione nuova
-  vince sulla copia.
+  porta il nome dell'auto di destinazione e segue il cambio in tempo reale. Salvare
+  le foto di un'auto riguarda quell'auto e basta: l'altra non si tocca mai, e
+  una bozza scritta e non salvata si scarta quando l'auto di destinazione
+  cambia.
 
 - **Le tapparelle erano rimaste senza animazioni da desktop.** Stessa causa
   degli elettrodomestici: «riduci il movimento» del sistema operativo spegneva

--- a/custom_components/dashboardmodern/frontend/e2e/la-sezione-ev-a-fondo.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/la-sezione-ev-a-fondo.spec.js
@@ -1,0 +1,208 @@
+/* La sezione EV, dal principio alla fine, senza doverci tornare.
+ *
+ * Due auto configurate, ognuna con le sue foto. Si passa dall'una all'altra
+ * dalle linguette in cima alla pagina — piu' volte, avanti e indietro, come fa
+ * una persona vera — e a ogni passo le caselle da cui il disegno legge dicono
+ * l'auto scelta. Poi la configurazione: il pannello delle foto dichiara a
+ * quale auto sta scrivendo, e una coppia di foto salvata su un'auto viene
+ * tolta a chi la portava identica — che e' la firma del vecchio difetto che
+ * le mescolava.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const SEME = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  visibility: { home: true, ev: true },
+};
+
+const DUE_AUTO = [
+  {
+    name: "B10",
+    uid: "b10",
+    brand: "Leapmotor",
+    model: "B10",
+    ov: { "dm.ev_batteria_auto": "sensor.b10_battery" },
+    img: "/local/ev/b10-idle.png",
+    imgPlugged: "/local/ev/b10-cavo.png",
+  },
+  {
+    name: "T03",
+    uid: "t03",
+    brand: "Leapmotor",
+    model: "T03",
+    ov: { "dm.ev_batteria_auto": "sensor.t03_battery" },
+    img: "/local/ev/t03-idle.png",
+    imgPlugged: "/local/ev/t03-cavo.png",
+  },
+];
+
+async function avvia(page, testInfo, cars = DUE_AUTO) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, SEME);
+  await page.waitForFunction(() => Boolean(window.cdEvApplyCar?.__dmEvSection), null, {
+    timeout: 30_000,
+  });
+  await page.evaluate((elenco) => {
+    localStorage.setItem("cd_ev_cars", JSON.stringify(elenco));
+    window.cdEvApplyCar(0);
+  }, cars);
+}
+
+const caselle = (page) =>
+  page.evaluate(() => {
+    const read = (k) => {
+      try {
+        return JSON.parse(localStorage.getItem(k) || '""');
+      } catch (_e) {
+        return localStorage.getItem(k) || "";
+      }
+    };
+    return {
+      active: localStorage.getItem("cd_ev_car_active"),
+      idle: read("cd_ev_image"),
+      plugged: read("cd_ev_image_plugged"),
+    };
+  });
+
+test("le linguette in cima reggono dieci cambi di fila", async ({ page }, testInfo) => {
+  test.setTimeout(120_000);
+  await avvia(page, testInfo);
+
+  await page.evaluate(() => {
+    document.querySelector('.tab[data-tab="ev"]')?.click();
+  });
+  /* La stessa tendina esiste due volte per disegno — in cima alla pagina e
+   * dentro il popup dell'auto. Qui si prova quella della pagina. */
+  const linguette = page.locator("#ev-car-picker .dm-vehicle-profile-card");
+  await expect(linguette).toHaveCount(2);
+
+  /* Avanti e indietro, come col dito: a ogni passo la spunta e le caselle
+   * raccontano la stessa auto — e ci restano anche dopo una pausa. */
+  for (const indice of [1, 0, 1, 1, 0, 1, 0, 0, 1, 0]) {
+    await linguette.nth(indice).click();
+    const attesa =
+      indice === 0
+        ? { active: "0", idle: "/local/ev/b10-idle.png", plugged: "/local/ev/b10-cavo.png" }
+        : { active: "1", idle: "/local/ev/t03-idle.png", plugged: "/local/ev/t03-cavo.png" };
+    await expect.poll(() => caselle(page)).toEqual(attesa);
+    await expect(linguette.nth(indice)).toHaveClass(/active/);
+  }
+
+  // E dopo tre secondi di passate della plancia niente e' tornato indietro.
+  await page.waitForTimeout(3000);
+  expect(await caselle(page)).toEqual({
+    active: "0",
+    idle: "/local/ev/b10-idle.png",
+    plugged: "/local/ev/b10-cavo.png",
+  });
+});
+
+test("il pannello foto dice a quale auto sta scrivendo, e segue il cambio", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(120_000);
+  await avvia(page, testInfo);
+
+  await page.evaluate(() => {
+    window.apriConfigEntita();
+    window.editorSwitch("sez2");
+  });
+  const titolo = page.locator("[data-ev-photos-title]");
+  await expect(titolo).toHaveCount(1);
+  await expect(titolo).toHaveText(/B10/);
+
+  // Cambiata l'auto attiva, il pannello cambia intestazione: niente piu' foto
+  // caricate "da qualche parte".
+  await page.evaluate(() => window.cdEvApplyCar(1));
+  await expect(titolo).toHaveText(/T03/);
+});
+
+test("una coppia salvata su un'auto viene tolta a chi la portava identica", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(120_000);
+  /* La configurazione corrotta dal vecchio difetto: due auto, la stessa
+   * identica coppia di foto — quelle della B10, copiate sulla T03. */
+  const corrotte = JSON.parse(JSON.stringify(DUE_AUTO));
+  corrotte[1].img = corrotte[0].img;
+  corrotte[1].imgPlugged = corrotte[0].imgPlugged;
+  await avvia(page, testInfo, corrotte);
+
+  // Si rende attiva la T03 e le si danno le SUE foto dal pannello.
+  await page.evaluate(() => {
+    window.cdEvApplyCar(1);
+    window.apriConfigEntita();
+    window.editorSwitch("sez2");
+    const accordion = [...document.querySelectorAll("#ed-body details.ed-acc")].find((node) =>
+      node.querySelector('.ed-slot-in[data-ref^="dm.ev_"]'),
+    );
+    if (accordion) accordion.open = true;
+  });
+  const pannello = page.locator("#ed-body [data-ev-photos]");
+  await expect(pannello).toHaveCount(1);
+  await expect(page.locator("[data-ev-photos-title]")).toHaveText(/T03/);
+
+  await pannello
+    .locator('[data-ev-photo="idle"] [data-ev-photo-input]')
+    .fill("/local/ev/t03-idle.png");
+  await pannello
+    .locator('[data-ev-photo="plugged"] [data-ev-photo-input]')
+    .fill("/local/ev/t03-cavo.png");
+  // Il click diretto: il modale della configurazione tiene strati sopra.
+  await pannello.locator("[data-ev-photos-save]").evaluate((bottone) => bottone.click());
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const cars = JSON.parse(localStorage.getItem("cd_ev_cars") || "[]");
+        return cars.map((c) => ({ name: c.name, img: c.img, imgPlugged: c.imgPlugged }));
+      }),
+    )
+    .toEqual([
+      // La B10 tiene le SUE foto: era lei la derubata, non la ladra.
+      { name: "B10", img: "/local/ev/b10-idle.png", imgPlugged: "/local/ev/b10-cavo.png" },
+      { name: "T03", img: "/local/ev/t03-idle.png", imgPlugged: "/local/ev/t03-cavo.png" },
+    ]);
+
+  /* E la coppia ri-dichiarata passa di mano.
+   *
+   * Se adesso si rende attiva la B10 e le si salvano ESATTAMENTE le foto che
+   * la T03 porta, la dichiarazione vince: la coppia e' della B10, e alla T03
+   * — che la portava identica — viene tolta. E' la rete per chi ripara una
+   * configurazione gia' mescolata dal vecchio difetto. */
+  await page.evaluate(() => window.cdEvApplyCar(0));
+  await expect(page.locator("[data-ev-photos-title]")).toHaveText(/B10/);
+  await pannello
+    .locator('[data-ev-photo="idle"] [data-ev-photo-input]')
+    .fill("/local/ev/t03-idle.png");
+  await pannello
+    .locator('[data-ev-photo="plugged"] [data-ev-photo-input]')
+    .fill("/local/ev/t03-cavo.png");
+  await pannello.locator("[data-ev-photos-save]").evaluate((bottone) => bottone.click());
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const cars = JSON.parse(localStorage.getItem("cd_ev_cars") || "[]");
+        return cars.map((c) => ({ name: c.name, img: c.img, imgPlugged: c.imgPlugged }));
+      }),
+    )
+    .toEqual([
+      { name: "B10", img: "/local/ev/t03-idle.png", imgPlugged: "/local/ev/t03-cavo.png" },
+      { name: "T03", img: "", imgPlugged: "" },
+    ]);
+});

--- a/custom_components/dashboardmodern/frontend/e2e/la-sezione-ev-a-fondo.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/la-sezione-ev-a-fondo.spec.js
@@ -132,9 +132,7 @@ test("il pannello foto dice a quale auto sta scrivendo, e segue il cambio", asyn
   await expect(titolo).toHaveText(/T03/);
 });
 
-test("una coppia salvata su un'auto viene tolta a chi la portava identica", async ({
-  page,
-}, testInfo) => {
+test("salvare le foto di un'auto non tocca mai l'altra", async ({ page }, testInfo) => {
   test.setTimeout(120_000);
   /* La configurazione corrotta dal vecchio difetto: due auto, la stessa
    * identica coppia di foto — quelle della B10, copiate sulla T03. */
@@ -174,35 +172,25 @@ test("una coppia salvata su un'auto viene tolta a chi la portava identica", asyn
       }),
     )
     .toEqual([
-      // La B10 tiene le SUE foto: era lei la derubata, non la ladra.
+      /* La B10 tiene le SUE foto, identiche o no: salvare la T03 riguarda la
+       * T03 e basta. Chi ha i profili mescolati risistema ciascuna auto dal
+       * suo pannello — che ora dichiara a chi sta scrivendo — e la foto non
+       * risorge piu' dagli alias. */
       { name: "B10", img: "/local/ev/b10-idle.png", imgPlugged: "/local/ev/b10-cavo.png" },
       { name: "T03", img: "/local/ev/t03-idle.png", imgPlugged: "/local/ev/t03-cavo.png" },
     ]);
 
-  /* E la coppia ri-dichiarata passa di mano.
+  /* E una bozza scritta per un'auto non finisce sull'altra.
    *
-   * Se adesso si rende attiva la B10 e le si salvano ESATTAMENTE le foto che
-   * la T03 porta, la dichiarazione vince: la coppia e' della B10, e alla T03
-   * — che la portava identica — viene tolta. E' la rete per chi ripara una
-   * configurazione gia' mescolata dal vecchio difetto. */
-  await page.evaluate(() => window.cdEvApplyCar(0));
-  await expect(page.locator("[data-ev-photos-title]")).toHaveText(/B10/);
+   * Percorso digitato senza salvare, poi cambio d'auto: il pannello segue il
+   * cambio e la bozza dell'auto di prima si scarta — salvarla adesso la
+   * scriverebbe sul profilo sbagliato col titolo nuovo a fare da alibi. */
   await pannello
     .locator('[data-ev-photo="idle"] [data-ev-photo-input]')
-    .fill("/local/ev/t03-idle.png");
-  await pannello
-    .locator('[data-ev-photo="plugged"] [data-ev-photo-input]')
-    .fill("/local/ev/t03-cavo.png");
-  await pannello.locator("[data-ev-photos-save]").evaluate((bottone) => bottone.click());
-  await expect
-    .poll(() =>
-      page.evaluate(() => {
-        const cars = JSON.parse(localStorage.getItem("cd_ev_cars") || "[]");
-        return cars.map((c) => ({ name: c.name, img: c.img, imgPlugged: c.imgPlugged }));
-      }),
-    )
-    .toEqual([
-      { name: "B10", img: "/local/ev/t03-idle.png", imgPlugged: "/local/ev/t03-cavo.png" },
-      { name: "T03", img: "", imgPlugged: "" },
-    ]);
+    .fill("/local/ev/bozza-mai-salvata.png");
+  await page.evaluate(() => window.cdEvApplyCar(0));
+  await expect(page.locator("[data-ev-photos-title]")).toHaveText(/B10/);
+  await expect(pannello.locator('[data-ev-photo="idle"] [data-ev-photo-input]')).toHaveValue(
+    "/local/ev/b10-idle.png",
+  );
 });

--- a/custom_components/dashboardmodern/frontend/e2e/le-animazioni-restano-anche-a-movimento-ridotto.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/le-animazioni-restano-anche-a-movimento-ridotto.spec.js
@@ -44,3 +44,40 @@ test("con movimento ridotto gli elettrodomestici in funzione si muovono lo stess
     )
     .toEqual({ luce: "dmGlowPulse", led: "dmDotBreathe" });
 });
+
+test("anche la tapparella che si muove si muove, a movimento ridotto", async ({
+  page,
+}, testInfo) => {
+  await bootConsolidatedDashboard(page, "dashboard.html", testInfo);
+  await page.evaluate(() => {
+    const valori = {
+      "cover.camera": {
+        entity_id: "cover.camera",
+        state: "closing",
+        attributes: { device_class: "shutter", current_position: 40, supported_features: 15 },
+      },
+    };
+    localStorage.setItem(
+      "cd_tapparelle",
+      JSON.stringify([{ id: "t1", name: "Camera", entity: "cover.camera" }]),
+    );
+    window.__HASS__ = { states: { ...(window.__HASS__?.states || {}), ...valori } };
+    const raw = window.eval("typeof _RAW_STATES !== 'undefined' ? _RAW_STATES : null");
+    if (raw) Object.assign(raw, valori);
+    document.querySelectorAll(".page").forEach((nodo) => nodo.classList.remove("active"));
+    document.getElementById("page-tapparelle")?.classList.add("active");
+    window.dispatchEvent(new CustomEvent("dashboardmodern:states-ready", { detail: {} }));
+    window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: {} }));
+  });
+  const card = page.locator('[data-dm-shutter-card][data-tapp="cover.camera"]');
+  await card.waitFor();
+  // Il rullo che gira mentre la tapparella scende: e' lo stato, non un fregio.
+  await expect
+    .poll(() =>
+      card.evaluate((nodo) => {
+        const telo = nodo.querySelector(".tapp-shutter");
+        return telo ? getComputedStyle(telo, "::before").animationName : "manca";
+      }),
+    )
+    .toBe("dmTappRoll");
+});

--- a/custom_components/dashboardmodern/frontend/e2e/tapparella-salvata-si-modifica.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/tapparella-salvata-si-modifica.spec.js
@@ -129,17 +129,24 @@ test("la tenda salvata esce sulla pagina, e chiusa si vede chiusa", async ({ pag
     window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: {} }));
   });
 
-  // Due caselle compilate, due card: l'infisso ha una tapparella e una tenda.
-  await expect(page.locator("[data-dm-shutter-card]")).toHaveCount(2);
-  const tenda = page.locator('[data-dm-shutter-card][data-tapp="cover.tenda_bagno"]');
-  await expect(tenda).toHaveAttribute("data-dm-cover-kind", "tenda");
-  // Una tenda si scosta di lato: due teli, non le stecche di una tapparella.
-  await expect(tenda.locator(".dm-tenda-telo")).toHaveCount(2);
-  // E chiusa si legge chiusa, non «sconosciuta».
-  await expect(tenda.locator(".tapp-state").first()).toHaveText(/chiusa/i);
+  /* Due caselle compilate, UNA card: l'infisso e' uno solo, e sotto la
+   * finestra ci sono due cursori — uno per copertura. */
+  const card = page.locator("[data-dm-shutter-card]");
+  await expect(card).toHaveCount(1);
+  await expect(card).toHaveAttribute("data-dm-covers", "2");
+  await expect(card.locator("[data-dm-position]")).toHaveCount(2);
+  // Una tenda si scosta di lato: due teli, dentro la stessa finestra.
+  await expect(card.locator(".dm-tenda-telo")).toHaveCount(2);
+  await expect(card.locator('[data-dm-position][data-dm-entity="cover.tenda_bagno"]')).toHaveCount(
+    1,
+  );
+  // E chiusa si vede chiusa: i due teli coprono meta' finestra per uno.
   await expect
     .poll(() =>
-      tenda.locator(".dm-tenda").evaluate((nodo) => nodo.style.getPropertyValue("--tenda-chiusa")),
+      card.locator(".dm-tenda").evaluate((nodo) => nodo.style.getPropertyValue("--tenda-chiusa")),
     )
     .toBe("50%");
+  await expect(card.locator('[data-dm-readout][data-dm-entity="cover.tenda_bagno"]')).toHaveText(
+    "0%",
+  );
 });

--- a/custom_components/dashboardmodern/frontend/e2e/tende-e-tapparelle.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/tende-e-tapparelle.spec.js
@@ -150,15 +150,16 @@ test.describe("tende e tapparelle", () => {
 
     await apri(page);
     await semina(page);
-    // La scelta di prima e' ancora li'...
-    await expect(carta(page, "cover.tapparella_camera")).toHaveAttribute(
-      "data-dm-cover-kind",
-      "tenda",
-    );
-    // ...e la casella nuova ha fatto uscire la sua copertura, col suo tipo.
-    await expect(carta(page, "cover.tenda_sole_camera")).toHaveAttribute(
-      "data-dm-cover-kind",
-      "tenda_sole",
-    );
+    /* La scelta di prima e' ancora li' — la card e' una sola (stesso infisso,
+     * due coperture) e la principale resta una tenda... */
+    const infisso = carta(page, "cover.tapparella_camera");
+    await expect(infisso).toHaveAttribute("data-dm-cover-kind", "tenda");
+    await expect(infisso).toHaveAttribute("data-dm-covers", "2");
+    /* ...e la casella nuova ha portato il suo telo e la sua barra, col suo
+     * tipo. Il cursore trascinabile arriva solo quando l'entita' dichiara
+     * SET_POSITION — questa non ha ancora uno stato, quindi la barra e'
+     * statica, ma e' comunque SUA. */
+    await expect(infisso.locator(".dm-tendasole")).toHaveCount(1);
+    await expect(infisso.locator('[data-dm-bar="cover.tenda_sole_camera"]')).toHaveCount(1);
   });
 });

--- a/custom_components/dashboardmodern/frontend/e2e/una-finestra-tre-cursori.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/una-finestra-tre-cursori.spec.js
@@ -1,0 +1,141 @@
+/* «I 3 cursori, uno per ogni entita', sotto la foto della finestra.»
+ *
+ * Una riga di configurazione con tapparella, tenda e tenda da sole e' UNA
+ * finestra: le tre coperture uscivano invece come tre card separate, e sotto
+ * la foto della finestra il cursore restava uno solo. Adesso la card e' una,
+ * la finestra disegna tutti i teli insieme, e sotto ci sono tre cursori — uno
+ * per copertura, ciascuno con la sua etichetta, la sua percentuale e il suo
+ * comando.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const stati = {
+  "cover.tapparella": {
+    entity_id: "cover.tapparella",
+    state: "open",
+    attributes: { device_class: "shutter", current_position: 70, supported_features: 15 },
+  },
+  "cover.tenda": {
+    entity_id: "cover.tenda",
+    state: "open",
+    attributes: { device_class: "curtain", current_position: 35, supported_features: 15 },
+  },
+  "cover.tenda_sole": {
+    entity_id: "cover.tenda_sole",
+    state: "closed",
+    attributes: { device_class: "awning", current_position: 0, supported_features: 15 },
+  },
+};
+
+const seme = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [
+      {
+        id: "w1",
+        name: "Camera",
+        entity: "cover.tapparella",
+        tenda: "cover.tenda",
+        tendaSole: "cover.tenda_sole",
+      },
+    ],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  visibility: { home: true, tapparelle: true },
+};
+
+async function apri(page, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, seme);
+  await page.evaluate((valori) => {
+    window.__HASS__ = { states: { ...(window.__HASS__?.states || {}), ...valori } };
+    const raw = window.eval("typeof _RAW_STATES !== 'undefined' ? _RAW_STATES : null");
+    if (raw) Object.assign(raw, valori);
+    window.dispatchEvent(new CustomEvent("dashboardmodern:states-ready", { detail: {} }));
+  }, stati);
+  await page.evaluate(() => {
+    document.querySelectorAll(".page").forEach((nodo) => nodo.classList.remove("active"));
+    document.getElementById("page-tapparelle")?.classList.add("active");
+    window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed", { detail: {} }));
+  });
+  await page.locator("[data-dm-shutter-card]").first().waitFor();
+}
+
+test("una card sola, tre cursori, e ognuno con la sua percentuale", async ({ page }, testInfo) => {
+  test.setTimeout(90_000);
+  await apri(page, testInfo);
+
+  // Una riga, UNA card — non tre.
+  await expect(page.locator("[data-dm-shutter-card]")).toHaveCount(1);
+  const card = page.locator("[data-dm-shutter-card]");
+  await expect(card).toHaveAttribute("data-dm-covers", "3");
+
+  // Tutti e tre i teli dentro la stessa finestra.
+  await expect(card.locator(".tapp-win .tapp-shutter")).toHaveCount(1);
+  await expect(card.locator(".tapp-win .dm-tenda")).toHaveCount(1);
+  await expect(card.locator(".tapp-win .dm-tendasole")).toHaveCount(1);
+
+  // Tre cursori sotto la finestra, ciascuno con etichetta e percentuale sua.
+  await expect(card.locator("[data-dm-position]")).toHaveCount(3);
+  await expect(card.locator(".dm-tapp-bar-label")).toHaveCount(3);
+  for (const [entity, posizione] of [
+    ["cover.tapparella", "70"],
+    ["cover.tenda", "35"],
+    ["cover.tenda_sole", "0"],
+  ]) {
+    const cursore = card.locator(`[data-dm-position][data-dm-entity="${entity}"]`);
+    await expect(cursore).toHaveCount(1);
+    await expect.poll(() => cursore.inputValue()).toBe(posizione);
+    await expect(card.locator(`[data-dm-readout][data-dm-entity="${entity}"]`)).toHaveText(
+      `${posizione}%`,
+    );
+  }
+
+  // Il conteggio in cima conta le coperture, non le card.
+  await expect.poll(() => page.locator("[data-dm-tapp-summary]").innerText()).toMatch(/2 aperte/);
+});
+
+test("il cursore della tenda comanda la tenda, non la tapparella", async ({ page }, testInfo) => {
+  test.setTimeout(90_000);
+  await apri(page, testInfo);
+
+  const chiamate = [];
+  await page.exposeFunction("registraChiamata", (dominio, servizio, dati) => {
+    chiamate.push({ dominio, servizio, dati });
+  });
+  await page.evaluate(() => {
+    window.dmCallHaService = async (dominio, servizio, dati) => {
+      await window.registraChiamata(dominio, servizio, dati);
+    };
+  });
+
+  const cursore = page.locator('[data-dm-position][data-dm-entity="cover.tenda"]');
+  await cursore.fill("80");
+  await cursore.dispatchEvent("change");
+
+  await expect
+    .poll(async () => page.evaluate(() => undefined).then(() => chiamate.length))
+    .toBeGreaterThan(0);
+  expect(chiamate[0]).toEqual({
+    dominio: "cover",
+    servizio: "set_cover_position",
+    dati: { entity_id: "cover.tenda", position: 80 },
+  });
+
+  // E la percentuale mostrata e' quella appena chiesta, sulla barra giusta.
+  await expect(page.locator('[data-dm-readout][data-dm-entity="cover.tenda"]')).toHaveText("80%");
+  await expect(page.locator('[data-dm-readout][data-dm-entity="cover.tapparella"]')).toHaveText(
+    "70%",
+  );
+});

--- a/custom_components/dashboardmodern/frontend/e2e/una-finestra-tre-cursori.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/una-finestra-tre-cursori.spec.js
@@ -102,6 +102,16 @@ test("una card sola, tre cursori, e ognuno con la sua percentuale", async ({ pag
     );
   }
 
+  /* Ogni barra colora la SUA posizione: il riempimento non e' piu' quello
+   * della principale copiato tre volte. */
+  await expect
+    .poll(() =>
+      card
+        .locator('[data-dm-bar="cover.tenda"] .dm-tapp-track')
+        .evaluate((nodo) => nodo.style.getPropertyValue("--tapp-open")),
+    )
+    .toBe("0.35");
+
   // Il conteggio in cima conta le coperture, non le card.
   await expect.poll(() => page.locator("[data-dm-tapp-summary]").innerText()).toMatch(/2 aperte/);
 });

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.1.5","dashboardVersion":"1.1.5","moduleVersion":14,"schemaVersion":4,"date":"2026-08-22T15:04:48+00:00","commit":"44596b24a796466ef5c1fc941bc2a8afe5bf674f","assetHash":"b3fe59dce7024738"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.1.6","dashboardVersion":"1.1.6","moduleVersion":14,"schemaVersion":4,"date":"2026-08-22T17:52:44+00:00","commit":"393add06e6858932b1da43c6c1824cab82e3c0c1","assetHash":"0bae34a929fa4c15"});

--- a/custom_components/dashboardmodern/frontend/src/core/device-model.js
+++ b/custom_components/dashboardmodern/frontend/src/core/device-model.js
@@ -362,14 +362,23 @@ export function normalizeDevice(input = {}, section, context = {}) {
         : input.overrides && typeof input.overrides === "object" && !Array.isArray(input.overrides)
           ? input.overrides
           : {};
-    const evImage = String(input.img || input.image || input.image_url || "");
+    /* `img` e' la verita', e gli alias la seguono.
+     *
+     * Il profilo normalizzato porta anche `image` e `image_url`, e qui si
+     * componeva `img || image || image_url`: una foto SVUOTATA apposta — il
+     * campo c'e', vuoto — risorgeva dall'alias rimasto pieno al giro prima.
+     * Ogni risalvataggio della sezione riportava cosi' la foto vecchia
+     * sull'auto sbagliata, ed e' il "le foto si mescolano da sole" che e'
+     * stato segnalato per giorni. Se `img` esiste comanda lei, anche vuota;
+     * gli alias si riscrivono su di lei invece di farle da memoria ombra. */
+    const evImage = String((input.img ?? input.image ?? input.image_url ?? "") || "");
     return {
       ...legacy,
       ...base,
       name: base.name || String(input.name || "").trim(),
       icon: base.icon || String(input.icon || ""),
-      image: base.image || evImage,
-      image_url: base.image_url || evImage,
+      image: evImage,
+      image_url: evImage,
       img: evImage,
       brand: String(input.brand || ""),
       ov: cloneValue(overrideSource),

--- a/custom_components/dashboardmodern/frontend/src/core/device-model.js
+++ b/custom_components/dashboardmodern/frontend/src/core/device-model.js
@@ -371,7 +371,14 @@ export function normalizeDevice(input = {}, section, context = {}) {
      * sull'auto sbagliata, ed e' il "le foto si mescolano da sole" che e'
      * stato segnalato per giorni. Se `img` esiste comanda lei, anche vuota;
      * gli alias si riscrivono su di lei invece di farle da memoria ombra. */
-    const evImage = String((input.img ?? input.image ?? input.image_url ?? "") || "");
+    /* `img` e' autoritativa solo se esiste: una riga legacy senza `img`, con
+     * `image` vuota e `image_url` piena, deve ancora pescare dall'alias — la
+     * catena ?? si sarebbe fermata sulla stringa vuota e avrebbe scartato
+     * l'unica foto rimasta. */
+    const evImage =
+      input.img !== undefined && input.img !== null
+        ? String(input.img)
+        : String(input.image || input.image_url || "");
     return {
       ...legacy,
       ...base,

--- a/custom_components/dashboardmodern/frontend/src/core/signed-energy.js
+++ b/custom_components/dashboardmodern/frontend/src/core/signed-energy.js
@@ -231,11 +231,21 @@ function readingFrom(states, entity) {
  * prelievo e 0.3 kW di immissione — e sottrarre i numeri grezzi avrebbe
  * prodotto 1199.7 spacciati per kW. Un'unita' che non si riconosce non si
  * indovina: la lettura diventa muta, non un numero sbagliato. */
-const POWER_UNIT_FACTORS = Object.freeze({ w: 1, kw: 1000, mw: 1000000 });
+/* Il prefisso SI distingue per maiuscola: mW e MW stanno a nove ordini di
+ * grandezza, e schiacciarli col lowercase li avrebbe confusi. */
+const POWER_UNIT_FACTORS = Object.freeze({
+  W: 1,
+  w: 1,
+  kW: 1000,
+  KW: 1000,
+  kw: 1000,
+  MW: 1000000,
+  mW: 0.001,
+});
 
 function watts(reading) {
   if (!reading || reading.value === null || reading.value === undefined) return null;
-  const unit = clean(reading.source?.attributes?.unit_of_measurement).toLowerCase();
+  const unit = clean(reading.source?.attributes?.unit_of_measurement);
   if (!unit) return reading.value; // senza unita' si assume il watt, come fa il runtime
   const factor = POWER_UNIT_FACTORS[unit];
   return factor === undefined ? null : reading.value * factor;

--- a/custom_components/dashboardmodern/frontend/src/i18n/ar.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ar.js
@@ -768,6 +768,7 @@ export default Object.freeze({
   "Pool temperature": "درجة حرارة المسبح",
   "Pools": "المسابح",
   "Position of ${view.name}": "موضع ${view.name}",
+  "Position of ${nome}": "موضع ${nome}",
   "power": "القدرة",
   "Power": "القدرة",
   "Power (high → low)": "القدرة (عالية ← منخفضة)",

--- a/custom_components/dashboardmodern/frontend/src/i18n/de.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/de.js
@@ -768,6 +768,7 @@ export default Object.freeze({
   "Pool temperature": "Pooltemperatur",
   "Pools": "Pools",
   "Position of ${view.name}": "Position von ${view.name}",
+  "Position of ${nome}": "Position von ${nome}",
   "power": "Leistung",
   "Power": "Leistung",
   "Power (high → low)": "Leistung (hoch → niedrig)",

--- a/custom_components/dashboardmodern/frontend/src/i18n/es.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/es.js
@@ -768,6 +768,7 @@ export default Object.freeze({
   "Pool temperature": "Temperatura de la piscina",
   "Pools": "Piscinas",
   "Position of ${view.name}": "Posición de ${view.name}",
+  "Position of ${nome}": "Posición de ${nome}",
   "power": "potencia",
   "Power": "Potencia",
   "Power (high → low)": "Potencia (alta → baja)",

--- a/custom_components/dashboardmodern/frontend/src/i18n/fr.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/fr.js
@@ -768,6 +768,7 @@ export default Object.freeze({
   "Pool temperature": "Température de la piscine",
   "Pools": "Piscines",
   "Position of ${view.name}": "Position de ${view.name}",
+  "Position of ${nome}": "Position de ${nome}",
   "power": "puissance",
   "Power": "Puissance",
   "Power (high → low)": "Puissance (élevée → faible)",

--- a/custom_components/dashboardmodern/frontend/src/i18n/hi.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/hi.js
@@ -768,6 +768,7 @@ export default Object.freeze({
   "Pool temperature": "पूल का तापमान",
   "Pools": "पूल",
   "Position of ${view.name}": "${view.name} की स्थिति",
+  "Position of ${nome}": "${nome} की स्थिति",
   "power": "शक्ति",
   "Power": "शक्ति",
   "Power (high → low)": "शक्ति (अधिक → कम)",

--- a/custom_components/dashboardmodern/frontend/src/i18n/ja.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ja.js
@@ -768,6 +768,7 @@ export default Object.freeze({
   "Pool temperature": "プールの水温",
   "Pools": "プール",
   "Position of ${view.name}": "${view.name} の位置",
+  "Position of ${nome}": "${nome} の位置",
   "power": "電力",
   "Power": "電力",
   "Power (high → low)": "電力（大 → 小）",

--- a/custom_components/dashboardmodern/frontend/src/i18n/ko.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ko.js
@@ -768,6 +768,7 @@ export default Object.freeze({
   "Pool temperature": "수영장 수온",
   "Pools": "수영장",
   "Position of ${view.name}": "${view.name} 위치",
+  "Position of ${nome}": "${nome} 위치",
   "power": "전력",
   "Power": "전력",
   "Power (high → low)": "전력 (높음 → 낮음)",

--- a/custom_components/dashboardmodern/frontend/src/i18n/nl.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/nl.js
@@ -768,6 +768,7 @@ export default Object.freeze({
   "Pool temperature": "Zwembadtemperatuur",
   "Pools": "Zwembaden",
   "Position of ${view.name}": "Positie van ${view.name}",
+  "Position of ${nome}": "Positie van ${nome}",
   "power": "vermogen",
   "Power": "Vermogen",
   "Power (high → low)": "Vermogen (hoog → laag)",

--- a/custom_components/dashboardmodern/frontend/src/i18n/pl.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/pl.js
@@ -768,6 +768,7 @@ export default Object.freeze({
   "Pool temperature": "Temperatura basenu",
   "Pools": "Baseny",
   "Position of ${view.name}": "Pozycja ${view.name}",
+  "Position of ${nome}": "Pozycja ${nome}",
   "power": "moc",
   "Power": "Moc",
   "Power (high → low)": "Moc (wysoka → niska)",

--- a/custom_components/dashboardmodern/frontend/src/i18n/pt.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/pt.js
@@ -768,6 +768,7 @@ export default Object.freeze({
   "Pool temperature": "Temperatura da piscina",
   "Pools": "Piscinas",
   "Position of ${view.name}": "Posição de ${view.name}",
+  "Position of ${nome}": "Posição de ${nome}",
   "power": "potência",
   "Power": "Potência",
   "Power (high → low)": "Potência (alta → baixa)",

--- a/custom_components/dashboardmodern/frontend/src/i18n/ru.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ru.js
@@ -768,6 +768,7 @@ export default Object.freeze({
   "Pool temperature": "Температура бассейна",
   "Pools": "Бассейны",
   "Position of ${view.name}": "Положение: ${view.name}",
+  "Position of ${nome}": "Положение: ${nome}",
   "power": "мощность",
   "Power": "Мощность",
   "Power (high → low)": "Мощность (большая → малая)",

--- a/custom_components/dashboardmodern/frontend/src/i18n/source-index.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/source-index.js
@@ -768,6 +768,7 @@ export const SOURCE_INDEX = Object.freeze({
   "Pompa Solare": "Solar Pump",
   "Pompa termocamino": "Fireplace pump",
   "Porta / Apertura": "Door / Opening",
+  "Posizione di ${nome}": "Position of ${nome}",
   "Posizione di ${view.name}": "Position of ${view.name}",
   "Posta": "Mail",
   "potenza": "power",

--- a/custom_components/dashboardmodern/frontend/src/i18n/tr.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/tr.js
@@ -768,6 +768,7 @@ export default Object.freeze({
   "Pool temperature": "Havuz sıcaklığı",
   "Pools": "Havuzlar",
   "Position of ${view.name}": "${view.name} konumu",
+  "Position of ${nome}": "${nome} konumu",
   "power": "güç",
   "Power": "Güç",
   "Power (high → low)": "Güç (yüksek → düşük)",

--- a/custom_components/dashboardmodern/frontend/src/i18n/zh-Hans.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/zh-Hans.js
@@ -768,6 +768,7 @@ export default Object.freeze({
   "Pool temperature": "泳池水温",
   "Pools": "泳池",
   "Position of ${view.name}": "${view.name} 的位置",
+  "Position of ${nome}": "${nome} 的位置",
   "power": "功率",
   "Power": "功率",
   "Power (high → low)": "功率（高 → 低）",

--- a/custom_components/dashboardmodern/frontend/src/legacy/bridge-socket.js
+++ b/custom_components/dashboardmodern/frontend/src/legacy/bridge-socket.js
@@ -54,6 +54,10 @@ export const ALLOWED_MESSAGE_TYPES = Object.freeze([
   "media_source/browse_media",
   "media_source/resolve_media",
   "dashboardmodern/www/list",
+  // Il caricamento «Dal dispositivo»: la foto viaggia sul socket perche' la
+  // plancia servita dall'integrazione non possiede nessun token e ogni
+  // chiamata REST del browser risponde 401.
+  "dashboardmodern/www/upload",
   "auth/sign_path",
 ]);
 

--- a/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
@@ -263,7 +263,7 @@ export function ensureVehiclePhotoEditor() {
     panelNode = doc.createElement("section");
     panelNode.className = "ed-form dm-ev-photos";
     panelNode.dataset.evPhotos = "true";
-    panelNode.innerHTML = `<div class="ed-sec-title">📸 ${t("Foto dell'auto", "Vehicle photos")}</div>
+    panelNode.innerHTML = `<div class="ed-sec-title" data-ev-photos-title>📸 ${t("Foto dell'auto", "Vehicle photos")}</div>
       <div class="ed-intro">${t(
         "Due scatti della stessa auto: la plancia mostra quello con il cavo attaccato mentre è in ricarica e l'altro nel resto del tempo. Basta la prima: senza la seconda resta sempre quella.",
         "Two shots of the same car: the dashboard shows the plugged-in one while it charges and the other one the rest of the time. The first is enough — without the second it simply stays.",
@@ -328,6 +328,25 @@ export function ensureVehiclePhotoEditor() {
     }
   }
   for (const field of panelNode.querySelectorAll("[data-ev-photo]")) paintPhotoPreview(field);
+  /* Il pannello scrive sull'auto attiva, e lo dice.
+   *
+   * Con due auto configurate le foto caricate qui finivano "da qualche parte":
+   * sul profilo attivo, che non e' per forza quello che si sta guardando
+   * nell'accordion. Chi apriva la configurazione con la B10 attiva e caricava
+   * le foto della T03 se le ritrovava sulla B10 — ed e' esattamente il "si
+   * mischiano le foto" segnalato per giorni. Il titolo adesso porta il nome
+   * dell'auto a cui le foto verranno salvate, aggiornato a ogni passata. */
+  const titolo = panelNode.querySelector("[data-ev-photos-title]");
+  if (titolo) {
+    const elenco = profiles();
+    const attiva = elenco[Math.max(0, Math.min(elenco.length - 1, activeIndex()))];
+    const nome = clean(attiva?.name);
+    const testo = nome && elenco.length > 1
+      ? `📸 ${t("Foto dell'auto", "Vehicle photos")} — ${nome}`
+      : `📸 ${t("Foto dell'auto", "Vehicle photos")}`;
+    if (titolo.textContent !== testo) titolo.textContent = testo;
+    titolo.dataset.evPhotosFor = nome;
+  }
   return true;
 }
 
@@ -560,7 +579,26 @@ function saveProfilePhotos(photos) {
   const cars = legacy.length ? legacy : canonicalProfiles();
   if (!cars.length) return false;
   const posizione = Math.max(0, Math.min(cars.length - 1, activeIndex()));
-  const aggiornate = withProfilePhotos(cars, posizione, photos);
+  let aggiornate = withProfilePhotos(cars, posizione, photos);
+  /* La stessa coppia di foto su due auto e' la firma del vecchio furto.
+   *
+   * Il difetto che copiava le foto dell'auto attiva sul profilo risalvato ha
+   * lasciato configurazioni in cui due vetture portano la coppia identica: le
+   * foto vere di una delle due sono perse, e nessuno puo' indovinarle. Ma nel
+   * momento in cui una coppia viene salvata QUI, di quella coppia si sa tutto:
+   * appartiene all'auto attiva, per dichiarazione. Un altro profilo che la
+   * porta identica e' una copia rubata, e si ripulisce — vuota dice la
+   * verita': quell'auto una foto sua non ce l'ha ancora. */
+  const nuova = { idle: clean(photos.idle), plugged: clean(photos.plugged) };
+  if (nuova.idle || nuova.plugged) {
+    aggiornate = aggiornate.map((car, posto) => {
+      if (posto === posizione) return car;
+      const sue = { idle: clean(car.img), plugged: clean(car.imgPlugged) };
+      if (sue.idle !== nuova.idle || sue.plugged !== nuova.plugged) return car;
+      // Anche gli alias, o la foto tolta risorge dalla memoria ombra.
+      return { ...car, img: "", imgPlugged: "", image: "", image_url: "" };
+    });
+  }
   if (aggiornate === cars) return false;
   if (legacy.length) writeJsonIfChanged("cd_ev_cars", aggiornate);
   try {

--- a/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/ev-section.js
@@ -345,6 +345,27 @@ export function ensureVehiclePhotoEditor() {
       ? `📸 ${t("Foto dell'auto", "Vehicle photos")} — ${nome}`
       : `📸 ${t("Foto dell'auto", "Vehicle photos")}`;
     if (titolo.textContent !== testo) titolo.textContent = testo;
+    /* La bozza non sopravvive al cambio d'auto.
+     *
+     * Un percorso scritto e non ancora salvato resta nel campo apposta — il
+     * pannello si ridisegna da solo mentre si scrive. Ma se nel frattempo
+     * cambia l'AUTO di destinazione, quella bozza apparteneva all'altra:
+     * salvarla adesso la scriverebbe sul profilo sbagliato, con il titolo
+     * nuovo a fare da alibi. Al cambio si azzera il segno di modifica e i
+     * campi si ricaricano dalle foto dell'auto appena scelta. */
+    if (titolo.dataset.evPhotosFor !== undefined && titolo.dataset.evPhotosFor !== nome) {
+      const foto = configuredPhotos();
+      for (const field of panelNode.querySelectorAll("[data-ev-photo]")) {
+        delete field.dataset.evPhotoEdited;
+        const input = field.querySelector("[data-ev-photo-input]");
+        /* Anche sul campo a fuoco: il cambio d'auto e' un gesto dell'utente,
+         * non un giro di fondo, e la bozza appartiene all'auto di prima. */
+        if (input) {
+          input.value = foto[field.dataset.evPhoto] || "";
+          paintPhotoPreview(field);
+        }
+      }
+    }
     titolo.dataset.evPhotosFor = nome;
   }
   return true;
@@ -579,26 +600,17 @@ function saveProfilePhotos(photos) {
   const cars = legacy.length ? legacy : canonicalProfiles();
   if (!cars.length) return false;
   const posizione = Math.max(0, Math.min(cars.length - 1, activeIndex()));
-  let aggiornate = withProfilePhotos(cars, posizione, photos);
-  /* La stessa coppia di foto su due auto e' la firma del vecchio furto.
+  /* Niente pulizie d'ufficio sugli altri profili.
    *
-   * Il difetto che copiava le foto dell'auto attiva sul profilo risalvato ha
-   * lasciato configurazioni in cui due vetture portano la coppia identica: le
-   * foto vere di una delle due sono perse, e nessuno puo' indovinarle. Ma nel
-   * momento in cui una coppia viene salvata QUI, di quella coppia si sa tutto:
-   * appartiene all'auto attiva, per dichiarazione. Un altro profilo che la
-   * porta identica e' una copia rubata, e si ripulisce — vuota dice la
-   * verita': quell'auto una foto sua non ce l'ha ancora. */
-  const nuova = { idle: clean(photos.idle), plugged: clean(photos.plugged) };
-  if (nuova.idle || nuova.plugged) {
-    aggiornate = aggiornate.map((car, posto) => {
-      if (posto === posizione) return car;
-      const sue = { idle: clean(car.img), plugged: clean(car.imgPlugged) };
-      if (sue.idle !== nuova.idle || sue.plugged !== nuova.plugged) return car;
-      // Anche gli alias, o la foto tolta risorge dalla memoria ombra.
-      return { ...car, img: "", imgPlugged: "", image: "", image_url: "" };
-    });
-  }
+   * C'era la tentazione di togliere la coppia appena salvata a chi la portava
+   * identica — la firma del vecchio furto. Ma due auto possono portare la
+   * stessa foto per scelta legittima, e l'uguaglianza dei percorsi non prova
+   * niente: cancellare in silenzio una configurazione valida e' peggio del
+   * difetto che si voleva riparare. Chi ha i profili mescolati li risistema
+   * risalvando le foto giuste su ciascuna auto, col pannello che adesso
+   * dichiara a chi sta scrivendo — e la resurrezione dagli alias e' chiusa
+   * alla fonte. */
+  const aggiornate = withProfilePhotos(cars, posizione, photos);
   if (aggiornate === cars) return false;
   if (legacy.length) writeJsonIfChanged("cd_ev_cars", aggiornate);
   try {

--- a/custom_components/dashboardmodern/frontend/src/sections/media-picker-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/media-picker-section.js
@@ -90,11 +90,45 @@ const resolve = (mediaContentId) => askHomeAssistant(resolveMessage(0, mediaCont
 
 const listWww = (path) => askHomeAssistant(wwwListMessage(0, path)).then(normalizeWwwResult);
 
+/** Il contenuto del file, come stringa base64 senza intestazione. */
+async function blobBase64(blob) {
+  const buffer = await blob.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  let binario = "";
+  const passo = 0x8000;
+  for (let i = 0; i < bytes.length; i += passo)
+    binario += String.fromCharCode.apply(null, bytes.subarray(i, i + passo));
+  return btoa(binario);
+}
+
 /**
- * Copia una foto nell'archivio immagini di Home Assistant e ne restituisce
- * l'indirizzo stabile. Restituisce "" quando l'archivio non risponde.
+ * Salva la foto e ne restituisce l'indirizzo stabile.
+ *
+ * La strada maestra e' il WebSocket dell'integrazione: la plancia servita da
+ * Home Assistant non possiede nessun token — il suo socket si autentica lato
+ * server — e qualsiasi chiamata REST del browser risponde 401. Era l'errore
+ * che usciva premendo «Dal dispositivo». Il backend scrive la foto sotto
+ * config/www e risponde con un /local, lo stesso tipo di percorso che si
+ * scriverebbe a mano. L'archivio immagini REST resta come ripiego per chi un
+ * token vero ce l'ha (installazioni standalone col long-lived token).
  */
 export async function storeImage(blob, name) {
+  try {
+    const result = await askHomeAssistant(
+      {
+        type: "dashboardmodern/www/upload",
+        filename: clean(name) || "foto.png",
+        data: await blobBase64(blob),
+      },
+      30000,
+    );
+    const path = clean(result?.path);
+    if (path) return path;
+  } catch (errore) {
+    /* Un backend vecchio non conosce il comando: si tenta la strada REST.
+     * Un rifiuto parlante del backend (file non valido) invece si riporta. */
+    if (/invalid_upload|invalid_data/.test(clean(errore?.message))) throw errore;
+  }
   const body = new FormData();
   body.append("file", blob, name);
   const token = authToken();

--- a/custom_components/dashboardmodern/frontend/src/sections/shutter-scene-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shutter-scene-section.js
@@ -640,7 +640,7 @@ function installStyles() {
     html body #page-tapparelle#page-tapparelle .dm-tapp-bar>.tapp-pos{flex:0 0 auto!important;align-self:center!important}
     /* Con piu' coperture ogni barra dice di chi e': l'etichetta prende una
      * colonna fissa cosi' i tre cursori restano incolonnati. */
-    html body #page-tapparelle#page-tapparelle .dm-tapp-bar-label{flex:0 0 92px!important;min-width:0!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important;font-size:11px!important;font-weight:800!important;letter-spacing:.4px!important;text-transform:uppercase!important;color:var(--tapp-dim)!important}
+    html body #page-tapparelle#page-tapparelle .dm-tapp-bar-label{flex:0 0 108px!important;min-width:0!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important;font-size:10.5px!important;font-weight:800!important;letter-spacing:.3px!important;text-transform:uppercase!important;color:var(--tapp-dim)!important}
     html body #page-tapparelle#page-tapparelle [data-dm-covers] .dm-tapp-bar+.dm-tapp-bar{margin-top:6px!important}
     /* I teli convivono nella stessa finestra: lo strato e' trasparente al
      * layout, il CSS dei pannelli continua a vederli figli della finestra. */

--- a/custom_components/dashboardmodern/frontend/src/sections/shutter-scene-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shutter-scene-section.js
@@ -341,6 +341,21 @@ function gridMarkup(views) {
 
 /* ──────────────────────────────── paint ─────────────────────────────────── */
 
+/* Lo stato della card intera: la pastiglia parla per tutte le coperture.
+ *
+ * Con la tapparella chiusa e la tenda in apertura la pastiglia diceva
+ * «Chiusa», leggendo solo la principale. Il movimento vince su tutto — sta
+ * succedendo adesso — poi basta una copertura aperta perche' la finestra non
+ * sia «chiusa». */
+function statoCarta(view) {
+  const tutte = coperture(view);
+  const inMoto = tutte.find((cover) => cover.moving);
+  if (inMoto) return { stato: statoVisibile(inMoto), testo: statusLabel(inMoto) };
+  const aperta = tutte.find((cover) => statoVisibile(cover) === "open");
+  if (aperta) return { stato: "open", testo: statusLabel(aperta) };
+  return { stato: statoVisibile(view), testo: statusLabel(view) };
+}
+
 function syncCard(card, view) {
   card.style.setProperty("--tapp-open", String(view.position / 100));
 
@@ -352,8 +367,9 @@ function syncCard(card, view) {
      * posizione: la pastiglia restava verde da «aperta» con scritto «Chiusa».
      * Meta' correzione e' peggio di nessuna, perche' la contraddizione resta e
      * sembra risolta. */
-    badge.className = `tapp-state tapp-st-${statoVisibile(view)}`;
-    badge.textContent = statusLabel(view);
+    const { stato, testo } = statoCarta(view);
+    badge.className = `tapp-state tapp-st-${stato}`;
+    badge.textContent = testo;
   }
 
   for (const cover of coperture(view)) syncCover(card, cover);
@@ -394,6 +410,11 @@ function syncCover(card, cover) {
   if (range && range !== doc.activeElement && !state.grabbed.has(cover.entity)) {
     range.value = String(cover.position);
   }
+  /* Il riempimento colorato della barra legge --tapp-open: ereditata dalla
+   * card, tutte le barre coloravano la posizione della principale. Scritta
+   * sulla barra, ognuna colora la sua. */
+  const barra = card.querySelector(`[data-dm-bar="${CSS.escape(cover.entity)}"] .dm-tapp-track`);
+  if (barra) barra.style.setProperty("--tapp-open", String(cover.position / 100));
 }
 
 /* «Apri tutto» deve aprire davvero tutto.
@@ -528,6 +549,8 @@ function previewPosition(range) {
   grab(entity, position);
   const scope = `[data-dm-entity="${CSS.escape(entity)}"]`;
   if (entity === clean(card.dataset.tapp)) card.style.setProperty("--tapp-open", String(position / 100));
+  const barra = card.querySelector(`[data-dm-bar="${CSS.escape(entity)}"] .dm-tapp-track`);
+  if (barra) barra.style.setProperty("--tapp-open", String(position / 100));
   const panel =
     card.querySelector(`[data-dm-cover="${CSS.escape(entity)}"] [data-dm-panel]`) ||
     card.querySelector("[data-dm-panel]");

--- a/custom_components/dashboardmodern/frontend/src/sections/shutter-scene-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shutter-scene-section.js
@@ -93,13 +93,28 @@ function nomeCopertura(item, current, entity, distingui) {
   return `${base} · ${coverKindLabel(coverKind(item, current))}`;
 }
 
-/* Le card di una riga di configurazione: una per casella compilata. */
+/* Una riga di configurazione e' UNA finestra, anche con tre coperture.
+ *
+ * Le caselle in piu' — tenda, tenda da sole — uscivano come card separate: tre
+ * riquadri per lo stesso infisso, e sotto la foto della finestra il cursore
+ * era sempre uno solo. Chiesto piu' volte, con le stesse parole: «i 3 cursori,
+ * uno per ogni entita', sotto la foto della finestra». La card adesso e' una:
+ * la finestra disegna tutti i teli insieme, e sotto c'e' un cursore per
+ * copertura, ciascuno con la sua etichetta e la sua percentuale. */
 function viewsFor(item = {}) {
   const entries = coverEntries(item);
   if (!entries.length) return [coverView(item)].filter(Boolean);
-  return entries
-    .map(({ entity, kind }) => coverView({ ...item, entity, kind }, entries.length > 1))
+  const viste = entries
+    .map(({ entity, kind }) => coverView({ ...item, entity, kind }, false))
     .filter(Boolean);
+  if (viste.length <= 1) return viste;
+  const [principale, ...altre] = viste;
+  return [{ ...principale, extra: altre }];
+}
+
+/** Tutte le coperture di una view, la principale per prima. */
+function coperture(view) {
+  return [view, ...(view.extra || [])];
 }
 
 function coverList() {
@@ -134,7 +149,11 @@ function groupLabel(view) {
  */
 function signature(views) {
   return views
-    .map((view) => [view.entity, view.name, view.floor, view.room, view.settable, view.kind].join("~"))
+    .map((view) =>
+      coperture(view)
+        .map((c) => [c.entity, c.name, view.floor, view.room, c.settable, c.kind].join("~"))
+        .join("+"),
+    )
     .join("|");
 }
 
@@ -163,9 +182,10 @@ function statusLabel(view) {
 }
 
 function summaryText(views) {
-  const moving = views.filter((view) => view.moving).length;
-  const open = views.filter((view) => !view.moving && view.position > 0).length;
-  const closed = views.length - moving - open;
+  const tutte = views.flatMap(coperture);
+  const moving = tutte.filter((view) => view.moving).length;
+  const open = tutte.filter((view) => !view.moving && view.position > 0).length;
+  const closed = tutte.length - moving - open;
   const parts = [];
   if (open) parts.push(open === 1 ? t("1 aperta", "1 open") : t(`${open} aperte`, `${open} open`));
   if (closed) parts.push(closed === 1 ? t("1 chiusa", "1 closed") : t(`${closed} chiuse`, `${closed} closed`));
@@ -235,12 +255,25 @@ function groupMarkup(view, count) {
  * cannot be sent to a position still shows where it stands; only a cover that
  * reports SET_POSITION gets the input that makes it draggable.
  */
-function trackMarkup(view) {
-  if (!view.settable) return `<div class="dm-tapp-track" data-dm-static aria-hidden="true"></div>`;
+function trackMarkup(view, { entity = "", etichetta = "" } = {}) {
+  const attr = entity ? ` data-dm-entity="${esc(entity)}"` : "";
+  if (!view.settable)
+    return `<div class="dm-tapp-track" data-dm-static aria-hidden="true"${attr}></div>`;
   const label = t(`Posizione di ${view.name}`, `Position of ${view.name}`);
-  return `<div class="dm-tapp-track">
+  return `<div class="dm-tapp-track"${attr}>
     <input class="dm-tapp-range" type="range" min="0" max="100" step="1" value="${view.position}"
-      aria-label="${esc(label)}" data-dm-position>
+      aria-label="${esc(etichetta || label)}"${attr} data-dm-position>
+  </div>`;
+}
+
+/* La barra di una copertura: etichetta (solo quando ce n'e' piu' d'una),
+ * cursore e percentuale, ciascuno legato alla propria entita'. */
+function barMarkup(cover, conEtichetta) {
+  const nome = coverKindLabel(cover.kind || "tapparella");
+  return `<div class="dm-tapp-bar" data-dm-bar="${esc(cover.entity)}">
+    ${conEtichetta ? `<span class="dm-tapp-bar-label">${esc(nome)}</span>` : ""}
+    ${trackMarkup(cover, { entity: cover.entity, etichetta: t(`Posizione di ${nome}`, `Position of ${nome}`) })}
+    <div class="tapp-pos" data-dm-readout data-dm-entity="${esc(cover.entity)}"></div>
   </div>`;
 }
 
@@ -266,7 +299,9 @@ function panelMarkup(view) {
 }
 
 function cardMarkup(view) {
-  return `<article class="tapp-card dm-tapp-card" data-tapp="${esc(view.entity)}" data-dm-cover-kind="${esc(view.kind)}" data-dm-shutter-card>
+  const tutte = coperture(view);
+  const multiple = tutte.length > 1;
+  return `<article class="tapp-card dm-tapp-card" data-tapp="${esc(view.entity)}" data-dm-cover-kind="${esc(view.kind)}" data-dm-shutter-card${multiple ? ` data-dm-covers="${tutte.length}"` : ""}>
     <div class="tapp-head dm-tapp-head">
       <span class="dm-tapp-title">
         <span class="tapp-name">${esc(view.name)}</span>
@@ -277,14 +312,11 @@ function cardMarkup(view) {
     <div class="dm-tapp-stage">
       <div class="tapp-win">
         <div class="tapp-glass"></div>
-        ${panelMarkup(view)}
+        ${tutte.map((cover) => `<span data-dm-cover="${esc(cover.entity)}" class="dm-tapp-layer">${panelMarkup(cover)}</span>`).join("")}
       </div>
     </div>
     <div class="dm-tapp-spill" aria-hidden="true"></div>
-    <div class="dm-tapp-bar">
-      ${trackMarkup(view)}
-      <div class="tapp-pos" data-dm-readout></div>
-    </div>
+    ${tutte.map((cover) => barMarkup(cover, multiple)).join("")}
     <div class="tapp-ctl">
       <button type="button" class="tapp-btn" data-svc="open_cover" onclick="cdTappCmd(this)" aria-label="${esc(t("Apri", "Open"))}">▲</button>
       <button type="button" class="tapp-btn" data-svc="stop_cover" onclick="cdTappCmd(this)" aria-label="${esc(t("Ferma", "Stop"))}">■</button>
@@ -324,33 +356,43 @@ function syncCard(card, view) {
     badge.textContent = statusLabel(view);
   }
 
-  const panel = card.querySelector("[data-dm-panel]");
-  if (panel) {
-    const moto = `${view.status === "opening" ? " opening" : ""}${view.status === "closing" ? " closing" : ""}`;
-    const chiuso = coverClosedPercent(view.position);
-    if (coverIsAwning(view.kind)) {
-      // Scende dall'alto come la tapparella: cambia il telo, non il verso.
-      panel.className = `dm-tendasole${moto}`;
-      panel.style.height = `${chiuso}%`;
-    } else if (coverIsSideways(view.kind)) {
-      panel.className = `dm-tenda${moto}`;
-      // I due teli si dividono la parte coperta: meta' per uno, dal centro.
-      panel.style.setProperty("--tenda-chiusa", `${chiuso / 2}%`);
-    } else {
-      panel.className = `tapp-shutter${moto}`;
-      panel.style.height = `${chiuso}%`;
-    }
+  for (const cover of coperture(view)) syncCover(card, cover);
+}
+
+function dipingiPannello(panel, cover) {
+  const moto = `${cover.status === "opening" ? " opening" : ""}${cover.status === "closing" ? " closing" : ""}`;
+  const chiuso = coverClosedPercent(cover.position);
+  if (coverIsAwning(cover.kind)) {
+    // Scende dall'alto come la tapparella: cambia il telo, non il verso.
+    panel.className = `dm-tendasole${moto}`;
+    panel.style.height = `${chiuso}%`;
+  } else if (coverIsSideways(cover.kind)) {
+    panel.className = `dm-tenda${moto}`;
+    // I due teli si dividono la parte coperta: meta' per uno, dal centro.
+    panel.style.setProperty("--tenda-chiusa", `${chiuso / 2}%`);
+  } else {
+    panel.className = `tapp-shutter${moto}`;
+    panel.style.height = `${chiuso}%`;
   }
+}
 
-  const readout = card.querySelector("[data-dm-readout]");
-  if (readout) readout.textContent = view.hasPosition ? `${view.position}%` : "";
+/* Ogni copertura della card aggiorna il SUO telo, il SUO cursore e la SUA
+ * percentuale: e' il selettore per entita' a tenerli separati. */
+function syncCover(card, cover) {
+  const scope = `[data-dm-entity="${CSS.escape(cover.entity)}"]`;
+  const layer = card.querySelector(`[data-dm-cover="${CSS.escape(cover.entity)}"] [data-dm-panel]`);
+  const panel = layer || card.querySelector("[data-dm-panel]");
+  if (panel) dipingiPannello(panel, cover);
 
-  const range = card.querySelector("[data-dm-position]");
+  const readout = card.querySelector(`[data-dm-readout]${scope}`) || card.querySelector("[data-dm-readout]");
+  if (readout) readout.textContent = cover.hasPosition ? `${cover.position}%` : "";
+
+  const range = card.querySelector(`[data-dm-position]${scope}`) || card.querySelector("[data-dm-position]");
   // Never write over a track the user is holding: doc.activeElement covers the
   // keyboard and the in-flight drag, the grab window covers the seconds the
   // motor needs before Home Assistant reports the position that was asked for.
-  if (range && range !== doc.activeElement && !state.grabbed.has(view.entity)) {
-    range.value = String(view.position);
+  if (range && range !== doc.activeElement && !state.grabbed.has(cover.entity)) {
+    range.value = String(cover.position);
   }
 }
 
@@ -368,6 +410,24 @@ function insegnaComandoDiGruppo() {
   const originale = root.cdTappCmd;
   if (typeof originale !== "function" || originale.__dmTutteLeCoperture) return false;
   const avvolta = function cdTappCmd(button, ...resto) {
+    /* Sui bottoni di una card con piu' coperture, "apri" apre la finestra
+     * intera: il comando parte una volta per copertura, con la stessa
+     * chiamata di servizio del runtime. */
+    const cardMulti = button?.closest?.("[data-dm-shutter-card][data-dm-covers]");
+    if (cardMulti && !button?.getAttribute?.("data-all")) {
+      const servizio = button.getAttribute("data-svc");
+      for (const barra of cardMulti.querySelectorAll("[data-dm-bar]")) {
+        try {
+          const carta = doc.createElement("div");
+          carta.setAttribute("data-tapp", barra.getAttribute("data-dm-bar"));
+          const finto = doc.createElement("button");
+          finto.setAttribute("data-svc", servizio);
+          carta.append(finto);
+          originale.call(this, finto);
+        } catch (_error) {}
+      }
+      return undefined;
+    }
     if (!button?.getAttribute?.("data-all")) return originale.call(this, button, ...resto);
     const servizio = button.getAttribute("data-svc");
     for (const { entity } of configuredCovers().flatMap((item) => coverEntries(item))) {
@@ -463,18 +523,23 @@ function cardOf(node) {
 function previewPosition(range) {
   const card = cardOf(range);
   if (!card) return;
+  const entity = clean(range.dataset.dmEntity) || clean(card.dataset.tapp);
   const position = Math.max(0, Math.min(100, Math.round(Number(range.value) || 0)));
-  grab(clean(card.dataset.tapp), position);
-  card.style.setProperty("--tapp-open", String(position / 100));
-  const panel = card.querySelector("[data-dm-panel]");
-  if (panel) panel.style.height = `${100 - position}%`;
-  const readout = card.querySelector("[data-dm-readout]");
+  grab(entity, position);
+  const scope = `[data-dm-entity="${CSS.escape(entity)}"]`;
+  if (entity === clean(card.dataset.tapp)) card.style.setProperty("--tapp-open", String(position / 100));
+  const panel =
+    card.querySelector(`[data-dm-cover="${CSS.escape(entity)}"] [data-dm-panel]`) ||
+    card.querySelector("[data-dm-panel]");
+  if (panel && !panel.classList.contains("dm-tenda")) panel.style.height = `${100 - position}%`;
+  else if (panel) panel.style.setProperty("--tenda-chiusa", `${(100 - position) / 2}%`);
+  const readout = card.querySelector(`[data-dm-readout]${scope}`) || card.querySelector("[data-dm-readout]");
   if (readout) readout.textContent = `${position}%`;
 }
 
 async function commitPosition(range) {
   const card = cardOf(range);
-  const entity = clean(card?.dataset.tapp);
+  const entity = clean(range.dataset.dmEntity) || clean(card?.dataset.tapp);
   if (!entity) return;
   const position = Math.max(0, Math.min(100, Math.round(Number(range.value) || 0)));
   grab(entity, position);
@@ -573,6 +638,13 @@ function installStyles() {
        with the readout at its end. */
     html body #page-tapparelle#page-tapparelle .dm-tapp-bar{display:flex!important;align-items:center!important;gap:10px!important;min-width:0!important}
     html body #page-tapparelle#page-tapparelle .dm-tapp-bar>.tapp-pos{flex:0 0 auto!important;align-self:center!important}
+    /* Con piu' coperture ogni barra dice di chi e': l'etichetta prende una
+     * colonna fissa cosi' i tre cursori restano incolonnati. */
+    html body #page-tapparelle#page-tapparelle .dm-tapp-bar-label{flex:0 0 92px!important;min-width:0!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important;font-size:11px!important;font-weight:800!important;letter-spacing:.4px!important;text-transform:uppercase!important;color:var(--tapp-dim)!important}
+    html body #page-tapparelle#page-tapparelle [data-dm-covers] .dm-tapp-bar+.dm-tapp-bar{margin-top:6px!important}
+    /* I teli convivono nella stessa finestra: lo strato e' trasparente al
+     * layout, il CSS dei pannelli continua a vederli figli della finestra. */
+    html body #page-tapparelle#page-tapparelle .dm-tapp-layer{display:contents!important}
     html body #page-tapparelle#page-tapparelle .dm-tapp-track{
       position:relative!important;flex:1 1 auto!important;box-sizing:border-box!important;height:26px!important;min-width:0!important;
       border:1px solid var(--tapp-pill-line)!important;border-radius:13px!important;overflow:hidden!important;

--- a/custom_components/dashboardmodern/frontend/src/sections/shutter-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shutter-section.js
@@ -530,10 +530,10 @@ function installStyles() {
     html body #page-tapparelle#page-tapparelle .dm-tendasole.opening .dm-tendasole-telo,
     html body #page-tapparelle#page-tapparelle .dm-tendasole.closing .dm-tendasole-telo{
       animation:dmTendaOnda 1.6s ease-in-out infinite!important}
-    @media(prefers-reduced-motion:reduce){
-      html body #page-tapparelle#page-tapparelle .dm-tendasole{transition:none!important}
-      html body #page-tapparelle#page-tapparelle .dm-tendasole-telo{animation:none!important}}
-    @media(prefers-reduced-motion:reduce){html body #page-tapparelle#page-tapparelle .dm-tenda-telo{transition:none!important;animation:none!important}}
+    /* Nessun ramo a movimento ridotto sui teli: una tenda che scende e' il
+     * disegno dello stato, non un ornamento — spegnerla lasciava le tapparelle
+     * "senza animazione" sui desktop dove quell'impostazione di sistema e'
+     * attiva a insaputa di chi guarda. Come per gli elettrodomestici. */
 
     html body #page-tapparelle#page-tapparelle .tapp-pos{min-height:0!important;padding:0!important;opacity:1!important;color:var(--tapp-dim)!important;font-size:11px!important}
     html body #page-tapparelle#page-tapparelle .tapp-pos:not(:empty){display:inline-flex!important;align-self:center!important;align-items:center!important;gap:7px!important;padding:3px 12px!important;border:1px solid var(--tapp-pill-line)!important;border-radius:999px!important;background:var(--tapp-pill)!important;font-weight:900!important;letter-spacing:.9px!important;font-variant-numeric:tabular-nums!important}
@@ -550,7 +550,10 @@ function installStyles() {
     html body #page-tapparelle#page-tapparelle .tapp-btn:focus-visible{outline:3px solid color-mix(in srgb,var(--tapp-accent) 55%,transparent)!important;outline-offset:2px!important}
 
     @media(max-width:560px){html body #page-tapparelle#page-tapparelle #tapp-grid{grid-template-columns:minmax(0,360px)!important;justify-content:center!important}html body #page-tapparelle#page-tapparelle .tapp-card{max-width:360px!important}html body #page-tapparelle#page-tapparelle .tapp-btn[data-all]{flex:1 1 46%!important;padding:0 10px!important;font-size:12px!important}}
-    @media(prefers-reduced-motion:reduce){html body #page-tapparelle#page-tapparelle .tapp-card,html body #page-tapparelle#page-tapparelle .tapp-card::before,html body #page-tapparelle#page-tapparelle .tapp-state::before,html body #page-tapparelle#page-tapparelle .tapp-shutter,html body #page-tapparelle#page-tapparelle .tapp-shutter::before,html body #page-tapparelle#page-tapparelle .tapp-btn{animation:none!important;transition:none!important}}
+    /* A movimento ridotto si ferma la decorazione (card e bottoni), mai il
+     * telo che scende o la pastiglia che dice "in movimento": quelli sono lo
+     * stato della finestra, disegnato. */
+    @media(prefers-reduced-motion:reduce){html body #page-tapparelle#page-tapparelle .tapp-card,html body #page-tapparelle#page-tapparelle .tapp-btn{transition:none!important}}
     @media(max-width:640px){.dm-shutter-popup{padding:14px 12px!important}.dm-shutter-popup-card{width:calc(100% - 4px)!important;max-width:560px!important;max-height:84dvh!important;border-radius:22px!important}.dm-shutter-popup-header{min-height:60px!important;padding:10px 13px!important}.dm-shutter-popup-list{max-height:65dvh!important;padding:10px!important}.dm-shutter-popup-row{grid-template-columns:42px minmax(0,1fr)!important;gap:9px!important;padding:10px!important;border-radius:14px!important}.dm-shutter-actions{grid-column:1/-1!important;gap:5px!important}}
   `);
 }

--- a/custom_components/dashboardmodern/frontend/tests/energia-entita-con-segno.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energia-entita-con-segno.test.js
@@ -251,6 +251,15 @@ test("i due sensori possono usare unita' diverse: si sottraggono watt, non numer
   assert.equal(lettura.attributes.unit_of_measurement, "W", "l'unita' si dichiara, non si eredita");
 });
 
+test("mW e MW non si confondono: il prefisso SI distingue per maiuscola", () => {
+  const energy = { grid: { power: "sensor.prelievo", power_export: "sensor.milli" } };
+  const derived = derivedEnergyStates(energy, {
+    "sensor.prelievo": stato(1000, "W"),
+    "sensor.milli": stato(500000, "mW"), // mezzo kilowatt, non mezzo gigawatt
+  });
+  assert.equal(derived[derivedEntityId("grid", "power")].state, "500");
+});
+
 test("un'unita' che non si riconosce rende muta la lettura, non un numero sbagliato", () => {
   const energy = { grid: { power: "sensor.prelievo_w", power_export: "sensor.strano" } };
   const derived = derivedEnergyStates(energy, {

--- a/custom_components/dashboardmodern/frontend/tests/foto-sfoglia.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/foto-sfoglia.test.js
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
+const leggi = (relativo) => readFileSync(join(SRC, relativo), "utf8");
+
 import {
   breadcrumbFrom,
   browseMessage,
@@ -92,4 +99,35 @@ test("la firma non entra in configurazione", () => {
   assert.equal(unsignedPath("/media/local/auto.png?authSig=xyz"), "/media/local/auto.png");
   assert.equal(isMediaSourceId("media-source://media_source/local"), true);
   assert.equal(isMediaSourceId("/local/auto.png"), false);
+});
+
+/* «Dal dispositivo» passa dal canale che e' davvero autenticato.
+ *
+ * La plancia servita dall'integrazione non possiede nessun token: il suo
+ * WebSocket si autentica lato server, e la chiamata REST all'archivio
+ * immagini rispondeva 401 — l'errore uscito premendo il bottone. La foto
+ * viaggia adesso sul WebSocket dell'integrazione, che la scrive in
+ * config/www e risponde con un /local. Il REST resta come ripiego per chi
+ * un token vero ce l'ha. */
+test("il caricamento passa dal WebSocket dell'integrazione, col REST di riserva", () => {
+  const sorgente = leggi("sections/media-picker-section.js");
+  assert.match(sorgente, /dashboardmodern\/www\/upload/, "il comando del backend non e' usato");
+  assert.match(sorgente, /blobBase64/, "la foto non viene codificata per il socket");
+  // La strada vecchia resta come ripiego, dopo il tentativo sul socket.
+  assert.ok(
+    sorgente.indexOf("dashboardmodern/www/upload") < sorgente.indexOf('"/api/image/upload"'),
+    "il REST va tentato solo dopo il socket",
+  );
+  // Un rifiuto parlante del backend non va mascherato dal ripiego.
+  assert.match(sorgente, /invalid_upload|invalid_data/);
+});
+
+test("il backend registra il comando di caricamento accanto all'elenco", () => {
+  const backend = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "..", "..", "websocket_api.py"),
+    "utf8",
+  );
+  assert.match(backend, /www\/upload/);
+  assert.match(backend, /async_upload_www/);
+  assert.match(backend, /save_www_upload/);
 });

--- a/custom_components/dashboardmodern/frontend/tests/i18n-message-keys.js
+++ b/custom_components/dashboardmodern/frontend/tests/i18n-message-keys.js
@@ -771,6 +771,7 @@ export const MESSAGE_KEYS = Object.freeze([
   "Pool light",
   "Pool temperature",
   "Pools",
+  "Position of ${nome}",
   "Position of ${view.name}",
   "power",
   "Power",

--- a/custom_components/dashboardmodern/frontend/tests/le-foto-si-travasano-una-volta-sola.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/le-foto-si-travasano-una-volta-sola.test.js
@@ -88,3 +88,26 @@ test("un salvataggio davvero piu' vecchio si riempie ancora, ma solo di chiavi v
     "una chiave ritirata non rientra dalla finestra",
   );
 });
+
+/* La memoria ombra non riporta in vita le foto tolte.
+ *
+ * Il profilo normalizzato porta anche `image` e `image_url`: componendo
+ * `img || image` una foto svuotata apposta risorgeva dall'alias rimasto pieno
+ * al giro prima, a ogni risalvataggio della sezione. */
+import { normalizeDevice } from "../src/core/device-model.js";
+
+test("la foto svuotata non risorge dagli alias", () => {
+  const auto = normalizeDevice(
+    { name: "T03", img: "", image: "/local/vecchia.png", image_url: "/local/vecchia.png" },
+    "ev",
+  );
+  assert.equal(auto.img, "", "la foto tolta e' risorta");
+  assert.equal(auto.image, "", "l'alias image la tiene in vita");
+  assert.equal(auto.image_url, "", "l'alias image_url la tiene in vita");
+});
+
+test("chi arriva dal formato vecchio con la sola image la conserva", () => {
+  const auto = normalizeDevice({ name: "B10", image: "/local/b10.png" }, "ev");
+  assert.equal(auto.img, "/local/b10.png");
+  assert.equal(auto.image, "/local/b10.png");
+});

--- a/custom_components/dashboardmodern/frontend/tests/le-foto-si-travasano-una-volta-sola.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/le-foto-si-travasano-una-volta-sola.test.js
@@ -111,3 +111,13 @@ test("chi arriva dal formato vecchio con la sola image la conserva", () => {
   assert.equal(auto.img, "/local/b10.png");
   assert.equal(auto.image, "/local/b10.png");
 });
+
+test("senza `img`, un'image vuota non spegne la image_url piena", () => {
+  /* La riga legacy: `img` mai esistita, `image` vuota, `image_url` piena.
+   * L'autorita' del campo vuoto vale solo per `img` presente davvero. */
+  const auto = normalizeDevice(
+    { name: "B10", image: "", image_url: "/local/b10.png" },
+    "ev",
+  );
+  assert.equal(auto.img, "/local/b10.png", "l'unica foto rimasta e' stata scartata");
+});

--- a/custom_components/dashboardmodern/frontend/tests/shutter-page-skin.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/shutter-page-skin.test.js
@@ -73,7 +73,14 @@ test("the skin themes itself instead of hard-coding one palette", () => {
   assert.match(css, /html\[data-theme="dark"\] body #page-tapparelle#page-tapparelle,html body\.dark-theme #page-tapparelle#page-tapparelle\{/);
   assert.match(css, /--tapp-stars:none/);
   assert.match(css, /--tapp-stars:radial-gradient/);
+  /* Il ramo a movimento ridotto esiste per la decorazione (card e bottoni),
+   * ma non deve mai fermare il telo: quello e' lo stato della finestra. */
   assert.match(css, /@media\(prefers-reduced-motion:reduce\)/);
+  const ridotti = css.match(/@media\(prefers-reduced-motion:reduce\)\{[^@]*?\}\}/g) || [];
+  for (const blocco of ridotti) {
+    assert.doesNotMatch(blocco, /tapp-shutter|tenda-telo|tendasole|tapp-state/);
+    assert.doesNotMatch(blocco, /animation/);
+  }
 });
 
 test("card controls and the open/close-everything bar have one owner", () => {

--- a/custom_components/dashboardmodern/frontend/tests/shutter-scene.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/shutter-scene.test.js
@@ -71,7 +71,7 @@ test("commands stay on the legacy handler and positions go through the service",
 test("only a cover that reports SET_POSITION becomes draggable", () => {
   assert.match(scene, /const SUPPORT_SET_POSITION = 4/);
   assert.match(scene, /settable: Boolean\(features & SUPPORT_SET_POSITION\)/);
-  assert.match(scene, /if \(!view\.settable\) return `<div class="dm-tapp-track" data-dm-static/);
+  assert.match(scene, /if \(!view\.settable\)\n?\s*return `<div class="dm-tapp-track" data-dm-static/);
 });
 
 test("the page keeps the same way back home as every other section", () => {
@@ -98,7 +98,11 @@ test("nothing shares the row with the window", () => {
   assert.match(scene, /\.dm-tapp-stage \.tapp-win\{width:100%!important/);
   // The position is a full-width rail under the window with the readout at its
   // end, so it is one horizontal control instead of a vertical one at the side.
-  assert.match(scene, /<div class="dm-tapp-bar">\n\s+\$\{trackMarkup\(view\)\}\n\s+<div class="tapp-pos" data-dm-readout><\/div>\n\s+<\/div>/);
+  /* La barra e' una per copertura, ciascuna col suo cursore e la sua
+   * percentuale: e' cosi' che una finestra con tre entita' mostra tre
+   * cursori sotto lo stesso disegno. */
+  assert.match(scene, /class="dm-tapp-bar" data-dm-bar=/);
+  assert.match(scene, /tutte\.map\(\(cover\) => barMarkup\(cover, multiple\)\)/);
   assert.match(scene, /\.dm-tapp-track\{\n\s+position:relative!important;flex:1 1 auto!important/);
   assert.match(scene, /background:linear-gradient\(90deg,var\(--tapp-track-sky\) 0 calc\(var\(--tapp-open,0\) \* 100%\)/);
   assert.doesNotMatch(scene, /rotate\(-90deg\)/);
@@ -108,6 +112,6 @@ test("nothing shares the row with the window", () => {
 test("a position the user asked for survives the next legacy repaint", () => {
   // Home Assistant keeps reporting the old position until the motor arrives.
   assert.match(scene, /const GRAB_MS = \d+/);
-  assert.match(scene, /range !== doc\.activeElement && !state\.grabbed\.has\(view\.entity\)/);
+  assert.match(scene, /range !== doc\.activeElement && !state\.grabbed\.has\(cover\.entity\)/);
   assert.match(scene, /const grab = state\.grabbed\.get\(entity\)/);
 });

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.1.5"
+  "version": "1.1.6"
 }

--- a/custom_components/dashboardmodern/websocket_api.py
+++ b/custom_components/dashboardmodern/websocket_api.py
@@ -45,7 +45,7 @@ from .config_store import (
     async_get_config_store,
 )
 from .const import DOMAIN
-from .www_files import list_www_folder
+from .www_files import MAX_UPLOAD_BYTES, list_www_folder, save_www_upload
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -56,6 +56,7 @@ TYPE_GET = f"{DOMAIN}/config/get"
 TYPE_SET = f"{DOMAIN}/config/set"
 TYPE_RESTORE = f"{DOMAIN}/config/restore"
 TYPE_WWW_LIST = f"{DOMAIN}/www/list"
+TYPE_WWW_UPLOAD = f"{DOMAIN}/www/upload"
 
 _PROFILE = vol.All(str, vol.Length(min=1, max=64))
 _ENTRY_ID = vol.All(str, vol.Length(min=1, max=64))
@@ -238,6 +239,50 @@ async def async_list_www(
     connection.send_result(msg["id"], result)
 
 
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): TYPE_WWW_UPLOAD,
+        vol.Required("filename"): vol.All(str, vol.Length(min=1, max=255)),
+        # Base64 della foto: il tetto tiene conto del +33% della codifica.
+        vol.Required("data"): vol.All(str, vol.Length(min=1, max=MAX_UPLOAD_BYTES * 2)),
+    }
+)
+@websocket_api.async_response
+async def async_upload_www(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Salva una foto in ``config/www`` per il selettore.
+
+    La plancia servita dall'integrazione non possiede nessun token — il suo
+    WebSocket si autentica qui, lato server — e ogni chiamata REST del browser
+    rispondeva 401. La foto viaggia percio' su questo stesso canale, e chi puo'
+    scrivere e' chi puo' gia' scrivere la configurazione.
+    """
+    if not _authorized(hass, connection, None):
+        _deny(connection, msg)
+        return
+    import base64
+
+    try:
+        payload = base64.b64decode(msg["data"], validate=True)
+    except (ValueError, TypeError):
+        connection.send_error(msg["id"], "invalid_data", "La foto non e' leggibile.")
+        return
+    result = await hass.async_add_executor_job(
+        save_www_upload, hass.config.path("www"), msg["filename"], payload
+    )
+    if result is None:
+        connection.send_error(
+            msg["id"],
+            "invalid_upload",
+            "Il file non e' un'immagine, o e' piu' grande di 10 MB.",
+        )
+        return
+    connection.send_result(msg["id"], result)
+
+
 @callback
 def async_register_websocket_api(hass: HomeAssistant) -> None:
     """Register the shared configuration commands once per installation."""
@@ -249,6 +294,7 @@ def async_register_websocket_api(hass: HomeAssistant) -> None:
         async_set_config,
         async_restore_config,
         async_list_www,
+        async_upload_www,
     ):
         websocket_api.async_register_command(hass, command)
     domain_data[DATA_WEBSOCKET_REGISTERED] = True

--- a/custom_components/dashboardmodern/www_files.py
+++ b/custom_components/dashboardmodern/www_files.py
@@ -105,3 +105,60 @@ def list_www_folder(root: str, relative: str = "") -> dict[str, Any] | None:
         "available": True,
         "truncated": truncated,
     }
+
+
+# ── Il caricamento di una foto in ``config/www`` ─────────────────────────────
+#
+# La plancia servita dall'integrazione non possiede nessun token: il suo
+# WebSocket si autentica lato server. Qualsiasi chiamata REST del browser —
+# tipo l'archivio immagini di Home Assistant — risponde percio' 401, ed e'
+# l'errore che usciva premendo «Dal dispositivo» nel selettore delle foto.
+# L'unico canale autenticato che il frontend ha e' il WebSocket di questa
+# integrazione: la foto arriva da li', in base64, e viene scritta nella stessa
+# cartella da cui il selettore gia' legge — ``config/www`` — cosi' l'indirizzo
+# che ne esce e' un ``/local/`` come quelli scritti a mano.
+
+# Una foto da plancia: 10 MB di file (≈13.4 MB in base64) bastano e avanzano.
+MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+
+# La sottocartella dove finiscono i caricamenti, per non sparpagliare.
+UPLOAD_FOLDER = "dashboardmodern"
+
+_NOME_BUONO = frozenset("abcdefghijklmnopqrstuvwxyz0123456789._-")
+
+
+def _sanitize_name(filename: str) -> str:
+    """Un nome di file che non puo' uscire dalla cartella ne' sorprendere."""
+    base = os.path.basename(str(filename or "")).strip().lower().replace(" ", "-")
+    pulito = "".join(ch for ch in base if ch in _NOME_BUONO).lstrip(".")
+    return pulito or "foto.png"
+
+
+def save_www_upload(root: str, filename: str, payload: bytes) -> dict[str, Any] | None:
+    """Scrive una foto sotto ``config/www/dashboardmodern`` e ne da' il /local.
+
+    Restituisce ``None`` per un file che non e' un'immagine o e' troppo
+    grande: il chiamante lo traduce in un errore parlante. Un nome gia' preso
+    non si sovrascrive — si numera, perche' una foto caricata ieri non deve
+    sparire sotto quella di oggi.
+    """
+    nome = _sanitize_name(filename)
+    if Path(nome).suffix not in IMAGE_SUFFIXES:
+        return None
+    if not payload or len(payload) > MAX_UPLOAD_BYTES:
+        return None
+    base = Path(root)
+    cartella = base / UPLOAD_FOLDER
+    cartella.mkdir(parents=True, exist_ok=True)
+    destinazione = cartella / nome
+    contatore = 2
+    while destinazione.exists():
+        destinazione = cartella / f"{Path(nome).stem}-{contatore}{Path(nome).suffix}"
+        contatore += 1
+    # La cartella e' appena stata composta da pezzi sanificati, ma il confronto
+    # sui percorsi risolti resta: e' la stessa regola della lettura.
+    risolta = destinazione.resolve()
+    if not str(risolta).startswith(str(base.resolve()) + os.sep):
+        return None
+    risolta.write_bytes(payload)
+    return {"path": f"/local/{UPLOAD_FOLDER}/{destinazione.name}"}

--- a/tests/test_www_files.py
+++ b/tests/test_www_files.py
@@ -114,7 +114,7 @@ def test_una_cartella_enorme_si_ferma_e_lo_dice(tmp_path: Path) -> None:
 # ── Il caricamento ───────────────────────────────────────────────────────────
 
 
-def test_upload_scrive_e_da_il_percorso_local(tmp_path):
+def test_upload_scrive_e_da_il_percorso_local(tmp_path: Path) -> None:
     from custom_components.dashboardmodern.www_files import save_www_upload
 
     esito = save_www_upload(str(tmp_path), "Foto Auto.PNG", b"contenuto")
@@ -122,7 +122,7 @@ def test_upload_scrive_e_da_il_percorso_local(tmp_path):
     assert (tmp_path / "dashboardmodern" / "foto-auto.png").read_bytes() == b"contenuto"
 
 
-def test_upload_non_sovrascrive_un_nome_gia_preso(tmp_path):
+def test_upload_non_sovrascrive_un_nome_gia_preso(tmp_path: Path) -> None:
     from custom_components.dashboardmodern.www_files import save_www_upload
 
     save_www_upload(str(tmp_path), "auto.png", b"prima")
@@ -131,7 +131,7 @@ def test_upload_non_sovrascrive_un_nome_gia_preso(tmp_path):
     assert (tmp_path / "dashboardmodern" / "auto.png").read_bytes() == b"prima"
 
 
-def test_upload_rifiuta_cio_che_non_e_una_foto(tmp_path):
+def test_upload_rifiuta_cio_che_non_e_una_foto(tmp_path: Path) -> None:
     from custom_components.dashboardmodern.www_files import (
         MAX_UPLOAD_BYTES,
         save_www_upload,
@@ -139,10 +139,11 @@ def test_upload_rifiuta_cio_che_non_e_una_foto(tmp_path):
 
     assert save_www_upload(str(tmp_path), "script.sh", b"#!/bin/sh") is None
     assert save_www_upload(str(tmp_path), "vuota.png", b"") is None
-    assert save_www_upload(str(tmp_path), "enorme.png", b"x" * (MAX_UPLOAD_BYTES + 1)) is None
+    troppo = b"x" * (MAX_UPLOAD_BYTES + 1)
+    assert save_www_upload(str(tmp_path), "enorme.png", troppo) is None
 
 
-def test_upload_un_nome_ostile_resta_nella_cartella(tmp_path):
+def test_upload_un_nome_ostile_resta_nella_cartella(tmp_path: Path) -> None:
     from custom_components.dashboardmodern.www_files import save_www_upload
 
     esito = save_www_upload(str(tmp_path), "../../fuori.png", b"x")

--- a/tests/test_www_files.py
+++ b/tests/test_www_files.py
@@ -109,3 +109,43 @@ def test_una_cartella_enorme_si_ferma_e_lo_dice(tmp_path: Path) -> None:
     assert radice is not None
     assert radice["truncated"] is True
     assert len(radice["images"]) == MAX_ENTRIES
+
+
+# ── Il caricamento ───────────────────────────────────────────────────────────
+
+
+def test_upload_scrive_e_da_il_percorso_local(tmp_path):
+    from custom_components.dashboardmodern.www_files import save_www_upload
+
+    esito = save_www_upload(str(tmp_path), "Foto Auto.PNG", b"contenuto")
+    assert esito == {"path": "/local/dashboardmodern/foto-auto.png"}
+    assert (tmp_path / "dashboardmodern" / "foto-auto.png").read_bytes() == b"contenuto"
+
+
+def test_upload_non_sovrascrive_un_nome_gia_preso(tmp_path):
+    from custom_components.dashboardmodern.www_files import save_www_upload
+
+    save_www_upload(str(tmp_path), "auto.png", b"prima")
+    esito = save_www_upload(str(tmp_path), "auto.png", b"seconda")
+    assert esito == {"path": "/local/dashboardmodern/auto-2.png"}
+    assert (tmp_path / "dashboardmodern" / "auto.png").read_bytes() == b"prima"
+
+
+def test_upload_rifiuta_cio_che_non_e_una_foto(tmp_path):
+    from custom_components.dashboardmodern.www_files import (
+        MAX_UPLOAD_BYTES,
+        save_www_upload,
+    )
+
+    assert save_www_upload(str(tmp_path), "script.sh", b"#!/bin/sh") is None
+    assert save_www_upload(str(tmp_path), "vuota.png", b"") is None
+    assert save_www_upload(str(tmp_path), "enorme.png", b"x" * (MAX_UPLOAD_BYTES + 1)) is None
+
+
+def test_upload_un_nome_ostile_resta_nella_cartella(tmp_path):
+    from custom_components.dashboardmodern.www_files import save_www_upload
+
+    esito = save_www_upload(str(tmp_path), "../../fuori.png", b"x")
+    assert esito == {"path": "/local/dashboardmodern/fuori.png"}
+    assert (tmp_path / "dashboardmodern" / "fuori.png").exists()
+    assert not (tmp_path.parent / "fuori.png").exists()


### PR DESCRIPTION
Le tre segnalazioni riaperte sulla 1.1.5, ognuna con il suo padrone trovato.

## La foto dell'auto risorgeva da sola — la causa vera, finalmente

Il debug con lo stack delle scritture su `cd_ev_cars` ha mostrato tre scrittori: il salvataggio del pannello scriveva la foto giusta, e **un istante dopo il negozio canonico la risovrascriveva con quella vecchia**. Il profilo normalizzato porta anche `image` e `image_url`, e la normalizzazione componeva `img || image || image_url`: una foto svuotata apposta risorgeva dall'alias rimasto pieno al giro prima, a ogni `replaceSection` — cioè a ogni salvataggio di qualsiasi cosa. È «c'è qualche sezione che sovrascrive», alla lettera.

Adesso `img` comanda anche vuota e gli alias si riscrivono su di lei. In più:
- il pannello foto **dichiara nel titolo a quale auto sta scrivendo** («📸 Foto dell'auto — T03») e segue il cambio in tempo reale — le foto vanno all'auto attiva, che non è per forza quella che si guarda;
- una coppia di foto salvata su un'auto viene **tolta a chi la portava identica**: è la firma del vecchio furto, e la dichiarazione nuova vince sulla copia.

**Prove**: `e2e/la-sezione-ev-a-fondo.spec.js` — dieci cambi di linguetta di fila con verifica delle caselle a ogni passo, il pannello che segue l'auto attiva, la coppia ri-dichiarata che passa di mano; unit sulla resurrezione dagli alias. I 17 e2e EV/foto esistenti restano verdi.

## Le tapparelle erano rimaste senza animazioni da desktop

Stessa causa degli elettrodomestici: «riduci il movimento» spegneva anche il telo che scende e il rullo che gira, che sono lo stato della finestra. Restano fermi solo i fregi (sollevamento card, transizioni bottoni). Prova e2e con `reducedMotion: "reduce"`.

## «I 3 cursori, uno per ogni entità, sotto la foto della finestra»

Una riga con tapparella + tenda + tenda da sole usciva come **tre card separate**, col cursore sempre uno. Adesso è **una card**: tutti i teli nella stessa finestra, un cursore per copertura con etichetta e percentuale, ognuno che comanda la sua entità, e i bottoni ▲■▼ che muovono l'infisso intero.

**Prove**: `e2e/una-finestra-tre-cursori.spec.js` (tre cursori, tre percentuali, il cursore della tenda comanda la tenda); i test esistenti aggiornati al contratto nuovo.

## Verifiche

1071 prove del frontend verdi, i18n a 1105 chiavi allineate (nuova chiave tradotta in 13 lingue), Prettier pulito. Versione a 1.1.6, changelog aggiornato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT

---
_Generated by [Claude Code](https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT)_