### PR TITLE
1.3.6 — un modello dentro il motore, e lo sfarfallio dell'Energia con un padrone solo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,122 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.3.6
+
+### Aggiunto
+
+- **Le finestre leggono i numeri, non li elencano soltanto.** Dentro il motore
+  c'e' adesso un modello di una grandezza nel tempo: prende le letture delle ore
+  precedenti e ne ricava le quattro cose che servono per dire qualcosa di
+  sensato su un numero — da che parte sta andando, quando arrivera' dove deve
+  arrivare, quale sia il suo valore abituale, e se quello di adesso sia normale.
+
+  Prima la finestra diceva «574 W» e nient'altro, e un numero da solo non si sa
+  se e' tanto o poco: 574 watt sono normali per una casa e tantissimi per un
+  frigorifero. Adesso dice «Piu' alto del solito per quest'ora: 900 W contro
+  300 W», e quando lo scostamento e' forte la sezione diventa da guardare anche
+  se non c'e' niente di acceso — che e' il caso per cui un modello serve, perche'
+  contando le cose accese non lo si trova.
+
+  Non c'e' un modello di linguaggio, ed e' una scelta: non si puo' chiedere a chi
+  installa una plancia per la propria casa di installare anche un'intelligenza
+  artificiale, di pagarla a ogni finestra che apre e di mandare fuori casa le
+  letture dei propri sensori. E su questo mestiere — contare — un modello di
+  linguaggio e' lo strumento sbagliato: sbaglia i conti, e li sbaglia in modo
+  plausibile.
+
+  Tre scelte tengono onesto il modello, e sono anche i tre modi di sbagliarlo. Il
+  tempo pesa: Home Assistant registra una lettura quando il valore cambia, non a
+  intervalli regolari, e un sensore fermo a zero per sei ore che poi fa tre
+  picchi in un minuto, contando le letture, «di solito» sta al picco — contando
+  il tempo sta a zero, che e' la verita'. Si usa la mediana e non la media, che
+  un inverter capace di leggere sessantamila watt per due secondi sposterebbe
+  per un'ora intera. E una tendenza si annuncia solo se c'e': una retta la si
+  traccia anche sul rumore, e sotto una certa bonta' la risposta e' «ferma»
+  invece di una salita inventata. Stessa prudenza sulle previsioni, che tacciono
+  quando l'arrivo cade oltre l'orizzonte: «la batteria sara' piena fra ventisei
+  ore» e' un modo raffinato di non dire niente.
+
+  Il modello non sa niente di sezioni, di finestre e di documento — prende numeri
+  e restituisce numeri — quindi serve anche per altro: una soglia di avviso, una
+  previsione dentro una sezione, il colore di una scheda.
+
+- **Una lettura propria per ogni sezione.** Dieci sezioni su diciassette non
+  avevano una frase loro e cadevano su un ripiego che sa contare soltanto cose
+  accese e spente. Da li' l'Energia scriveva «4 cose, nessuna in funzione» con il
+  fotovoltaico a 2,16 kW — le sue quattro righe sono casa, solare, rete e
+  batteria — e la Sicurezza scriveva «Qui non c'e' ancora niente» con l'antifurto
+  elencato subito sotto, perche' il suo antifurto non e' una riga. Non erano
+  frasi imprecise: parlavano di un'altra cosa.
+
+  Adesso l'Energia ragiona sul bilancio — «Il sole fa 2,16 kW e la casa ne usa
+  574 W: ne avanzano 1,59 kW», con sotto «La batteria si carica a 1,47 kW»,
+  perche' il segno meno detto a parole toglie un'ambiguita' che nessuno e' tenuto
+  a sciogliere. La Temperatura dice la distanza fra la stanza piu' calda e la
+  piu' fredda, che e' il dato utile: la media da sola non lo e'. La Piscina col
+  pH fuori norma diventa da guardare anche senza niente acceso. Dove il dato non
+  c'e' non si inventa niente e non si scrive una riga vuota: si dice di meno.
+
+### Corretto
+
+- **La batteria del flusso Energia sfarfallava fra due formati.** Nel video
+  arrivato dalla casa: la bolla diceva «▼ 1796 W / SOC 75%» e due fotogrammi dopo
+  «-1796 W / 75 %», avanti e indietro. Non era un'animazione: erano quattro mani
+  sullo stesso numero. Il guscio col suo formattatore, il modulo del flusso con
+  la freccia, un modulo di rattoppo con una terza forma, e un quarto che teneva
+  un MutationObserver sul nodo per rimettere il prefisso «SOC» addosso a quello
+  che ci scrivevano gli altri. Sorvegliare un nodo per disfare la scrittura di un
+  altro modulo non e' una correzione: e' il secondo padrone che litiga col primo.
+  Adesso il padrone e' uno, e si prende il cartello che ferma la mano del guscio
+  prima che arrivi il primo stato, cosi' non si vede nemmeno il lampo iniziale.
+
+- **Nelle Stanze la luce si accendeva ma non cambiava stato.** Il comando
+  partiva, Home Assistant accendeva la luce, e la scheda restava «SPENTA». La
+  scheda e' quella della pagina Luci — le Stanze se la prendono da li', perche'
+  due schede per la stessa luce vorrebbe dire mantenerne due — ma il
+  riallineamento era rimasto chiuso dentro la pagina Luci, e per giunta si
+  fermava quando quella pagina non era quella aperta. Adesso chi possiede il
+  disegno possiede anche l'aggiornamento, per tutte le sue schede dovunque siano.
+  In piu' il tocco si vede subito, invece di aspettare il giro completo del
+  comando: se lo stato che arriva dice il contrario vince lui, e la promessa
+  scade da sola, cosi' un comando che non arriva a destinazione non lascia una
+  scheda che mente.
+
+- **La finestra del Clima lasciava tre voragini fra le etichette e i comandi.**
+  L'etichetta ha una larghezza fissa di ottantadue pixel, che nella riga
+  orizzontale e' la colonna di sinistra; sul telefono la riga diventa una colonna
+  e quegli ottantadue pixel smettono di essere una larghezza e diventano
+  un'altezza — la parola «Modalita'» alta ottantadue pixel, col vuoto sotto. La
+  correzione esisteva gia' ma era scritta per una sola delle due finestre: un
+  selettore aggiornato e il suo gemello dimenticato. Duecentodieci pixel di vuoto
+  in meno.
+
+- **Sotto «Comandi» c'erano cose che non si comandano.** Nella finestra
+  dell'Energia stavano Casa, Solare, Rete e Batteria: quattro letture, senza un
+  tasto. Lo stesso per Telecamere, Solare termico e Piscina. Un titolo che
+  annuncia comandi dove non ce ne sono manda a cercare qualcosa che non c'e', e
+  chi cerca pensa che sia rotto. Adesso il titolo guarda cosa c'e' davvero sotto.
+  E le percentuali si vedono prima di leggerle: sotto il nome c'e' una barra che
+  diventa rossa sotto il venti per cento.
+
+- **Trentatre regole di stile morte sul Clima, e tre conflitti veri.** La scheda
+  del Clima aveva due pelli, in due fogli diversi, che si contendevano
+  quattordici misure con valori in disaccordo — la scheda alta 248 pixel o senza
+  minimo, il numero grande 46 o 28, i bordi 22 o 17. Vinceva chi caricava per
+  ultimo, quindi la misura vera non stava scritta da nessuna parte; e nel
+  frattempo quella scheda non la disegna piu' nessuno. Se ne vanno tutte e due.
+  Restavano tre conflitti veri — il marchio dell'auto, il grassetto di un avviso,
+  l'imbottitura di un'intestazione — e adesso ognuna di quelle decisioni ha un
+  padrone solo. Una prova rifa' il conto a ogni giro e pretende zero.
+
+- **Lo storico chiesto a Recorder ha un padrone solo.** Il grafico delle
+  temperature aveva la sua domanda con la sua cache; quando anche le finestre
+  hanno avuto bisogno delle stesse letture, copiarla avrebbe fatto due padroni
+  dello stesso traffico — due cache che non si parlano, due domande per la stessa
+  entita', e la certezza che prima o poi una scada con una regola diversa
+  dall'altra. La domanda non blocca niente: la finestra si apre col numero che
+  ha, e si ridisegna quando la risposta arriva.
+
 ## 1.3.5
 
 ### Aggiunto

--- a/custom_components/dashboardmodern/frontend/e2e/il-modello-parla-nella-finestra.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/il-modello-parla-nella-finestra.spec.js
@@ -1,0 +1,103 @@
+/* Il modello nel tempo arriva davvero fin dentro la finestra.
+ *
+ * Le prove senza browser dicono gia' che il modello conta giusto e che il
+ * motore ne ricava le frasi. Quello che non possono dire e' se quelle letture
+ * arrivano fin li': in mezzo ci sono la domanda a Recorder, la sua cache, la
+ * forma delle righe che Home Assistant restituisce e il ridisegno che deve
+ * scattare quando la risposta atterra — quattro punti in cui la catena si
+ * spezza in silenzio, lasciando una finestra che sta in piedi e non dice
+ * niente di piu' di prima.
+ *
+ * Lo storico qui e' finto ma nella forma vera — «{ state, last_changed }», come
+ * lo manda Home Assistant — e va installato prima che la plancia parta: il
+ * servizio si costruisce all'avvio, e un broker messo dopo non lo sostituisce.
+ * Tre giorni a 300 W a quest'ora, e adesso 900: il modello deve accorgersene.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const SEME = {
+  schema_version: 4,
+  sections: {
+    rooms: [{ id: "r1", name: "Salone", icon: "mdi:sofa" }],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {
+      house: { power: "sensor.casa_w" },
+      solar: { power: "sensor.solare_w" },
+      battery: { power: "sensor.batteria_w", soc: "sensor.batteria_soc" },
+      grid: { power: "sensor.rete_w" },
+    },
+  },
+  visibility: { energy: true, rooms: true },
+};
+
+test("le letture di prima arrivano fin dentro la finestra", async ({ page }, testInfo) => {
+  test.setTimeout(120_000);
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+
+  await page.addInitScript(() => {
+    const adesso = Date.now();
+    const righe = [];
+    for (let giorno = 0; giorno < 3; giorno += 1)
+      for (let i = 0; i < 10; i += 1)
+        righe.push({
+          state: "300",
+          last_changed: new Date(adesso - giorno * 86_400_000 - i * 300_000).toISOString(),
+        });
+    righe.push({ state: "900", last_changed: new Date(adesso).toISOString() });
+    const broker = {
+      request: async (messaggio) =>
+        messaggio?.type === "history/history_during_period" ? [righe] : null,
+    };
+    /* Si lascia che la plancia assegni il suo servizio — glielo si impedisce e
+     * l'avvio muore, perche' in un modulo l'assegnazione a una proprieta' di
+     * sola lettura lancia — ma il broker resta il nostro. */
+    let vero = null;
+    Object.defineProperty(window, "DashboardModernEnergyService", {
+      configurable: true,
+      get: () => ({ ...(vero || {}), broker }),
+      set: (valore) => {
+        vero = valore;
+      },
+    });
+  });
+
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, SEME);
+  await page.locator("#setup-wizard").evaluateAll((nodi) => nodi.forEach((n) => n.remove()));
+  await page.waitForFunction(() => window.__DASHBOARDMODERN_SECTION_RUNTIME__?.installed, null, {
+    timeout: 60_000,
+  });
+
+  const esito = await page.evaluate(async () => {
+    const storico = await import("/src/sections/storico-condiviso-section.js");
+    const analisi = await import("/src/core/analisi-sezione.js");
+    /* La prima domanda torna «non lo so ancora»: e' apposta, la finestra si
+     * apre lo stesso col numero che ha gia'. */
+    const prima = storico.puntiDi("sensor.casa_w", 3);
+    await new Promise((risolvi) => setTimeout(risolvi, 600));
+    const punti = storico.puntiDi("sensor.casa_w", 3);
+    const finestra = analisi.analisiDellaSezione(
+      { key: "energia", rows: [{ group: "house", watts: 900 }] },
+      (italiano) => italiano,
+      Date.now(),
+      punti,
+    );
+    return { prima, quanti: punti?.length ?? null, frase: finestra?.frase, punti: finestra?.punti };
+  });
+
+  console.log("FINESTRA:", JSON.stringify(esito, null, 1));
+  expect(esito.prima, "la prima domanda non aspetta: torna «non lo so ancora»").toBe(null);
+  expect(esito.quanti, "le letture devono arrivare").toBeGreaterThan(20);
+  expect(
+    esito.punti.join(" | "),
+    "il modello deve accorgersi che 900 W non sono i soliti 300 di quest'ora",
+  ).toMatch(/Piu' alto del solito per quest'ora/);
+});

--- a/custom_components/dashboardmodern/frontend/e2e/il-pannello-non-lascia-il-vuoto.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/il-pannello-non-lascia-il-vuoto.spec.js
@@ -1,0 +1,99 @@
+/* Nella finestra del Clima l'etichetta non lascia il vuoto sotto di se'.
+ *
+ * Nella schermata arrivata dalla casa vera si vedeva questo: «MODALITA'» in
+ * alto, poi un buco, poi le pastiglie; «TEMPERATURA», un buco, il passo;
+ * «VENTOLA», un buco, i numeri. Tre voragini in una finestra sola.
+ *
+ * Il motivo: l'etichetta ha «flex:0 0 82px», che nella riga orizzontale e' la
+ * larghezza della colonna di sinistra. Sul telefono la riga diventa una
+ * colonna, e quegli ottantadue pixel smettono di essere una larghezza e
+ * diventano un'altezza — la parola «Modalita'» alta 82 pixel, col vuoto sotto.
+ * La correzione c'era gia' («flex:none» sotto i 600), ma era scritta per una
+ * sola delle due finestre: la riga sopra le nominava tutt'e due, queste no.
+ * Un selettore aggiornato e il suo gemello dimenticato — che e' la stessa
+ * famiglia di difetti dei due padroni, vista dall'altra parte.
+ *
+ * Qui si misura l'altezza vera dell'etichetta a plancia aperta. Una parola di
+ * dieci pixel di corpo non puo' occuparne ottanta: se ci torna, il gemello e'
+ * stato dimenticato un'altra volta.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const SEME = {
+  schema_version: 4,
+  sections: {
+    rooms: [{ id: "r1", name: "Salone", icon: "mdi:sofa" }],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [{ id: "k1", entity: "climate.salone", room: "r1", name: "Salone" }],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+  },
+  visibility: { clima: true, rooms: true },
+};
+
+test("l'etichetta del pannello non lascia il vuoto", async ({ page }, testInfo) => {
+  test.setTimeout(120_000);
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, SEME);
+  await page.locator("#setup-wizard").evaluateAll((nodi) => nodi.forEach((n) => n.remove()));
+  await page.waitForFunction(() => window.__DASHBOARDMODERN_SECTION_RUNTIME__?.installed, null, {
+    timeout: 60_000,
+  });
+
+  await page.evaluate(() => {
+    const grezzi = eval("_RAW_STATES");
+    grezzi["climate.salone"] = {
+      entity_id: "climate.salone",
+      state: "off",
+      attributes: {
+        friendly_name: "Salone",
+        current_temperature: 31,
+        temperature: 26,
+        hvac_modes: ["fan_only", "dry", "cool", "heat", "heat_cool", "off"],
+        fan_modes: ["auto", "Silence", "1", "2", "3", "4", "5"],
+        fan_mode: "Silence",
+      },
+    };
+    window.applyStates?.();
+    window.render?.();
+  });
+  await page.evaluate(() => window.showPage?.("clima"));
+  await page.waitForTimeout(700);
+  await page.evaluate(() => {
+    document
+      .querySelector(
+        "#page-clima [data-dm-cl-card],#page-clima .dm-cl-card,#page-clima [data-entity]",
+      )
+      ?.click();
+  });
+  await page.waitForTimeout(800);
+
+  const righe = await page.evaluate(() => {
+    const finestra = document.querySelector("#clima-popup-overlay, #dm-widget-popup");
+    if (!finestra) return [];
+    return [...finestra.querySelectorAll(".dm-w-panel-row")].map((nodo) => ({
+      alto: Math.round(nodo.getBoundingClientRect().height),
+      testo: nodo.textContent.replace(/\s+/g, " ").trim().slice(0, 26),
+      etichetta: Math.round(
+        nodo.querySelector(".dm-w-panel-lbl")?.getBoundingClientRect().height ?? 0,
+      ),
+    }));
+  });
+
+  for (const riga of righe)
+    console.log(`riga ${riga.alto}px — etichetta ${riga.etichetta}px — ${riga.testo}`);
+  expect(righe.length, "il pannello del Clima deve avere le sue righe").toBeGreaterThan(0);
+  for (const riga of righe)
+    expect(
+      riga.etichetta,
+      `l'etichetta «${riga.testo}» e' alta ${riga.etichetta}px: e' il flex-basis della ` +
+        "colonna, che in verticale e' diventato un'altezza",
+    ).toBeLessThan(30);
+});

--- a/custom_components/dashboardmodern/frontend/e2e/il-titolo-dice-cosa-ce-sotto.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/il-titolo-dice-cosa-ce-sotto.spec.js
@@ -1,0 +1,117 @@
+/* Un blocco intitolato «Comandi» ha qualcosa da premere.
+ *
+ * Nella finestra dell'Energia, sotto «COMANDI», stavano Casa, Solare, Rete e
+ * Batteria: quattro letture, senza un tasto. Lo stesso per Telecamere, Solare
+ * termico e Piscina. Un titolo che annuncia comandi dove non ce ne sono manda
+ * a cercare qualcosa che non c'e', e chi cerca pensa che sia rotto.
+ *
+ * Il titolo adesso guarda cosa c'e' davvero nel blocco invece di deciderlo a
+ * tavolino: se c'e' qualcosa da premere sono comandi, altrimenti sono letture.
+ * Qui si apre ogni finestra e si pretende che le due cose vadano d'accordo —
+ * in tutt'e due i versi, perche' anche il contrario sarebbe un difetto: un
+ * blocco pieno di interruttori intitolato «Letture» direbbe che non si tocca.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const SEME = {
+  schema_version: 4,
+  sections: {
+    rooms: [{ id: "r1", name: "Salone", icon: "mdi:sofa" }],
+    cameras: [{ id: "c1", name: "Ingresso", entity: "camera.ingresso" }],
+    appliances: [],
+    loads: [],
+    lights: [{ id: "l1", entity: "light.salone", room: "r1" }],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {
+      house: { power: "sensor.casa_w" },
+      solar: { power: "sensor.solare_w" },
+      battery: { power: "sensor.batteria_w", soc: "sensor.batteria_soc" },
+      grid: { power: "sensor.rete_w" },
+    },
+  },
+  visibility: { energy: true, rooms: true, lights: true, security: true },
+};
+
+test("il titolo del blocco dice cosa c'e' sotto", async ({ page }, testInfo) => {
+  test.setTimeout(120_000);
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, SEME);
+  await page.locator("#setup-wizard").evaluateAll((nodi) => nodi.forEach((n) => n.remove()));
+  await page.waitForFunction(() => window.__DASHBOARDMODERN_SECTION_RUNTIME__?.installed, null, {
+    timeout: 60_000,
+  });
+
+  await page.evaluate(() => {
+    const grezzi = eval("_RAW_STATES");
+    const metti = (id, valore, unita) => {
+      grezzi[id] = {
+        entity_id: id,
+        state: String(valore),
+        attributes: { friendly_name: id, unit_of_measurement: unita },
+      };
+    };
+    metti("sensor.casa_w", 574, "W");
+    metti("sensor.solare_w", 2160, "W");
+    metti("sensor.batteria_w", -1470, "W");
+    metti("sensor.batteria_soc", 75, "%");
+    metti("sensor.rete_w", 41, "W");
+    metti("light.salone", "on");
+    window.applyStates?.();
+    window.render?.();
+  });
+  await page.waitForTimeout(1000);
+
+  const chiavi = await page.evaluate(() =>
+    [...document.querySelectorAll("[data-dm-widget]")].map((n) => n.dataset.dmWidget),
+  );
+  expect(chiavi.length, "servono delle tessere da aprire").toBeGreaterThan(0);
+
+  for (const chiave of chiavi) {
+    await page.evaluate((k) => document.querySelector(`[data-dm-widget="${k}"]`)?.click(), chiave);
+    await page.waitForTimeout(450);
+    const blocchi = await page.evaluate(() => {
+      const finestra = document.getElementById("dm-widget-popup");
+      if (!finestra) return [];
+      /* Il blocco e' il titolo piu' tutte le righe che lo seguono fino al
+       * titolo dopo: si guarda quello che sta sotto ciascuno, non tutta la
+       * finestra — altrove ci sono interruttori che non gli appartengono. */
+      const fuori = [];
+      for (const titolo of finestra.querySelectorAll(".dm-w-titoletto")) {
+        let premibili = 0;
+        for (let n = titolo.nextElementSibling; n; n = n.nextElementSibling) {
+          if (n.classList.contains("dm-w-titoletto")) break;
+          premibili += n.querySelectorAll("button,input,select,[role=switch]").length;
+        }
+        fuori.push({ testo: titolo.textContent.trim(), premibili });
+      }
+      return fuori;
+    });
+
+    for (const blocco of blocchi) {
+      const diceComandi = /^(?:Comandi|Controls)$/i.test(blocco.testo);
+      const diceLetture = /^(?:Letture|Readings)$/i.test(blocco.testo);
+      if (diceComandi)
+        expect(
+          blocco.premibili,
+          `«${chiave}»: il blocco si chiama «${blocco.testo}» ma sotto non c'e' niente da premere`,
+        ).toBeGreaterThan(0);
+      if (diceLetture)
+        expect(
+          blocco.premibili,
+          `«${chiave}»: il blocco si chiama «${blocco.testo}» ma sotto ci sono ${blocco.premibili} comandi`,
+        ).toBe(0);
+    }
+
+    await page.evaluate(() =>
+      document
+        .querySelector("#dm-widget-popup [data-dm-close],#dm-widget-popup .dm-w-chiudi")
+        ?.click(),
+    );
+    await page.waitForTimeout(200);
+  }
+});

--- a/custom_components/dashboardmodern/frontend/e2e/la-batteria-non-cambia-faccia.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/la-batteria-non-cambia-faccia.spec.js
@@ -1,0 +1,93 @@
+/* Il numero della batteria non cambia faccia da solo.
+ *
+ * Nel video si vedeva questo: nel flusso dell'Energia la bolla della batteria
+ * diceva «▼ 1796 W / SOC 75%», e due fotogrammi dopo «-1796 W / 75 %», e poi
+ * di nuovo la prima. Non era un'animazione: erano quattro mani sullo stesso
+ * nodo — il guscio col suo formattatore, questo modulo, un modulo di rattoppo
+ * con un terzo formato, e un quarto che teneva un MutationObserver per
+ * rimettere il prefisso «SOC» addosso a quello che scrivevano gli altri.
+ *
+ * Qui si fanno quaranta cambi di stato e si conta quante forme diverse passano
+ * dalle due caselle. Una sola: se ne compaiono due, sono due padroni.
+ */
+import { test, expect } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+const SEME = {
+  schema_version: 4,
+  sections: {
+    rooms: [{ id: "r1", name: "Salone", icon: "mdi:sofa" }],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {
+      house: { power: "sensor.casa_w" },
+      solar: { power: "sensor.solare_w" },
+      battery: { power: "sensor.batteria_w", soc: "sensor.batteria_soc" },
+      grid: { power: "sensor.rete_w" },
+    },
+  },
+  visibility: { energy: true },
+};
+test("nel flusso la batteria ha una forma sola", async ({ page }, testInfo) => {
+  test.setTimeout(120_000);
+  await page.route("https://**", (r) => r.fulfill({ status: 200, body: "" }));
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, SEME);
+  await page.locator("#setup-wizard").evaluateAll((n) => n.forEach((x) => x.remove()));
+  await page.waitForFunction(() => window.__DASHBOARDMODERN_SECTION_RUNTIME__?.installed, null, {
+    timeout: 60000,
+  });
+  await page.evaluate(() => {
+    const g = eval("_RAW_STATES");
+    const m = (id, v, u) => {
+      g[id] = { entity_id: id, state: String(v), attributes: { unit_of_measurement: u } };
+    };
+    m("sensor.casa_w", 92, "W");
+    m("sensor.solare_w", 2257, "W");
+    m("sensor.batteria_w", -1796, "W");
+    m("sensor.batteria_soc", 75, "%");
+    m("sensor.rete_w", -208, "W");
+  });
+  await page.evaluate(() => {
+    window.__F__ = { soc: [], batt: [] };
+    for (const [id, k] of [
+      ["v-battery-soc", "soc"],
+      ["v-battery", "batt"],
+    ]) {
+      const n = document.getElementById(id);
+      if (n)
+        new MutationObserver(() => window.__F__[k].push(n.textContent.trim())).observe(n, {
+          childList: true,
+          characterData: true,
+          subtree: true,
+        });
+    }
+  });
+  for (let i = 0; i < 40; i++) {
+    await page.evaluate((i) => {
+      const g = eval("_RAW_STATES");
+      g["sensor.casa_w"] = {
+        entity_id: "sensor.casa_w",
+        state: String(92 + i),
+        attributes: { unit_of_measurement: "W" },
+      };
+      window.dispatchEvent(new CustomEvent("dm-states-updated"));
+      window.applyStates?.();
+      window.render?.();
+      window.refreshAll?.();
+    }, i);
+    await page.waitForTimeout(60);
+  }
+  await page.waitForTimeout(800);
+  const f = await page.evaluate(() => window.__F__);
+  const forme = (a) => [...new Set(a)];
+  console.log("SOC  scritture:", f.soc.length, "forme distinte:", JSON.stringify(forme(f.soc)));
+  console.log("BATT scritture:", f.batt.length, "forme distinte:", JSON.stringify(forme(f.batt)));
+  expect(forme(f.soc).length, "il SOC deve avere una forma sola").toBeLessThanOrEqual(1);
+  expect(forme(f.batt).length, "la potenza deve avere una forma sola").toBeLessThanOrEqual(1);
+});

--- a/custom_components/dashboardmodern/frontend/e2e/le-luci-nelle-stanze-rispondono.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/le-luci-nelle-stanze-rispondono.spec.js
@@ -1,0 +1,112 @@
+/* Nelle Stanze la luce cambia stato davvero.
+ *
+ * «Nella sezione Stanze se accendo una luce non cambia stato, non c'e' il
+ * refresh stato quindi il problema continua.» Era vero, e il comando partiva
+ * benissimo: Home Assistant accendeva la luce e la card restava «SPENTA».
+ *
+ * La card e' quella della pagina Luci — le Stanze se la prendono da li',
+ * perche' due card per la stessa luce vorrebbe dire mantenerne due — ma il
+ * riallineamento era rimasto chiuso dentro la pagina Luci, e per giunta si
+ * fermava subito quando quella pagina non era quella aperta. Il giro veloce
+ * delle Stanze riscriveva le letture e i testi di stato, e le card della luce
+ * non le guardava; il giro lungo parte solo quando cambia la struttura, che
+ * accendendo una luce non cambia.
+ *
+ * Qui si pretendono quattro momenti, e sono quattro difetti diversi se
+ * mancano: com'e' prima, che si muova al tocco senza aspettare la risposta,
+ * che la conferma tenga, e che uno spegnimento arrivato da fuori la corregga.
+ * L'ultimo e' quello che tiene onesto l'ottimismo: una card che si muove al
+ * tocco e poi non torna indietro quando il comando fallisce mente, ed e'
+ * peggio di una che non si muove.
+ */
+import { test, expect } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+const SEME = {
+  schema_version: 4,
+  sections: {
+    rooms: [{ id: "r1", name: "Salone", icon: "mdi:sofa" }],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [{ id: "l1", entity: "light.salone", room: "r1" }],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+  },
+  visibility: { rooms: true, lights: true },
+};
+test("la luce cambia stato quando Home Assistant risponde", async ({ page }, testInfo) => {
+  test.setTimeout(120_000);
+  await page.route("https://**", (r) => r.fulfill({ status: 200, body: "" }));
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, SEME);
+  await page.locator("#setup-wizard").evaluateAll((n) => n.forEach((x) => x.remove()));
+  await page.waitForFunction(() => window.__DASHBOARDMODERN_SECTION_RUNTIME__?.installed, null, {
+    timeout: 60000,
+  });
+  await page.evaluate(() => {
+    const g = eval("_RAW_STATES");
+    g["light.salone"] = {
+      entity_id: "light.salone",
+      state: "off",
+      attributes: { friendly_name: "Salone" },
+    };
+    window.applyStates?.();
+    window.render?.();
+  });
+  await page.evaluate(() => window.showPage?.("stanze"));
+  await page.waitForTimeout(700);
+
+  const carta = '#page-stanze [data-dm-lucip="light.salone"]';
+  await page.waitForSelector(carta, { timeout: 15000, state: "attached" });
+  const leggi = () =>
+    page.evaluate((c) => {
+      const n = document.querySelector(c);
+      return n
+        ? {
+            classe: n.className,
+            premuto: n.querySelector("[data-dm-lucip-toggle]")?.getAttribute("aria-pressed"),
+            stato: n.querySelector("[data-dm-lucip-state]")?.textContent?.trim(),
+          }
+        : null;
+    }, carta);
+  console.log("prima:", JSON.stringify(await leggi()));
+
+  await page.evaluate((c) => document.querySelector(c + " [data-dm-lucip-toggle]")?.click(), carta);
+  await page.waitForTimeout(200);
+  console.log("dopo il tocco (ottimismo):", JSON.stringify(await leggi()));
+
+  // Home Assistant conferma: la luce e' accesa
+  await page.evaluate(() => {
+    const g = eval("_RAW_STATES");
+    g["light.salone"] = {
+      entity_id: "light.salone",
+      state: "on",
+      attributes: { friendly_name: "Salone" },
+    };
+    window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed"));
+    window.applyStates?.();
+    window.render?.();
+  });
+  await page.waitForTimeout(600);
+  console.log("dopo la conferma:", JSON.stringify(await leggi()));
+
+  // ora il caso che rompe: lo stato torna a spento (comando fallito, o spenta da altrove)
+  await page.evaluate(() => {
+    const g = eval("_RAW_STATES");
+    g["light.salone"] = {
+      entity_id: "light.salone",
+      state: "off",
+      attributes: { friendly_name: "Salone" },
+    };
+    window.dispatchEvent(new CustomEvent("dashboardmodern:state-changed"));
+    window.applyStates?.();
+    window.render?.();
+  });
+  await page.waitForTimeout(600);
+  const finale = await leggi();
+  console.log("dopo lo spegnimento da fuori:", JSON.stringify(finale));
+  expect(finale.premuto, "l'interruttore deve seguire lo stato vero").toBe("false");
+});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.3.5","dashboardVersion":"1.3.5","moduleVersion":14,"schemaVersion":4,"date":"2026-08-29T06:11:01+00:00","commit":"3c7bb851ffd189372164ca2125738e34daf5e829","assetHash":"f2e36f5a2ded8503"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.3.6","dashboardVersion":"1.3.6","moduleVersion":14,"schemaVersion":4,"date":"2026-08-29T09:57:19+00:00","commit":"c90a8eadf608a87eb719c939ce2e7649d00a7cf1","assetHash":"3fbd290169ba9b79"});

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
@@ -48,6 +48,7 @@
 <link rel="modulepreload" href="../src/core/light-model.js">
 <link rel="modulepreload" href="../src/core/media-picker.js">
 <link rel="modulepreload" href="../src/core/migrations.js">
