### PR TITLE
Le tessere appena rifatte dicono a chi le decora di ripassare

### DIFF
--- a/custom_components/dashboardmodern/frontend/src/sections/beta9-real-device-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta9-real-device-polish-section.js
@@ -728,6 +728,11 @@ export function installBeta9RealDevicePolishSection() {
     if (/^(cover|binary_sensor|sensor|light)\./.test(id)) schedule();
   });
 
+  /* Le tessere del ponte si sono appena rifatte: i nodi sono nuovi e non
+   * portano niente addosso. Aspettare il prossimo evento di stato vorrebbe
+   * dire un avviso appena scattato che resta immobile chissa' per quanto. */
+  root.addEventListener?.("dashboardmodern:widgets-painted", () => schedule());
+
   /* La card del marchio non e' piu' affar nostro: la costruisce e la comanda
    * la Personalizzazione, da sola. Restava un ascolto sul suo riquadro, e uno
    * sull'errore di caricamento di un'immagine di marchio — immagini che non

--- a/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
@@ -1374,6 +1374,16 @@ export function renderHomeWidgets() {
     grid.innerHTML = models.map((widget, index) => tileMarkup(widget, index)).join("");
     for (const widget of models) viste().add(widget.key);
     cambiato = true;
+    /* Le tessere sono nuove: chi le decora deve saperlo.
+     *
+     * Il movimento dell'avviso — la porta che si apre, la goccia che cade —
+     * lo disegna un altro modulo, che si sveglia sugli eventi di stato. Se le
+     * tessere nascono DOPO l'ultima passata di quel modulo, restano ferme
+     * finche' non capita un altro evento: per un avviso appena scattato puo'
+     * volerci parecchio. Cosi' invece si annuncia, e chi ascolta ripassa. */
+    try {
+      root.dispatchEvent?.(new CustomEvent("dashboardmodern:widgets-painted"));
+    } catch (_errore) {}
   } else {
     // Solo i valori: la tessera resta dov'e', l'apertura non riparte.
     for (const widget of models) {


### PR DESCRIPTION
Il cancello del rilascio della 1.3.0 si è fermato su una sola prova, `an alert animates the way its own alert behaves`, e solo su webkit-ipad: rossa, poi verde sullo stesso codice, poi rossa di nuovo. Una corsa, non un difetto di quella prova.

Il movimento dell'avviso — la porta che si apre, la goccia che cade — lo disegna `beta9-real-device-polish-section.js`, che si sveglia sugli eventi di stato. Le tessere del ponte le disegna un altro modulo, sul suo giro. Se le tessere nascono **dopo** l'ultima passata del primo, i nodi sono nuovi e non portano niente addosso: restano immobili finché non capita un altro evento di stato — che per un avviso appena scattato può voler dire parecchio tempo, e in una prova vuol dire il timeout.

Adesso il ponte annuncia di aver ridipinto (`dashboardmodern:widgets-painted`) e chi decora ripassa. Nessun import fra i due: l'annuncio è l'unico legame.

## Verifica

- 1286 prove unitarie, verdi
- `beta32-real-device-uniformity` verde su desktop e mobile
- formato pulito

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT)_