+<link rel="modulepreload" href="../src/core/modello-nel-tempo.js">
 <link rel="modulepreload" href="../src/core/oggetti-widget.js">
 <link rel="modulepreload" href="../src/core/period-service.js">
 <link rel="modulepreload" href="../src/core/person-model.js">
@@ -169,6 +170,7 @@
 <link rel="modulepreload" href="../src/sections/shutter-sky-section.js">
 <link rel="modulepreload" href="../src/sections/shutter-window-section.js">
 <link rel="modulepreload" href="../src/sections/solar-thermal-design-section.js">
+<link rel="modulepreload" href="../src/sections/storico-condiviso-section.js">
 <link rel="modulepreload" href="../src/sections/subload-popup-section.js">
 <link rel="modulepreload" href="../src/sections/temperature-layout-section.js">
 <link rel="modulepreload" href="../src/sections/temperature-section.js">

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
@@ -15,6 +15,7 @@
 <link rel="modulepreload" href="./build-info.js">
 <link rel="modulepreload" href="./modules-entry.js">
 <link rel="modulepreload" href="../src/core/alarm-panel.js">
+<link rel="modulepreload" href="../src/core/analisi-sezione.js">
 <link rel="modulepreload" href="../src/core/appliance-artwork.js">
 <link rel="modulepreload" href="../src/core/appliance-card-view-model.js">
 <link rel="modulepreload" href="../src/core/appliance-cycle-tracker.js">

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard.html
@@ -48,6 +48,7 @@
 <link rel="modulepreload" href="../src/core/light-model.js">
 <link rel="modulepreload" href="../src/core/media-picker.js">
 <link rel="modulepreload" href="../src/core/migrations.js">
+<link rel="modulepreload" href="../src/core/modello-nel-tempo.js">
 <link rel="modulepreload" href="../src/core/oggetti-widget.js">
 <link rel="modulepreload" href="../src/core/period-service.js">
 <link rel="modulepreload" href="../src/core/person-model.js">
@@ -169,6 +170,7 @@
 <link rel="modulepreload" href="../src/sections/shutter-sky-section.js">
 <link rel="modulepreload" href="../src/sections/shutter-window-section.js">
 <link rel="modulepreload" href="../src/sections/solar-thermal-design-section.js">
+<link rel="modulepreload" href="../src/sections/storico-condiviso-section.js">
 <link rel="modulepreload" href="../src/sections/subload-popup-section.js">
 <link rel="modulepreload" href="../src/sections/temperature-layout-section.js">
 <link rel="modulepreload" href="../src/sections/temperature-section.js">

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard.html
@@ -15,6 +15,7 @@
 <link rel="modulepreload" href="./build-info.js">
 <link rel="modulepreload" href="./modules-entry.js">
 <link rel="modulepreload" href="../src/core/alarm-panel.js">
+<link rel="modulepreload" href="../src/core/analisi-sezione.js">
 <link rel="modulepreload" href="../src/core/appliance-artwork.js">
 <link rel="modulepreload" href="../src/core/appliance-card-view-model.js">
 <link rel="modulepreload" href="../src/core/appliance-cycle-tracker.js">

--- a/custom_components/dashboardmodern/frontend/src/core/analisi-sezione.js
+++ b/custom_components/dashboardmodern/frontend/src/core/analisi-sezione.js
@@ -50,7 +50,12 @@ const IN_ITALIANO = (italiano) => italiano;
 
 /* ── attrezzi ──────────────────────────────────────────────────────────── */
 
+/* `Number(null)` fa zero, e uno zero e' una misura: senza questo controllo una
+ * stanza senza sensore di umidita' entrava nella media come 0%, e un'auto senza
+ * lettura della carica diventava un'auto al 12% da guardare. Un dato che manca
+ * non e' un dato che vale zero. */
 const num = (valore) => {
+  if (valore == null || valore === "") return null;
   const n = Number(valore);
   return Number.isFinite(n) ? n : null;
 };
@@ -66,7 +71,13 @@ function watt(valore, lingua = "it-IT") {
   return `${numero(n, 0, lingua)} W`;
 }
 
-const lingua = (tr) => (tr("it", "en") === "en" ? "en-US" : "it-IT");
+/* La lingua per i numeri arriva da fuori, non si indovina.
+ *
+ * Qui si chiedeva a `tr("it","en")` chi fosse: in italiano torna «it», in
+ * inglese «en», e in tedesco torna quello che c'e' nel catalogo — quindi si
+ * finiva su «en-US», e una finestra tedesca mescolava un titolo «1,25 kW» con
+ * un'analisi «1.25 kW». Chi chiama la lingua ce l'ha: la passa. */
+const lingua = (tr, dichiarata) => dichiarata || (tr("it", "en") === "en" ? "en-US" : "it-IT");
 
 /* Il piu' grande e il piu' piccolo di un elenco, per campo. */
 function estremi(righe, campo) {
@@ -109,7 +120,7 @@ const LETTURE = Object.freeze({
   /* L'Energia non e' un elenco di cose accese: e' un bilancio. Chi produce,
    * chi consuma, e dove finisce la differenza. */
   energia: (tr, tessera) => {
-    const l = lingua(tr);
+    const l = lingua(tr, tessera?.lingua);
     const di = (gruppo) => num(tessera?.rows?.find((r) => r?.group === gruppo)?.watts);
     const casa = di("house");
     const sole = di("solar");
@@ -203,13 +214,17 @@ const LETTURE = Object.freeze({
 
   /* Il fotovoltaico dentro il solare termico: sonde e pompa. */
   solare: (tr, tessera) => {
-    const l = lingua(tr);
+    const l = lingua(tr, tessera?.lingua);
     const righe = Array.isArray(tessera?.rows) ? tessera.rows : [];
     const pompa = tessera?.attiva === true;
-    const gradi = righe.filter((r) => num(r?.temperature ?? r?.value) != null);
+    /* Il grado si legge dal campo grezzo, non dal testo: il testo e' «68°», e
+     * `Number("68°")` non e' un numero. Le righe di questa sezione portano
+     * `raw` accanto a `value` proprio per questo. */
+    const gradoDi = (r) => num(r?.raw ?? r?.temperature);
+    const gradi = righe.filter((r) => gradoDi(r) != null);
     const punti = [];
     const estremo = estremi(
-      gradi.map((r) => ({ ...r, gradi: num(r.temperature ?? r.value) })),
+      gradi.map((r) => ({ ...r, gradi: gradoDi(r) })),
       "gradi",
     );
     if (estremo && estremo.massimo !== estremo.minimo) {
@@ -303,7 +318,7 @@ const LETTURE = Object.freeze({
 
   /* La Temperatura: la media da sola non dice niente, la differenza si'. */
   temperatura: (tr, tessera) => {
-    const l = lingua(tr);
+    const l = lingua(tr, tessera?.lingua);
     const righe = (Array.isArray(tessera?.rows) ? tessera.rows : []).filter(
       (r) => num(r?.temperature) != null,
     );
@@ -348,7 +363,7 @@ const LETTURE = Object.freeze({
   },
 
   elettrodomestici: (tr, tessera, adesso) => {
-    const l = lingua(tr);
+    const l = lingua(tr, tessera?.lingua);
     const righe = Array.isArray(tessera?.rows) ? tessera.rows : [];
     const accesi = righe.filter((r) => pulito(r?.mode) === "running");
     const punti = [];
@@ -400,11 +415,32 @@ const LETTURE = Object.freeze({
     };
   },
 
+  /* Con piu' di un'auto la tessera dice due cose che non parlano della stessa
+   * macchina: `ring` e' la carica piu' bassa fra tutte, `attiva` dice che
+   * QUALCUNA e' attaccata. Messe insieme diventano «quella al 10% e' in
+   * carica» mentre in carica c'e' l'altra, che sta all'80%. Con una sola auto
+   * le due cose coincidono e si puo' dire; con piu' d'una si dice di meno, che
+   * e' meglio di dire il falso. */
   ev: (tr, tessera) => {
-    const l = lingua(tr);
+    const l = lingua(tr, tessera?.lingua);
     const righe = Array.isArray(tessera?.rows) ? tessera.rows : [];
     const allaPresa = tessera?.attiva === true;
     const carica = num(tessera?.ring);
+    const piuAuto = (Number(tessera?.quante) || righe.length) > 1;
+    if (piuAuto && carica != null)
+      return {
+        tono: allaPresa ? VERDETTI.corso : carica < 20 ? VERDETTI.guarda : VERDETTI.bene,
+        frase: allaPresa
+          ? tr(
+              `Una e' in carica; la piu' scarica e' al ${Math.round(carica)}%.`,
+              `One is charging; the lowest is at ${Math.round(carica)}%.`,
+            )
+          : tr(
+              `Nessuna attaccata; la piu' scarica e' al ${Math.round(carica)}%.`,
+              `None plugged in; the lowest is at ${Math.round(carica)}%.`,
+            ),
+        punti: [],
+      };
     const punti = [];
     const km = righe.map((r) => num(r?.km)).filter((v) => v != null);
     if (km.length)
@@ -443,7 +479,16 @@ const LETTURE = Object.freeze({
 
   robot: (tr, tessera) => {
     const righe = Array.isArray(tessera?.rows) ? tessera.rows : [];
+    /* La tessera dice gia' quanti ne stanno lavorando, col suo conto: se le
+     * righe non portano il campo grezzo — puo' succedere con dati vecchi — si
+     * ricade su quello invece di dire che sono tutti fermi. */
     const attivi = righe.filter((r) => r?.cleaning === true || pulito(r?.state) === "cleaning");
+    if (!attivi.length && tessera?.attiva === true)
+      return {
+        tono: VERDETTI.corso,
+        frase: tr("Qualcuno sta pulendo.", "One is cleaning."),
+        punti: [],
+      };
     const cariche = righe.map((r) => num(r?.battery)).filter((v) => v != null);
     const piuScarico = cariche.length ? Math.min(...cariche) : null;
     const punti = [];
@@ -486,7 +531,7 @@ const LETTURE = Object.freeze({
   },
 
   piscina: (tr, tessera) => {
-    const l = lingua(tr);
+    const l = lingua(tr, tessera?.lingua);
     const righe = Array.isArray(tessera?.rows) ? tessera.rows : [];
     const trova = (nome) => righe.find((r) => pulito(r?.name).toLowerCase() === nome);
     const acqua = num(trova(tr("acqua", "water"))?.raw ?? trova(tr("acqua", "water"))?.value);
@@ -531,6 +576,12 @@ const LETTURE = Object.freeze({
   irrigazione: (tr, tessera, adesso) => {
     const righe = Array.isArray(tessera?.rows) ? tessera.rows : [];
     const bagnano = righe.filter((r) => r?.on === true || r?.running === true);
+    if (!bagnano.length && tessera?.attiva === true)
+      return {
+        tono: VERDETTI.corso,
+        frase: tr("Sta irrigando.", "Watering."),
+        punti: [],
+      };
     const umidita = num(tessera?.ring);
     const punti = [];
     if (umidita != null && !bagnano.length)
@@ -574,12 +625,14 @@ export function analisiDellaSezione(
   traduci = IN_ITALIANO,
   adesso = Date.now(),
   storia = null,
+  linguaDeiNumeri = null,
 ) {
   const lettura = LETTURE[tessera?.key];
   if (!lettura) return null;
-  const esito = lettura(traduci, tessera || {}, adesso);
+  const conLingua = { ...(tessera || {}), lingua: linguaDeiNumeri || tessera?.lingua || null };
+  const esito = lettura(traduci, conLingua, adesso);
   if (!esito?.frase) return null;
-  const dalModello = puntiDelModello(tessera, storia, traduci, adesso);
+  const dalModello = puntiDelModello(conLingua, storia, traduci, adesso);
   return {
     tono: dalModello.tono || esito.tono || VERDETTI.bene,
     frase: esito.frase,
@@ -613,7 +666,7 @@ const FORMA = Object.freeze({
 function puntiDelModello(tessera, storia, tr, adesso) {
   const forma = FORMA[tessera?.key];
   if (!forma || !storia) return { punti: [], tono: null };
-  const l = lingua(tr);
+  const l = lingua(tr, tessera?.lingua);
   const scrivi = (v) => forma.unita(v, l);
   const lettura = letturaNelTempo(storia, { adesso, bersaglio: forma.bersaglio(tessera) });
   if (!lettura) return { punti: [], tono: null };

--- a/custom_components/dashboardmodern/frontend/src/core/analisi-sezione.js
+++ b/custom_components/dashboardmodern/frontend/src/core/analisi-sezione.js
@@ -1,0 +1,597 @@
+/* Il motore di analisi delle finestre.
+ *
+ * Cosa risolve. Fino a ieri la finestra di una tessera diceva una frase presa
+ * da un ripiego generico: contava le righe, contava quante erano «accese» e
+ * scriveva «4 cose, nessuna in funzione». Su una sezione fatta di cose che si
+ * accendono e si spengono ha un senso; sulle altre no, e le altre erano dieci
+ * su diciassette. L'Energia scriveva «4 cose, nessuna in funzione» mentre il
+ * fotovoltaico faceva 2,16 kW — le sue quattro righe sono casa, solare, rete
+ * e batteria, che non sono cose accese o spente. La Sicurezza scriveva «Qui
+ * non c'e' ancora niente» con l'antifurto elencato subito sotto, perche' il
+ * suo antifurto non e' una riga. Non erano frasi imprecise: erano frasi che
+ * parlavano di un'altra cosa.
+ *
+ * Come funziona. Ogni sezione ha la sua lettura, scritta sui dati che quella
+ * sezione ha davvero: l'Energia ragiona sul bilancio fra produzione, consumo,
+ * batteria e rete; la Temperatura sulla distanza fra la stanza piu' calda e
+ * la piu' fredda; l'Irrigazione su quali zone stanno bagnando e da quanto.
+ * Dove il dato non c'e' non si inventa niente e non si scrive una riga vuota:
+ * si dice di meno.
+ *
+ * Cosa restituisce: un tono, una frase e dei punti. La frase e' la riga
+ * grande, quella che si legge; i punti sono le cose precise che la
+ * sostengono, e stanno sotto in piccolo. Il tono decide il colore della
+ * pillola — verde quando non c'e' niente da fare, ambra quando qualcosa sta
+ * lavorando adesso, rosso quando qualcuno deve guardarci.
+ *
+ * Perche' e' qui e non nel modulo che disegna. Non tocca il documento: si
+ * prova con i numeri, senza browser. Una frase che conta male e' sbagliata
+ * senza rompersi, e a occhio non si vede — l'unico modo di accorgersene e'
+ * pretendere il testo giusto a partire da dati noti, ed e' quello che fa
+ * `tests/lanalisi-delle-sezioni.test.js`.
+ *
+ * Sulla parola «intelligenza». Qui non c'e' un modello di linguaggio e non ci
+ * si parla: e' un motore di regole che legge i numeri. La scelta e'
+ * deliberata e vale la pena dirla. Una finestra si apre e deve rispondere
+ * subito, sempre uguale a se stessa e senza sbagliare un conto; un modello
+ * remoto ci mette secondi, costa a ogni apertura, manda fuori casa i dati
+ * della casa e sui numeri e' proprio dove sbaglia. Le frasi qui sotto sono
+ * scritte a mano ma i numeri dentro sono calcolati, quindi dicono sempre la
+ * cosa vera. Se un giorno si vorra' un commento in prosa da un agente di
+ * conversazione di Home Assistant, il posto dove innestarlo e'
+ * `commentoInPiu`: arriva dopo, e se non arriva la finestra sta in piedi
+ * lo stesso.
+ */
+
+import { daQuanto, numero, VERDETTI } from "./racconto-tessera.js";
+
+const IN_ITALIANO = (italiano) => italiano;
+
+/* ── attrezzi ──────────────────────────────────────────────────────────── */
+
+const num = (valore) => {
+  const n = Number(valore);
+  return Number.isFinite(n) ? n : null;
+};
+
+const pulito = (valore) => String(valore ?? "").trim();
+
+/* Watt leggibili: sotto il migliaio l'intero, sopra i kW con due decimali. */
+function watt(valore, lingua = "it-IT") {
+  const n = num(valore);
+  if (n == null) return "—";
+  const assoluto = Math.abs(n);
+  if (assoluto >= 1000) return `${numero(n / 1000, 2, lingua)} kW`;
+  return `${numero(n, 0, lingua)} W`;
+}
+
+const lingua = (tr) => (tr("it", "en") === "en" ? "en-US" : "it-IT");
+
+/* Il piu' grande e il piu' piccolo di un elenco, per campo. */
+function estremi(righe, campo) {
+  const buone = righe.filter((r) => num(r?.[campo]) != null);
+  if (!buone.length) return null;
+  const ordinate = [...buone].sort((a, b) => num(a[campo]) - num(b[campo]));
+  return { minimo: ordinate[0], massimo: ordinate[ordinate.length - 1] };
+}
+
+const media = (valori) => {
+  const buoni = valori.map(num).filter((v) => v != null);
+  return buoni.length ? buoni.reduce((s, v) => s + v, 0) / buoni.length : null;
+};
+
+const nomeDi = (riga) =>
+  pulito(riga?.name) || pulito(riga?.nome) || pulito(riga?.entity) || pulito(riga?.id);
+
+/* Un elenco di nomi che non diventa mai un muro: due e poi «e altri». */
+function elenco(nomi, tr) {
+  const buoni = nomi.filter(Boolean);
+  if (!buoni.length) return "";
+  if (buoni.length === 1) return buoni[0];
+  if (buoni.length === 2) return buoni.join(tr(" e ", " and "));
+  return `${buoni.slice(0, 2).join(", ")}${tr(" e altri", " and others")}`;
+}
+
+/* Da quanto va avanti, quando il dato c'e'. */
+function daQuandoDelleRighe(righe, adesso) {
+  const momenti = righe
+    .map((r) => Number(r?.daQuando))
+    .filter((q) => Number.isFinite(q) && q > 0 && q <= adesso);
+  return momenti.length ? (adesso - Math.max(...momenti)) / 60000 : null;
+}
+
+/* ── le letture, una per sezione ───────────────────────────────────────── */
+
+/* Ognuna riceve (tr, tessera, adesso) e torna {tono, frase, punti}.
+ * `punti` puo' essere vuoto: sotto la frase non compare niente. */
+const LETTURE = Object.freeze({
+  /* L'Energia non e' un elenco di cose accese: e' un bilancio. Chi produce,
+   * chi consuma, e dove finisce la differenza. */
+  energia: (tr, tessera) => {
+    const l = lingua(tr);
+    const di = (gruppo) => num(tessera?.rows?.find((r) => r?.group === gruppo)?.watts);
+    const casa = di("house");
+    const sole = di("solar");
+    const rete = di("grid");
+    const batteria = di("battery");
+    const punti = [];
+
+    if (casa == null && sole == null)
+      return {
+        tono: VERDETTI.bene,
+        frase: tr("Non c'e' ancora niente da leggere.", "Nothing to read yet."),
+        punti,
+      };
+
+    const oggi = num(tessera?.today);
+    if (oggi != null)
+      punti.push(
+        tr(`Da mezzanotte ${numero(oggi, 1, l)} kWh`, `${numero(oggi, 1, l)} kWh since midnight`),
+      );
+
+    /* La batteria: positiva vuol dire che sta dando corrente a casa,
+     * negativa che si sta caricando. E' la convenzione del flusso, e detta
+     * a parole toglie l'ambiguita' del segno — nella finestra si leggeva
+     * «Batteria -1,47 kW» e nessuno e' tenuto a sapere cosa vuol dire. */
+    if (batteria != null && Math.abs(batteria) >= 10)
+      punti.push(
+        batteria < 0
+          ? tr(
+              `La batteria si carica a ${watt(-batteria, l)}`,
+              `Battery charging at ${watt(-batteria, l)}`,
+            )
+          : tr(`La batteria copre ${watt(batteria, l)}`, `Battery covering ${watt(batteria, l)}`),
+      );
+
+    if (rete != null && Math.abs(rete) >= 10)
+      punti.push(
+        rete < 0
+          ? tr(`In rete vanno ${watt(-rete, l)}`, `${watt(-rete, l)} exported to the grid`)
+          : tr(`Dalla rete arrivano ${watt(rete, l)}`, `${watt(rete, l)} drawn from the grid`),
+      );
+
+    /* La frase grande e' il rapporto fra quello che si produce e quello che
+     * si consuma: e' la cosa che si vuole sapere aprendo l'Energia. */
+    if (sole != null && sole > 20 && casa != null) {
+      if (sole >= casa) {
+        const avanzo = sole - casa;
+        return {
+          tono: VERDETTI.bene,
+          frase:
+            avanzo < 50
+              ? tr(
+                  `Il sole copre esattamente la casa: ${watt(sole, l)}.`,
+                  `Solar exactly covers the house: ${watt(sole, l)}.`,
+                )
+              : tr(
+                  `Il sole fa ${watt(sole, l)} e la casa ne usa ${watt(casa, l)}: ne avanzano ${watt(avanzo, l)}.`,
+                  `Solar is making ${watt(sole, l)} against ${watt(casa, l)} used: ${watt(avanzo, l)} to spare.`,
+                ),
+          punti,
+        };
+      }
+      const quota = Math.round((sole / casa) * 100);
+      return {
+        tono: VERDETTI.corso,
+        frase: tr(
+          `Il sole copre ${quota}% dei ${watt(casa, l)} che sta usando la casa.`,
+          `Solar covers ${quota}% of the ${watt(casa, l)} the house is using.`,
+        ),
+        punti,
+      };
+    }
+
+    if (casa == null)
+      return {
+        tono: VERDETTI.bene,
+        frase: tr("Il sole non produce.", "No solar production."),
+        punti,
+      };
+    return {
+      tono: VERDETTI.bene,
+      frase:
+        sole == null || sole <= 20
+          ? tr(
+              `La casa usa ${watt(casa, l)}, senza sole.`,
+              `The house is using ${watt(casa, l)}, no sun.`,
+            )
+          : tr(`La casa usa ${watt(casa, l)}.`, `The house is using ${watt(casa, l)}.`),
+      punti,
+    };
+  },
+
+  /* Il fotovoltaico dentro il solare termico: sonde e pompa. */
+  solare: (tr, tessera) => {
+    const l = lingua(tr);
+    const righe = Array.isArray(tessera?.rows) ? tessera.rows : [];
+    const pompa = tessera?.attiva === true;
+    const gradi = righe.filter((r) => num(r?.temperature ?? r?.value) != null);
+    const punti = [];
+    const estremo = estremi(
+      gradi.map((r) => ({ ...r, gradi: num(r.temperature ?? r.value) })),
+      "gradi",
+    );
+    if (estremo && estremo.massimo !== estremo.minimo) {
+      punti.push(
+        tr(
+          `La piu' calda e' ${nomeDi(estremo.massimo)} a ${numero(estremo.massimo.gradi, 1, l)}°`,
+          `Hottest is ${nomeDi(estremo.massimo)} at ${numero(estremo.massimo.gradi, 1, l)}°`,
+        ),
+      );
+      punti.push(
+        tr(
+          `La piu' fredda ${nomeDi(estremo.minimo)} a ${numero(estremo.minimo.gradi, 1, l)}°`,
+          `Coldest ${nomeDi(estremo.minimo)} at ${numero(estremo.minimo.gradi, 1, l)}°`,
+        ),
+      );
+    }
+    if (!gradi.length)
+      return {
+        tono: pompa ? VERDETTI.corso : VERDETTI.bene,
+        frase: pompa
+          ? tr("La pompa sta girando.", "The pump is running.")
+          : tr("La pompa e' ferma.", "The pump is idle."),
+        punti,
+      };
+    if (!estremo)
+      return {
+        tono: VERDETTI.bene,
+        frase: tr("Nessuna sonda risponde.", "No probe responding."),
+        punti,
+      };
+    const salto = estremo.massimo.gradi - estremo.minimo.gradi;
+    if (pompa)
+      return {
+        tono: VERDETTI.corso,
+        frase: tr(
+          `La pompa gira: ${numero(salto, 1, l)}° di salto fra il pannello e l'accumulo.`,
+          `Pump running: ${numero(salto, 1, l)}° between panel and store.`,
+        ),
+        punti,
+      };
+    return {
+      tono: VERDETTI.bene,
+      frase: tr(
+        `Pompa ferma, ${numero(salto, 1, l)}° di salto fra la sonda piu' calda e la piu' fredda.`,
+        `Pump idle, ${numero(salto, 1, l)}° between the hottest and coldest probe.`,
+      ),
+      punti,
+    };
+  },
+
+  /* La Sicurezza non ha righe: ha un antifurto e degli ingressi. */
+  sicurezza: (tr, tessera) => {
+    const porte = Array.isArray(tessera?.doors) ? tessera.doors : [];
+    const punti = [];
+    if (porte.length)
+      punti.push(
+        tr(
+          `${porte.length} ingress${porte.length === 1 ? "o sorvegliato" : "i sorvegliati"}`,
+          `${porte.length} monitored entrance${porte.length === 1 ? "" : "s"}`,
+        ),
+      );
+    if (tessera?.triggered)
+      return {
+        tono: VERDETTI.guarda,
+        frase: tr("L'antifurto sta suonando.", "The alarm is going off."),
+        punti,
+      };
+    if (!tessera?.alarm)
+      return {
+        tono: VERDETTI.bene,
+        frase: porte.length
+          ? tr(
+              `Nessun antifurto configurato, ${porte.length} ingressi sorvegliati.`,
+              `No alarm configured, ${porte.length} entrances monitored.`,
+            )
+          : tr("Non c'e' un antifurto configurato.", "No alarm configured."),
+        punti: [],
+      };
+    if (tessera?.armed)
+      return {
+        tono: VERDETTI.corso,
+        frase: tr("L'antifurto e' inserito.", "The alarm is armed."),
+        punti,
+      };
+    return {
+      tono: VERDETTI.bene,
+      frase: tr("L'antifurto e' disinserito.", "The alarm is disarmed."),
+      punti,
+    };
+  },
+
+  /* La Temperatura: la media da sola non dice niente, la differenza si'. */
+  temperatura: (tr, tessera) => {
+    const l = lingua(tr);
+    const righe = (Array.isArray(tessera?.rows) ? tessera.rows : []).filter(
+      (r) => num(r?.temperature) != null,
+    );
+    if (!righe.length)
+      return {
+        tono: VERDETTI.bene,
+        frase: tr("Nessuna sonda risponde.", "No probe responding."),
+        punti: [],
+      };
+    const estremo = estremi(righe, "temperature");
+    const mediaGradi = media(righe.map((r) => r.temperature));
+    const punti = [];
+    const umidita = media(righe.map((r) => r.humidity));
+    if (umidita != null)
+      punti.push(
+        tr(`Umidita' media ${Math.round(umidita)}%`, `Average humidity ${Math.round(umidita)}%`),
+      );
+    if (righe.length === 1)
+      return {
+        tono: VERDETTI.bene,
+        frase: tr(
+          `${nomeDi(righe[0])} e' a ${numero(righe[0].temperature, 1, l)}°.`,
+          `${nomeDi(righe[0])} is at ${numero(righe[0].temperature, 1, l)}°.`,
+        ),
+        punti,
+      };
+    const salto = num(estremo.massimo.temperature) - num(estremo.minimo.temperature);
+    punti.push(
+      tr(
+        `La piu' fredda e' ${nomeDi(estremo.minimo)} a ${numero(estremo.minimo.temperature, 1, l)}°`,
+        `Coldest is ${nomeDi(estremo.minimo)} at ${numero(estremo.minimo.temperature, 1, l)}°`,
+      ),
+    );
+    return {
+      tono: VERDETTI.bene,
+      frase: tr(
+        `Media ${numero(mediaGradi, 1, l)}° su ${righe.length} stanze, ${numero(salto, 1, l)}° fra la piu' calda (${nomeDi(estremo.massimo)}) e la piu' fredda.`,
+        `${numero(mediaGradi, 1, l)}° average across ${righe.length} rooms, ${numero(salto, 1, l)}° between the warmest (${nomeDi(estremo.massimo)}) and the coldest.`,
+      ),
+      punti,
+    };
+  },
+
+  elettrodomestici: (tr, tessera, adesso) => {
+    const l = lingua(tr);
+    const righe = Array.isArray(tessera?.rows) ? tessera.rows : [];
+    const accesi = righe.filter((r) => pulito(r?.mode) === "running");
+    const punti = [];
+    const potenza = accesi.reduce((s, r) => s + (num(r?.watts) || 0), 0);
+    if (potenza > 10)
+      punti.push(tr(`Insieme fanno ${watt(potenza, l)}`, `Together they draw ${watt(potenza, l)}`));
+    const minuti = daQuandoDelleRighe(accesi, adesso);
+    if (minuti != null)
+      punti.push(
+        tr(`Il piu' recente da ${daQuanto(minuti, tr)}`, `Latest one ${daQuanto(minuti, tr)}`),
+      );
+    if (!righe.length)
+      return {
+        tono: VERDETTI.bene,
+        frase: tr("Non ce n'e' nessuno configurato.", "None configured."),
+        punti: [],
+      };
+    if (!accesi.length)
+      return {
+        tono: VERDETTI.bene,
+        frase: tr(`Tutti fermi, ${righe.length} in tutto.`, `All idle, ${righe.length} in total.`),
+        punti: [],
+      };
+    return {
+      tono: VERDETTI.corso,
+      frase: tr(
+        `${elenco(accesi.map(nomeDi), tr)} in funzione, su ${righe.length}.`,
+        `${elenco(accesi.map(nomeDi), tr)} running, out of ${righe.length}.`,
+      ),
+      punti,
+    };
+  },
+
+  telecamere: (tr, tessera) => {
+    const righe = Array.isArray(tessera?.rows) ? tessera.rows : [];
+    if (!righe.length)
+      return {
+        tono: VERDETTI.bene,
+        frase: tr("Nessuna telecamera configurata.", "No cameras configured."),
+        punti: [],
+      };
+    return {
+      tono: VERDETTI.bene,
+      frase: tr(
+        `${righe.length} telecamer${righe.length === 1 ? "a" : "e"}: ${elenco(righe.map(nomeDi), tr)}.`,
+        `${righe.length} camera${righe.length === 1 ? "" : "s"}: ${elenco(righe.map(nomeDi), tr)}.`,
+      ),
+      punti: [],
+    };
+  },
+
+  ev: (tr, tessera) => {
+    const l = lingua(tr);
+    const righe = Array.isArray(tessera?.rows) ? tessera.rows : [];
+    const allaPresa = tessera?.attiva === true;
+    const carica = num(tessera?.ring);
+    const punti = [];
+    const km = righe.map((r) => num(r?.km)).filter((v) => v != null);
+    if (km.length)
+      punti.push(
+        tr(`${numero(km[0], 0, l)} km di autonomia`, `${numero(km[0], 0, l)} km of range`),
+      );
+    if (carica == null)
+      return {
+        tono: allaPresa ? VERDETTI.corso : VERDETTI.bene,
+        frase: allaPresa
+          ? tr("E' in carica.", "It is charging.")
+          : tr("Non e' attaccata.", "Not plugged in."),
+        punti,
+      };
+    if (allaPresa)
+      return {
+        tono: VERDETTI.corso,
+        frase: tr(`In carica, al ${Math.round(carica)}%.`, `Charging, at ${Math.round(carica)}%.`),
+        punti,
+      };
+    if (carica < 20)
+      return {
+        tono: VERDETTI.guarda,
+        frase: tr(
+          `E' al ${Math.round(carica)}% e non e' attaccata.`,
+          `At ${Math.round(carica)}% and not plugged in.`,
+        ),
+        punti,
+      };
+    return {
+      tono: VERDETTI.bene,
+      frase: tr(`E' al ${Math.round(carica)}%, ferma.`, `At ${Math.round(carica)}%, idle.`),
+      punti,
+    };
+  },
+
+  robot: (tr, tessera) => {
+    const righe = Array.isArray(tessera?.rows) ? tessera.rows : [];
+    const attivi = righe.filter((r) => r?.cleaning === true || pulito(r?.state) === "cleaning");
+    const cariche = righe.map((r) => num(r?.battery)).filter((v) => v != null);
+    const piuScarico = cariche.length ? Math.min(...cariche) : null;
+    const punti = [];
+    if (piuScarico != null && !attivi.length)
+      punti.push(
+        tr(
+          `La carica piu' bassa e' ${Math.round(piuScarico)}%`,
+          `Lowest charge is ${Math.round(piuScarico)}%`,
+        ),
+      );
+    if (!righe.length)
+      return {
+        tono: VERDETTI.bene,
+        frase: tr("Nessun robot configurato.", "No vacuum configured."),
+        punti: [],
+      };
+    if (attivi.length)
+      return {
+        tono: VERDETTI.corso,
+        frase: tr(
+          `${elenco(attivi.map(nomeDi), tr)} sta pulendo.`,
+          `${elenco(attivi.map(nomeDi), tr)} is cleaning.`,
+        ),
+        punti: [],
+      };
+    if (piuScarico != null && piuScarico < 20)
+      return {
+        tono: VERDETTI.guarda,
+        frase: tr(
+          `Fermi, e il piu' scarico e' al ${Math.round(piuScarico)}%.`,
+          `Idle, and the lowest is at ${Math.round(piuScarico)}%.`,
+        ),
+        punti: [],
+      };
+    return {
+      tono: VERDETTI.bene,
+      frase: tr(`Tutti fermi, ${righe.length} in tutto.`, `All idle, ${righe.length} in total.`),
+      punti,
+    };
+  },
+
+  piscina: (tr, tessera) => {
+    const l = lingua(tr);
+    const righe = Array.isArray(tessera?.rows) ? tessera.rows : [];
+    const trova = (nome) => righe.find((r) => pulito(r?.name).toLowerCase() === nome);
+    const acqua = num(trova(tr("acqua", "water"))?.raw ?? trova(tr("acqua", "water"))?.value);
+    const ph = num(trova("ph")?.raw ?? trova("ph")?.value);
+    const punti = [];
+    if (ph != null) {
+      const fuori = ph < 7 || ph > 7.6;
+      punti.push(
+        fuori
+          ? tr(
+              `Il pH e' ${numero(ph, 1, l)}, fuori dai 7,0–7,6`,
+              `pH is ${numero(ph, 1, l)}, outside 7.0–7.6`,
+            )
+          : tr(`Il pH e' ${numero(ph, 1, l)}, nella norma`, `pH is ${numero(ph, 1, l)}, in range`),
+      );
+      if (fuori)
+        return {
+          tono: VERDETTI.guarda,
+          frase:
+            acqua == null
+              ? tr("Il pH e' fuori norma.", "pH is out of range.")
+              : tr(
+                  `Acqua a ${numero(acqua, 1, l)}°, ma il pH e' fuori norma.`,
+                  `Water at ${numero(acqua, 1, l)}°, but pH is out of range.`,
+                ),
+          punti,
+        };
+    }
+    if (acqua == null)
+      return {
+        tono: VERDETTI.bene,
+        frase: tr("Non c'e' ancora una lettura.", "No reading yet."),
+        punti,
+      };
+    return {
+      tono: VERDETTI.bene,
+      frase: tr(`L'acqua e' a ${numero(acqua, 1, l)}°.`, `Water is at ${numero(acqua, 1, l)}°.`),
+      punti,
+    };
+  },
+
+  irrigazione: (tr, tessera, adesso) => {
+    const righe = Array.isArray(tessera?.rows) ? tessera.rows : [];
+    const bagnano = righe.filter((r) => r?.on === true || r?.running === true);
+    const umidita = num(tessera?.ring);
+    const punti = [];
+    if (umidita != null && !bagnano.length)
+      punti.push(tr(`Terreno al ${Math.round(umidita)}%`, `Soil at ${Math.round(umidita)}%`));
+    const minuti = daQuandoDelleRighe(bagnano, adesso);
+    if (minuti != null)
+      punti.push(tr(`Va avanti da ${daQuanto(minuti, tr)}`, `Running ${daQuanto(minuti, tr)}`));
+    if (!righe.length)
+      return {
+        tono: VERDETTI.bene,
+        frase: tr("Nessuna zona configurata.", "No zone configured."),
+        punti: [],
+      };
+    if (bagnano.length)
+      return {
+        tono: VERDETTI.corso,
+        frase: tr(
+          `${elenco(bagnano.map(nomeDi), tr)} sta bagnando, su ${righe.length} zone.`,
+          `${elenco(bagnano.map(nomeDi), tr)} watering, of ${righe.length} zones.`,
+        ),
+        punti,
+      };
+    return {
+      tono: VERDETTI.bene,
+      frase: tr(
+        `${righe.length} zon${righe.length === 1 ? "a ferma" : "e ferme"}.`,
+        `${righe.length} zone${righe.length === 1 ? "" : "s"} idle.`,
+      ),
+      punti,
+    };
+  },
+});
+
+/* ── la porta d'ingresso ───────────────────────────────────────────────── */
+
+/* Chi non ha una lettura sua non riceve una frase sbagliata: riceve niente, e
+ * chi disegna sa che sotto il verdetto non va scritto nulla. E' meglio di una
+ * riga che parla di un'altra sezione. */
+export function analisiDellaSezione(tessera, traduci = IN_ITALIANO, adesso = Date.now()) {
+  const lettura = LETTURE[tessera?.key];
+  if (!lettura) return null;
+  const esito = lettura(traduci, tessera || {}, adesso);
+  if (!esito?.frase) return null;
+  return {
+    tono: esito.tono || VERDETTI.bene,
+    frase: esito.frase,
+    punti: (esito.punti || []).filter(Boolean),
+  };
+}
+
+/* Le sezioni che questo motore sa leggere. Serve alla prova che pretende che
+ * non ne manchi nessuna, e a chi disegna per sapere in anticipo se c'e' da
+ * fare spazio all'analisi. */
+export const SEZIONI_LETTE = Object.freeze(Object.keys(LETTURE));
+
+/* Il posto dove innestare un commento in prosa, se un giorno lo si vorra'.
+ *
+ * Torna sempre niente: e' un innesto dichiarato, non una funzione a meta'.
+ * Chi lo riempira' dovra' tenere due cose. La prima: arriva dopo, e la
+ * finestra dev'essere gia' completa e leggibile senza. La seconda: i numeri
+ * restano quelli calcolati qui sopra — un commento puo' aggiungere il perche',
+ * non rifare il conto. */
+export function commentoInPiu() {
+  return null;
+}

--- a/custom_components/dashboardmodern/frontend/src/core/analisi-sezione.js
+++ b/custom_components/dashboardmodern/frontend/src/core/analisi-sezione.js
@@ -44,6 +44,7 @@
  */
 
 import { daQuanto, numero, VERDETTI } from "./racconto-tessera.js";
+import { letturaNelTempo, SOGLIE_INSOLITO } from "./modello-nel-tempo.js";
 
 const IN_ITALIANO = (italiano) => italiano;
 
@@ -568,16 +569,101 @@ const LETTURE = Object.freeze({
 /* Chi non ha una lettura sua non riceve una frase sbagliata: riceve niente, e
  * chi disegna sa che sotto il verdetto non va scritto nulla. E' meglio di una
  * riga che parla di un'altra sezione. */
-export function analisiDellaSezione(tessera, traduci = IN_ITALIANO, adesso = Date.now()) {
+export function analisiDellaSezione(
+  tessera,
+  traduci = IN_ITALIANO,
+  adesso = Date.now(),
+  storia = null,
+) {
   const lettura = LETTURE[tessera?.key];
   if (!lettura) return null;
   const esito = lettura(traduci, tessera || {}, adesso);
   if (!esito?.frase) return null;
+  const dalModello = puntiDelModello(tessera, storia, traduci, adesso);
   return {
-    tono: esito.tono || VERDETTI.bene,
+    tono: dalModello.tono || esito.tono || VERDETTI.bene,
     frase: esito.frase,
-    punti: (esito.punti || []).filter(Boolean),
+    punti: [...(esito.punti || []), ...dalModello.punti].filter(Boolean),
   };
+}
+
+/* ── quello che il modello aggiunge, quando c'e' una storia ────────────── */
+
+/* Come si scrive il numero di questa sezione, e verso cosa sta andando.
+ *
+ * Il modello conta e basta: non sa se quei numeri sono watt o gradi, e non
+ * deve saperlo. Il verso — il pieno di una batteria, l'obiettivo di un
+ * termostato — e' invece una cosa della sezione, e sta scritta qui. */
+const FORMA = Object.freeze({
+  energia: { unita: (v, l) => watt(v, l), bersaglio: () => null },
+  temperatura: { unita: (v, l) => `${numero(v, 1, l)}°`, bersaglio: () => null },
+  solare: { unita: (v, l) => `${numero(v, 1, l)}°`, bersaglio: () => null },
+  piscina: { unita: (v, l) => `${numero(v, 1, l)}°`, bersaglio: () => null },
+  ev: { unita: (v) => `${Math.round(v)}%`, bersaglio: (t) => (t?.attiva ? 100 : null) },
+  robot: { unita: (v) => `${Math.round(v)}%`, bersaglio: () => null },
+  irrigazione: { unita: (v) => `${Math.round(v)}%`, bersaglio: () => null },
+  elettrodomestici: { unita: (v, l) => watt(v, l), bersaglio: () => null },
+});
+
+/* Al massimo due righe.
+ *
+ * Il modello sa dire cinque cose; scriverle tutte trasforma la finestra in un
+ * bollettino, e chi legge smette a meta'. Si tengono le due che rispondono
+ * alle domande vere: «e' normale?» e «dove sta andando?». */
+function puntiDelModello(tessera, storia, tr, adesso) {
+  const forma = FORMA[tessera?.key];
+  if (!forma || !storia) return { punti: [], tono: null };
+  const l = lingua(tr);
+  const scrivi = (v) => forma.unita(v, l);
+  const lettura = letturaNelTempo(storia, { adesso, bersaglio: forma.bersaglio(tessera) });
+  if (!lettura) return { punti: [], tono: null };
+
+  const punti = [];
+  let tono = null;
+
+  /* «E' normale?» — e la risposta ha senso solo con un riferimento: il solito
+   * a quest'ora se la storia copre piu' giorni, altrimenti il solito e basta.
+   * Sotto la soglia non si dice niente: «e' nella norma» e' una riga sprecata,
+   * perche' e' il caso di quasi sempre. */
+  const riferimento = lettura.abituale || lettura.solito;
+  if (lettura.insolito != null && lettura.insolito >= SOGLIE_INSOLITO.notevole && riferimento) {
+    const sopra = lettura.valore > riferimento.centro;
+    const quando = lettura.abituale
+      ? tr("per quest'ora", "for this time of day")
+      : tr("delle ultime ore", "over the last few hours");
+    punti.push(
+      sopra
+        ? tr(
+            `Piu' alto del solito ${quando}: ${scrivi(lettura.valore)} contro ${scrivi(riferimento.centro)}`,
+            `Higher than usual ${quando}: ${scrivi(lettura.valore)} against ${scrivi(riferimento.centro)}`,
+          )
+        : tr(
+            `Piu' basso del solito ${quando}: ${scrivi(lettura.valore)} contro ${scrivi(riferimento.centro)}`,
+            `Lower than usual ${quando}: ${scrivi(lettura.valore)} against ${scrivi(riferimento.centro)}`,
+          ),
+    );
+    /* Un valore molto fuori dal solito e' una cosa da guardare, qualunque
+     * cosa dica il conteggio delle righe. E' il caso per cui questo modello
+     * esiste: nessuno sta «facendo» niente, eppure c'e' qualcosa. */
+    if (lettura.insolito >= SOGLIE_INSOLITO.forte) tono = VERDETTI.guarda;
+  }
+
+  /* «Dove sta andando?» — l'arrivo se il modello sa dire quando, altrimenti
+   * il passo. L'arrivo e' la risposta migliore delle due: «piena fra un'ora»
+   * dice piu' di «sale del dodici per cento all'ora». */
+  if (lettura.arrivo) {
+    const fraQuanto = daQuanto((lettura.arrivo - adesso) / 60000, tr);
+    punti.push(tr(`Ci arriva ${fraQuanto}`, `Getting there ${fraQuanto}`));
+  } else if (lettura.tendenza && lettura.tendenza.verso !== "ferma") {
+    const passo = Math.abs(lettura.tendenza.perOra);
+    punti.push(
+      lettura.tendenza.verso === "sale"
+        ? tr(`Sale di ${scrivi(passo)} all'ora`, `Rising ${scrivi(passo)} per hour`)
+        : tr(`Scende di ${scrivi(passo)} all'ora`, `Falling ${scrivi(passo)} per hour`),
+    );
+  }
+
+  return { punti, tono };
 }
 
 /* Le sezioni che questo motore sa leggere. Serve alla prova che pretende che

--- a/custom_components/dashboardmodern/frontend/src/core/modello-nel-tempo.js
+++ b/custom_components/dashboardmodern/frontend/src/core/modello-nel-tempo.js
@@ -186,7 +186,7 @@ export function quandoTocca(punti, bersaglio, { adesso = Date.now(), orizzonteOr
  * valore sballato gonfia la deviazione standard e con lei la soglia di
  * «insolito», che e' il modo in cui una guardia smette di suonare.
  */
-export function ilSolito(punti) {
+export function ilSolito(punti, { adesso = Date.now() } = {}) {
   const letture = serie(punti);
   if (letture.length < 2) return null;
 
@@ -195,6 +195,16 @@ export function ilSolito(punti) {
     const durata = letture[i + 1].quando - letture[i].quando;
     if (durata > 0) pesate.push({ valore: letture[i].valore, peso: durata });
   }
+  /* L'ultima lettura dura fino ad adesso, e va pesata come le altre.
+   *
+   * Pesando solo gli intervalli fra letture consecutive, l'ultima non ne
+   * aveva nessuno e valeva zero. Su una casa e' il caso normale: un sensore
+   * passa da 100 a 200 un'ora fa e poi non cambia piu': con l'ultima a peso
+   * zero, il solito resta 100 e il 200 di adesso risulta fortemente insolito —
+   * cioe' si annuncia una stranezza a un sensore che sta fermo da un'ora. */
+  const ultima = letture[letture.length - 1];
+  const codaFinoAOra = adesso - ultima.quando;
+  if (codaFinoAOra > 0) pesate.push({ valore: ultima.valore, peso: codaFinoAOra });
   if (!pesate.length) return null;
 
   const centro = medianaPesata(pesate);
@@ -242,7 +252,7 @@ export function ilSolitoAQuestOra(punti, { adesso = Date.now(), larghezzaOre = 1
   if (vicine.length < PUNTI_MINIMI) return null;
   const giorni = new Set(vicine.map((l) => new Date(l.quando).toDateString()));
   if (giorni.size < 2) return null;
-  const solito = ilSolito(vicine);
+  const solito = ilSolito(vicine, { adesso });
   return solito ? { ...solito, giorni: giorni.size, ora: bersaglio } : null;
 }
 
@@ -311,7 +321,7 @@ export function letturaNelTempo(punti, { adesso = Date.now(), bersaglio = null }
   const letture = serie(punti);
   if (!letture.length) return null;
   const adessoValore = letture[letture.length - 1].valore;
-  const solito = ilSolito(letture);
+  const solito = ilSolito(letture, { adesso });
   const abituale = ilSolitoAQuestOra(letture, { adesso });
   const riferimento = abituale || solito;
   return {

--- a/custom_components/dashboardmodern/frontend/src/core/modello-nel-tempo.js
+++ b/custom_components/dashboardmodern/frontend/src/core/modello-nel-tempo.js
@@ -1,0 +1,331 @@
+/* Il modello di una grandezza nel tempo.
+ *
+ * Cosa fa. Prende una serie di letture — quando, quanto — e ne ricava le
+ * quattro cose che servono per dire qualcosa di sensato su un numero: da che
+ * parte sta andando, quando arrivera' dove deve arrivare, quale sia il suo
+ * valore abituale, e se quello di adesso sia normale o no.
+ *
+ * Perche' esiste. La finestra di una sezione sapeva dire «574 W» e nient'altro.
+ * Un numero da solo non si sa se e' tanto o poco: 574 watt sono normali per una
+ * casa e tantissimi per un frigorifero. Per dirlo bisogna sapere cosa fa di
+ * solito quel numero, ed e' esattamente cio' che questo modulo calcola.
+ *
+ * Perche' non c'e' un modello di linguaggio. Perche' non si puo' chiedere a
+ * chi installa una plancia per la propria casa di installare anche un'AI, di
+ * pagarla a ogni finestra che apre e di mandare fuori casa le letture dei
+ * propri sensori. E perche' su questo mestiere — contare — un modello di
+ * linguaggio e' lo strumento sbagliato: sbaglia i conti, e li sbaglia in modo
+ * plausibile, che e' il peggiore dei modi. Qui i conti sono conti.
+ *
+ * Le tre scelte di modello che vale la pena conoscere.
+ *
+ * 1. Il tempo pesa. Home Assistant registra una lettura quando il valore
+ *    cambia, non a intervalli regolari: un sensore che sta a zero per sei ore
+ *    e poi fa tre picchi in un minuto lascia una lettura per le sei ore e tre
+ *    per il minuto. Contando le letture, quel sensore «di solito» e' al picco;
+ *    contando il tempo che ha passato a ciascun valore, di solito e' a zero —
+ *    che e' la verita'. Ogni lettura pesa quanto e' durata.
+ *
+ * 2. Si usa la mediana, non la media. Un fotovoltaico che per due secondi
+ *    legge 60000 W per un difetto dell'inverter sposta la media di un'ora
+ *    intera; la mediana non la sposta. In casa i valori sballati non sono
+ *    l'eccezione, sono il mercoledi'.
+ *
+ * 3. Una tendenza si annuncia solo se c'e'. La retta che meglio segue i punti
+ *    si puo' tracciare sempre, anche su una nuvola di rumore: quanto quella
+ *    retta spieghi davvero i punti lo dice la sua bonta', e sotto una certa
+ *    bonta' qui si risponde «ferma» invece di inventare una salita.
+ *
+ * Dove si usa. Le letture delle sezioni in `analisi-sezione.js`, per adesso.
+ * Ma non sa niente di sezioni, di finestre e di documento: prende numeri e
+ * restituisce numeri. Va bene per una soglia di avviso, per una previsione
+ * nella pagina di una sezione, per decidere se una scheda debba colorarsi.
+ */
+
+/* ── attrezzi ──────────────────────────────────────────────────────────── */
+
+const ORA = 3600_000;
+
+const numero = (valore) => {
+  const n = Number(valore);
+  return Number.isFinite(n) ? n : null;
+};
+
+/* Quanti punti servono prima di dire qualcosa. Sotto questi non si e' prudenti:
+ * si e' zitti. Tre letture in un'ora non sono una tendenza, sono tre letture. */
+const PUNTI_MINIMI = 5;
+const ARCO_MINIMO = 10 * 60_000;
+
+/* La retta si annuncia solo se spiega almeno questa parte dei punti. Sotto,
+ * quello che si vede e' rumore con una retta disegnata sopra. */
+const BONTA_MINIMA = 0.35;
+
+/* ── la serie ──────────────────────────────────────────────────────────── */
+
+/**
+ * Mette in ordine una serie di letture e butta quello che non e' un numero.
+ *
+ * Accetta `{quando, valore}`, `{when, value}` e `{t, v}`: le tre forme che
+ * girano gia' nel progetto, cosi' chi ha una serie non deve rimodellarla per
+ * darla qui.
+ */
+export function serie(punti) {
+  /* La chiamano tutte le funzioni di qui, sempre, anche quando la serie sembra
+   * gia' a posto. Il primo tentativo aveva una scorciatoia — «se il primo punto
+   * ha gia' la forma giusta, salta» — e su una serie in ordine inverso le
+   * durate venivano negative e il solito spariva. Una funzione che ordina non
+   * puo' dare per scontato l'ordine. */
+  if (!Array.isArray(punti)) return [];
+  const puliti = [];
+  for (const punto of punti) {
+    const quando = numero(punto?.quando ?? punto?.when ?? punto?.t ?? punto?.[0]);
+    const valore = numero(punto?.valore ?? punto?.value ?? punto?.v ?? punto?.[1]);
+    if (quando == null || valore == null) continue;
+    puliti.push({ quando, valore });
+  }
+  puliti.sort((a, b) => a.quando - b.quando);
+  return puliti;
+}
+
+/** L'arco di tempo coperto, in millisecondi. */
+export function arco(letture) {
+  if (letture.length < 2) return 0;
+  return letture[letture.length - 1].quando - letture[0].quando;
+}
+
+const abbastanza = (letture) => letture.length >= PUNTI_MINIMI && arco(letture) >= ARCO_MINIMO;
+
+/* ── da che parte sta andando ──────────────────────────────────────────── */
+
+/**
+ * La retta che meglio segue i punti.
+ *
+ * Torna la pendenza in unita' all'ora, il verso a parole, e la bonta' — quanto
+ * quella retta spieghi davvero i punti, da 0 a 1. Il verso e' «ferma» quando la
+ * bonta' non basta: una retta la si puo' tracciare anche sul rumore, e
+ * annunciare una salita che non c'e' e' peggio che tacere.
+ *
+ * Torna `null` quando i punti sono troppo pochi o troppo ravvicinati.
+ */
+export function tendenza(punti) {
+  const letture = serie(punti);
+  if (!abbastanza(letture)) return null;
+
+  const inizio = letture[0].quando;
+  const ore = letture.map((l) => (l.quando - inizio) / ORA);
+  const valori = letture.map((l) => l.valore);
+  const n = letture.length;
+  const mediaOre = ore.reduce((s, v) => s + v, 0) / n;
+  const mediaValori = valori.reduce((s, v) => s + v, 0) / n;
+
+  let sopra = 0;
+  let sotto = 0;
+  for (let i = 0; i < n; i += 1) {
+    sopra += (ore[i] - mediaOre) * (valori[i] - mediaValori);
+    sotto += (ore[i] - mediaOre) ** 2;
+  }
+  if (sotto === 0) return null;
+  const pendenza = sopra / sotto;
+  const quota = mediaValori - pendenza * mediaOre;
+
+  let residui = 0;
+  let totale = 0;
+  for (let i = 0; i < n; i += 1) {
+    residui += (valori[i] - (quota + pendenza * ore[i])) ** 2;
+    totale += (valori[i] - mediaValori) ** 2;
+  }
+  const bonta = totale === 0 ? 0 : Math.max(0, 1 - residui / totale);
+  const seguita = bonta >= BONTA_MINIMA;
+
+  return {
+    perOra: pendenza,
+    quota,
+    bonta,
+    verso: !seguita ? "ferma" : pendenza > 0 ? "sale" : pendenza < 0 ? "scende" : "ferma",
+    primo: letture[0],
+    ultimo: letture[n - 1],
+  };
+}
+
+/**
+ * Quando la tendenza incontrera' un valore.
+ *
+ * Torna il momento in millisecondi, oppure `null` — e i «null» qui sono la
+ * parte importante: si tace quando la tendenza non c'e', quando va dalla parte
+ * sbagliata, e quando il momento cade oltre l'orizzonte. Dire «la batteria
+ * sara' piena fra ventisei ore» e' un modo raffinato di non dire niente: da
+ * qui a ventisei ore succede tutt'altro.
+ */
+export function quandoTocca(punti, bersaglio, { adesso = Date.now(), orizzonteOre = 12 } = {}) {
+  const meta = numero(bersaglio);
+  const linea = tendenza(punti);
+  if (meta == null || !linea || linea.verso === "ferma") return null;
+  const ultimo = linea.ultimo.valore;
+  const distanza = meta - ultimo;
+  if (distanza === 0) return adesso;
+  /* La pendenza deve puntare verso il bersaglio, non allontanarsene. */
+  if (Math.sign(distanza) !== Math.sign(linea.perOra)) return null;
+  const ore = distanza / linea.perOra;
+  if (!Number.isFinite(ore) || ore <= 0 || ore > orizzonteOre) return null;
+  return adesso + ore * ORA;
+}
+
+/* ── il valore abituale ────────────────────────────────────────────────── */
+
+/**
+ * Il solito: la mediana pesata sul tempo, e di quanto ci si allontana.
+ *
+ * «Pesata sul tempo» e' la scelta che conta. Ogni lettura vale quanto e'
+ * durata, cioe' fino alla lettura dopo: un sensore fermo a zero per sei ore e
+ * poi con tre picchi in un minuto ha come solito lo zero, non il picco. Senza
+ * questo peso, «di solito» diventa «di solito quando cambia», che di una casa
+ * non dice niente.
+ *
+ * Lo scarto e' quello assoluto mediano — la mediana di quanto le letture
+ * distano dalla mediana. Non e' la deviazione standard, ed e' apposta: un solo
+ * valore sballato gonfia la deviazione standard e con lei la soglia di
+ * «insolito», che e' il modo in cui una guardia smette di suonare.
+ */
+export function ilSolito(punti) {
+  const letture = serie(punti);
+  if (letture.length < 2) return null;
+
+  const pesate = [];
+  for (let i = 0; i < letture.length - 1; i += 1) {
+    const durata = letture[i + 1].quando - letture[i].quando;
+    if (durata > 0) pesate.push({ valore: letture[i].valore, peso: durata });
+  }
+  if (!pesate.length) return null;
+
+  const centro = medianaPesata(pesate);
+  const distanze = pesate.map((p) => ({ valore: Math.abs(p.valore - centro), peso: p.peso }));
+  const scarto = medianaPesata(distanze);
+  const valori = letture.map((l) => l.valore);
+  return {
+    centro,
+    scarto,
+    minimo: Math.min(...valori),
+    massimo: Math.max(...valori),
+    arco: arco(letture),
+  };
+}
+
+function medianaPesata(pesate) {
+  const ordinate = [...pesate].sort((a, b) => a.valore - b.valore);
+  const totale = ordinate.reduce((s, p) => s + p.peso, 0);
+  let corso = 0;
+  for (const punto of ordinate) {
+    corso += punto.peso;
+    if (corso >= totale / 2) return punto.valore;
+  }
+  return ordinate[ordinate.length - 1].valore;
+}
+
+/**
+ * Il solito a quest'ora del giorno.
+ *
+ * Una casa non e' uguale a se stessa alle tre di notte e alle otto di sera: il
+ * consumo abituale delle otto e' fuori norma alle tre. Si guardano quindi le
+ * letture cadute nella stessa fascia oraria, e si pretendono almeno due giorni
+ * distinti — con un giorno solo non e' un'abitudine, e' quello che e'
+ * successo ieri.
+ */
+export function ilSolitoAQuestOra(punti, { adesso = Date.now(), larghezzaOre = 1 } = {}) {
+  const letture = serie(punti);
+  if (letture.length < PUNTI_MINIMI) return null;
+  const oraDi = (istante) => new Date(istante).getHours();
+  const bersaglio = oraDi(adesso);
+  const vicine = letture.filter((l) => {
+    const distanza = Math.abs(oraDi(l.quando) - bersaglio);
+    return Math.min(distanza, 24 - distanza) <= larghezzaOre;
+  });
+  if (vicine.length < PUNTI_MINIMI) return null;
+  const giorni = new Set(vicine.map((l) => new Date(l.quando).toDateString()));
+  if (giorni.size < 2) return null;
+  const solito = ilSolito(vicine);
+  return solito ? { ...solito, giorni: giorni.size, ora: bersaglio } : null;
+}
+
+/**
+ * Quanto e' insolito un valore: di quanti scarti si allontana dal solito.
+ *
+ * Zero vuol dire «e' il solito». Sopra tre, e' una cosa che quel sensore non
+ * fa quasi mai. Con lo scarto a zero — un valore che non si e' mai mosso — un
+ * qualunque scostamento e' infinitamente insolito, e allora si risponde con
+ * una misura del cambiamento invece che con una divisione per zero.
+ */
+export function quantoInsolito(valore, solito) {
+  const v = numero(valore);
+  if (v == null || !solito) return null;
+  const distanza = Math.abs(v - solito.centro);
+  if (solito.scarto > 0) return distanza / solito.scarto;
+  if (distanza === 0) return 0;
+  const scala = Math.abs(solito.centro) || 1;
+  return (distanza / scala) * 10;
+}
+
+/* ── chi pesa di piu' ──────────────────────────────────────────────────── */
+
+/**
+ * La voce che pesa di piu' in un insieme, e quanto pesa.
+ *
+ * Serve alla domanda che ci si fa davanti a un totale: «e chi lo sta
+ * consumando?». Torna la voce, la sua quota sul totale e se domina davvero —
+ * cioe' se vale la pena nominarla invece di elencarle tutte.
+ */
+export function chiPesaDiPiu(voci, quanto = (voce) => voce?.valore) {
+  if (!Array.isArray(voci) || !voci.length) return null;
+  const pesate = voci
+    .map((voce) => ({ voce, peso: numero(quanto(voce)) ?? 0 }))
+    .filter((v) => v.peso > 0)
+    .sort((a, b) => b.peso - a.peso);
+  if (!pesate.length) return null;
+  const totale = pesate.reduce((s, v) => s + v.peso, 0);
+  const primo = pesate[0];
+  const quota = totale > 0 ? primo.peso / totale : 0;
+  return {
+    voce: primo.voce,
+    peso: primo.peso,
+    quota,
+    totale,
+    quante: pesate.length,
+    /* «Domina» vuol dire: da sola vale piu' di tutte le altre messe insieme.
+     * E' la soglia oltre la quale nominare quella e basta racconta la cosa
+     * meglio di un elenco. */
+    domina: quota > 0.5 && pesate.length > 1,
+  };
+}
+
+/* ── la lettura completa ───────────────────────────────────────────────── */
+
+/**
+ * Tutto quello che il modello sa dire di una serie, in un colpo solo.
+ *
+ * E' la porta comoda: chi ha una serie e un valore di adesso chiede qui e si
+ * prende quello che gli serve. Ogni campo puo' essere `null`, e un `null` va
+ * letto come «di questo non so dire niente» — non come zero. Chi disegna deve
+ * poter distinguere «la batteria e' ferma» da «non so se la batteria si
+ * muove», perche' sono due frasi diverse.
+ */
+export function letturaNelTempo(punti, { adesso = Date.now(), bersaglio = null } = {}) {
+  const letture = serie(punti);
+  if (!letture.length) return null;
+  const adessoValore = letture[letture.length - 1].valore;
+  const solito = ilSolito(letture);
+  const abituale = ilSolitoAQuestOra(letture, { adesso });
+  const riferimento = abituale || solito;
+  return {
+    valore: adessoValore,
+    punti: letture.length,
+    arco: arco(letture),
+    tendenza: tendenza(letture),
+    solito,
+    abituale,
+    insolito: riferimento ? quantoInsolito(adessoValore, riferimento) : null,
+    arrivo: bersaglio == null ? null : quandoTocca(letture, bersaglio, { adesso }),
+  };
+}
+
+/* Le soglie con cui si legge `insolito`, dichiarate una volta sola perche' chi
+ * ne scrive una frase e chi ne colora una scheda usino le stesse. */
+export const SOGLIE_INSOLITO = Object.freeze({ notevole: 2, forte: 3.5 });

--- a/custom_components/dashboardmodern/frontend/src/core/racconto-tessera.js
+++ b/custom_components/dashboardmodern/frontend/src/core/racconto-tessera.js
@@ -42,6 +42,17 @@ const PAROLE_VERDETTO = Object.freeze({
   guarda: ["Da guardare", "Needs a look"],
 });
 
+/* La parola che accompagna un tono.
+ *
+ * Serve a chi il tono lo decide altrove: il motore di analisi puo' dire «da
+ * guardare» per una piscina col pH fuori norma, dove il conteggio delle righe
+ * direbbe «tutto regolare» perche' non c'e' niente di acceso. La pillola
+ * dev'essere quella del tono vero, non quella del conteggio. */
+export function parolaDelVerdetto(tono, traduci = IN_ITALIANO) {
+  const parole = PAROLE_VERDETTO[tono] || PAROLE_VERDETTO.bene;
+  return traduci(parole[0], parole[1]);
+}
+
 /* Il verdetto di una tessera.
  *
  * L'ordine conta: se c'e' qualcosa da guardare lo si dice, anche se nel

--- a/custom_components/dashboardmodern/frontend/src/i18n/ar.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ar.js
@@ -1811,4 +1811,5 @@ export default Object.freeze({
   "The readings": "القياسات",
   "The state": "الحالة",
   "Controls": "أدوات التحكم",
+  "Readings": "القراءات",
 });

--- a/custom_components/dashboardmodern/frontend/src/i18n/de.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/de.js
@@ -1811,4 +1811,5 @@ export default Object.freeze({
   "The readings": "Die Messwerte",
   "The state": "Der Zustand",
   "Controls": "Steuerung",
+  "Readings": "Messwerte",
 });

--- a/custom_components/dashboardmodern/frontend/src/i18n/es.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/es.js
@@ -1811,4 +1811,5 @@ export default Object.freeze({
   "The readings": "Las medidas",
   "The state": "El estado",
   "Controls": "Controles",
+  "Readings": "Lecturas",
 });

--- a/custom_components/dashboardmodern/frontend/src/i18n/fr.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/fr.js
@@ -1811,4 +1811,5 @@ export default Object.freeze({
   "The readings": "Les mesures",
   "The state": "L'état",
   "Controls": "Commandes",
+  "Readings": "Relevés",
 });

--- a/custom_components/dashboardmodern/frontend/src/i18n/hi.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/hi.js
@@ -1811,4 +1811,5 @@ export default Object.freeze({
   "The readings": "माप",
   "The state": "स्थिति",
   "Controls": "नियंत्रण",
+  "Readings": "रीडिंग",
 });

--- a/custom_components/dashboardmodern/frontend/src/i18n/ja.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ja.js
@@ -1811,4 +1811,5 @@ export default Object.freeze({
   "The readings": "計測値",
   "The state": "状態",
   "Controls": "操作",
+  "Readings": "計測値",
 });

--- a/custom_components/dashboardmodern/frontend/src/i18n/ko.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ko.js
@@ -1811,4 +1811,5 @@ export default Object.freeze({
   "The readings": "측정값",
   "The state": "상태",
   "Controls": "제어",
+  "Readings": "측정값",
 });

--- a/custom_components/dashboardmodern/frontend/src/i18n/nl.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/nl.js
@@ -1811,4 +1811,5 @@ export default Object.freeze({
   "The readings": "De metingen",
   "The state": "De staat",
   "Controls": "Bediening",
+  "Readings": "Metingen",
 });

--- a/custom_components/dashboardmodern/frontend/src/i18n/pl.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/pl.js
@@ -1811,4 +1811,5 @@ export default Object.freeze({
   "The readings": "Pomiary",
   "The state": "Stan",
   "Controls": "Sterowanie",
+  "Readings": "Odczyty",
 });

--- a/custom_components/dashboardmodern/frontend/src/i18n/pt.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/pt.js
@@ -1811,4 +1811,5 @@ export default Object.freeze({
   "The readings": "As medições",
   "The state": "O estado",
   "Controls": "Comandos",
+  "Readings": "Leituras",
 });

--- a/custom_components/dashboardmodern/frontend/src/i18n/ru.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ru.js
@@ -1811,4 +1811,5 @@ export default Object.freeze({
   "The readings": "Показания",
   "The state": "Состояние",
   "Controls": "Управление",
+  "Readings": "Показания",
 });

--- a/custom_components/dashboardmodern/frontend/src/i18n/source-index.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/source-index.js
@@ -999,6 +999,7 @@ export const SOURCE_INDEX = Object.freeze({
   "Leggo aree ed entità da Home Assistant…": "Reading areas and entities from Home Assistant…",
   "Leggo…": "Reading…",
   "Letto da Home Assistant. Una luce dietro uno switch accende e spegne soltanto; luminosità e colore compaiono nel popup solo se l'entità li dichiara.": "Read from Home Assistant. A light behind a switch only turns on and off; brightness and colour appear in the popup only when the entity declares them.",
+  "Letture": "Readings",
   "limite 75°": "75° limit",
   "Limite di sicurezza": "Safety limit",
   "Lingua / variante": "Language / variant",

--- a/custom_components/dashboardmodern/frontend/src/i18n/tr.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/tr.js
@@ -1811,4 +1811,5 @@ export default Object.freeze({
   "The readings": "Ölçümler",
   "The state": "Durum",
   "Controls": "Kontroller",
+  "Readings": "Ölçümler",
 });

--- a/custom_components/dashboardmodern/frontend/src/i18n/zh-Hans.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/zh-Hans.js
@@ -1811,4 +1811,5 @@ export default Object.freeze({
   "The readings": "读数",
   "The state": "状态",
   "Controls": "控制",
+  "Readings": "读数",
 });

--- a/custom_components/dashboardmodern/frontend/src/sections/appliance-showcase-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/appliance-showcase-section.js
@@ -41,6 +41,8 @@ import {
   installStyle,
   readJson,
   root,
+  scriviSeCambia,
+  scriviTestoSeCambia,
   section,
   t,
 } from "./shared.js";
@@ -640,7 +642,7 @@ function renderSidebar(shell, models, counts, rooms, labels) {
   }
   const statesHost = shell.querySelector("[data-dm-states]");
   if (statesHost) {
-    statesHost.innerHTML = [
+    scriviSeCambia(statesHost, [
       sideItem({
         key: "running",
         kind: "state",
@@ -673,7 +675,7 @@ function renderSidebar(shell, models, counts, rooms, labels) {
         count: counts.alarm,
         active: state.ui.filter === "alarm",
       }),
-    ].join("");
+    ].join(""));
   }
   const overview = shell.querySelector("[data-dm-side-overview]");
   if (overview)
@@ -684,11 +686,11 @@ function renderSidebar(shell, models, counts, rooms, labels) {
   const watts = shell.querySelector("[data-dm-total-watts]");
   if (watts) {
     const label = formatPowerLabel(counts.watts);
-    if (watts.textContent !== label) watts.textContent = label;
+    scriviTestoSeCambia(watts, label);
   }
   const active = shell.querySelector("[data-dm-total-running]");
   if (active && active.textContent !== String(counts.running))
-    active.textContent = String(counts.running);
+    scriviTestoSeCambia(active, String(counts.running));
   const spark = shell.querySelector("[data-dm-spark]");
   if (spark) {
     const { line, area } = filoDaZero(state.spark, 100, 28);

--- a/custom_components/dashboardmodern/frontend/src/sections/beta16-real-device-layout-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta16-real-device-layout-section.js
@@ -324,24 +324,8 @@ function installStyles() {
       #page-clima .clima-page-mode-switch[data-dm-beta12-climate="true"]{width:calc(100% - 12px)!important;margin:8px auto 14px!important;padding:4px!important;gap:3px!important;border-radius:20px!important}
       #page-clima .clima-page-mode-switch[data-dm-beta12-climate="true"] .clima-page-mode-btn{min-height:52px!important;padding:7px 6px!important;gap:6px!important;border-radius:16px!important;font-size:13px!important;letter-spacing:.8px!important}
       #page-clima .clima-page-mode-switch[data-dm-beta12-climate="true"] .clima-page-mode-btn .icon{font-size:21px!important}
-
-      #page-clima .clima-premium-grid{grid-template-columns:repeat(2,minmax(0,1fr))!important;gap:8px!important}
       #page-clima .dm-beta16-climate-group-heading{display:none!important}
       #page-clima .dm-beta16-climate-room{display:flex!important;align-items:center!important;min-width:0!important;margin:-2px 0 0!important;padding:3px 6px!important;border-radius:9px!important;background:rgba(14,165,233,.08)!important;color:var(--text-dim,#64748b)!important;font-size:8px!important;font-weight:850!important;line-height:1.15!important;white-space:nowrap!important;overflow:hidden!important;text-overflow:ellipsis!important}
-      #page-clima .cp-card{box-sizing:border-box!important;min-width:0!important;padding:10px 8px!important;border-radius:17px!important;gap:7px!important}
-      #page-clima .cp-header{gap:5px!important;min-width:0!important}
-      #page-clima .cp-title-wrap{gap:5px!important;min-width:0!important}
-      #page-clima .cp-icon{width:29px!important;height:29px!important;min-width:29px!important;border-radius:9px!important;font-size:15px!important}
-      #page-clima .cp-name{min-width:0!important;max-width:100%!important;font-size:12px!important;line-height:1.1!important;white-space:nowrap!important;overflow:hidden!important;text-overflow:ellipsis!important}
-      #page-clima .cp-badge{padding:3px 6px!important;font-size:8px!important;white-space:nowrap!important}
-      #page-clima .cp-body{gap:6px!important;min-width:0!important}
-      #page-clima .cp-temp-target .lbl,#page-clima .cp-temp-current-lbl{font-size:7px!important;letter-spacing:.4px!important}
-      #page-clima .cp-temp-target .val{font-size:28px!important;line-height:1!important}
-      #page-clima .cp-temp-current{font-size:16px!important;line-height:1!important}
-      #page-clima .cp-controls{min-height:42px!important;padding:3px!important;border-radius:13px!important}
-      #page-clima .cp-btn{min-width:0!important;min-height:36px!important;font-size:22px!important}
-      #page-clima .cp-pwr{min-width:0!important;font-size:18px!important}
-      #page-clima .clima-section-title{margin:14px 0 8px 3px!important;font-size:11px!important;line-height:1.2!important}
 
       #page-temp .dm-temperature-room-tabs{padding-left:8px!important;padding-right:8px!important;margin-top:6px!important}
       #page-temp .dm-temperature-room-tabs>button{min-height:38px!important;padding:7px 10px!important;font-size:11px!important;border-radius:13px!important}
@@ -349,11 +333,7 @@ function installStyles() {
     }
 
     @media(max-width:360px){
-      #page-clima .clima-premium-grid{grid-template-columns:repeat(2,minmax(0,1fr))!important;gap:6px!important}
-      #page-clima .cp-card{padding:9px 7px!important;border-radius:15px!important}
-      #page-clima .cp-name{font-size:11px!important}
       #page-clima .dm-beta16-climate-room{font-size:7.5px!important;padding:3px 5px!important}
-      #page-clima .cp-temp-target .val{font-size:25px!important}
     }
   `);
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/beta22-load-slots-hotfix-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta22-load-slots-hotfix-section.js
@@ -287,32 +287,6 @@ function syncCanonicalLoadBubbles() {
   return true;
 }
 
-function syncBatterySoc() {
-  if (!doc) return false;
-  const energy = readSection("energy", {});
-  const entity = socEntity(energy);
-  const battery = doc.querySelector("#view-ist #n-battery,#n-battery");
-  if (!battery) return false;
-  let node = battery.querySelector("#v-battery-soc,.dm-battery-soc");
-  if (!node) {
-    node = doc.createElement("small");
-    node.id = "v-battery-soc";
-    node.className = "dm-battery-soc";
-    battery.append(node);
-  }
-  if (!entity) {
-    node.hidden = true;
-    node.textContent = "";
-    node.removeAttribute("data-entity");
-    return true;
-  }
-  const value = stateNumber(entity);
-  node.hidden = false;
-  node.dataset.entity = entity;
-  node.textContent = value === null ? "SOC —" : `SOC ${Math.round(value)}%`;
-  return true;
-}
-
 function canonicalRoomName(row) {
   const id = clean(row?.dataset?.roomId);
   const rooms = readSection("rooms", []);
@@ -411,10 +385,14 @@ function schedaAperta() {
   return Boolean(doc?.getElementById?.("editor-modal") || doc?.getElementById?.("ed-body"));
 }
 
+/* Lo stato di carica della batteria non si scrive piu' da qui: il padrone e'
+ * `energy-flow-section`, che disegna la bolla. Qui ne restava una seconda
+ * copia con un formato suo, e le due si riscrivevano addosso a ogni cambio di
+ * stato — lo sfarfallio della sezione Energia. Il ripiego «se la casella non
+ * c'e' la creo» e' passato di la' insieme al resto. */
 function applyAll() {
   flowState.frame = 0;
   syncCanonicalLoadBubbles();
-  syncBatterySoc();
   if (!schedaAperta()) return;
   repairTemperatureRows();
   repairEnergyCostEditor();

--- a/custom_components/dashboardmodern/frontend/src/sections/beta24-energy-recovery-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta24-energy-recovery-section.js
@@ -16,7 +16,6 @@ import { ENERGY_SLOT_MAP } from "../core/energy-projection.js";
 const root = globalThis;
 const doc = root.document;
 const PATCH_MARKER = "__DASHBOARDMODERN_BETA24_STORE_RECOVERY__";
-const SOC_MARKER = "dmBeta24SocOwner";
 const PERSIST_META_KEY = "dm_persistence_meta";
 
 const clean = (value) => String(value ?? "").trim();
@@ -289,39 +288,22 @@ export function installBeta24StoreRecovery() {
   return true;
 }
 
+/* La forma canonica del testo del SOC: «SOC 75%».
+ *
+ * Qui c'era anche un MutationObserver che sorvegliava il nodo e ci rimetteva
+ * questo prefisso ogni volta che qualcun altro lo toglieva. Sorvegliare un
+ * nodo per disfare quello che ci scrive un altro modulo non e' una
+ * correzione: e' il secondo padrone che litiga col primo, e nel video si
+ * vedeva il numero cambiare faccia avanti e indietro. Adesso il testo lo
+ * scrive giusto chi lo possiede — `energy-flow-section` — e non c'e' piu'
+ * niente da normalizzare a posteriori. La funzione resta perche' dice qual e'
+ * la forma giusta, e una prova la usa per pretenderla. */
 export function normalizeBatterySocText(value) {
   const text = clean(value);
   if (!text) return text;
   if (/^soc\b/i.test(text)) return `SOC ${text.replace(/^soc\s*/i, "")}`.trim();
   if (/^(?:\d+(?:[.,]\d+)?%|—)$/.test(text)) return `SOC ${text}`;
   return text;
-}
-
-function normalizeBatterySocNode(node) {
-  if (!node || node.hidden) return false;
-  const normalized = normalizeBatterySocText(node.textContent);
-  if (!normalized || normalized === clean(node.textContent)) return false;
-  node.textContent = normalized;
-  return true;
-}
-
-function bindBatterySocOwner() {
-  const node = doc?.querySelector?.("#view-ist #v-battery-soc,#v-battery-soc");
-  if (!node) return false;
-  normalizeBatterySocNode(node);
-  if (node.dataset?.[SOC_MARKER] === "true") return true;
-  if (node.dataset) node.dataset[SOC_MARKER] = "true";
-  if (typeof root.MutationObserver === "function") {
-    const observer = new root.MutationObserver(() => normalizeBatterySocNode(node));
-    observer.observe(node, { childList: true, characterData: true, subtree: true });
-  }
-  return true;
-}
-
-function scheduleSocOwner() {
-  root.requestAnimationFrame?.(bindBatterySocOwner);
-  root.setTimeout?.(bindBatterySocOwner, 0);
-  root.setTimeout?.(bindBatterySocOwner, 120);
 }
 
 function requestInitialRemoteReconcile() {
@@ -336,17 +318,6 @@ function requestInitialRemoteReconcile() {
 function installRuntimeRecovery() {
   installBeta24StoreRecovery();
   requestInitialRemoteReconcile();
-  for (const name of [
-    "dashboardmodern:legacy-ready",
-    "dashboardmodern:runtime-ready",
-    "dashboardmodern:states-ready",
-    "dashboardmodern:energy-stable",
-    "dashboardmodern:period-bundle",
-  ])
-    root.addEventListener?.(name, scheduleSocOwner);
-  if (doc?.readyState === "loading")
-    doc.addEventListener("DOMContentLoaded", scheduleSocOwner, { once: true });
-  else scheduleSocOwner();
 }
 
 installRuntimeRecovery();

--- a/custom_components/dashboardmodern/frontend/src/sections/beta4-mobile-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta4-mobile-polish-section.js
@@ -662,7 +662,12 @@ function installStyles() {
      * sull'elemento. Adesso il colore lo porta il marchio (Tesla rosso, BMW
      * blu, Renault giallo) e per le case il cui marchio e' nero decide il tema.
      * Qui restano la forma e il fondo, che erano l'altra meta' del lavoro. */
-    .dm-car-brand{display:grid!important;place-items:center!important;background:transparent!important}
+    /* Il «display» lo dichiara personalization-section, che il marchio lo
+       disegna: qui c'era un «grid!important» che vinceva sul suo «inline-grid»,
+       quindi la riga del padrone non si e' mai vista. Adesso il padrone dice
+       «grid» — cioe' quello che si vedeva davvero — e qui resta soltanto lo
+       sfondo, che e' la cosa per cui questo foglio esiste. */
+    .dm-car-brand{place-items:center!important;background:transparent!important}
     .dm-beta5-brand-logo{display:grid!important;place-items:center!important;width:82px!important;height:54px!important;color:currentColor!important}
     .dm-beta5-brand-logo svg{display:block!important;width:78px!important;height:50px!important;max-width:100%!important;overflow:visible!important}
     /* Il riquadro del marchio e la sua pastiglia li misura beta9: le tre

--- a/custom_components/dashboardmodern/frontend/src/sections/beta7-regression-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta7-regression-section.js
@@ -243,20 +243,16 @@ function installStyles() {
     #editor-modal .dm-beta7-action-form-row #ed-qa-icon{display:none!important}
     #editor-modal .dm-beta7-action-form-row .dm-beta6-qa-icon-trigger{grid-area:icon!important;display:grid!important;place-items:center!important;width:64px!important;min-width:64px!important;max-width:64px!important;height:54px!important;min-height:54px!important;margin:0!important;padding:8px!important;border-radius:16px!important;background:var(--card-background-color,var(--card-bg,#fff))!important;border:1px solid var(--divider-color,var(--card-border,#dbe4ee))!important;color:var(--accent,#0ea5e9)!important;overflow:hidden!important}
 
-    /* Clima: su telefono due card compatte per riga, senza aspect-ratio quadrato
-       che dilata target, temperatura ambiente e barra comandi. */
-    #page-clima .clima-premium-grid{grid-template-columns:repeat(2,minmax(0,1fr))!important;gap:14px!important}
-    #page-clima .cp-card{aspect-ratio:auto!important;min-height:248px!important;height:auto!important;padding:18px!important;gap:14px!important;border-radius:22px!important;justify-content:space-between!important}
-    #page-clima .cp-header{gap:10px!important}
-    #page-clima .cp-title-wrap{min-width:0!important;gap:10px!important}
-    #page-clima .cp-name{min-width:0!important;overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important;font-size:15px!important}
-    #page-clima .cp-badge{flex:0 0 auto!important}
-    #page-clima .cp-body{display:grid!important;grid-template-columns:minmax(0,1fr) auto!important;align-items:end!important;gap:16px!important;padding:2px 2px 4px!important}
-    #page-clima .cp-temp-target .val{font-size:46px!important;line-height:.95!important}
-    #page-clima .cp-temp-current-wrap{align-items:flex-end!important;text-align:right!important}
-    #page-clima .cp-temp-current{font-size:23px!important;line-height:1!important}
-    #page-clima .cp-controls{min-height:58px!important;padding:6px!important;border-radius:17px!important}
-    #page-clima .cp-btn{height:46px!important;font-size:20px!important}
+    /* La scheda del Clima non si skinna piu' da qui, e non da nessun rattoppo.
+       Ne restavano due copie, in questo foglio e in beta16, che si
+       contendevano quattordici decisioni con valori diversi: la card alta
+       248px o senza minimo, il numero grande 46px o 28px, i bordi 22px o
+       17px. Vinceva chi caricava per ultimo, quindi la misura vera non era
+       scritta da nessuna parte. Solo che quella card non la disegna piu'
+       nessuno: la pagina Clima e' tutta di climate-thermal-section — contati
+       a plancia aperta, con e senza i dati vecchi del guscio, i nodi «cp-*»
+       sono zero. Se un giorno quel markup tornera', le sue misure le scrivera'
+       chi lo disegna, in un posto solo. */
 
     /* La Tapparella non è più skinnata qui.
        Quella pelle risale a Beta 7 e disegnava una finestra alta 180px con il
@@ -275,12 +271,10 @@ function installStyles() {
          un numero da 43 pixel che non si e' mai visto — ne vincevano 28.
          L'unica cosa che era davvero di qui e' che la scheda non ha un'altezza
          minima sul telefono: quella resta. */
-      #page-clima .cp-card{min-height:0!important}
       #editor-modal .ed-row.dm-beta7-action-row{grid-template-columns:44px minmax(0,1fr) 40px 40px!important;gap:7px!important;padding:9px!important}
     }
 
     @media(hover:none){
-      #page-clima .cp-card:hover{transform:none!important}
     }
   `);
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/connection-recovery-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/connection-recovery-section.js
@@ -19,7 +19,14 @@
  * della rete, e intanto a intervalli che si allargano. Da connessi non resta
  * acceso niente.
  */
-import { doc, english, lexicalGlobal, root, t } from "./shared.js";
+import {
+  doc,
+  english,
+  lexicalGlobal,
+  root,
+  scriviTestoSeCambia,
+  t,
+} from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_CONNECTION_RECOVERY__";
 const state = (root[KEY] ||= { installed: false, listeners: false, timer: 0, attempts: 0, lastTry: 0 });
@@ -81,7 +88,7 @@ function announceRetry() {
   const label = doc?.getElementById("conn-text");
   if (!label || connectionUp()) return false;
   const text = t("Riconnessione…", "Reconnecting…");
-  if (label.textContent !== text) label.textContent = text;
+  scriviTestoSeCambia(label, text);
   return true;
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-crud-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-crud-section.js
@@ -574,7 +574,9 @@ function installStyles() {
          vedeva sballato. Qui resta solo cio' che non e' impaginazione. */
       #editor-modal [data-energy-panel="report"] .dm-report-row .dm-entity-field{min-width:0!important;margin:0!important}
       #editor-modal .dm-report-history-help{grid-column:1/-1;color:var(--secondary-text-color,#64748b);font-size:11px;line-height:1.4}
-      #editor-modal .dm-report-row[data-history-valid="false"] .dm-report-history-help{color:var(--warning-color,#b45309);font-weight:800}
+      /* Il grassetto dell'avviso lo decide report-editor-section, che disegna
+         quella riga: qui c'era un 800 che perdeva sempre contro il suo 850. */
+      #editor-modal .dm-report-row[data-history-valid="false"] .dm-report-history-help{color:var(--warning-color,#b45309)}
       #editor-modal .dm-edit-existing{background:color-mix(in srgb,var(--info-color,#0ea5e9) 14%,transparent)!important;color:var(--info-color,#0369a1)!important}
       #editor-modal .dm-edit-cancel{width:100%;margin-top:7px;background:var(--secondary-background-color,#e8eef5)!important;color:var(--text,#0f172a)!important}
       #editor-modal [data-dm-editing="true"]{outline:2px solid color-mix(in srgb,var(--info-color,#0ea5e9) 45%,transparent);outline-offset:2px}

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-flow-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-flow-section.js
@@ -16,6 +16,7 @@ import {
   locale,
   readJson,
   root,
+  scriviTestoSeCambia,
   section,
   wrapFunction,
   writeIconGlyph,
@@ -50,21 +51,59 @@ function stateNumber(states, entity) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+/* Lo stato di carica della batteria ha un padrone solo, ed e' questo.
+ *
+ * Ne aveva quattro. Il guscio scriveva `75 %` col suo formattatore; questo
+ * modulo scriveva `75%`; `beta22-load-slots-hotfix` scriveva `SOC 75%`; e
+ * `beta24-energy-recovery` teneva un MutationObserver sul nodo che rimetteva
+ * il prefisso «SOC» addosso a quello che scrivevano gli altri. Quattro mani
+ * sullo stesso numero, con tre forme diverse: quello che si vedeva era il
+ * numero che cambiava faccia a ogni cambio di stato — «▼ 1796 W / SOC 75%» e
+ * poi «-1796 W / 75 %», avanti e indietro. Era lo sfarfallio della sezione
+ * Energia, e non era un difetto di disegno: erano due testi che si
+ * alternavano.
+ *
+ * Adesso scrive solo questo, col prefisso che avevano scelto gli altri due —
+ * «SOC» dice cos'e' quel numero, e senza si legge come una percentuale di
+ * qualcosa che non si sa. Passa dal delegato, che lascia il cartello
+ * `data-dm-padrone`: e' quel cartello che ferma la mano del guscio.
+ */
 export function renderBatterySoc(targetDocument, energy = {}, states = {}) {
-  const node = targetDocument?.getElementById?.("v-battery-soc");
+  const node = nodoDelSoc(targetDocument);
   if (!node) return "—";
   const entity = clean(
     energy?.battery?.soc ||
       energy?.battery?.battery_soc_entity ||
       energy?.battery?.battery_soc,
   );
+  /* Senza entita' configurata la casella non si mostra vuota: si toglie.
+   * Il comportamento arriva da beta22, che qui dentro non c'e' piu'. */
+  if (!entity) {
+    node.hidden = true;
+    scriviTestoSeCambia(node, "");
+    node.removeAttribute("data-entity");
+    return "—";
+  }
   const value = stateNumber(states, entity);
-  const text = entity && value !== null ? `${Math.round(value)}%` : "—";
-  // Only when it changes: this runs on every pass, and rewriting the same
-  // reading is a mutation for every observer and a repaint for nothing.
-  if (node.textContent !== text) node.textContent = text;
+  const text = value === null ? "SOC —" : `SOC ${Math.round(value)}%`;
+  node.hidden = false;
+  scriviTestoSeCambia(node, text);
   if (node.dataset.entity !== entity) node.dataset.entity = entity;
   return text;
+}
+
+/* La casella nasce qui se il guscio non l'ha disegnata: prima la creava
+ * beta22, ed e' l'unica ragione per cui quel modulo toccava questo nodo. */
+function nodoDelSoc(targetDocument) {
+  const gia = targetDocument?.getElementById?.("v-battery-soc");
+  if (gia) return gia;
+  const bolla = targetDocument?.querySelector?.("#view-ist #n-battery,#n-battery");
+  if (!bolla) return null;
+  const nuovo = targetDocument.createElement("small");
+  nuovo.id = "v-battery-soc";
+  nuovo.className = "dm-battery-soc";
+  bolla.append(nuovo);
+  return nuovo;
 }
 
 function parseNumber(node) {
@@ -388,10 +427,10 @@ function ensureBubble(stage, node, period, scale) {
   setStyleProperty(element, "--dm-flow-mobile-left", `${node.mobile.left}%`);
   setStyleProperty(element, "--dm-flow-mobile-top", `${node.mobile.top}%`);
   const label = element.querySelector(".node-label");
-  if (label && label.textContent !== node.name) label.textContent = node.name;
+  scriviTestoSeCambia(label, node.name);
   writeIcon(element.querySelector(".node-icon"), node.icon);
   const value = element.querySelector(".dm-flow-value");
-  if (value && value.textContent !== node.text) value.textContent = node.text;
+  scriviTestoSeCambia(value, node.text);
   element.dataset.dmCanonicalLoad = node.id;
   element.dataset.dmFlowPeriod = period;
   element.dataset.dmFlowActive = node.active ? "true" : "false";
@@ -672,8 +711,7 @@ export function refreshEnergyFlows() {
   const testo = batteryReadout(batteria);
   if (testo) {
     for (const id of ["v-battery", "m-v-battery"]) {
-      const nodo = doc.getElementById(id);
-      if (nodo && nodo.textContent !== testo) nodo.textContent = testo;
+      scriviTestoSeCambia(doc.getElementById(id), testo);
     }
   }
   renderBatterySoc(doc, section("energy", {}), allStates());
@@ -786,7 +824,25 @@ export function installEnergyFlowSection() {
     true,
   );
   bindStore();
+  rivendicaLeBolleDellaBatteria();
   scheduleSettled();
+}
+
+/* Le due caselle della batteria si rivendicano all'installazione, prima che
+ * arrivi il primo stato.
+ *
+ * Il cartello `data-dm-padrone` ferma la mano del guscio, ma solo da quando
+ * c'e'. Chi lo lasciava alla prima passata di disegno arrivava tardi: il
+ * guscio aveva gia' scritto la sua forma — `-1796 W` — e quella si vedeva per
+ * un istante prima che il modulo la coprisse con `▼ 1796 W`. Misurato: due
+ * scritture su quaranta cambi di stato, cioe' un lampo solo all'avvio, ma un
+ * lampo che si vede. Rivendicare subito lo toglie: il guscio quelle caselle
+ * non le scrive mai, nemmeno la prima volta. */
+function rivendicaLeBolleDellaBatteria() {
+  for (const id of ["v-battery", "m-v-battery", "v-battery-soc"]) {
+    const nodo = doc?.getElementById?.(id);
+    if (nodo?.dataset && nodo.dataset.dmPadrone !== "moduli") nodo.dataset.dmPadrone = "moduli";
+  }
 }
 
 if (doc?.readyState === "loading")

--- a/custom_components/dashboardmodern/frontend/src/sections/history-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/history-section.js
@@ -1,4 +1,13 @@
-import { clean, doc, installStyle, locale, root, section, t } from "./shared.js";
+import {
+  clean,
+  doc,
+  installStyle,
+  locale,
+  root,
+  scriviTestoSeCambia,
+  section,
+  t,
+} from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_HISTORY_SECTION__";
 const state = (root[KEY] ||= {
@@ -185,7 +194,7 @@ function paintZoomBadge() {
   const labels = state.chart?.data?.labels || [];
   const range = badge.querySelector("[data-dm-hist-range]");
   const text = `${clean(labels[view.min])} – ${clean(labels[view.max])}`;
-  if (range && range.textContent !== text) range.textContent = text;
+  scriviTestoSeCambia(range, text);
 }
 
 function applyWindow(window) {
@@ -462,7 +471,7 @@ export async function openHistory(event, entityId, name, hours = 24) {
   modal.dataset.dmHistoryEntity = entity;
   delete modal.dataset.dmHistoryError;
   const title = doc.getElementById("hist-title");
-  if (title) title.textContent = state.currentName;
+  scriviTestoSeCambia(title, state.currentName);
   doc.querySelectorAll(".hist-time-btn").forEach((button) =>
     button.classList.toggle("active", Number(button.dataset.hours) === Number(hours)),
   );

--- a/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
@@ -29,8 +29,10 @@ import { oggettoWidget } from "../core/oggetti-widget.js";
 import {
   bricioleDellaSezione,
   fraseDellaTessera,
+  parolaDelVerdetto,
   verdettoDellaTessera,
 } from "../core/racconto-tessera.js";
+import { analisiDellaSezione } from "../core/analisi-sezione.js";
 import {
   coverEntries,
   coverKindLabel,
@@ -2417,13 +2419,31 @@ function corsaMarkup(widget) {
  * quanto, e dove va a finire.» Il verdetto e' la pillola colorata; la frase la
  * scrive il modulo puro, che sa dire «2 zone su 5 accese, manca 1,2°» invece
  * di lasciare undici righe da mettere insieme a mente. */
+/* Il verdetto e la frase, e sotto i punti che la sostengono.
+ *
+ * La frase la scrive il motore di analisi quando la sezione ha una lettura
+ * sua — l'Energia ragiona sul bilancio, la Temperatura sulla distanza fra la
+ * stanza piu' calda e la piu' fredda — e in quel caso il tono lo decide la
+ * lettura, non il conteggio delle righe: una piscina col pH fuori norma e' da
+ * guardare anche se non c'e' niente «acceso».
+ *
+ * Le sette sezioni fatte di cose che si accendono e si spengono continuano ad
+ * avere la loro frase di prima, che li' e' giusta.
+ */
 function verdettoEFrase(widget) {
+  const lettura = analisiDellaSezione(widget, t);
   const verdetto = verdettoDellaTessera(widget, t);
+  const tono = lettura?.tono || verdetto.tono;
+  const parola = tono === verdetto.tono ? verdetto.testo : parolaDelVerdetto(tono, t);
   const misura = clean(widget.value);
   const nota = clean(widget.caption);
-  return `<section class="dm-w-racconto" data-dm-verdetto="${verdetto.tono}">
-      <span class="dm-w-verdetto">${esc(verdetto.testo)}</span>
-      <p class="dm-w-frase">${esc(fraseDellaTessera(widget, t))}</p>
+  const punti = lettura?.punti?.length
+    ? `<ul class="dm-w-punti">${lettura.punti.map((p) => `<li>${esc(p)}</li>`).join("")}</ul>`
+    : "";
+  return `<section class="dm-w-racconto" data-dm-verdetto="${tono}">
+      <span class="dm-w-verdetto">${esc(parola)}</span>
+      <p class="dm-w-frase">${esc(lettura?.frase || fraseDellaTessera(widget, t))}</p>
+      ${punti}
       ${
         misura
           ? `<div class="dm-w-misura"><b>${esc(misura)}</b>${
@@ -3396,6 +3416,18 @@ html[data-theme="dark"] #dm-widget-popup .dm-widget-detail .dm-w-close:hover{col
 #dm-widget-popup .dm-w-frase{
   margin:0;font-size:14.5px;line-height:1.45;font-weight:700;
   color:var(--text,#0f172a);text-wrap:balance}
+/* I punti che sostengono la frase: piccoli, sotto, uno per riga. La frase
+ * dice la cosa; i punti dicono i numeri su cui si regge — «la batteria si
+ * carica a 1,47 kW», «in rete vanno 41 W» — che nella riga grande non ci
+ * starebbero senza farne un paragrafo. */
+#dm-widget-popup .dm-w-punti{
+  margin:2px 0 0;padding:0;list-style:none;display:flex;flex-direction:column;gap:3px}
+#dm-widget-popup .dm-w-punti li{
+  position:relative;padding-inline-start:13px;font-size:12.5px;line-height:1.4;
+  font-weight:650;color:var(--muted,#64748b)}
+#dm-widget-popup .dm-w-punti li::before{
+  content:"";position:absolute;inset-inline-start:2px;top:.62em;
+  width:4px;height:4px;border-radius:50%;background:currentColor;opacity:.55}
 #dm-widget-popup .dm-w-misura{display:flex;align-items:baseline;gap:10px;flex-wrap:wrap}
 #dm-widget-popup .dm-w-misura b{
   font-family:'Oswald',system-ui,sans-serif;font-weight:300;

--- a/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
@@ -631,7 +631,15 @@ function temperatureModel(states) {
     .map((room) => {
       const temperature = numOf(states, room.temp);
       const humidity = numOf(states, clean(room.hum) || clean(room.temp).replace("_temperature", "_humidity"));
-      return { name: clean(room.name) || clean(room.id), temperature, humidity };
+      /* L'entita' resta sulla riga: senza, la finestra non sa a chi chiedere
+       * lo storico, e la Temperatura non poteva mai avere la sua analisi nel
+       * tempo. */
+      return {
+        name: clean(room.name) || clean(room.id),
+        entity: clean(room.temp),
+        temperature,
+        humidity,
+      };
     })
     .filter((row) => row.temperature != null);
   if (!rows.length) return null;
@@ -759,19 +767,28 @@ function rigaDaEntita(states, entity, glifo = "•") {
   if (STATI_MUTI.test(grezzo)) return null;
   const nome = friendlyName(states, chiave);
   const numero = numOf(states, chiave);
+  /* Accanto al testo che si legge, il dato grezzo per chi conta.
+   *
+   * La riga portava solo il valore gia' formattato — «56.2°», «Acceso» — e chi
+   * doveva farci un conto trovava una stringa: `Number("56.2°")` non e' un
+   * numero, e l'analisi delle sonde del solare termico non usciva mai. Il
+   * testo e' per gli occhi, `raw` e `on` per i conti. */
   if (numero != null) {
     const unita = clean(stato?.attributes?.unit_of_measurement);
     const cifre = Number.isInteger(numero) || Math.abs(numero) >= 100 ? 0 : 1;
     return {
       glyph: glifo,
       name: nome,
+      entity: chiave,
+      raw: numero,
+      unit: unita,
       value: `${formatNumber(numero, cifre)}${unita ? ` ${unita}` : ""}`,
     };
   }
   if (STATI_ACCESI.test(grezzo))
-    return { glyph: glifo, name: nome, value: t("Acceso", "On") };
+    return { glyph: glifo, name: nome, entity: chiave, on: true, value: t("Acceso", "On") };
   if (STATI_SPENTI.test(grezzo))
-    return { glyph: glifo, name: nome, value: t("Spento", "Off") };
+    return { glyph: glifo, name: nome, entity: chiave, on: false, value: t("Spento", "Off") };
   return { glyph: glifo, name: nome, value: grezzo };
 }
 
@@ -948,9 +965,17 @@ function robotsModel(states) {
      * puliscono la notizia e' che stanno pulendo. */
     ring: attivi.length ? null : piuScarico,
     attiva: attivi.length > 0,
+    /* Come per l'irrigazione: il testo per gli occhi, i campi grezzi per chi
+     * conta. Senza, un aspirapolvere che sta pulendo veniva annunciato come
+     * fermo, e l'avviso di batteria scarica non poteva mai uscire. */
     rows: viste.map((vista) => ({
       glyph: vista.cleaning ? "🧹" : vista.charging ? "🔌" : "🤖",
       name: vista.name,
+      cleaning: vista.cleaning,
+      charging: vista.charging,
+      state: vista.state,
+      battery: vista.battery,
+      entity: clean(vista.entity),
       value: vista.battery == null
         ? robotStateLabel(vista.state)
         : `${robotStateLabel(vista.state)} · ${Math.round(vista.battery)}%`,
@@ -1145,9 +1170,16 @@ function irrigationModel(states) {
         : t("umidità terreno", "soil moisture"),
     ring: inFunzione.length ? null : umidita,
     attiva: inFunzione.length > 0,
+    /* Accanto al testo che si legge va il dato grezzo, che serve a chi conta.
+     * Le righe portavano solo «in funzione» / «ferma» tradotto, e il motore di
+     * analisi — che cerca un booleano — leggeva tutte le zone come ferme
+     * proprio mentre l'acqua usciva. Il testo e' per gli occhi, `on` per i
+     * conti: due mestieri, due campi. */
     rows: attive.map((zona) => ({
       glyph: "🌱",
       name: clean(zona.name) || clean(zona.entity),
+      on: zonaInFunzione(states, zona),
+      entity: clean(zona.entity),
       value: zonaInFunzione(states, zona)
         ? t("in funzione", "running")
         : t("ferma", "idle"),
@@ -1633,6 +1665,11 @@ function rowShell(inner, attrs = "") {
  * percentuale smette di essere un dato e diventa una cosa da guardare.
  */
 function livelloMarkup(percentuale) {
+  /* `Number(null)` fa zero, e uno zero passa tutti i controlli che seguono:
+   * senza questa riga ogni riga senza percentuale — una temperatura, un pH,
+   * un acceso/spento — si prendeva una barra rossa vuota, cioe' l'avviso di
+   * «quasi scarico» sopra una cosa che una carica non ce l'ha. */
+  if (percentuale == null || percentuale === "") return "";
   const valore = Number(percentuale);
   if (!Number.isFinite(valore) || valore < 0 || valore > 100) return "";
   const quota = Math.round(valore);
@@ -2490,7 +2527,18 @@ function entitaDelRacconto(widget) {
  * rete per aprirsi, su una casa senza Recorder, non si apre. */
 function storiaDelWidget(widget) {
   const entita = entitaDelRacconto(widget);
-  return entita ? puntiDi(entita, 3) : null;
+  if (!entita) return null;
+  /* Il valore di adesso va in coda alla storia: la risposta dello storico vale
+   * nove minuti, e senza questa coda il modello leggerebbe come «adesso» un
+   * valore vecchio fino a nove minuti — arrivando a contraddire il numero
+   * grande della stessa finestra. */
+  const stato = allStates()?.[entita];
+  const vivo = Number(clean(stato?.state));
+  return puntiDi(
+    entita,
+    3,
+    Number.isFinite(vivo) ? { adesso: { quando: Date.now(), valore: vivo } } : {},
+  );
 }
 
 function verdettoEFrase(widget) {

--- a/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
@@ -1158,13 +1158,14 @@ function irrigationModel(states) {
  * un'icona, un nome e un valore. */
 function rowsDetail(widget) {
   return (widget.rows || [])
-    .map((row) =>
-      rowShell(
+    .map((row) => {
+      const livello = livelloMarkup(percentualeDellaRiga(row));
+      return rowShell(
         `<span class="dm-w-glyph" aria-hidden="true">${row.glyph || "•"}</span>
-         <span class="dm-w-name">${esc(row.name)}</span>
+         <span class="dm-w-name">${esc(row.name)}${livello}</span>
          <b class="dm-w-val">${esc(row.value)}</b>`,
-      ),
-    )
+      );
+    })
     .join("");
 }
 
@@ -1618,6 +1619,36 @@ function tileMarkup(widget, index = 0) {
 
 function rowShell(inner, attrs = "") {
   return `<div class="dm-w-row" ${attrs}>${inner}</div>`;
+}
+
+/* Una percentuale si vede prima di leggerla.
+ *
+ * Le righe delle finestre dicevano «12%» e basta: per sapere se era poco o
+ * tanto bisognava leggere il numero e pensarci. Una barra sotto il nome lo
+ * dice a colpo d'occhio, e il numero resta dov'e' — la barra aggiunge, non
+ * sostituisce. Si mette solo dove la percentuale ha un fondo e un pieno che
+ * vogliono dire qualcosa: una carica, una posizione, un'umidita'. Sotto il
+ * venti per cento cambia colore, che e' la soglia a cui la stessa
+ * percentuale smette di essere un dato e diventa una cosa da guardare.
+ */
+function livelloMarkup(percentuale) {
+  const valore = Number(percentuale);
+  if (!Number.isFinite(valore) || valore < 0 || valore > 100) return "";
+  const quota = Math.round(valore);
+  return `<span class="dm-w-livello" aria-hidden="true"${quota <= 20 ? ' data-basso="true"' : ""}>
+      <i style="width:${quota}%"></i>
+    </span>`;
+}
+
+/* La percentuale di una riga, quando ce l'ha e vuol dire un livello. */
+function percentualeDellaRiga(riga) {
+  for (const campo of ["battery", "position", "level", "soc", "humidity", "percent"]) {
+    const valore = Number(riga?.[campo]);
+    if (Number.isFinite(valore)) return valore;
+  }
+  const testo = String(riga?.value ?? "").trim();
+  const trovata = /^(\d{1,3})(?:[.,]\d+)?\s*%$/.exec(testo);
+  return trovata ? Number(trovata[1]) : null;
 }
 
 function todoItemMarkup(list, item, today) {
@@ -2466,7 +2497,21 @@ function detailBody(widget, states) {
   return `${verdettoEFrase(widget)}
     ${caselleDelleMisure(widget)}
     ${pilloleDelloStato(widget)}
-    ${comandi ? `<h4 class="dm-w-titoletto">${esc(t("Comandi", "Controls"))}</h4>${comandi}` : ""}`;
+    ${comandi ? `<h4 class="dm-w-titoletto">${esc(titoloDelBlocco(comandi))}</h4>${comandi}` : ""}`;
+}
+
+/* Il titolo dice cosa c'e' sotto, e non sempre sono comandi.
+ *
+ * Nella finestra dell'Energia sotto «COMANDI» stavano Casa, Solare, Rete e
+ * Batteria: quattro letture, che non si comandano — non c'e' niente da
+ * premere. Lo stesso per Telecamere, Solare termico e Piscina. Un titolo che
+ * annuncia comandi dove non ce ne sono manda a cercare un tasto che non
+ * esiste. Si guarda cosa c'e' davvero nel blocco invece di deciderlo a
+ * tavolino: se c'e' qualcosa da premere sono comandi, altrimenti sono letture.
+ */
+function titoloDelBlocco(markup) {
+  const siPreme = /<(?:button|input|select)\b|role="switch"/.test(markup);
+  return siPreme ? t("Comandi", "Controls") : t("Letture", "Readings");
 }
 
 function detailRows(widget, states) {
@@ -3420,6 +3465,16 @@ html[data-theme="dark"] #dm-widget-popup .dm-widget-detail .dm-w-close:hover{col
  * dice la cosa; i punti dicono i numeri su cui si regge — «la batteria si
  * carica a 1,47 kW», «in rete vanno 41 W» — che nella riga grande non ci
  * starebbero senza farne un paragrafo. */
+/* La barra del livello: sta sotto il nome, larga quanto la colonna, e non
+   sposta niente — due pixel e mezzo di altezza dentro la riga che c'era gia'. */
+#dm-widget-popup .dm-w-livello{
+  display:block;margin-top:5px;height:3px;border-radius:999px;overflow:hidden;
+  background:color-mix(in srgb,var(--text-dim,#94a3b8) 22%,transparent)}
+#dm-widget-popup .dm-w-livello>i{
+  display:block;height:100%;border-radius:inherit;
+  background:var(--dm-widget-accent,#0ea5e9);
+  transition:width .3s ease}
+#dm-widget-popup .dm-w-livello[data-basso="true"]>i{background:#e11d48}
 #dm-widget-popup .dm-w-punti{
   margin:2px 0 0;padding:0;list-style:none;display:flex;flex-direction:column;gap:3px}
 #dm-widget-popup .dm-w-punti li{

--- a/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
@@ -3610,11 +3610,19 @@ html[data-theme="dark"] #dm-widget-popup .dm-widget-detail .dm-w-close:hover{col
 :is(#dm-widget-popup,#clima-popup-overlay) .dm-w-panel-note{
   margin:0;font-size:11px;font-weight:700;color:var(--text-dim,#94a3b8)}
 /* Sul telefono l'etichetta va sopra: ottantadue pixel di colonna, su
-   trecentonovanta, lasciavano alle modalita' una pastiglia per riga. */
+   trecentonovanta, lasciavano alle modalita' una pastiglia per riga.
+   Le tre righe valgono per tutt'e due le finestre. Le ultime due erano scritte
+   per la sola «#dm-widget-popup», e la gemella e' rimasta indietro: nella
+   finestra del Clima la riga diventava una colonna ma l'etichetta teneva il
+   suo «flex:0 0 82px», che in colonna non e' piu' una larghezza ma
+   un'altezza. Misurato: la parola «Modalita'» alta ottantadue pixel, con
+   sotto il vuoto — sono i buchi che si vedevano fra «MODALITA'» e le
+   pastiglie, fra «TEMPERATURA» e il suo passo, fra «VENTOLA» e i numeri.
+   La riga sopra le nominava gia' tutt'e due; queste due no. */
 @media(max-width:600px){
   :is(#dm-widget-popup,#clima-popup-overlay) .dm-w-panel-row{flex-direction:column;align-items:stretch;gap:6px}
-  #dm-widget-popup .dm-w-panel-lbl{flex:none}
-  #dm-widget-popup .dm-w-stepper{align-self:flex-start}
+  :is(#dm-widget-popup,#clima-popup-overlay) .dm-w-panel-lbl{flex:none}
+  :is(#dm-widget-popup,#clima-popup-overlay) .dm-w-stepper{align-self:flex-start}
 }
 #dm-widget-popup .dm-w-row{
   position:relative;display:flex;align-items:center;gap:12px;

--- a/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
@@ -33,6 +33,7 @@ import {
   verdettoDellaTessera,
 } from "../core/racconto-tessera.js";
 import { analisiDellaSezione } from "../core/analisi-sezione.js";
+import { puntiDi, quandoArrivaLoStorico } from "./storico-condiviso-section.js";
 import {
   coverEntries,
   coverKindLabel,
@@ -2461,8 +2462,39 @@ function corsaMarkup(widget) {
  * Le sette sezioni fatte di cose che si accendono e si spengono continuano ad
  * avere la loro frase di prima, che li' e' giusta.
  */
+/* L'entita' che racconta la storia di una tessera.
+ *
+ * E' quella del numero grande: se la finestra mostra i watt di casa, la storia
+ * che interessa e' quella dei watt di casa. Dove il numero grande non viene da
+ * un'entita' sola — le luci, le tapparelle, che sono elenchi — non c'e' niente
+ * da chiedere, e infatti quelle sezioni una lettura nel tempo non ce l'hanno.
+ */
+function entitaDelRacconto(widget) {
+  if (widget?.key === "energia") {
+    const energia = section("energy", {}) || {};
+    return clean(energia?.house?.power) || "dm.energy_potenza_consumo_casa";
+  }
+  if (widget?.key === "temperatura") return clean(widget?.rows?.[0]?.entity);
+  if (widget?.key === "ev") return clean(widget?.rows?.[0]?.batteria || widget?.rows?.[0]?.entity);
+  if (["solare", "piscina", "robot", "irrigazione"].includes(widget?.key))
+    return clean(widget?.rows?.[0]?.entity);
+  if (widget?.key === "elettrodomestici")
+    return clean(widget?.running?.[0]?.entity || widget?.rows?.[0]?.entity);
+  return "";
+}
+
+/* Le tre ore precedenti, se lo storico le ha gia' date.
+ *
+ * Non si aspetta: la finestra si apre subito col numero che c'e', e se la
+ * storia arriva dopo la finestra si ridisegna. Una finestra che aspetta la
+ * rete per aprirsi, su una casa senza Recorder, non si apre. */
+function storiaDelWidget(widget) {
+  const entita = entitaDelRacconto(widget);
+  return entita ? puntiDi(entita, 3) : null;
+}
+
 function verdettoEFrase(widget) {
-  const lettura = analisiDellaSezione(widget, t);
+  const lettura = analisiDellaSezione(widget, t, Date.now(), storiaDelWidget(widget));
   const verdetto = verdettoDellaTessera(widget, t);
   const tono = lettura?.tono || verdetto.tono;
   const parola = tono === verdetto.tono ? verdetto.testo : parolaDelVerdetto(tono, t);
@@ -4312,6 +4344,12 @@ export function installHomeWidgetsSection() {
     "dashboardmodern:editor-rendered",
   ])
     root.addEventListener?.(eventName, schedule);
+  /* La storia delle ore precedenti arriva quando arriva, e la finestra non
+   * l'aspetta per aprirsi: si apre col numero che c'e' gia'. Quando la
+   * risposta atterra, pero', il racconto ha due righe in piu' da dire — «piu'
+   * alto del solito per quest'ora», «ci arriva fra un'ora» — e vanno mostrate
+   * senza che l'utente debba chiudere e riaprire. */
+  quandoArrivaLoStorico(schedule);
   // Il numero delle voci aperte E' lo stato dell'entita': quando cambia, le
   // voci vanno rilette — la spunta fatta da un altro dispositivo arriva cosi'.
   root.addEventListener?.("dashboardmodern:state-changed", (event) => {

--- a/custom_components/dashboardmodern/frontend/src/sections/lights-page-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/lights-page-section.js
@@ -327,6 +327,34 @@ function paint() {
   return true;
 }
 
+/* Riallinea OGNI card della luce del documento, dovunque sia disegnata.
+ *
+ * La card e' di questo modulo, ma non la disegna solo questo modulo: la pagina
+ * Stanze si prende `pageCardMarkup` da qui, perche' una seconda card per la
+ * stessa luce vorrebbe dire mantenerne due. Il riallineamento pero' era rimasto
+ * chiuso dentro `#lucip-wrap`, e `paint` per giunta si fermava subito se la
+ * pagina Luci non era quella aperta. Risultato: nelle Stanze si accendeva la
+ * luce, Home Assistant la accendeva davvero, e la card restava «SPENTA»
+ * finche' non si passava dalla pagina Luci — «se accendo una luce non cambia
+ * stato, non c'e' il refresh».
+ *
+ * Un padrone solo, quindi, ma con lo sguardo lungo: chi possiede il disegno
+ * possiede anche l'aggiornamento, e lo fa per tutte le sue card. Le Stanze non
+ * ne tengono una copia — due modi di aggiornare la stessa card sono due
+ * padroni, che e' il difetto da cui veniamo. */
+export function riallineaLeCardDelleLuci() {
+  if (!doc) return 0;
+  let quante = 0;
+  for (const card of doc.querySelectorAll("[data-dm-lucip]")) {
+    const entity = clean(card.getAttribute("data-dm-lucip"));
+    const view = entity ? viewOf(entity) : null;
+    if (!view) continue;
+    syncCard(card, view);
+    quante += 1;
+  }
+  return quante;
+}
+
 function syncCard(card, view) {
   card.classList.toggle("is-on", view.on);
   card.dataset.dmLucipAvailable = String(view.available);
@@ -383,11 +411,28 @@ function syncValues(wrap, groups, views) {
 
 /* ─────────────────────────────── comandi ────────────────────────────────── */
 
+/* La lettura di una luce, col pegno del tocco davanti allo stato.
+ *
+ * Il pegno e' quello che l'utente ha appena chiesto e Home Assistant non ha
+ * ancora confermato: dura pochi secondi e serve perche' la card si muova
+ * all'istante invece di restare ferma per tutto il giro del comando. Scaduto
+ * il pegno — o arrivato uno stato che dice il contrario — comanda lo stato,
+ * che e' la verita'. Un comando che non arriva a destinazione non lascia
+ * quindi una card che mente: torna da sola com'era. */
 function viewOf(id) {
   const entity = clean(id);
   if (!entity) return null;
   const names = readJson("cd_luci", {});
-  return lightView(entity, { name: names[entity], state: allStates()[entity] });
+  const stato = allStates()[entity];
+  const view = lightView(entity, { name: names[entity], state: stato });
+  const promesso = heldValue(entity, "power");
+  if (promesso == null || !view.available) return view;
+  if (promesso === view.on) {
+    // lo stato ha confermato: il pegno ha finito il suo mestiere
+    releaseHolds(entity);
+    return view;
+  }
+  return { ...view, on: promesso };
 }
 
 function callService(command) {
@@ -446,12 +491,22 @@ function live(view, change, field, value, { commit = false } = {}) {
   }
 }
 
+/* Il tocco si vede subito, e lo stato vero poi conferma o corregge.
+ *
+ * Prima si aspettava il giro completo — comando a Home Assistant, stato di
+ * ritorno, ridisegno — e in quel mezzo secondo la card non faceva niente: chi
+ * tocca non sa se ha toccato. Adesso la card si muove all'istante e il valore
+ * si trattiene per il tempo del giro; quando lo stato arriva, se dice il
+ * contrario vince lui. Il pegno scade da solo, cosi' un comando che non arriva
+ * a destinazione non lascia una card che mente per sempre. */
 function toggleLight(id) {
   const view = viewOf(id);
   if (!view) return;
+  const acceso = !view.on;
   feedback();
   releaseHolds(view.id);
-  send(view, { power: !view.on });
+  holdValue(view.id, "power", acceso);
+  send(view, { power: acceso });
   schedule();
 }
 
@@ -536,6 +591,9 @@ function repaint() {
   ensureLightsTab();
   teachNavVisibility();
   paint();
+  /* Dopo `paint`, che si ferma se la pagina Luci non e' quella aperta: le card
+   * disegnate altrove — le Stanze — vanno riallineate lo stesso. */
+  riallineaLeCardDelleLuci();
 }
 
 function schedule() {

--- a/custom_components/dashboardmodern/frontend/src/sections/lights-page-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/lights-page-section.js
@@ -508,6 +508,16 @@ function toggleLight(id) {
   holdValue(view.id, "power", acceso);
   send(view, { power: acceso });
   schedule();
+  /* Il ritorno indietro va programmato, non solo permesso.
+   *
+   * Il pegno scade da solo, ma la scadenza si guarda quando qualcuno ridisegna:
+   * se il comando non arriva a destinazione — servizio fallito, connessione
+   * caduta — non arriva nemmeno un cambio di stato, quindi nessuno ridisegna e
+   * la scheda resta accesa per sempre su una luce che e' spenta. Un ridisegno
+   * messo in coda alla scadenza chiude il cerchio: o nel frattempo lo stato ha
+   * confermato, e non cambia niente, o il pegno e' scaduto e la scheda torna
+   * com'era. */
+  root.setTimeout?.(schedule, HOLD_MS + 60);
 }
 
 function setRoomPower(room, on) {

--- a/custom_components/dashboardmodern/frontend/src/sections/page-masthead-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/page-masthead-section.js
@@ -534,8 +534,12 @@ function installStyles() {
     }
     /* Le fasce che portavano il titolo di Solare termico e MiniPC ora portano
        solo la pastiglia di stato: si stringono su quella invece di lasciare in
-       mezzo la banda vuota di quando c'era anche il titolo. */
-    #page-boiler .boiler-header{padding:12px 22px!important}
+       mezzo la banda vuota di quando c'era anche il titolo.
+       L'imbottitura del Solare termico non si scrive piu' qui: la scrive
+       solar-thermal-design-section, che quell'intestazione la disegna, e la
+       lega al segno che questa fascia le lascia addosso, «dm-mast-folded».
+       Prima erano due fogli a dichiarare la stessa imbottitura con due valori
+       diversi, e vinceva chi caricava per ultimo. */
     #page-server .srv-hero-top{padding-top:12px!important;padding-bottom:12px!important}
 
     /* The heading a page printed for itself: kept in the document for whoever

--- a/custom_components/dashboardmodern/frontend/src/sections/personalization-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/personalization-section.js
@@ -722,7 +722,7 @@ function installStyles() {
        l'hanno se lo scrivono addosso, e quelli che non ce l'hanno — i marchi
        sostanzialmente neri, lasciati apposta senza — devono seguire
        l'inchiostro di dove stanno, non diventare azzurri. */
-    .dm-car-brand{display:inline-grid;place-items:center;color:inherit}.dm-action-glyph{display:inline-grid;place-items:center;color:var(--primary-color,#0ea5e9);line-height:1}.dm-action-glyph svg{display:block!important;max-width:100%!important;max-height:100%!important}
+    .dm-car-brand{display:grid;place-items:center;color:inherit}.dm-action-glyph{display:inline-grid;place-items:center;color:var(--primary-color,#0ea5e9);line-height:1}.dm-action-glyph svg{display:block!important;max-width:100%!important;max-height:100%!important}
     /* La pastiglia del marchio, nel selettore dell'auto, la dimensiona il
        modulo che le ha dato la forma giusta sul telefono. Qui c'erano cinque
        misure che ne correggevano altrettante, tutte perdenti: la pastiglia da

--- a/custom_components/dashboardmodern/frontend/src/sections/solar-thermal-design-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/solar-thermal-design-section.js
@@ -139,6 +139,19 @@ function stylesheet() {
     box-shadow:0 30px 70px rgba(0,0,0,.45);
   }
 
+  /* Quando la fascia della plancia si prende il titolo, questa intestazione
+     resta con la sola pastiglia di stato e si stringe: senza, in mezzo
+     rimaneva la banda vuota di quando il titolo c'era. La regola sta qui —
+     l'intestazione e' di questo modulo — e si accende dal segno che la fascia
+     lascia sul titolo ripiegato. Il ripiego per chi non ha «:has()» e'
+     l'imbottitura piena, che e' il disegno di prima: piu' larga del dovuto, ma
+     giusta. */
+  @supports selector(:has(*)) {
+    #page-boiler .boiler-header:has([data-dm-mast-folded="true"]) {
+      padding:12px 22px;
+    }
+  }
+
   #page-boiler .boiler-header {
     position:relative;
     display:block;

--- a/custom_components/dashboardmodern/frontend/src/sections/solar-thermal-design-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/solar-thermal-design-section.js
@@ -33,6 +33,7 @@ import {
   installStyle,
   restyleOnLocaleChange,
   root,
+  scriviTestoSeCambia,
   t,
   wrapFunction,
 } from "./shared.js";
@@ -1120,7 +1121,7 @@ function stylesheet() {
 function element(tag, className, text) {
   const node = doc.createElement(tag);
   if (className) node.className = className;
-  if (text) node.textContent = text;
+  if (text) scriviTestoSeCambia(node, text);
   return node;
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/storico-condiviso-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/storico-condiviso-section.js
@@ -1,0 +1,129 @@
+/* Un padrone solo per lo storico chiesto a Recorder.
+ *
+ * Chi vuole sapere cos'ha fatto un'entita' nelle ultime ore lo chiede qui, e
+ * qui c'e' una cache: la stessa entita' chiesta due volte nello stesso giro
+ * non produce due domande.
+ *
+ * Perche' esiste. Il grafico delle temperature aveva il suo modo di chiedere
+ * lo storico, con la sua cache. Quando anche la finestra di una tessera ha
+ * avuto bisogno della stessa cosa — il modello nel tempo vuole le letture di
+ * prima per dire se quella di adesso e' normale — la strada breve era
+ * copiarne il codice. Sarebbero stati due padroni dello stesso traffico verso
+ * Recorder: due cache che non si parlano, quindi due domande per la stessa
+ * entita', e la certezza che prima o poi una delle due scada con una regola
+ * diversa dall'altra. E' il difetto che si sta togliendo dappertutto in questi
+ * giorni; qui si evitava di crearne uno nuovo.
+ *
+ * Come si usa. `serieDi` non aspetta: torna quello che ha, e `null` se non ha
+ * ancora niente. La domanda parte per conto suo e, quando la risposta arriva,
+ * chiama chi si era iscritto. Chi disegna deve poter disegnare subito — il
+ * numero grande della finestra c'e' gia', la storia arriva dopo — perche' una
+ * finestra che aspetta la rete per aprirsi e' una finestra che su una casa
+ * senza Recorder non si apre.
+ */
+
+import { normalizeHistoryRows } from "./history-section.js";
+import { clean, root } from "./shared.js";
+
+const KEY = "__dmStoricoCondiviso";
+const state = (root[KEY] ||= {
+  cache: new Map(),
+  inCorso: new Map(),
+  iscritti: new Set(),
+});
+
+/* Quanto vale una risposta prima di richiederla. Nove minuti: lo storico di
+ * un'ora non cambia faccia in nove minuti, e chi apre e chiude una finestra
+ * tre volte di fila non deve produrre tre domande. */
+const BUONA_PER = 9 * 60_000;
+
+/* Dopo un errore si riprova presto ma non subito: una casa senza Recorder
+ * risponderebbe «no» a ogni giro di disegno, e sarebbero decine al minuto. */
+const RIPROVA_DOPO = 25_000;
+
+async function chiedi(entity, ore) {
+  const broker = root.DashboardModernEnergyService?.broker;
+  if (typeof broker?.request !== "function") throw new Error("storico non raggiungibile");
+  const fine = new Date();
+  const inizio = new Date(fine.getTime() - ore * 3600_000);
+  const risposta = await broker.request({
+    type: "history/history_during_period",
+    start_time: inizio.toISOString(),
+    end_time: fine.toISOString(),
+    entity_ids: [entity],
+    include_start_time_state: true,
+    significant_changes_only: false,
+    minimal_response: true,
+    no_attributes: true,
+  });
+  return normalizeHistoryRows(risposta, entity);
+}
+
+/**
+ * Le letture di un'entita' nelle ultime ore, se ci sono gia'.
+ *
+ * Torna `null` finche' non c'e' niente, e un elenco — anche vuoto — quando la
+ * risposta e' arrivata. Il `null` va letto come «non lo so ancora», che non e'
+ * «non c'e' storia»: chi disegna, sul `null`, non deve scrivere «nessun dato».
+ */
+export function serieDi(entity, ore = 3) {
+  const nome = clean(entity);
+  if (!nome) return null;
+  const chiave = `${nome}@${ore}`;
+  const avuta = state.cache.get(chiave);
+  const adesso = Date.now();
+  const valeFino = avuta?.fallita ? RIPROVA_DOPO : BUONA_PER;
+  if (avuta && adesso - avuta.quando < valeFino) return avuta.righe;
+  if (state.inCorso.has(chiave)) return avuta?.righe ?? null;
+
+  state.inCorso.set(
+    chiave,
+    chiedi(nome, ore)
+      .then((righe) => {
+        state.cache.set(chiave, { righe, quando: Date.now(), fallita: !righe.length });
+        return righe;
+      })
+      .catch(() => {
+        state.cache.set(chiave, { righe: [], quando: Date.now(), fallita: true });
+        return [];
+      })
+      .finally(() => {
+        state.inCorso.delete(chiave);
+        for (const avvisa of state.iscritti) {
+          try {
+            avvisa(nome, ore);
+          } catch (_errore) {
+            /* Un iscritto che si rompe non ferma gli altri. */
+          }
+        }
+      }),
+  );
+  return avuta?.righe ?? null;
+}
+
+/** Chiamami quando arriva una risposta. Torna la funzione per disiscriversi. */
+export function quandoArrivaLoStorico(avvisa) {
+  if (typeof avvisa !== "function") return () => {};
+  state.iscritti.add(avvisa);
+  return () => state.iscritti.delete(avvisa);
+}
+
+/* Le letture nella forma che vuole il modello nel tempo: quando e quanto.
+ *
+ * Lo storico normalizzato le da' come «{ state, time }», dove lo stato e'
+ * ancora il testo che ha mandato Home Assistant — «21.4», ma anche «on» o
+ * «unavailable». Qui passa solo cio' che e' un numero: il modello misura, e su
+ * «unavailable» non c'e' niente da misurare. Buttarli e' meglio che contarli
+ * zero, che farebbe sembrare spento un sensore che era solo irraggiungibile. */
+export function puntiDi(entity, ore = 3) {
+  const righe = serieDi(entity, ore);
+  if (!righe) return null;
+  const punti = [];
+  for (const riga of righe) {
+    const valore = Number(riga?.state);
+    const quando = Number(riga?.time);
+    if (Number.isFinite(valore) && Number.isFinite(quando) && quando > 0)
+      punti.push({ quando, valore });
+  }
+  return punti;
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/storico-condiviso-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/storico-condiviso-section.js
@@ -115,7 +115,7 @@ export function quandoArrivaLoStorico(avvisa) {
  * «unavailable». Qui passa solo cio' che e' un numero: il modello misura, e su
  * «unavailable» non c'e' niente da misurare. Buttarli e' meglio che contarli
  * zero, che farebbe sembrare spento un sensore che era solo irraggiungibile. */
-export function puntiDi(entity, ore = 3) {
+export function puntiDi(entity, ore = 3, { adesso = null } = {}) {
   const righe = serieDi(entity, ore);
   if (!righe) return null;
   const punti = [];
@@ -124,6 +124,19 @@ export function puntiDi(entity, ore = 3) {
     const quando = Number(riga?.time);
     if (Number.isFinite(valore) && Number.isFinite(quando) && quando > 0)
       punti.push({ quando, valore });
+  }
+  /* La lettura di adesso si appende in coda, se chi chiama ce l'ha.
+   *
+   * La risposta vale nove minuti, e in quei nove minuti la coda della serie
+   * resta ferma a com'era: chi legge l'ultimo punto come «il valore di adesso»
+   * — ed e' quello che fa il modello — poteva raccontare una stranezza che
+   * contraddiceva il numero grande della stessa finestra, per nove minuti. Il
+   * valore vivo lo sa gia' chi disegna: lo passa, e la coda e' vera. */
+  const vivo = Number(adesso?.valore);
+  const quandoVivo = Number(adesso?.quando);
+  if (Number.isFinite(vivo) && Number.isFinite(quandoVivo)) {
+    const ultimo = punti[punti.length - 1];
+    if (!ultimo || quandoVivo > ultimo.quando) punti.push({ quando: quandoVivo, valore: vivo });
   }
   return punti;
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/temperature-trend-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/temperature-trend-section.js
@@ -6,24 +6,18 @@
 // to the card popup — no chart library, so it costs nothing to load and scales
 // to any width the page happens to have.
 import { temperatureEntries } from "./beta25-real-device-fixes-section.js";
-import { normalizeHistoryRows } from "./history-section.js";
+import { quandoArrivaLoStorico, serieDi } from "./storico-condiviso-section.js";
 import { clean, doc, english, installStyle, locale, root, section, t } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_TEMPERATURE_TREND__";
 const state = (root[KEY] ||= {
   installed: false,
   listeners: false,
-  cache: new Map(),
-  pending: new Map(),
   frame: 0,
   hours: 24,
   signature: "",
 });
 
-const FRESH_FOR = 9 * 60 * 1000;
-// A dashboard often paints before Home Assistant answers. A failed read must not
-// pin an empty chart for the whole refresh window, so it is retried much sooner.
-const RETRY_AFTER = 25 * 1000;
 const VIEW = Object.freeze({ width: 720, height: 250, left: 38, right: 54, top: 14, bottom: 24 });
 
 /* The chart is drawn one unit per pixel: a fixed viewBox stretched to the panel
@@ -283,49 +277,16 @@ function degrees(value) {
   return `${value.toFixed(1).replace(".", t(",", "."))}°`;
 }
 
-async function fetchHistory(entity, hours) {
-  const broker = root.DashboardModernEnergyService?.broker;
-  if (typeof broker?.request !== "function") throw new Error("history transport unavailable");
-  const end = new Date();
-  const start = new Date(end.getTime() - hours * 60 * 60 * 1000);
-  const result = await broker.request({
-    type: "history/history_during_period",
-    start_time: start.toISOString(),
-    end_time: end.toISOString(),
-    entity_ids: [entity],
-    include_start_time_state: true,
-    significant_changes_only: false,
-    minimal_response: true,
-    no_attributes: true,
-  });
-  return normalizeHistoryRows(result, entity);
-}
-
+/* Lo storico lo chiede il modulo condiviso, non piu' questo.
+ *
+ * Qui c'erano la domanda a Recorder e la sua cache. Quando anche la finestra
+ * di una tessera ha avuto bisogno delle stesse letture, tenerle qui avrebbe
+ * voluto dire copiarle di la': due cache che non si parlano, due domande per
+ * la stessa entita', e la certezza che prima o poi una delle due scada con una
+ * regola diversa. Adesso il padrone e' uno, e quando risponde avvisa: da li'
+ * riparte il disegno. */
 function rowsFor(entity, hours) {
-  const key = `${entity}@${hours}`;
-  const cached = state.cache.get(key);
-  const now = Date.now();
-  const freshFor = cached?.failed ? RETRY_AFTER : FRESH_FOR;
-  if (cached && now - cached.at < freshFor) return cached.rows;
-  if (state.pending.has(key)) return cached?.rows || null;
-
-  state.pending.set(
-    key,
-    fetchHistory(entity, hours)
-      .then((rows) => {
-        state.cache.set(key, { rows, at: Date.now(), failed: !rows.length });
-        return rows;
-      })
-      .catch(() => {
-        state.cache.set(key, { rows: [], at: Date.now(), failed: true });
-        return [];
-      })
-      .finally(() => {
-        state.pending.delete(key);
-        schedule();
-      }),
-  );
-  return cached?.rows || null;
+  return serieDi(entity, hours);
 }
 
 function svg(name, attributes = {}) {
@@ -631,12 +592,16 @@ function installStyles() {
   );
 }
 
+/* La risposta allo storico arriva quando arriva: da li' si ridisegna. Prima
+ * lo faceva la coda della domanda, che stava in questo modulo; adesso la
+ * domanda e' del modulo condiviso, e chi vuole saperlo si iscrive. */
 export function installTemperatureTrendSection() {
   if (!doc) return false;
   installStyles();
   renderTemperatureTrend();
   if (!state.listeners) {
     state.listeners = true;
+    quandoArrivaLoStorico(schedule);
     for (const eventName of [
       "dashboardmodern:legacy-ready",
       "dashboardmodern:runtime-ready",

--- a/custom_components/dashboardmodern/frontend/tests/beta16-real-device-layout.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta16-real-device-layout.test.js
@@ -36,7 +36,13 @@ test("beta16 runtime loads after beta14 and owns the requested mobile contracts"
     assert.ok(beta14 >= 0, "beta14 import is present");
     assert.ok(beta16 > beta14, "beta16 loads after beta14");
   }
-  assert.match(source, /grid-template-columns:repeat\(2,minmax\(0,1fr\)\)!important/);
+  /* La griglia a due colonne del Clima non si pretende piu' qui: quel foglio
+     e' andato via insieme al resto delle regole sulla scheda `cp-*`. Erano
+     quattordici misure decise da questo foglio e da beta7-regression in
+     disaccordo — la card alta 248px o senza minimo, il numero grande 46px o
+     28px — su un markup che nessuno disegna piu': la pagina Clima e' tutta di
+     climate-thermal-section, e a plancia aperta i nodi `cp-*` sono zero, con
+     e senza i dati vecchi del guscio. */
   assert.match(source, /clima-page-mode-btn\{min-height:52px!important/);
   assert.match(source, /dm-temperature-room-tabs/);
   assert.match(source, /dmBeta16ActionName/);

--- a/custom_components/dashboardmodern/frontend/tests/beta7-regressions.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta7-regressions.test.js
@@ -36,12 +36,25 @@ test("brand contract is claimed before load failure and after every vehicle rend
   assert.match(source, /guardAll\(\);\n\s*return result;/);
 });
 
-test("beta7 final polish owns quick actions and climate, and no longer skins the shutters", async () => {
+test("beta7 final polish owns quick actions, and non skinna piu' ne' clima ne' tapparelle", async () => {
   const source = await readFile(regressionsUrl, "utf8");
   assert.match(source, /polishQuickActionCards/);
   assert.match(source, /dm-beta7-existing-action-icon/);
   assert.match(source, /dm-beta7-action-form-row/);
-  assert.match(source, /aspect-ratio:auto/);
+  /* Il Clima non lo skinna piu' nemmeno questo foglio.
+   *
+   * Ne aveva una pelle intera per la scheda `cp-*`, e beta16 ne aveva
+   * un'altra: quattordici misure decise da due fogli in disaccordo — la card
+   * alta 248px o senza minimo, il numero grande 46px o 28px, i bordi 22px o
+   * 17px — dove vinceva chi caricava per ultimo. Un commento qui dentro
+   * diceva gia' «sotto i 760 la scheda del Clima la impagina beta16»: se
+   * n'erano accorti, e le due pelli erano rimaste tutt'e due.
+   *
+   * Solo che quella scheda non la disegna piu' nessuno: la pagina Clima e'
+   * tutta di climate-thermal-section, e a plancia aperta i nodi `cp-*` sono
+   * zero — contati con e senza i dati vecchi del guscio. Come la pelle della
+   * tapparella qui sotto, se ne va. */
+  assert.doesNotMatch(source, /#page-clima[^\n]*\.cp-/);
   // The shutter repaint guard stays; the Beta 7 window skin does not. It was
   // the only sheet declaring left/right/top on .tapp-shutter, so it detached
   // the closed panel from the opening the current skin draws.

--- a/custom_components/dashboardmodern/frontend/tests/energy-loads.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energy-loads.test.js
@@ -40,9 +40,21 @@ test("fixed flow slots migrate once without deleting legacy values", () => {
   assert.deepEqual(migrateLegacyEnergyLoads([], overrides, { metadata: { energy_loads_migrated: true } }), []);
 });
 
-test("battery SOC renders a percentage and keeps the legacy fallback", async () => {
+/* Il testo dello stato di carica: «SOC 78%», col prefisso.
+ *
+ * Qui si pretendeva «78%», senza prefisso, e la casella lo diceva davvero —
+ * ma solo per un istante: un altro modulo teneva un MutationObserver sul nodo
+ * e ci rimetteva «SOC» addosso, un terzo lo riscriveva a modo suo, e il
+ * guscio con un quarto formato. Sullo schermo il numero cambiava faccia da
+ * solo. Adesso il padrone e' uno, e la forma e' quella che si vedeva piu'
+ * spesso: «SOC» dice di cosa e' quella percentuale, che accanto a un numero
+ * in watt non e' ovvio.
+ *
+ * Senza entita' configurata la casella non dice «—»: si toglie. Annunciare un
+ * dato per dire che non ce l'hai e' peggio che non annunciarlo. */
+test("lo stato di carica dice cos'e', e sparisce se non e' configurato", async () => {
   const { renderBatterySoc } = await import("../src/sections/energy-flow-section.js");
-  const node = { textContent: "", dataset: {} };
+  const node = { textContent: "", hidden: false, dataset: {}, removeAttribute() {} };
   const document = { getElementById: (id) => (id === "v-battery-soc" ? node : null) };
   assert.equal(
     renderBatterySoc(
@@ -50,9 +62,23 @@ test("battery SOC renders a percentage and keeps the legacy fallback", async () 
       { battery: { battery_soc_entity: "sensor.battery_soc" } },
       { "sensor.battery_soc": { state: "78" } },
     ),
-    "78%",
+    "SOC 78%",
   );
-  assert.equal(node.textContent, "78%");
+  assert.equal(node.textContent, "SOC 78%");
+  assert.equal(node.hidden, false);
+
+  // l'entita' risponde ma non con un numero: la casella resta, il valore no
+  assert.equal(
+    renderBatterySoc(
+      document,
+      { battery: { battery_soc_entity: "sensor.battery_soc" } },
+      { "sensor.battery_soc": { state: "unavailable" } },
+    ),
+    "SOC —",
+  );
+
+  // nessuna entita' configurata: la casella si toglie
   assert.equal(renderBatterySoc(document, { battery: {} }, {}), "—");
-  assert.equal(node.textContent, "—");
+  assert.equal(node.hidden, true);
+  assert.equal(node.textContent, "");
 });

--- a/custom_components/dashboardmodern/frontend/tests/i18n-message-keys.js
+++ b/custom_components/dashboardmodern/frontend/tests/i18n-message-keys.js
@@ -1327,6 +1327,7 @@ export const MESSAGE_KEYS = Object.freeze([
   "Read from Home Assistant. A light behind a switch only turns on and off; brightness and colour appear in the popup only when the entity declares them.",
   "Reading areas and entities from Home Assistant…",
   "Reading…",
+  "Readings",
   "reads",
   "Ready",
   "Real photo of your appliance shown instead of the artwork.",

--- a/custom_components/dashboardmodern/frontend/tests/il-modello-nel-tempo.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/il-modello-nel-tempo.test.js
@@ -212,3 +212,19 @@ test("la lettura completa, e i suoi null che vogliono dire «non so»", () => {
   assert.equal(scarsa.arrivo, null);
   assert.equal(letturaNelTempo([], { adesso: ADESSO }), null);
 });
+
+test("l'ultima lettura pesa fino ad adesso, non zero", () => {
+  /* Il caso normale in una casa: un sensore sta a 100 per mezz'ora, passa a
+   * 200 due ore e mezza fa, e da allora non cambia piu'. Pesando solo gli
+   * intervalli fra letture, l'ultima non ne ha nessuno e vale zero: il solito
+   * resterebbe 100 e il 200 di adesso risulterebbe fortemente insolito — cioe'
+   * si annuncerebbe una stranezza a un sensore fermo da due ore e mezza. */
+  const punti = [];
+  for (let i = 0; i < 7; i += 1)
+    punti.push({ quando: ADESSO - 3 * ORA + i * 5 * MINUTO, valore: 100 });
+  punti.push({ quando: ADESSO - 2.5 * ORA, valore: 200 });
+
+  const solito = ilSolito(punti, { adesso: ADESSO });
+  assert.equal(solito.centro, 200, "il 200 dura due ore e mezza, il 100 mezz'ora");
+  assert.ok(quantoInsolito(200, solito) < 1, "un sensore fermo da ore non e' una stranezza");
+});

--- a/custom_components/dashboardmodern/frontend/tests/il-modello-nel-tempo.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/il-modello-nel-tempo.test.js
@@ -1,0 +1,214 @@
+/* Il modello di una grandezza nel tempo dice la cosa vera.
+ *
+ * I casi qui sotto sono scelti per far cadere un modello ingenuo. Una media al
+ * posto di una mediana cade sul picco dell'inverter; una mediana senza il peso
+ * del tempo cade sul sensore fermo che fa tre picchi; una retta senza bonta'
+ * annuncia una salita nel rumore; una previsione senza orizzonte promette la
+ * batteria piena fra ventisei ore. Sono i quattro modi in cui un motore di
+ * analisi diventa un generatore di frasi false, e sono tutti silenziosi: la
+ * frase esce, si legge bene, e dice il contrario.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  arco,
+  chiPesaDiPiu,
+  ilSolito,
+  ilSolitoAQuestOra,
+  letturaNelTempo,
+  quandoTocca,
+  quantoInsolito,
+  serie,
+  SOGLIE_INSOLITO,
+  tendenza,
+} from "../src/core/modello-nel-tempo.js";
+
+const MINUTO = 60_000;
+const ORA = 3600_000;
+const ADESSO = Date.parse("2026-08-29T20:00:00Z");
+
+/** Letture regolari: `quanti` punti, uno ogni `passo`, valore da `fai`. */
+function regolari(quanti, passo, fai, fine = ADESSO) {
+  const fuori = [];
+  for (let i = quanti - 1; i >= 0; i -= 1) fuori.push({ quando: fine - i * passo, valore: fai(quanti - 1 - i) });
+  return fuori;
+}
+
+test("una serie si mette in ordine e butta quello che non e' un numero", () => {
+  const letture = serie([
+    { quando: 300, valore: 3 },
+    { quando: 100, valore: 1 },
+    { quando: 200, valore: "due" },
+    { quando: 150, valore: 1.5 },
+    null,
+  ]);
+  assert.deepEqual(
+    letture.map((l) => l.valore),
+    [1, 1.5, 3],
+  );
+  assert.equal(arco(letture), 200);
+});
+
+test("accetta le tre forme di punto che girano nel progetto", () => {
+  assert.equal(serie([{ when: 1, value: 2 }]).length, 1);
+  assert.equal(serie([{ t: 1, v: 2 }]).length, 1);
+  assert.equal(serie([{ quando: 1, valore: 2 }]).length, 1);
+});
+
+test("una salita si riconosce, e si misura all'ora", () => {
+  // da 20° a 23°, un grado all'ora, letto ogni dieci minuti
+  const punti = regolari(19, 10 * MINUTO, (i) => 20 + i / 6);
+  const linea = tendenza(punti);
+  assert.equal(linea.verso, "sale");
+  assert.ok(Math.abs(linea.perOra - 1) < 0.02, `un grado all'ora, ho ${linea.perOra}`);
+  assert.ok(linea.bonta > 0.99);
+});
+
+test("il rumore non e' una tendenza", () => {
+  /* Valori che ballano attorno a 500 senza andare da nessuna parte. Una retta
+   * ci si puo' tracciare sempre: la bonta' dice che non spiega niente, e il
+   * verso dev'essere «ferma» invece di una salita inventata. */
+  const ballo = [0, 40, -35, 25, -20, 45, -50, 15, 30, -10, 20, -25, 35, -40, 10];
+  const punti = regolari(ballo.length, 5 * MINUTO, (i) => 500 + ballo[i]);
+  const linea = tendenza(punti);
+  assert.ok(linea.bonta < 0.35, `bonta' ${linea.bonta}: su questo non si annuncia niente`);
+  assert.equal(linea.verso, "ferma");
+});
+
+test("con pochi punti, o su un arco troppo corto, non dice niente", () => {
+  assert.equal(tendenza(regolari(3, 10 * MINUTO, (i) => i)), null, "tre punti non sono una tendenza");
+  assert.equal(tendenza(regolari(10, 1000, (i) => i)), null, "dieci secondi non sono un arco");
+  assert.equal(tendenza([]), null);
+});
+
+test("il solito pesa il tempo, non le letture", () => {
+  /* Il caso che fa cadere una mediana ingenua: un sensore fermo a zero per sei
+   * ore, e poi tre picchi in un minuto. Le letture al picco sono tre su
+   * quattro; il tempo passato al picco e' un minuto su sei ore. Il solito e'
+   * lo zero. */
+  const punti = [
+    { quando: ADESSO - 6 * ORA, valore: 0 },
+    { quando: ADESSO - 3 * MINUTO, valore: 2000 },
+    { quando: ADESSO - 2 * MINUTO, valore: 2100 },
+    { quando: ADESSO - 1 * MINUTO, valore: 1950 },
+    { quando: ADESSO, valore: 0 },
+  ];
+  const solito = ilSolito(punti);
+  assert.equal(solito.centro, 0, `contando le letture verrebbe 1950; il tempo dice 0`);
+  assert.equal(solito.massimo, 2100, "il massimo resta quello che e' stato");
+});
+
+test("un valore sballato non sposta il solito", () => {
+  /* L'inverter che per due secondi legge sessantamila watt. Con una media, il
+   * solito di un'ora si sposta di mille watt; con la mediana, di niente. */
+  const punti = regolari(30, 2 * MINUTO, () => 500);
+  punti.splice(15, 0, { quando: punti[15].quando + 1000, valore: 60_000 });
+  const solito = ilSolito(punti);
+  assert.equal(solito.centro, 500);
+});
+
+test("quanto e' insolito: zero quando e' il solito, tanto quando non lo e'", () => {
+  const solito = { centro: 500, scarto: 50 };
+  assert.equal(quantoInsolito(500, solito), 0);
+  assert.equal(quantoInsolito(600, solito), 2);
+  assert.ok(quantoInsolito(700, solito) >= SOGLIE_INSOLITO.forte);
+  assert.equal(quantoInsolito("niente", solito), null);
+});
+
+test("un valore che non si e' mai mosso non fa dividere per zero", () => {
+  const solito = { centro: 20, scarto: 0 };
+  assert.equal(quantoInsolito(20, solito), 0);
+  const fuori = quantoInsolito(24, solito);
+  assert.ok(Number.isFinite(fuori) && fuori > 0, `deve essere un numero, ho ${fuori}`);
+});
+
+test("il solito a quest'ora pretende piu' di un giorno", () => {
+  const unGiorno = regolari(20, 3 * MINUTO, () => 800);
+  assert.equal(
+    ilSolitoAQuestOra(unGiorno, { adesso: ADESSO }),
+    null,
+    "con un giorno solo non e' un'abitudine, e' quello che e' successo ieri",
+  );
+
+  /* Tre giorni, stessa ora: adesso e' un'abitudine. */
+  const treGiorni = [];
+  for (let giorno = 0; giorno < 3; giorno += 1)
+    for (let i = 0; i < 6; i += 1)
+      treGiorni.push({ quando: ADESSO - giorno * 24 * ORA - i * 5 * MINUTO, valore: 800 + i });
+  const abituale = ilSolitoAQuestOra(treGiorni, { adesso: ADESSO });
+  assert.ok(abituale, "tre giorni alla stessa ora sono un'abitudine");
+  assert.equal(abituale.giorni, 3);
+});
+
+test("quando tocca il bersaglio, se ci arriva davvero", () => {
+  // batteria dal 50% al 62%, sei punti per l'ora: circa dodici punti all'ora
+  const punti = regolari(13, 5 * MINUTO, (i) => 50 + i);
+  const arrivo = quandoTocca(punti, 100, { adesso: ADESSO });
+  assert.ok(arrivo, "sale verso il cento: ci arriva");
+  const oreMancanti = (arrivo - ADESSO) / ORA;
+  assert.ok(oreMancanti > 2 && oreMancanti < 4, `circa tre ore, ho ${oreMancanti}`);
+});
+
+test("non promette un arrivo che non arriva", () => {
+  const sale = regolari(13, 5 * MINUTO, (i) => 50 + i);
+  assert.equal(quandoTocca(sale, 10, { adesso: ADESSO }), null, "sale: al dieci non ci torna");
+
+  const lenta = regolari(13, 5 * MINUTO, (i) => 50 + i * 0.02);
+  assert.equal(
+    quandoTocca(lenta, 100, { adesso: ADESSO }),
+    null,
+    "a questo passo ci mette giorni: dirlo e' un modo raffinato di non dire niente",
+  );
+
+  const ferma = regolari(13, 5 * MINUTO, () => 50);
+  assert.equal(quandoTocca(ferma, 100, { adesso: ADESSO }), null, "ferma non arriva da nessuna parte");
+});
+
+test("chi pesa di piu', e se domina davvero", () => {
+  const uno = chiPesaDiPiu(
+    [
+      { nome: "Forno", watt: 2200 },
+      { nome: "Frigo", watt: 120 },
+      { nome: "Router", watt: 15 },
+    ],
+    (v) => v.watt,
+  );
+  assert.equal(uno.voce.nome, "Forno");
+  assert.equal(uno.domina, true, "il forno da solo vale piu' di tutti gli altri");
+  assert.ok(uno.quota > 0.9);
+
+  const pari = chiPesaDiPiu(
+    [
+      { nome: "A", watt: 100 },
+      { nome: "B", watt: 95 },
+      { nome: "C", watt: 90 },
+    ],
+    (v) => v.watt,
+  );
+  assert.equal(pari.domina, false, "tre uguali: nominarne uno racconterebbe male");
+  assert.equal(chiPesaDiPiu([], (v) => v.watt), null);
+  assert.equal(chiPesaDiPiu([{ watt: 0 }], (v) => v.watt), null, "chi non pesa non conta");
+});
+
+test("la lettura completa, e i suoi null che vogliono dire «non so»", () => {
+  const punti = regolari(19, 10 * MINUTO, (i) => 20 + i / 6);
+  const lettura = letturaNelTempo(punti, { adesso: ADESSO, bersaglio: 24 });
+  assert.equal(lettura.valore, punti[punti.length - 1].valore);
+  assert.equal(lettura.tendenza.verso, "sale");
+  assert.ok(lettura.solito);
+  assert.ok(lettura.arrivo, "sale verso i 24: ci arriva");
+
+  /* Due punti soli: il solito si puo' dire, la tendenza no. Il null della
+   * tendenza va letto come «non so se si muove», che non e' «e' ferma». */
+  const scarsa = letturaNelTempo(
+    [
+      { quando: ADESSO - MINUTO, valore: 5 },
+      { quando: ADESSO, valore: 6 },
+    ],
+    { adesso: ADESSO },
+  );
+  assert.equal(scarsa.tendenza, null);
+  assert.equal(scarsa.arrivo, null);
+  assert.equal(letturaNelTempo([], { adesso: ADESSO }), null);
+});

--- a/custom_components/dashboardmodern/frontend/tests/lanalisi-delle-sezioni.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/lanalisi-delle-sezioni.test.js
@@ -1,0 +1,238 @@
+/* L'analisi di ogni sezione dice la cosa vera.
+ *
+ * I casi qui sotto non sono inventati: sono le schermate arrivate dalla casa
+ * vera, coi loro numeri. L'Energia con il fotovoltaico a 2,16 kW e la casa a
+ * 574 W scriveva «4 cose, nessuna in funzione», e non perche' contasse male:
+ * perche' quella frase veniva da un ripiego che sa contare solo cose accese e
+ * spente, e le quattro righe dell'Energia sono casa, solare, rete e batteria.
+ * La Sicurezza, con l'antifurto elencato nella finestra, scriveva «Qui non
+ * c'e' ancora niente», perche' il suo antifurto non e' una riga.
+ *
+ * Una frase sbagliata non rompe niente e a occhio non si vede: si legge, sembra
+ * una frase, e dice il contrario. L'unico modo di accorgersene e' pretendere il
+ * testo a partire da numeri noti, ed e' quello che si fa qui.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { analisiDellaSezione, SEZIONI_LETTE } from "../src/core/analisi-sezione.js";
+import { VERDETTI } from "../src/core/racconto-tessera.js";
+
+const IT = (italiano) => italiano;
+const EN = (_italiano, inglese) => inglese;
+
+test("Energia: col sole che avanza non dice «nessuna in funzione»", () => {
+  /* I numeri della schermata: casa 574 W, solare 2,16 kW, rete 41 W,
+   * batteria -1,47 kW (il segno meno vuol dire che si sta caricando). */
+  const esito = analisiDellaSezione({
+    key: "energia",
+    today: 2,
+    rows: [
+      { group: "house", watts: 574 },
+      { group: "solar", watts: 2160 },
+      { group: "grid", watts: 41 },
+      { group: "battery", watts: -1470 },
+    ],
+  }, IT);
+  assert.ok(esito, "l'Energia deve avere una sua lettura");
+  assert.doesNotMatch(esito.frase, /nessuna in funzione/i);
+  assert.match(esito.frase, /2,16 kW/, "deve dire quanto fa il sole");
+  assert.match(esito.frase, /574 W/, "deve dire quanto usa la casa");
+  assert.ok(
+    esito.punti.some((p) => /si carica a 1,47 kW/.test(p)),
+    `il segno della batteria va detto a parole, non lasciato al meno: ${JSON.stringify(esito.punti)}`,
+  );
+  assert.ok(
+    esito.punti.some((p) => /2,0 kWh/.test(p)),
+    "l'energia di oggi e' un punto, non si perde",
+  );
+});
+
+test("Energia: quando il sole non basta dice quanto ne copre", () => {
+  const esito = analisiDellaSezione({
+    key: "energia",
+    rows: [
+      { group: "house", watts: 2000 },
+      { group: "solar", watts: 500 },
+      { group: "grid", watts: 1500 },
+    ],
+  }, IT);
+  assert.match(esito.frase, /25%/, "500 su 2000 e' un quarto");
+  assert.ok(esito.punti.some((p) => /Dalla rete arrivano 1,50 kW/.test(p)));
+});
+
+test("Energia: di notte non parla di sole", () => {
+  const esito = analisiDellaSezione({
+    key: "energia",
+    rows: [
+      { group: "house", watts: 300 },
+      { group: "solar", watts: 0 },
+      { group: "grid", watts: 300 },
+    ],
+  }, IT);
+  assert.match(esito.frase, /senza sole/);
+  assert.doesNotMatch(esito.frase, /copre/);
+});
+
+test("Sicurezza: con l'antifurto non dice che non c'e' niente", () => {
+  const esito = analisiDellaSezione({
+    key: "sicurezza",
+    alarm: true,
+    armed: false,
+    triggered: false,
+    doors: [{ name: "Portoncino" }, { name: "Garage" }],
+  }, IT);
+  assert.doesNotMatch(esito.frase, /non c'e' ancora niente/i);
+  assert.match(esito.frase, /disinserito/i);
+  assert.ok(esito.punti.some((p) => /2 ingressi sorvegliati/.test(p)));
+});
+
+test("Sicurezza: quando suona il tono e' rosso", () => {
+  const esito = analisiDellaSezione(
+    { key: "sicurezza", alarm: true, armed: true, triggered: true, doors: [] },
+    IT,
+  );
+  assert.equal(esito.tono, VERDETTI.guarda);
+  assert.match(esito.frase, /suonando/);
+});
+
+test("Temperatura: dice la differenza, non solo la media", () => {
+  const esito = analisiDellaSezione({
+    key: "temperatura",
+    rows: [
+      { name: "Salone", temperature: 27.1, humidity: 48 },
+      { name: "Cucina", temperature: 24.4, humidity: 52 },
+      { name: "Garage", temperature: 21.8, humidity: 60 },
+    ],
+  }, IT);
+  assert.match(esito.frase, /Salone/, "la piu' calda si nomina");
+  assert.match(esito.frase, /5,3°/, "27,1 meno 21,8");
+  assert.match(esito.frase, /3 stanze/);
+  assert.ok(esito.punti.some((p) => /Garage/.test(p)), "la piu' fredda sta nei punti");
+});
+
+test("Temperatura: con una stanza sola non parla di differenze", () => {
+  const esito = analisiDellaSezione(
+    { key: "temperatura", rows: [{ name: "Salone", temperature: 22 }] },
+    IT,
+  );
+  assert.match(esito.frase, /Salone e' a 22,0°/);
+  assert.doesNotMatch(esito.frase, /fra la piu'/);
+});
+
+test("Elettrodomestici: nomina quelli accesi e somma i watt", () => {
+  const esito = analisiDellaSezione({
+    key: "elettrodomestici",
+    rows: [
+      { name: "Lavatrice", mode: "running", watts: 1200 },
+      { name: "Lavastoviglie", mode: "running", watts: 800 },
+      { name: "Forno", mode: "off", watts: 0 },
+    ],
+  }, IT);
+  assert.equal(esito.tono, VERDETTI.corso);
+  assert.match(esito.frase, /Lavatrice e Lavastoviglie/);
+  assert.match(esito.frase, /su 3/);
+  assert.ok(esito.punti.some((p) => /2,00 kW/.test(p)));
+});
+
+test("Piscina: il pH fuori norma vince sulla temperatura", () => {
+  const esito = analisiDellaSezione({
+    key: "piscina",
+    rows: [
+      { name: "Acqua", raw: 27.5 },
+      { name: "pH", raw: 8.1 },
+    ],
+  }, IT);
+  assert.equal(esito.tono, VERDETTI.guarda);
+  assert.match(esito.frase, /pH e' fuori norma/);
+  assert.match(esito.frase, /27,5°/);
+});
+
+test("Auto: sotto il venti per cento e staccata, e' da guardare", () => {
+  const esito = analisiDellaSezione({ key: "ev", ring: 12, attiva: false, rows: [] }, IT);
+  assert.equal(esito.tono, VERDETTI.guarda);
+  assert.match(esito.frase, /12%/);
+});
+
+test("Irrigazione: dice quale zona sta bagnando", () => {
+  const esito = analisiDellaSezione({
+    key: "irrigazione",
+    rows: [{ name: "Prato", on: true }, { name: "Siepe", on: false }],
+  }, IT);
+  assert.equal(esito.tono, VERDETTI.corso);
+  assert.match(esito.frase, /Prato sta bagnando/);
+  assert.match(esito.frase, /2 zone/);
+});
+
+test("Solare termico: dice il salto fra le sonde", () => {
+  const esito = analisiDellaSezione({
+    key: "solare",
+    attiva: true,
+    rows: [
+      { name: "Pannello", temperature: 68 },
+      { name: "Accumulo", temperature: 44 },
+    ],
+  }, IT);
+  assert.equal(esito.tono, VERDETTI.corso);
+  assert.match(esito.frase, /24,0°/);
+});
+
+test("chi non ha una lettura riceve niente, non una frase sbagliata", () => {
+  assert.equal(analisiDellaSezione({ key: "sezione-che-non-esiste", rows: [] }, IT), null);
+});
+
+test("ogni lettura risponde anche in inglese, e con un'altra frase", () => {
+  const casi = {
+    energia: { rows: [{ group: "house", watts: 500 }, { group: "solar", watts: 900 }] },
+    solare: { attiva: false, rows: [{ name: "P", temperature: 30 }, { name: "A", temperature: 20 }] },
+    sicurezza: { alarm: true, armed: true, doors: [{ name: "X" }] },
+    temperatura: { rows: [{ name: "A", temperature: 20 }, { name: "B", temperature: 24 }] },
+    elettrodomestici: { rows: [{ name: "A", mode: "running", watts: 100 }] },
+    telecamere: { rows: [{ name: "Ingresso" }] },
+    ev: { ring: 80, attiva: true, rows: [] },
+    robot: { rows: [{ name: "Robi", cleaning: true }] },
+    piscina: { rows: [{ name: "Acqua", raw: 26 }] },
+    irrigazione: { rows: [{ name: "Prato", on: true }] },
+  };
+  for (const chiave of SEZIONI_LETTE) {
+    const tessera = { key: chiave, ...(casi[chiave] || { rows: [] }) };
+    const italiano = analisiDellaSezione(tessera, IT);
+    const inglese = analisiDellaSezione(tessera, EN);
+    assert.ok(italiano?.frase, `${chiave}: manca la frase italiana`);
+    assert.ok(inglese?.frase, `${chiave}: manca la frase inglese`);
+    assert.notEqual(
+      italiano.frase,
+      inglese.frase,
+      `${chiave}: la frase inglese e' identica all'italiana, quindi non e' tradotta`,
+    );
+  }
+});
+
+test("le sezioni senza lettura propria sono solo quelle che ne hanno gia' una", () => {
+  /* Le sette che restano fuori — luci, clima, tapparelle, aperture, batterie,
+   * allagamenti, todo — la loro frase ce l'hanno gia' in racconto-tessera.js,
+   * e li' e' giusta: sono tutte fatte di cose che si accendono e si spengono.
+   * Questa prova esiste perche' se domani nasce una sezione nuova, e nessuno
+   * le scrive la lettura, non finisca a caso nel ripiego generico. */
+  const conFraseAltrove = ["luci", "clima", "tapparelle", "aperture", "batterie", "allagamenti", "todo"];
+  const tutte = [...SEZIONI_LETTE, ...conFraseAltrove].sort();
+  assert.deepEqual(tutte, [
+    "allagamenti",
+    "aperture",
+    "batterie",
+    "clima",
+    "elettrodomestici",
+    "energia",
+    "ev",
+    "irrigazione",
+    "luci",
+    "piscina",
+    "robot",
+    "sicurezza",
+    "solare",
+    "tapparelle",
+    "telecamere",
+    "temperatura",
+    "todo",
+  ]);
+});

--- a/custom_components/dashboardmodern/frontend/tests/lanalisi-delle-sezioni.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/lanalisi-delle-sezioni.test.js
@@ -236,3 +236,130 @@ test("le sezioni senza lettura propria sono solo quelle che ne hanno gia' una", 
     "todo",
   ]);
 });
+
+/* ── quello che il modello aggiunge ────────────────────────────────────── */
+
+const ORA = 3600_000;
+const MINUTO = 60_000;
+const ADESSO = Date.parse("2026-08-29T20:00:00Z");
+
+/** Letture regolari, una ogni `passo`, valore da `fai`. */
+function storia(quanti, passo, fai, fine = ADESSO) {
+  const fuori = [];
+  for (let i = quanti - 1; i >= 0; i -= 1)
+    fuori.push({ quando: fine - i * passo, valore: fai(quanti - 1 - i) });
+  return fuori;
+}
+
+test("senza storia il motore dice quello che diceva prima", () => {
+  const tessera = { key: "energia", rows: [{ group: "house", watts: 574 }] };
+  const senza = analisiDellaSezione(tessera, IT, ADESSO);
+  const conNiente = analisiDellaSezione(tessera, IT, ADESSO, null);
+  assert.deepEqual(senza, conNiente);
+  assert.ok(senza.frase, "la finestra sta in piedi anche senza storia");
+});
+
+test("il modello dice quando il consumo e' fuori dal solito", () => {
+  /* Tre giorni di storia: a quest'ora la casa fa 300 W. Adesso ne fa 900. */
+  const punti = [];
+  for (let giorno = 0; giorno < 3; giorno += 1)
+    for (let i = 0; i < 8; i += 1)
+      punti.push({ quando: ADESSO - giorno * 24 * ORA - i * 5 * MINUTO, valore: 300 });
+  punti.push({ quando: ADESSO, valore: 900 });
+
+  const esito = analisiDellaSezione(
+    { key: "energia", rows: [{ group: "house", watts: 900 }] },
+    IT,
+    ADESSO,
+    punti,
+  );
+  assert.ok(
+    esito.punti.some((p) => /Piu' alto del solito per quest'ora/.test(p)),
+    `manca il confronto col solito: ${JSON.stringify(esito.punti)}`,
+  );
+  assert.ok(esito.punti.some((p) => /900 W/.test(p)), "dice quanto fa adesso");
+  assert.ok(esito.punti.some((p) => /300 W/.test(p)), "e quanto fa di solito");
+});
+
+test("quando e' il solito non spreca una riga per dirlo", () => {
+  const punti = storia(30, 5 * MINUTO, () => 300);
+  const esito = analisiDellaSezione(
+    { key: "energia", rows: [{ group: "house", watts: 300 }] },
+    IT,
+    ADESSO,
+    punti,
+  );
+  assert.ok(
+    !esito.punti.some((p) => /solito/.test(p)),
+    "«e' nella norma» e' il caso di quasi sempre: dirlo e' una riga sprecata",
+  );
+});
+
+test("un valore molto fuori dal solito diventa da guardare", () => {
+  /* Nessuno sta «facendo» niente — nessuna riga accesa — eppure c'e'
+   * qualcosa: e' il caso per cui il modello esiste. */
+  const punti = storia(40, 3 * MINUTO, () => 200);
+  punti.push({ quando: ADESSO, valore: 3000 });
+  const esito = analisiDellaSezione(
+    { key: "energia", rows: [{ group: "house", watts: 3000 }] },
+    IT,
+    ADESSO,
+    punti,
+  );
+  assert.equal(esito.tono, VERDETTI.guarda);
+});
+
+test("il modello dice quando l'auto sara' carica", () => {
+  // dal 50% in su, un punto percentuale ogni cinque minuti
+  const punti = storia(13, 5 * MINUTO, (i) => 50 + i);
+  const esito = analisiDellaSezione(
+    { key: "ev", ring: 62, attiva: true, rows: [] },
+    IT,
+    ADESSO,
+    punti,
+  );
+  assert.ok(
+    esito.punti.some((p) => /Ci arriva/.test(p)),
+    `deve dire quando finisce: ${JSON.stringify(esito.punti)}`,
+  );
+});
+
+test("quando non sa dire l'arrivo dice almeno il passo", () => {
+  // la temperatura sale, ma non c'e' un bersaglio a cui arrivare
+  const punti = storia(19, 10 * MINUTO, (i) => 20 + i / 6);
+  const esito = analisiDellaSezione(
+    { key: "temperatura", rows: [{ name: "Salone", temperature: 23 }] },
+    IT,
+    ADESSO,
+    punti,
+  );
+  assert.ok(
+    esito.punti.some((p) => /Sale di 1,0° all'ora/.test(p)),
+    `deve dire il passo: ${JSON.stringify(esito.punti)}`,
+  );
+});
+
+test("sul rumore non annuncia nessuna salita", () => {
+  const ballo = [0, 40, -35, 25, -20, 45, -50, 15, 30, -10, 20, -25, 35, -40, 10];
+  const punti = storia(ballo.length, 5 * MINUTO, (i) => 500 + ballo[i]);
+  const esito = analisiDellaSezione(
+    { key: "energia", rows: [{ group: "house", watts: 510 }] },
+    IT,
+    ADESSO,
+    punti,
+  );
+  assert.ok(
+    !esito.punti.some((p) => /Sale|Scende/.test(p)),
+    `una retta si traccia anche sul rumore, ma non si annuncia: ${JSON.stringify(esito.punti)}`,
+  );
+});
+
+test("il modello non aggiunge mai piu' di due righe", () => {
+  const punti = storia(13, 5 * MINUTO, (i) => 50 + i);
+  const senza = analisiDellaSezione({ key: "ev", ring: 62, attiva: true, rows: [] }, IT, ADESSO);
+  const con = analisiDellaSezione({ key: "ev", ring: 62, attiva: true, rows: [] }, IT, ADESSO, punti);
+  assert.ok(
+    con.punti.length - senza.punti.length <= 2,
+    "scriverle tutte trasforma la finestra in un bollettino",
+  );
+});

--- a/custom_components/dashboardmodern/frontend/tests/lanalisi-delle-sezioni.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/lanalisi-delle-sezioni.test.js
@@ -363,3 +363,95 @@ test("il modello non aggiunge mai piu' di due righe", () => {
     "scriverle tutte trasforma la finestra in un bollettino",
   );
 });
+
+/* ── gli undici rilievi della revisione, uno per uno ────────────────────── */
+
+test("l'irrigazione che bagna non viene annunciata come ferma", () => {
+  /* Le righe portavano solo il testo tradotto — «in funzione» / «ferma» — e la
+   * lettura, che cerca un booleano, le trovava tutte ferme proprio mentre
+   * l'acqua usciva. Adesso la riga porta anche il dato grezzo. */
+  const conGrezzo = analisiDellaSezione(
+    { key: "irrigazione", attiva: true, rows: [{ name: "Prato", on: true, value: "in funzione" }] },
+    IT,
+  );
+  assert.equal(conGrezzo.tono, VERDETTI.corso);
+  assert.match(conGrezzo.frase, /Prato sta bagnando/);
+
+  /* E se il grezzo non c'e' — dati vecchi — si ricade sul conto della tessera
+   * invece di dire il falso. */
+  const senzaGrezzo = analisiDellaSezione(
+    { key: "irrigazione", attiva: true, rows: [{ name: "Prato", value: "in funzione" }] },
+    IT,
+  );
+  assert.equal(senzaGrezzo.tono, VERDETTI.corso);
+  assert.doesNotMatch(senzaGrezzo.frase, /ferme/);
+});
+
+test("il robot che pulisce non viene annunciato come fermo", () => {
+  const conGrezzo = analisiDellaSezione(
+    { key: "robot", rows: [{ name: "Robi", cleaning: true, battery: 60 }] },
+    IT,
+  );
+  assert.equal(conGrezzo.tono, VERDETTI.corso);
+
+  const senzaGrezzo = analisiDellaSezione(
+    { key: "robot", attiva: true, rows: [{ name: "Robi", value: "In pulizia · 60%" }] },
+    IT,
+  );
+  assert.equal(senzaGrezzo.tono, VERDETTI.corso, "il conto della tessera fa da rete");
+});
+
+test("le sonde del solare si leggono dal valore grezzo, non dal testo", () => {
+  /* «56.2°» attraverso Number fa NaN: l'analisi del salto fra le sonde non
+   * usciva mai. La riga adesso porta `raw` accanto a `value`. */
+  const esito = analisiDellaSezione(
+    {
+      key: "solare",
+      attiva: true,
+      rows: [
+        { name: "Pannello", raw: 68, value: "68°" },
+        { name: "Accumulo", raw: 44, value: "44°" },
+      ],
+    },
+    IT,
+  );
+  assert.match(esito.frase, /24,0°/, "il salto si calcola sul grezzo");
+});
+
+test("un dato che manca non vale zero", () => {
+  /* `Number(null)` fa zero, e uno zero e' una misura: una stanza senza sensore
+   * di umidita' entrava nella media come 0%. */
+  const esito = analisiDellaSezione(
+    {
+      key: "temperatura",
+      rows: [
+        { name: "A", temperature: 20, humidity: 50 },
+        { name: "B", temperature: 22, humidity: null },
+      ],
+    },
+    IT,
+  );
+  const umidita = esito.punti.find((p) => /Umidita/.test(p));
+  assert.match(umidita, /50%/, "la media e' di una stanza sola, non 25%");
+});
+
+test("con piu' auto non si dice che la piu' scarica e' in carica", () => {
+  /* `ring` e' la carica piu' bassa fra tutte, `attiva` dice che QUALCUNA e'
+   * attaccata: messe insieme diventavano «quella al 10% e' in carica» mentre in
+   * carica c'era l'altra, all'80%. */
+  const esito = analisiDellaSezione(
+    { key: "ev", ring: 10, attiva: true, quante: 2, rows: [{}, {}] },
+    IT,
+  );
+  assert.doesNotMatch(esito.frase, /^In carica, al 10%/);
+  assert.match(esito.frase, /la piu' scarica e' al 10%/);
+});
+
+test("la lingua dei numeri si passa, non si indovina", () => {
+  /* Chiedendo a tr("it","en") chi fosse, il tedesco finiva su «en-US»: una
+   * finestra tedesca mescolava un titolo «1,25 kW» con un'analisi «1.25 kW». */
+  const tessera = { key: "energia", rows: [{ group: "house", watts: 1250 }] };
+  const tedesco = (_it, en) => en;
+  assert.match(analisiDellaSezione(tessera, tedesco, Date.now(), null, "de-DE").frase, /1,25 kW/);
+  assert.match(analisiDellaSezione(tessera, tedesco, Date.now(), null, "en-US").frase, /1\.25 kW/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/nessuna-regola-con-due-padroni.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/nessuna-regola-con-due-padroni.test.js
@@ -1,0 +1,130 @@
+/* Nessuna decisione di stile ha due padroni che dicono cose diverse.
+ *
+ * Il difetto e' silenzioso finche' non morde. Due fogli che non si parlano
+ * dichiarano la stessa proprieta' sullo stesso selettore: finche' i valori
+ * coincidono non si vede niente, il giorno che uno dei due cambia vince quello
+ * che capita di caricare per ultimo, e la modifica «non fa effetto». E' cosi'
+ * che la scheda del Clima e' rimasta per mesi con quattordici misure decise da
+ * due fogli in disaccordo — la card alta 248px o senza minimo, il numero
+ * grande 46px o 28px — su un markup che nel frattempo nessuno disegnava piu'.
+ *
+ * Cosa conta come conflitto, e cosa no. Una regola dentro
+ * `@media(max-width:760px)` non contende quella fuori: e' l'override del
+ * telefono, ed e' esattamente il modo in cui si scrive una pagina responsiva.
+ * Per questo la chiave porta con se' il contesto della at-rule. Senza quella
+ * distinzione il conto diceva trentasette conflitti dove ce n'erano tre, e un
+ * numero gonfiato e' peggio di nessun numero: si smette di guardarlo.
+ *
+ * Due fogli che dichiarano lo stesso valore restano ammessi. Sono peso morto,
+ * non un difetto: nessuno vede niente di sbagliato, e stringere anche su
+ * quelli renderebbe questa prova un ostacolo invece di una rete.
+ */
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const QUI = dirname(fileURLToPath(import.meta.url));
+const CARTELLE = [join(QUI, "..", "src", "sections"), join(QUI, "..", "src", "core")];
+
+function sorgenti() {
+  const fuori = [];
+  for (const cartella of CARTELLE)
+    for (const nome of readdirSync(cartella).filter((n) => n.endsWith(".js")))
+      fuori.push({ nome, testo: readFileSync(join(cartella, nome), "utf8") });
+  return fuori;
+}
+
+/* Spezza il CSS in pezzi, ognuno col contesto della at-rule che lo contiene. */
+function pezziConContesto(css) {
+  const pezzi = [];
+  const re = /@(media|supports|container)([^{]*)\{/g;
+  let ultimo = 0;
+  let m;
+  while ((m = re.exec(css))) {
+    pezzi.push({ ctx: "", corpo: css.slice(ultimo, m.index) });
+    let livello = 1;
+    let i = m.index + m[0].length;
+    for (; i < css.length && livello > 0; i++) {
+      if (css[i] === "{") livello += 1;
+      else if (css[i] === "}") livello -= 1;
+    }
+    pezzi.push({
+      ctx: `@${m[1]}${m[2].replace(/\s+/g, " ").trim()}`,
+      corpo: css.slice(m.index + m[0].length, i - 1),
+    });
+    ultimo = i;
+    re.lastIndex = i;
+  }
+  pezzi.push({ ctx: "", corpo: css.slice(ultimo) });
+  return pezzi;
+}
+
+/* I passi di un'animazione non sono contesi: ogni modulo ha i suoi fotogrammi,
+ * col proprio nome, e `50%` dentro l'uno non c'entra con `50%` dentro l'altro. */
+const PASSO_DI_ANIMAZIONE = /^(?:\d+(?:\.\d+)?%|from|to)$/i;
+
+function censimento() {
+  const decisioni = new Map();
+  for (const { nome, testo } of sorgenti()) {
+    for (const blocco of testo.matchAll(/`([^`\\]|\\.)*`/g)) {
+      const css = blocco[0].slice(1, -1).replace(/\/\*[\s\S]*?\*\//g, "");
+      if (!/[.#:\w][^{}]*\{[^{}]*:[^{}]*\}/.test(css)) continue;
+      for (const { ctx, corpo } of pezziConContesto(css)) {
+        for (const regola of corpo.matchAll(/([^{}@][^{}]*)\{([^{}]*)\}/g)) {
+          const selettori = regola[1]
+            .split(",")
+            .map((s) => s.replace(/\s+/g, " ").trim())
+            .filter(Boolean);
+          for (const dichiarazione of regola[2].split(";")) {
+            const taglio = dichiarazione.indexOf(":");
+            if (taglio < 0) continue;
+            const proprieta = dichiarazione.slice(0, taglio).trim().toLowerCase();
+            if (!/^[-a-z]+$/.test(proprieta)) continue;
+            const valore = dichiarazione
+              .slice(taglio + 1)
+              .replace(/!\s*important/i, "")
+              .replace(/\s+/g, " ")
+              .trim();
+            for (const selettore of selettori) {
+              if (PASSO_DI_ANIMAZIONE.test(selettore)) continue;
+              const chiave = `${ctx}§${selettore}|${proprieta}`;
+              if (!decisioni.has(chiave)) decisioni.set(chiave, new Map());
+              const padroni = decisioni.get(chiave);
+              const suo = padroni.get(nome) || new Set();
+              suo.add(valore);
+              padroni.set(nome, suo);
+            }
+          }
+        }
+      }
+    }
+  }
+  return decisioni;
+}
+
+test("nessuna regola e' decisa da due fogli che dicono cose diverse", () => {
+  const decisioni = censimento();
+  assert.ok(
+    decisioni.size > 10_000,
+    `il censimento dovrebbe vedere migliaia di decisioni, ne ha viste ${decisioni.size}`,
+  );
+  const discordi = [];
+  for (const [chiave, padroni] of decisioni) {
+    if (padroni.size < 2) continue;
+    const valori = new Set([...padroni.values()].flatMap((v) => [...v]));
+    if (valori.size < 2) continue;
+    const dettaglio = [...padroni]
+      .map(([nome, v]) => `      ${[...v].join(" / ")}   <- ${nome}`)
+      .join("\n");
+    discordi.push(`  ${chiave}\n${dettaglio}`);
+  }
+  assert.deepEqual(
+    discordi,
+    [],
+    "queste decisioni hanno due padroni con valori diversi: vince chi carica per " +
+      "ultimo, e chi cambia il valore nel foglio che perde non vede succedere " +
+      `niente.\n${discordi.join("\n")}`,
+  );
+});

--- a/custom_components/dashboardmodern/frontend/tests/ogni-modulo-si-legge.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/ogni-modulo-si-legge.test.js
@@ -1,0 +1,61 @@
+/* Ogni modulo si legge, e se non si legge si sa quale.
+ *
+ * Il difetto che questa prova rende leggibile: il CSS di questo progetto vive
+ * dentro template literal, e dentro un template literal il backtick lo chiude.
+ * Un commento che nomina una proprieta' fra backtick — il modo naturale di
+ * scriverlo in JavaScript — taglia il foglio a meta' e rompe il modulo.
+ * Scrivendo le spiegazioni delle correzioni di oggi e' successo sei volte in
+ * cinque file.
+ *
+ * Le prove lo dicevano gia', ma male: «missing ) after argument list» a
+ * centinaia di righe dal punto vero, e dietro sette prove rosse che col
+ * difetto non c'entravano niente — erano tutte le prove che importavano quel
+ * modulo. Ci vuole mezz'ora per capire che il colpevole e' uno solo.
+ *
+ * Qui si prova a leggere ogni modulo per conto suo, e si dice il nome. Non e'
+ * un controllo di stile: e' la differenza fra «qualcosa e' rotto» e «e' rotto
+ * questo file». Nei commenti dentro un foglio si usano le virgolette basse.
+ */
+import assert from "node:assert/strict";
+import { readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const QUI = dirname(fileURLToPath(import.meta.url));
+const CARTELLE = ["core", "sections", "legacy", "transport"].map((n) => join(QUI, "..", "src", n));
+
+function moduli() {
+  const fuori = [];
+  for (const cartella of CARTELLE) {
+    let nomi = [];
+    try {
+      nomi = readdirSync(cartella).filter((n) => n.endsWith(".js"));
+    } catch (_errore) {
+      continue;
+    }
+    for (const nome of nomi) fuori.push({ nome, percorso: join(cartella, nome) });
+  }
+  return fuori;
+}
+
+test("ogni modulo si legge da solo", async () => {
+  const elenco = moduli();
+  assert.ok(elenco.length > 100, `dovrebbero essere piu' di cento moduli, ne ho visti ${elenco.length}`);
+  const rotti = [];
+  for (const { nome, percorso } of elenco) {
+    try {
+      await import(pathToFileURL(percorso).href);
+    } catch (errore) {
+      const messaggio = String(errore?.message || errore).split("\n")[0];
+      /* La causa piu' frequente ha un nome, e vale la pena dirlo qui invece di
+       * lasciarlo scoprire: un backtick dentro un foglio di stile. */
+      const indizio = /missing \) after argument list|Unexpected token/.test(messaggio)
+        ? " — spesso e' un backtick dentro un foglio di stile, che chiude il template literal"
+        : "";
+      rotti.push(`${nome}: ${messaggio}${indizio}`);
+    }
+  }
+  assert.deepEqual(rotti, [], `questi moduli non si leggono:\n  ${rotti.join("\n  ")}`);
+});

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -439,7 +439,23 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // ne ricava una frase e i punti che la reggono. Tenerli insieme voleva dire
   // un file dove il conteggio delle righe e il bilancio energetico si
   // guardano, ed e' il genere di vicinanza da cui nascono i due padroni.
-  assert.ok(relative.length <= 172, `production graph unexpectedly grew to ${relative.length} modules`);
+  // 173 col modello di una grandezza nel tempo: la finestra sapeva dire «574 W»
+  // e nient'altro, e un numero da solo non si sa se e' tanto o poco — 574 watt
+  // sono normali per una casa e tantissimi per un frigorifero. Il modulo
+  // prende una serie di letture e ne ricava le quattro cose che servono per
+  // dire qualcosa di sensato: da che parte sta andando, quando ci arrivera',
+  // quale sia il suo valore abituale, e se quello di adesso sia normale. Sta
+  // per conto suo perche' non sa niente di sezioni: conta e basta, e va bene
+  // anche per una soglia di avviso o per decidere se una scheda si colora.
+  //
+  // 174 col padrone unico dello storico. Il modello vuole le letture di prima,
+  // che il grafico delle temperature gia' chiedeva a Recorder con la sua cache.
+  // La strada breve era copiarne il codice nelle finestre: sarebbero stati due
+  // padroni dello stesso traffico, due cache che non si parlano, due domande
+  // per la stessa entita' e la certezza che prima o poi una scada con una
+  // regola diversa dall'altra. E' il difetto che si sta togliendo dappertutto
+  // in questi giorni: qui si evitava di crearne uno nuovo.
+  assert.ok(relative.length <= 174, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
 
   /* No polling, with two declared exceptions.

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -428,7 +428,18 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // puro, `racconto-tessera.js`, e si provano senza browser: una frase che
   // dice «da 40 minuti» o «finisce alle 19:20» e' esattamente il genere di
   // cosa che si sbaglia in silenzio, e a occhio non si vede.
-  assert.ok(relative.length <= 171, `production graph unexpectedly grew to ${relative.length} modules`);
+  // 172 col motore di analisi delle finestre: la frase sotto il verdetto
+  // veniva da un ripiego che sa contare solo cose accese e spente, e dieci
+  // sezioni su diciassette non sono fatte cosi'. L'Energia scriveva «4 cose,
+  // nessuna in funzione» col fotovoltaico a 2,16 kW; la Sicurezza «Qui non
+  // c'e' ancora niente» con l'antifurto elencato sotto. Le letture stanno in
+  // un modulo puro, `analisi-sezione.js`, separato da `racconto-tessera.js`
+  // perche' fanno due mestieri diversi: quello dice se una tessera e' in moto
+  // e come si chiama il suo verdetto, questo legge i numeri di una sezione e
+  // ne ricava una frase e i punti che la reggono. Tenerli insieme voleva dire
+  // un file dove il conteggio delle righe e il bilancio energetico si
+  // guardano, ed e' il genere di vicinanza da cui nascono i due padroni.
+  assert.ok(relative.length <= 172, `production graph unexpectedly grew to ${relative.length} modules`);
   assertAcyclic(edges);
 
   /* No polling, with two declared exceptions.

--- a/custom_components/dashboardmodern/frontend/tests/temperature-trend.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/temperature-trend.test.js
@@ -101,7 +101,15 @@ test("the panel is one owner that reads the selection instead of copying it", as
   // the filter broke in the first place.
   assert.match(source, /dm-beta16-temperature-tabs .dm-beta27-temperature-tab.active/);
   assert.doesNotMatch(source, /setInterval|MutationObserver/);
-  // The history transport is the one the card popup already uses.
-  assert.match(source, /history\/history_during_period/);
-  assert.match(source, /normalizeHistoryRows/);
+  /* Lo storico non se lo chiede da solo: lo chiede al modulo condiviso.
+   *
+   * Qui si pretendeva che la domanda a Recorder fosse scritta dentro questo
+   * file — «lo stesso trasporto che usa gia' la finestra della card». Era
+   * l'intenzione giusta detta nel modo debole: due moduli che scrivono la
+   * stessa domanda usano lo stesso trasporto per modo di dire, e ognuno ha la
+   * sua cache. Quando anche le finestre hanno avuto bisogno di quelle letture,
+   * la domanda e' passata a un padrone solo. Adesso la prova pretende quello:
+   * che qui la domanda non ci sia. */
+  assert.doesNotMatch(source, /history\/history_during_period/);
+  assert.match(source, /from "\.\/storico-condiviso-section\.js"/);
 });

--- a/custom_components/dashboardmodern/frontend/tests/un-padrone-per-nodo.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/un-padrone-per-nodo.test.js
@@ -1,0 +1,104 @@
+/* Ogni nodo che il guscio scrive ha un padrone solo fra i moduli.
+ *
+ * Il difetto che questa prova impedisce si vedeva a occhio nudo: nel flusso
+ * dell'Energia il numero della batteria cambiava faccia da solo, «▼ 1796 W /
+ * SOC 75%» e poi «-1796 W / 75 %», avanti e indietro a ogni cambio di stato.
+ * Non era un'animazione: erano quattro moduli che scrivevano lo stesso nodo
+ * con tre formati diversi, piu' il guscio col suo.
+ *
+ * La regola e' una sola, e vale per i sessantaquattro nodi che il guscio
+ * scrive con `setTxt`/`setHtml`: chi li scrive dal lato dei moduli dev'essere
+ * uno, e deve passare dal delegato di `shared.js`. Il delegato lascia sul
+ * nodo il cartello `data-dm-padrone="moduli"`, e il guscio quel nodo non lo
+ * tocca piu'. Scriverlo a mano — `nodo.textContent = ...` — salta il
+ * cartello, il guscio non se ne accorge e i due si riscrivono addosso: e'
+ * esattamente com'era nata questa.
+ *
+ * La prova legge i sorgenti invece di aprire un browser perche' il difetto e'
+ * nella struttura, non nel disegno: due padroni sono due padroni anche
+ * quando, per un caso di ordini, oggi finiscono per scrivere la stessa cosa.
+ */
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const QUI = dirname(fileURLToPath(import.meta.url));
+const RADICE = join(QUI, "..");
+const GUSCIO = join(RADICE, "legacy", "dashboard-runtime-it.js");
+const MODULI = join(RADICE, "src", "sections");
+
+/* Il delegato stesso, e chi non disegna ma smista. */
+const DELEGATI = new Set(["shared.js", "section-runtime.js"]);
+
+function nodiDelGuscio() {
+  const testo = readFileSync(GUSCIO, "utf8");
+  const trovati = new Set();
+  for (const m of testo.matchAll(/set(?:Txt|Html)\(\s*['"]([\w-]+)['"]/g)) trovati.add(m[1]);
+  return trovati;
+}
+
+function moduli() {
+  return readdirSync(MODULI)
+    .filter((n) => n.endsWith(".js") && !DELEGATI.has(n))
+    .map((nome) => ({ nome, testo: readFileSync(join(MODULI, nome), "utf8") }));
+}
+
+test("nessun nodo del guscio ha due padroni fra i moduli", () => {
+  const nodi = nodiDelGuscio();
+  assert.ok(
+    nodi.size > 40,
+    `il guscio dovrebbe scrivere decine di nodi, ne ho contati ${nodi.size}`,
+  );
+  const elenco = moduli();
+  const contesi = [];
+  for (const nodo of nodi) {
+    const cerca = new RegExp(`['"\`]#?${nodo}['"\`,\\]]`);
+    const padroni = elenco.filter((m) => cerca.test(m.testo)).map((m) => m.nome);
+    if (padroni.length > 1) contesi.push(`#${nodo}: ${padroni.join(", ")}`);
+  }
+  assert.deepEqual(
+    contesi,
+    [],
+    `questi nodi del guscio hanno piu' di un padrone fra i moduli:\n  ${contesi.join("\n  ")}`,
+  );
+});
+
+/* Chi prende un nodo del guscio e se lo mette in una variabile.
+ *
+ * Si guarda la variabile, non il file: un modulo puo' nominare un nodo del
+ * guscio per spostarlo o per leggerlo senza esserne il padrone — la striscia
+ * del meteo, per dire, prende `#w-temp` e la porta dentro l'intestazione, ma
+ * il numero continua a scriverlo il guscio. Quello non e' un secondo padrone.
+ * Lo diventa quando a quella variabile ci scrive addosso. */
+function preseDelNodo(testo, nodo) {
+  const prese = [];
+  const modi = [
+    new RegExp(`(?:const|let|var)\\s+([\\w$]+)\\s*=[^;\\n]*getElementById\\(\\s*["'\`]${nodo}["'\`]`, "g"),
+    new RegExp(`(?:const|let|var)\\s+([\\w$]+)\\s*=[^;\\n]*querySelector\\(\\s*["'\`][^"'\`]*#${nodo}\\b`, "g"),
+  ];
+  for (const modo of modi) for (const m of testo.matchAll(modo)) prese.push(m[1]);
+  return prese;
+}
+
+test("chi scrive un nodo del guscio passa dal delegato che lo rivendica", () => {
+  const nodi = nodiDelGuscio();
+  const senzaCartello = [];
+  for (const { nome, testo } of moduli()) {
+    for (const nodo of nodi) {
+      for (const variabile of preseDelNodo(testo, nodo)) {
+        const aMano = new RegExp(`\\b${variabile}\\.(?:textContent|innerHTML)\\s*=[^=]`);
+        const riga = testo.split("\n").findIndex((r) => aMano.test(r));
+        if (riga >= 0)
+          senzaCartello.push(`${nome}:${riga + 1} scrive #${nodo} a mano (\`${variabile}\`)`);
+      }
+    }
+  }
+  assert.deepEqual(
+    senzaCartello,
+    [],
+    `questi moduli scrivono un nodo del guscio senza rivendicarlo, quindi il guscio ` +
+      `continuera' a riscriverglielo sopra:\n  ${senzaCartello.join("\n  ")}`,
+  );
+});

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.3.5"
+  "version": "1.3.6"
 }


### PR DESCRIPTION
## Cosa risolve

Sei cose segnalate dalla casa vera, con schermate e un video, piu' il modello di analisi chiesto dopo.

### Lo sfarfallio dell'Energia, trovato nel video

Due fotogrammi a distanza: `▼ 1796 W / SOC 75%` diventa `-1796 W / 75 %`, e torna. Non era un'animazione: quel nodo aveva **quattro padroni** — il guscio col suo formattatore, `energy-flow-section` con la freccia, `beta22-load-slots-hotfix` con un terzo formato, e `beta24-energy-recovery` che teneva un **MutationObserver sul nodo per rimettere il prefisso «SOC» addosso a quello che ci scrivevano gli altri**. Sorvegliare un nodo per disfare la scrittura di un altro modulo non e' una correzione: e' il secondo padrone che litiga col primo.

Adesso il padrone e' uno, e rivendica il nodo all'installazione invece che alla prima passata: chi arrivava tardi lasciava vedere un lampo della forma del guscio. Misurato: da due forme alternate a una sola su quaranta cambi di stato.

### Le finestre che raccontavano cose sbagliate

**Dieci sezioni su diciassette non avevano una frase propria** e cadevano su un ripiego che sa contare solo cose accese e spente. Da li' «4 cose, nessuna in funzione» con il fotovoltaico a 2,16 kW, e «Qui non c'e' ancora niente» con l'antifurto elencato sotto. Non erano frasi imprecise: parlavano di un'altra cosa.

Ogni sezione ha adesso la sua lettura, fondata sui dati che ha davvero. L'Energia ragiona sul bilancio; la Temperatura sulla distanza fra la stanza piu' calda e la piu' fredda, che e' il dato utile; la Piscina col pH fuori norma diventa da guardare anche senza niente acceso.

### Il modello, dentro il motore

Su richiesta esplicita: niente AI da installare. Dentro il motore c'e' un modello di una grandezza nel tempo, che da una serie di letture ricava da che parte sta andando, quando arrivera' dove deve arrivare, quale sia il suo valore abituale, e se quello di adesso sia normale. La finestra passa da «574 W» a «Piu' alto del solito per quest'ora: 900 W contro 300 W».

Tre scelte lo tengono onesto, e sono i tre modi di sbagliarlo:

- **il tempo pesa** — un sensore fermo a zero per sei ore che poi fa tre picchi in un minuto, contando le letture «di solito» sta al picco; contando il tempo sta a zero, che e' la verita';
- **mediana, non media** — un inverter che legge 60000 W per due secondi sposterebbe la media di un'ora intera;
- **una tendenza si annuncia solo se c'e'** — una retta si traccia anche sul rumore, e sotto una certa bonta' la risposta e' «ferma». Le previsioni tacciono oltre l'orizzonte: «piena fra ventisei ore» e' un modo raffinato di non dire niente.

Non sa niente di sezioni, finestre o documento: prende numeri e restituisce numeri, quindi serve anche per una soglia di avviso o per il colore di una scheda.

### La luce nelle Stanze

Il comando partiva, Home Assistant accendeva la luce, la scheda restava «SPENTA». La scheda e' quella della pagina Luci, ma il riallineamento era chiuso li' dentro e si fermava quando quella pagina non era aperta. Adesso chi possiede il disegno possiede anche l'aggiornamento, e il tocco si vede subito — con lo stato che poi conferma o corregge, cosi' un comando fallito non lascia una scheda che mente.

### I duplicati

- **33 regole di stile morte sul Clima**: due pelli in due fogli che si contendevano quattordici misure in disaccordo, su un markup che nessuno disegna piu' (contati a plancia aperta: zero nodi).
- **3 conflitti veri** chiusi, ognuno con un padrone solo.
- **Lo storico chiesto a Recorder** ha adesso un padrone solo: copiarne la domanda nelle finestre avrebbe creato due cache che non si parlano.

### La finestra del Clima e i comandi

L'etichetta ha `flex:0 0 82px`, che in orizzontale e' una larghezza; sul telefono la riga diventa verticale e diventa **altezza**. La correzione esisteva ma era scritta per una sola delle due finestre — un selettore aggiornato e il gemello dimenticato. Da 82 a 12 pixel: 210 pixel di vuoto in meno.

E sotto «Comandi» c'erano quattro letture senza un tasto: adesso il titolo guarda cosa c'e' davvero sotto, e le percentuali hanno una barra che diventa rossa sotto il venti per cento.

## Una correzione a un numero che avevo dato

Avevo riferito 37 conflitti CSS. Erano gonfiati: contavo come conflitto anche una regola dentro `@media` che ne ridichiara una di fuori, che non e' un conflitto ma il modo in cui si scrive una pagina responsiva. I veri erano tre. La prova nuova tiene conto del contesto della at-rule, perche' un numero gonfiato e' peggio di nessun numero — si smette di guardarlo.

## Le prove

**1465 verdi**, 319 nel browser su desktop. Le nuove:

| Prova | Cosa pretende |
|---|---|
| `un-padrone-per-nodo` | nessuno dei 64 nodi del guscio ha due padroni fra i moduli — verificata rossa rimettendo il secondo |
| `nessuna-regola-con-due-padroni` | zero decisioni di stile contese e discordi, col contesto della at-rule |
| `il-modello-nel-tempo` | 14 casi scelti per far cadere un modello ingenuo: il picco che sposta la media, il sensore fermo che sembra spiccare, il rumore che sembra una salita |
| `lanalisi-delle-sezioni` | 23 casi coi numeri veri delle schermate arrivate dalla casa |
| `la-batteria-non-cambia-faccia` | quaranta cambi di stato, una forma sola |
| `le-luci-nelle-stanze-rispondono` | quattro momenti, compreso lo spegnimento da fuori che tiene onesto l'ottimismo |
| `il-modello-parla-nella-finestra` | storico finto nella forma vera: le letture arrivano fin dentro la finestra |
| `il-pannello-non-lascia-il-vuoto` | l'altezza vera dell'etichetta a plancia aperta |
| `il-titolo-dice-cosa-ce-sotto` | titolo e contenuto d'accordo nei due versi |
| `ogni-modulo-si-legge` | dice quale file e' rotto, invece di «missing ) after argument list» a centinaia di righe dal punto vero |

## Quello che resta aperto

La testata che sparisce sulla Home scrollando velocemente da smartphone: non sono riuscito a riprodurla, e non la dichiaro corretta.

Una fragilita' trovata scrivendo le prove: la plancia **assegna** `DashboardModernEnergyService` all'avvio, e rendere quella proprieta' di sola lettura fa morire l'avvio in silenzio. Aggirata nella prova, non toccata nel codice.

---
_Generated by [Claude Code](https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT)_