### PR TITLE
Versione 1.4.5-beta.1: la plancia arriva in un pacchetto, non in centosettantanove file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,9 +143,16 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
+      # Prima la provenienza, POI il pacchetto: `modules-entry.js` importa
+      # `build-info.js`, quindi impacchettare per primo ci murerebbe dentro la
+      # versione e il commit del file tracciato — quelli della release
+      # PRECEDENTE — e il build-info generato dopo non lo leggerebbe piu'
+      # nessuno. La plancia direbbe di essere la versione di ieri.
       - name: Impacchetta la plancia
         run: |
           npm ci
+          python scripts/generate_build_info.py --expected-commit "$GITHUB_SHA" \
+            --output custom_components/dashboardmodern/frontend/legacy/build-info.js
           node scripts/impacchetta-la-plancia.mjs
       - name: Generate build provenance from the selected HEAD
         run: python scripts/build_release.py --expected-commit "$GITHUB_SHA" --output dashboardmodern.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,18 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+      # La plancia va nel pacchetto impacchettata: nei sorgenti sono
+      # centosettantanove file JavaScript, e al primo avvio sono
+      # centosettantanove richieste. Il guscio riscritto qui finisce solo
+      # dentro lo zip; nel deposito restano i sorgenti, che si sviluppano cosi'.
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Impacchetta la plancia
+        run: |
+          npm ci
+          node scripts/impacchetta-la-plancia.mjs
       - name: Generate build provenance from the selected HEAD
         run: python scripts/build_release.py --expected-commit "$GITHUB_SHA" --output dashboardmodern.zip
       # Le note automatiche di GitHub elencano cosa è cambiato; il blocco di

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ dashboardmodern.zip
 # La cartella di lavoro dello script che prepara i ritratti: i PNG originali
 # si riscaricano, quello che si tiene sono i WebP gia' pronti.
 .avatar-cache/
+
+# Il pacchetto della plancia: si costruisce, non si conserva.
+custom_components/dashboardmodern/frontend/legacy/pacco/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dashboardmodern.zip
 
 # Il pacchetto della plancia: si costruisce, non si conserva.
 custom_components/dashboardmodern/frontend/legacy/pacco/
+custom_components/dashboardmodern/frontend/legacy/*.prima-del-pacco

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.4.5-beta.1
+
+Una beta per provare l'avvio impacchettato prima di darlo a tutti. Chi non
+chiede le versioni beta non la riceve.
+
+### Nuovo
+
+- **La plancia arriva in un pacchetto, non in centosettantanove file.** «Impiega
+  ancora troppo tempo in caricamento, soprattutto in primo avvio.» Non era il
+  velo: al primo avvio il browser scaricava centosettantanove file JavaScript
+  per quattro megabyte. Non in fila — il documento li precarica tutti insieme —
+  ma su HTTP/1.1 il browser ne serve sei per volta, ed erano una trentina di
+  ondate prima di avere tutto. Adesso sono tre file. Restano fuori i tredici
+  cataloghi delle lingue, quasi due megabyte a una casa che ne parla una sola:
+  arriva solo quella che serve. Se il pacchetto manca, la plancia parte lo
+  stesso dai sorgenti — e la Diagnostica runtime dice quale delle due strade sta
+  usando.
+
+### Corretto
+
+- **Le caselle del popup Lavatrice si scelgono dalla riga.** Nella finestra
+  «Modifica azione» ogni casella portava due tasti azzurri con la lente,
+  appaiati, e nessuno dei due era il modo giusto: in tutta la plancia
+  un'entita' si sceglie dalla riga stessa. Quella passata pero' girava solo
+  dentro le fisarmoniche delle Sezioni, e questa carta sta altrove.
+
 ## 1.4.4
 
 ### Nuovo

--- a/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
@@ -234,8 +234,23 @@ for (const variant of PRIMARY) {
     await page.evaluate(() => window.apriConfigEntita());
     await expect(page.locator('.ed-tab[data-tab="runtime"]')).toHaveCount(1);
     await page.locator('.ed-tab[data-tab="runtime"]').click();
-    await expect(page.locator("[data-runtime-diagnostics] .ed-row")).toHaveCount(11);
+    /* Una riga per voce, e il numero e' proprio la prova: se un'etichetta
+     * tradotta torna vuota la sua chiave collassa, la riga sparisce senza
+     * rumore, e solo il conto se ne accorge.
+     *
+     * Il conto e' passato da undici a dodici quando la plancia ha imparato a
+     * dire da dove arrivano le sue parti — impacchettate o sciolte. Ci sono
+     * volute quattro tornate di CI per capirlo, perche' il fallimento si
+     * leggeva come una prova ballerina: cadeva sempre e solo qui, e sempre e
+     * solo su uno shard. Non ballava affatto — contava giusto.
+     *
+     * Chi aggiunge una voce alza questo numero E la nomina qui sotto: cosi'
+     * la prossima volta il conto si legge invece di sembrare capriccio. */
+    await expect(page.locator("[data-runtime-diagnostics] .ed-row")).toHaveCount(12);
     await expect(page.locator("[data-runtime-diagnostics]")).toContainText("Integration version");
+    /* La dodicesima. Vale in tutt'e due gli stati, che e' il punto: la riga
+     * dice quale dei due, non presume. */
+    await expect(page.locator("[data-runtime-diagnostics]")).toContainText(/impacchettati|sciolti/);
     await page.evaluate(() => window.editorSwitch("sez1"));
     await expect(page.locator('#ed-body[data-renderer="energy"]')).toBeVisible();
     await page.screenshot({ path: `test-results/${testInfo.project.name}-${variant}-energy.png` });

--- a/custom_components/dashboardmodern/frontend/e2e/i-loghi-arrivano-senza-rete.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/i-loghi-arrivano-senza-rete.spec.js
@@ -33,11 +33,16 @@ test("con la rete staccata i loghi dei marchi si vedono lo stesso", async ({ pag
   await bootNamespacedDashboard(page, "dashboard.html", testInfo, seme);
 
   const esito = await page.evaluate(async () => {
-    const base = [...document.querySelectorAll("script")]
-      .map((nodo) => nodo.src)
-      .find((src) => src.includes("modules-entry"));
-    const radice = base ? base.replace(/\/legacy\/modules-entry.*$/, "") : "";
-    const catalogo = await import(`${radice}/src/core/personalization-catalog.js`);
+    /* Il catalogo si prende dai sorgenti, e la strada si conta dal DOCUMENTO.
+     *
+     * Prima si partiva dal tag dello script d'ingresso, che pero' cambia casa:
+     * impacchettata la plancia lo carica da `legacy/pacco/legacy/`, e togliere
+     * `/legacy/modules-entry...` da li' lasciava una radice dentro il
+     * pacchetto, dove i sorgenti non stanno. Il documento invece e' sempre
+     * `legacy/dashboard*.html`, col pacchetto e senza. */
+    const catalogo = await import(
+      new URL("../src/core/personalization-catalog.js", location.href).href
+    );
     const box = document.createElement("div");
     box.id = "dm-prova-loghi";
     document.body.append(box);

--- a/custom_components/dashboardmodern/frontend/e2e/le-caselle-si-scelgono-dalla-riga.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/le-caselle-si-scelgono-dalla-riga.spec.js
@@ -1,0 +1,175 @@
+/* Le caselle del popup Lavatrice si scelgono dalla riga, come tutte le altre.
+ *
+ * Dal campo, con lo scatto: «lente per ricerca entita nel config azioni rapide
+ * popup lavatrice: questa funzione e' stata deprecata con la nuova metodologia
+ * di ricerca entita'» — e poi, per essere chiari: «non c'e' la lente per la
+ * ricerca entita' ma si fa direttamente nella riga».
+ *
+ * Nella finestra «Modifica azione» ogni casella portava DUE tasti azzurri con
+ * la lente, appaiati: uno se lo disegnava la carta, l'altro glielo metteva la
+ * guardia del selettore, che non riconosceva il primo come gia' fatto. E
+ * nessuno dei due era il modo giusto: in tutta la plancia un'entita' si sceglie
+ * dalla riga stessa — la pastiglia che dice cosa c'e' dentro, il cestino per
+ * toglierla, «Modifica manuale» per chi vuole batterla a mano.
+ *
+ * Quella passata girava solo dentro le fisarmoniche delle Sezioni, e questa
+ * carta nella finestra di modifica sta altrove: non la raggiungeva. Adesso la
+ * carta la chiede, e vale nei due posti in cui compare.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const SEME = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  visibility: { home: true },
+};
+
+const AZIONI = [
+  { type: "builtin", builtin: "lavatrice", name: "Lavatrice", icon: "🧺" },
+  { type: "toggle", entity: "switch.frog", name: "Frog", icon: "⚡" },
+];
+
+async function apriLaModificaDellaLavatrice(page, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, SEME);
+  await page.locator("#setup-wizard").evaluateAll((nodi) => nodi.forEach((n) => n.remove()));
+  await page.evaluate((azioni) => {
+    localStorage.setItem("cd_quick_actions", JSON.stringify(azioni));
+    window.buildQuickActions?.();
+    if (!document.getElementById("editor-modal")?.classList.contains("show")) apriConfigEntita();
+    try {
+      editorSwitch("sez8");
+    } catch (_errore) {}
+  }, AZIONI);
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            [...document.querySelectorAll("#ed-body .ed-row")].filter((riga) =>
+              /Frog/.test(riga.textContent || ""),
+            ).length,
+        ),
+      { timeout: 20_000 },
+    )
+    .toBeGreaterThan(0);
+  /* La matita della riga «Lavatrice»: e' da li' che si arriva alla finestra
+   * dello scatto. */
+  await page.evaluate(() => {
+    const riga = [...document.querySelectorAll("#ed-body .ed-row")].find((r) =>
+      /Lavatrice/i.test(r.textContent || ""),
+    );
+    const matita = [...(riga?.querySelectorAll("button,.ed-del") || [])].find((b) =>
+      /✏️/.test(b.textContent || ""),
+    );
+    matita?.click();
+  });
+  const carta = page.locator("#dm-action-editor-modal [data-dm-lav-programmi]");
+  await expect(carta).toBeVisible({ timeout: 20_000 });
+  await expect(carta.locator(".dm-lav-slot-in")).toHaveCount(8);
+  return carta;
+}
+
+test("le caselle del popup hanno la riga di scelta, non la lente", async ({ page }, testInfo) => {
+  test.setTimeout(150_000);
+  const carta = await apriLaModificaDellaLavatrice(page, testInfo);
+
+  /* La riga di scelta su tutte e otto. Si aspetta, perche' la passata che
+   * decora arriva a giri e la carta nasce un istante prima. */
+  await expect
+    .poll(
+      () => page.evaluate(() => document.querySelectorAll(".dm-lav-slot > .dm-slot-chip").length),
+      { timeout: 20_000 },
+    )
+    .toBe(8);
+  await expect(carta.locator(".dm-lav-slot > .dm-slot-chip").first()).toContainText(
+    "Scegli entità",
+  );
+
+  /* E la lente non si vede piu'.
+   *
+   * Quella che la carta si disegnava da sola non c'e' proprio piu'. Della
+   * guardia ne resta una nel documento, nascosta insieme al campo grezzo:
+   * torna in vista solo con «Modifica manuale», dove si batte l'entita' a
+   * mano ed e' un aiuto. Quello che conta e' che a riga chiusa non se ne
+   * veda nessuna — erano due, appaiate, ed e' la segnalazione. */
+  const lentiVisibili = () =>
+    page.evaluate(
+      () =>
+        [
+          ...document.querySelectorAll(
+            ".dm-lav-slot .dm-entity-picker:not(.dm-slot-chip),.dm-lav-slot .dm-lav-slot-btn",
+          ),
+        ].filter((nodo) => nodo.getBoundingClientRect().width > 0).length,
+    );
+  await expect.poll(lentiVisibili, { timeout: 20_000 }).toBe(0);
+
+  /* Il tasto della carta e' proprio sparito dal documento, non solo nascosto:
+   * era un doppione di quello che fa la guardia. */
+  expect(await page.evaluate(() => document.querySelectorAll(".dm-lav-slot-btn").length)).toBe(0);
+});
+
+test("dalla riga si sceglie davvero, e la scelta si salva", async ({ page }, testInfo) => {
+  test.setTimeout(150_000);
+  const carta = await apriLaModificaDellaLavatrice(page, testInfo);
+  await expect
+    .poll(
+      () => page.evaluate(() => document.querySelectorAll(".dm-lav-slot > .dm-slot-chip").length),
+      { timeout: 20_000 },
+    )
+    .toBe(8);
+
+  /* Il tocco sulla riga apre il selettore del guscio, con IL CAMPO di questa
+   * carta: col nome dello slot scriverebbe nella riga gemella delle Sezioni. */
+  await page.evaluate(() => {
+    window.__DM_SCELTO__ = "";
+    const originale = window.wzPickEntity;
+    window.wzPickEntity = function (bersaglio, ...resto) {
+      window.__DM_SCELTO__ = bersaglio?.dataset?.ref || String(bersaglio);
+      return originale?.apply(this, [bersaglio, ...resto]);
+    };
+  });
+  await carta
+    .locator('.dm-lav-slot:has(.dm-lav-slot-in[data-ref="dm.lavatrice_programma"]) > .dm-slot-chip')
+    .click();
+  await expect.poll(() => page.evaluate(() => window.__DM_SCELTO__)).toBe("dm.lavatrice_programma");
+
+  /* E quello che entra nel campo si salva: e' il giro completo. */
+  await carta.locator('.dm-lav-slot-in[data-ref="dm.lavatrice_programma"]').evaluate((campo) => {
+    campo.value = "select.lavatrice_programma";
+    campo.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            JSON.parse(localStorage.getItem("cd_entity_overrides") || "{}")[
+              "dm.lavatrice_programma"
+            ] || "",
+        ),
+      { timeout: 20_000 },
+    )
+    .toBe("select.lavatrice_programma");
+
+  /* La riga adesso dice cosa c'e' dentro, invece di «Scegli entità». */
+  await expect(
+    carta.locator(
+      '.dm-lav-slot:has(.dm-lav-slot-in[data-ref="dm.lavatrice_programma"]) > .dm-slot-chip',
+    ),
+  ).toContainText("select.lavatrice_programma");
+});

--- a/custom_components/dashboardmodern/frontend/e2e/live-event-conflict.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/live-event-conflict.spec.js
@@ -5,12 +5,15 @@ import { PRIMARY } from "./helpers/variants.js";
 
 async function runtimeSnapshot(page) {
   return page.evaluate(async () => {
-    const entry = [...document.scripts].find((script) =>
-      /\/legacy\/modules-entry\.js(?:\?|$)/.test(script.src),
-    );
-    if (!entry?.src) throw new Error("DashboardModern module entry not found");
+    /* Il conto si prende dai sorgenti, e la strada si conta dal DOCUMENTO.
+     *
+     * Prima si partiva dal tag dello script d'ingresso, che pero' cambia casa:
+     * impacchettata la plancia lo carica da `legacy/pacco/legacy/`, e quel
+     * `../src/` finiva a puntare dentro il pacchetto, dove i sorgenti non
+     * stanno. Il documento invece e' sempre `legacy/dashboard*.html`, col
+     * pacchetto e senza, e da li' la strada e' una sola. */
     const { runtimeMetrics } = await import(
-      new URL("../src/core/runtime-metrics.js", entry.src).href
+      new URL("../src/core/runtime-metrics.js", location.href).href
     );
     return {
       metrics: runtimeMetrics.snapshot(),
@@ -40,12 +43,15 @@ async function waitForExpensiveRuntimeQuiescence(page) {
 
 async function resetRuntimeMetrics(page) {
   await page.evaluate(async () => {
-    const entry = [...document.scripts].find((script) =>
-      /\/legacy\/modules-entry\.js(?:\?|$)/.test(script.src),
-    );
-    if (!entry?.src) throw new Error("DashboardModern module entry not found");
+    /* Il conto si prende dai sorgenti, e la strada si conta dal DOCUMENTO.
+     *
+     * Prima si partiva dal tag dello script d'ingresso, che pero' cambia casa:
+     * impacchettata la plancia lo carica da `legacy/pacco/legacy/`, e quel
+     * `../src/` finiva a puntare dentro il pacchetto, dove i sorgenti non
+     * stanno. Il documento invece e' sempre `legacy/dashboard*.html`, col
+     * pacchetto e senza, e da li' la strada e' una sola. */
     const { runtimeMetrics } = await import(
-      new URL("../src/core/runtime-metrics.js", entry.src).href
+      new URL("../src/core/runtime-metrics.js", location.href).href
     );
     runtimeMetrics.reset();
   });

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.4","dashboardVersion":"1.4.4","moduleVersion":14,"schemaVersion":4,"date":"2026-09-01T03:27:25+00:00","commit":"d8dbf0da3bf65b0e0fe2de4d213b0e6436082369","assetHash":"d5c324f2ead9748c"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5-beta.1","dashboardVersion":"1.4.5-beta.1","moduleVersion":14,"schemaVersion":4,"date":"2026-09-01T09:18:03+00:00","commit":"550f0217ac100b3c8f64c30aa06d94eab2ae49b1","assetHash":"1581b9a425c354cd"});

--- a/custom_components/dashboardmodern/frontend/legacy/config.js
+++ b/custom_components/dashboardmodern/frontend/legacy/config.js
@@ -35,7 +35,18 @@
     if (releaseVersion) globalThis.DASHBOARD_VERSION = releaseVersion;
 
     state.started = true;
-    state.promise = import("../src/sections/section-runtime.js").catch((error) => {
+    /* Da dove arrivano le sezioni.
+     *
+     * Nei sorgenti sono centosettantanove file sciolti, e al primo avvio sono
+     * centosettantanove andate e ritorni: e' il tempo che si vede girare la
+     * rotella. Il pacchetto le mette in un file solo, e chi lo prepara lo
+     * dichiara qui. Senza dichiarazione vale la strada di sempre — cosi' i
+     * sorgenti restano avviabili come sono, e se il pacchetto manca la
+     * plancia parte lo stesso, veloce come prima e non piu' lenta. */
+    const pacco = globalThis.__DASHBOARDMODERN_PACCO_SEZIONI__;
+    state.promise = (
+      pacco ? import(pacco) : import("../src/sections/section-runtime.js")
+    ).catch((error) => {
       state.started = false;
       state.promise = null;
       if (state.unloading) return null;

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -623,7 +623,7 @@ function renderDiagnostics(target) {
      * differenza che si sente al primo avvio. Il pacchetto ha un ripiego: se
      * manca, la plancia parte lo stesso dai sorgenti — e allora e' bene poterlo
      * vedere a colpo d'occhio invece di indovinarlo dal cronometro. */
-    "Moduli": globalThis.__DASHBOARDMODERN_IMPACCHETTATA__ ? "impacchettati (3 file)" : "sciolti (179 file)",
+    Modules: globalThis.__DASHBOARDMODERN_IMPACCHETTATA__ ? "impacchettati (3 file)" : "sciolti (179 file)",
   };
   target.innerHTML = `<div class="ed-sec-title">🩺 ${t("diagnostics")}</div><div class="ed-list">${Object.entries(rows).map(([key, value]) => `<div class="ed-row"><div class="ed-row-main"><div class="ed-row-new">${esc(key)}</div><div class="ed-row-old mono">${esc(value)}</div></div></div>`).join("")}</div>`;
   target.dataset.runtimeDiagnostics = "true";

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -617,6 +617,13 @@ function renderDiagnostics(target) {
     "Static asset hash": location.pathname.match(/dashboardmodern_static\/([^/]+)/)?.[1] || BUILD_INFO.assetHash, [t("languageVariant")]: `${document.documentElement.lang || "?"} / ${location.pathname.split("/").pop()}`,
     [t("activeRenderer")]: document.querySelector(".ed-tab.active")?.dataset?.tab || "diagnostics",
     "Git commit": BUILD_INFO.commit, "Build date": BUILD_INFO.date,
+    /* Da dove sono arrivate le parti della plancia.
+     *
+     * Impacchettata sono tre file; sciolta sono centosettantanove, ed e' la
+     * differenza che si sente al primo avvio. Il pacchetto ha un ripiego: se
+     * manca, la plancia parte lo stesso dai sorgenti — e allora e' bene poterlo
+     * vedere a colpo d'occhio invece di indovinarlo dal cronometro. */
+    "Moduli": globalThis.__DASHBOARDMODERN_IMPACCHETTATA__ ? "impacchettati (3 file)" : "sciolti (179 file)",
   };
   target.innerHTML = `<div class="ed-sec-title">🩺 ${t("diagnostics")}</div><div class="ed-list">${Object.entries(rows).map(([key, value]) => `<div class="ed-row"><div class="ed-row-main"><div class="ed-row-new">${esc(key)}</div><div class="ed-row-old mono">${esc(value)}</div></div></div>`).join("")}</div>`;
   target.dataset.runtimeDiagnostics = "true";

--- a/custom_components/dashboardmodern/frontend/src/core/i18n.js
+++ b/custom_components/dashboardmodern/frontend/src/core/i18n.js
@@ -398,6 +398,22 @@ export function pick(it, en, locale = getLocale()) {
 /* Catalog loading                                                     */
 /* ------------------------------------------------------------------ */
 
+/* Dove stanno i cataloghi, visti da chi li chiede.
+ *
+ * Sono tredici file da centoventi chili l'uno: due milioni in tutto, e a una
+ * casa ne serve UNO. Restano quindi fuori dal pacchetto anche quando tutto il
+ * resto della plancia e' impacchettato in un file solo — chi parla italiano
+ * non deve scaricare il coreano.
+ *
+ * Ma un import relativo si conta da dove sta il codice, e il codice cambia
+ * casa: dai sorgenti sciolti gira da `src/core/`, impacchettato da `legacy/`.
+ * Chi mette insieme il pacchetto sa dove l'ha messo e lo dichiara qui; senza
+ * dichiarazione vale la strada di sempre, quella dei sorgenti. */
+export function cartellaDeiCataloghi() {
+  const dichiarata = String(root.__DASHBOARDMODERN_CATALOGHI__ || "");
+  return dichiarata || "../i18n/";
+}
+
 /**
  * Load the catalog for a locale. English needs none (it is the pivot) and
  * Italian is carried inline by every `t(it, en)` call site.
@@ -409,7 +425,7 @@ export function loadCatalog(code) {
   if (BUILT_IN_LOCALES.includes(target) || catalogs.has(target)) return Promise.resolve(target);
   const pending = pendingLoads.get(target);
   if (pending) return pending;
-  const promise = import(`../i18n/${target}.js`)
+  const promise = import(`${cartellaDeiCataloghi()}${target}.js`)
     .then((module) => {
       registerCatalog(target, module.default || module.catalog || {});
       return target;

--- a/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/editor-slots-section.js
@@ -175,6 +175,20 @@ function decorateBody(body) {
   return true;
 }
 
+/* Le stesse righe, anche fuori dalle fisarmoniche.
+ *
+ * La passata di sopra gira sui `.ed-acc-body`, cioe' dentro le fisarmoniche
+ * delle Sezioni. Una carta che le stesse righe le porta altrove — quella del
+ * popup Lavatrice, che compare anche nella finestra «Modifica azione» — non
+ * veniva mai raggiunta: le sue caselle restavano campi nudi con la lente
+ * accanto, mentre in tutta la plancia le entita' si scelgono dalla riga
+ * stessa. «Non c'e' la lente per la ricerca entita' ma si fa direttamente
+ * nella riga»: chi disegna una carta cosi' la chiede qui, e ottiene le stesse
+ * righe del resto. */
+export function decoraCaselleDiUnaCarta(contenitore) {
+  return decorateBody(contenitore) ? 1 : 0;
+}
+
 /* Rows the configuration no longer offers, taken out of the form.
  *
  * The runtime tries to hide these two itself, with an inline `display:none`

--- a/custom_components/dashboardmodern/frontend/src/sections/il-popup-della-lavatrice-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/il-popup-della-lavatrice-section.js
@@ -20,6 +20,7 @@
  */
 import { applianceHeroArtwork } from "../core/appliance-hero-artwork.js";
 import { applianceVisualKey } from "../core/device-model.js";
+import { decoraCaselleDiUnaCarta } from "./editor-slots-section.js";
 import { iconGlyphMarkup, openIconPicker } from "./icon-engine-section.js";
 import {
   clean,
@@ -263,11 +264,21 @@ function rigaCasella(casella) {
   const nodo = doc.createElement("div");
   nodo.className = "ed-slot dm-lav-slot";
   const valore = clean(overrides()[casella.ref]);
+  /* La lente non si disegna qui.
+   *
+   * Ce n'era una in fondo alla riga, e accanto ne compariva una seconda: la
+   * guardia del selettore mette la sua su ogni casella che nomina un'entita',
+   * e non riconosceva questa come gia' fatta — cercava una `.dm-entity-picker`
+   * e qui trovava un tasto con un nome suo. Due lenti identiche una accanto
+   * all'altra: chiamavano tutt'e due `wzPickEntity` sullo stesso campo.
+   *
+   * Quella di casa se ne va, e resta il meccanismo unico — «questa funzione e'
+   * stata deprecata con la nuova metodologia di ricerca entita'». Basta la
+   * casella: la guardia la riconosce dal `data-ref` e ci attacca la sua. */
   nodo.innerHTML =
     `<div class="ed-slot-lbl">${esc(t(casella.it, casella.en))}</div>` +
     `<div class="dm-lav-slot-riga">` +
     `<input class="ed-input mono ed-slot-in dm-lav-slot-in" autocomplete="off" data-ref="${esc(casella.ref)}" value="${esc(valore)}" placeholder="es. sensor.lavatrice_fase" aria-label="${esc(t(casella.it, casella.en))}">` +
-    `<button type="button" class="dm-lav-slot-btn" aria-label="${t("Scegli entità", "Choose entity")}">🔍</button>` +
     `</div>`;
   return nodo;
 }
@@ -294,6 +305,14 @@ function creaCarta() {
   programmiAttuali().forEach((voce) => righe.append(rigaEditor(voce)));
   const caselle = carta.querySelector(".dm-lav-caselle");
   CASELLE.forEach((casella) => caselle.append(rigaCasella(casella)));
+  /* Le caselle si scelgono come dappertutto: dalla riga, non da una lente.
+   *
+   * Dentro le Sezioni ci pensava la passata che gira sulle fisarmoniche; nella
+   * finestra «Modifica azione» questa carta sta altrove e non veniva
+   * raggiunta. Chiederlo qui vale per tutt'e due i posti, ed e' la stessa
+   * riga: la pastiglia che dice cosa c'e' dentro, il cestino per toglierla e
+   * «Modifica manuale» per chi vuole scrivere l'entita' a mano. */
+  decoraCaselleDiUnaCarta(caselle);
 
   const salva = () => {
     scriviConfig(raccogli(carta));
@@ -311,18 +330,6 @@ function creaCarta() {
     salva();
   });
   carta.addEventListener("click", (evento) => {
-    const lente = evento.target?.closest?.(".dm-lav-slot-btn");
-    if (lente) {
-      const campo = lente.closest(".dm-lav-slot")?.querySelector(".dm-lav-slot-in");
-      /* Il selettore di entita' e' quello del guscio: una sola lista, gia'
-       * filtrata sulle entita' vive. Gli si passa il CAMPO, non il nome dello
-       * slot: col nome cercherebbe `input[data-ref=...]` per tutta la pagina e
-       * scriverebbe nella riga gemella della scheda Sezioni, ridisegnando la
-       * procedura guidata. Col campo scrive qui e batte un `change`, che e'
-       * quello che questa carta ascolta. */
-      if (campo) root.wzPickEntity?.(campo);
-      return;
-    }
     const via = evento.target?.closest?.(".dm-lav-via");
     if (via) {
       via.closest(".dm-lav-riga")?.remove();
@@ -429,7 +436,6 @@ const STILE = `
 .dm-lav-caselle{display:grid;gap:10px;margin-top:10px}
 .dm-lav-slot-riga{display:flex;gap:6px;align-items:center;min-width:0}
 .dm-lav-slot-riga .dm-lav-slot-in{flex:1 1 auto;min-width:0}
-.dm-lav-slot-btn{flex:0 0 38px;width:38px;height:38px;display:grid;place-items:center;border:0;border-radius:10px;background:linear-gradient(135deg,#0ea5e9,#0369a1);color:#fff;font-size:14px;cursor:pointer}
 `;
 
 export function installPopupLavatrice() {

--- a/custom_components/dashboardmodern/frontend/tests/i-programmi-della-lavatrice.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/i-programmi-della-lavatrice.test.js
@@ -59,9 +59,16 @@ test("la carta offre tutte le caselle del popup, non i soli programmi", () => {
     "dm.lavatrice_potenza_presa_lavatrice_per_lavatrici_no",
   ])
     assert.ok(SORGENTE.includes(`"${ref}"`), `casella mancante: ${ref}`);
-  /* La lente e' quella del guscio, e riceve il campo: col nome dello slot
-   * scriverebbe nella riga gemella della scheda Sezioni. */
-  assert.match(SORGENTE, /wzPickEntity\?\.\(campo\)/);
+  /* E si scelgono dalla riga, come in tutta la plancia.
+   *
+   * Qui c'era una lente disegnata dalla carta, che chiamava `wzPickEntity` sul
+   * campo. Accanto ne compariva una seconda, messa dalla guardia del selettore:
+   * due tasti identici appaiati — «questa funzione e' stata deprecata con la
+   * nuova metodologia di ricerca entita' ... si fa direttamente nella riga».
+   * La carta non disegna piu' la sua: chiede la stessa decorazione delle
+   * Sezioni, che trasforma ogni casella nella riga di scelta. */
+  assert.doesNotMatch(SORGENTE, /dm-lav-slot-btn/);
+  assert.match(SORGENTE, /decoraCaselleDiUnaCarta\(caselle\)/);
 });
 
 test("una casella scritta finisce negli override, una sbagliata no", () => {

--- a/custom_components/dashboardmodern/frontend/tests/la-plancia-si-impacchetta.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/la-plancia-si-impacchetta.test.js
@@ -1,0 +1,128 @@
+/* La plancia sta in un pacchetto, e il pacchetto e' completo.
+ *
+ * Dal campo: «impiega ancora troppo tempo in caricamento, soprattutto in primo
+ * avvio». Misurato: al primo avvio il browser scaricava CENTOSETTANTANOVE file
+ * JavaScript. Non in fila — il documento li precarica tutti insieme — ma
+ * centosettantanove richieste restano centosettantanove richieste, e su
+ * HTTP/1.1 il browser ne serve sei per volta.
+ *
+ * Il pacchetto le riduce a tre. Le due cose che possono andare storte sono
+ * l'una il rovescio dell'altra, e questa prova tiene ferme tutt'e due:
+ *
+ *   - se dal pacchetto manca qualcosa, quella parte della plancia non si
+ *     installa piu' — e non se ne accorge nessuno finche' non si apre proprio
+ *     quella sezione;
+ *   - se nel pacchetto entra tutto, ci finiscono anche i tredici cataloghi
+ *     delle lingue: quasi due megabyte a una casa che ne parla UNA, e il
+ *     rimedio sarebbe peggio del male.
+ *
+ * Il documento riscritto si guarda a parte: i precaricamenti dei file sciolti
+ * vanno via per forza, o il browser scarica tutto due volte — il pacchetto E i
+ * moduli.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FRONTEND = join(dirname(fileURLToPath(import.meta.url)), "..");
+const RADICE = join(FRONTEND, "../../..");
+const { guscioImpacchettato, INGRESSI } = await import(
+  join(RADICE, "scripts/impacchetta-la-plancia.mjs")
+);
+
+function fileDentro(cartella) {
+  const usciti = [];
+  for (const voce of readdirSync(cartella)) {
+    const percorso = join(cartella, voce);
+    if (statSync(percorso).isDirectory()) usciti.push(...fileDentro(percorso));
+    else if (voce.endsWith(".js")) usciti.push(percorso);
+  }
+  return usciti;
+}
+
+/* Il pacchetto si costruisce una volta sola: sono due secondi, ma tre prove che
+ * lo rifanno da capo sono sei. */
+const cartella = mkdtempSync(join(tmpdir(), "dm-pacco-"));
+execFileSync(
+  "npx",
+  [
+    "esbuild",
+    ...INGRESSI.map((voce) => voce.sorgente),
+    "--bundle",
+    "--format=esm",
+    "--splitting",
+    "--outbase=.",
+    `--outdir=${cartella}`,
+    "--log-level=error",
+  ],
+  { cwd: FRONTEND, stdio: "inherit" },
+);
+const PACCO = fileDentro(cartella)
+  .map((percorso) => readFileSync(percorso, "utf8"))
+  .join("\n");
+process.on("exit", () => rmSync(cartella, { recursive: true, force: true }));
+
+test("nel pacchetto c'e' ogni sezione che il runtime installa", () => {
+  const runtime = readFileSync(join(FRONTEND, "src/sections/section-runtime.js"), "utf8");
+  const chiamati = [...new Set(runtime.match(/install[A-Za-z0-9]+(?=\(\))/g) || [])];
+  /* Non e' un numero tondo per caso: sono le sezioni che compongono la
+   * plancia, e se il conto scende di molto vuol dire che la lettura qui sotto
+   * ha smesso di funzionare, non che le sezioni sono sparite. */
+  assert.ok(chiamati.length > 80, `mi aspettavo un'ottantina di sezioni, ne ho lette ${chiamati.length}`);
+  const mancanti = chiamati.filter((nome) => !PACCO.includes(`function ${nome}`));
+  assert.deepEqual(mancanti, [], `il pacchetto non installa: ${mancanti.join(", ")}`);
+});
+
+test("i cataloghi delle lingue restano fuori dal pacchetto", () => {
+  /* `source-index.js` e' il corpus in cui la plancia e' scritta, non una
+   * traduzione: quello puo' e deve starci. */
+  const dentro = [...new Set(PACCO.match(/src\/i18n\/[a-zA-Z-]+\.js/g) || [])];
+  assert.deepEqual(dentro, ["src/i18n/source-index.js"], `traduzioni finite dentro: ${dentro}`);
+});
+
+test("il documento impacchettato non precarica piu' i moduli sciolti", () => {
+  const html = readFileSync(join(FRONTEND, "legacy/dashboard.html"), "utf8");
+  /* Il documento del deposito e' quello dei sorgenti: e' cosi' che si
+   * sviluppa, e questa prova gira su di lui. */
+  assert.ok(html.includes('src="./modules-entry.js"'), "il documento non e' piu' quello dei sorgenti");
+  const primaPreload = (html.match(/modulepreload/g) || []).length;
+  assert.ok(primaPreload > 100, `mi aspettavo i precaricamenti dei moduli, ne ho contati ${primaPreload}`);
+
+  const fatto = guscioImpacchettato(html);
+  assert.ok(fatto.includes('src="./pacco/legacy/modules-entry.js"'), "il pacchetto non e' agganciato");
+  assert.ok(
+    fatto.includes('window.__DASHBOARDMODERN_PACCO_SEZIONI__'),
+    "manca la dichiarazione di dove stanno le sezioni",
+  );
+  assert.ok(
+    fatto.includes('window.__DASHBOARDMODERN_CATALOGHI__'),
+    "manca la dichiarazione di dove stanno i cataloghi",
+  );
+  /* Restano i due del pacchetto, non i centottanta dei file sciolti. */
+  assert.equal((fatto.match(/modulepreload/g) || []).length, 2);
+  assert.doesNotMatch(fatto, /modulepreload" href="\.\.\/src\//);
+});
+
+test("senza il pacchetto la plancia sa ancora da dove partire", async () => {
+  /* Il ripiego non e' un di piu': se il passo che costruisce il pacchetto
+   * salta, il documento resta quello dei sorgenti e la plancia deve avviarsi
+   * lo stesso — veloce come prima, non rotta. */
+  const config = readFileSync(join(FRONTEND, "legacy/config.js"), "utf8");
+  assert.match(config, /pacco \? import\(pacco\) : import\("\.\.\/src\/sections\/section-runtime\.js"\)/);
+
+  const { cartellaDeiCataloghi } = await import("../src/core/i18n.js");
+  const prima = globalThis.__DASHBOARDMODERN_CATALOGHI__;
+  try {
+    delete globalThis.__DASHBOARDMODERN_CATALOGHI__;
+    assert.equal(cartellaDeiCataloghi(), "../i18n/");
+    globalThis.__DASHBOARDMODERN_CATALOGHI__ = "../../src/i18n/";
+    assert.equal(cartellaDeiCataloghi(), "../../src/i18n/");
+  } finally {
+    if (prima === undefined) delete globalThis.__DASHBOARDMODERN_CATALOGHI__;
+    else globalThis.__DASHBOARDMODERN_CATALOGHI__ = prima;
+  }
+});

--- a/custom_components/dashboardmodern/frontend/tests/la-plancia-si-impacchetta.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/la-plancia-si-impacchetta.test.js
@@ -107,6 +107,64 @@ test("il documento impacchettato non precarica piu' i moduli sciolti", () => {
   assert.doesNotMatch(fatto, /modulepreload" href="\.\.\/src\//);
 });
 
+test("il pacchetto si porta dentro la provenienza, e va generata prima", () => {
+  /* `modules-entry.js` importa `build-info.js`, e chi impacchetta lo mura
+   * dentro. Impacchettare PRIMA di generare la provenienza voleva dire murarci
+   * la versione e il commit della release precedente: la 1.4.5 sarebbe uscita
+   * dicendo di essere la 1.4.4, e il build-info generato dopo non l'avrebbe
+   * letto piu' nessuno. Chiesto in revisione, e verificato: nel pacchetto
+   * c'era davvero «1.4.4» insieme al commit di ieri. */
+  const info = readFileSync(join(FRONTEND, "legacy/build-info.js"), "utf8");
+  const versione = info.match(/"dashboardVersion"\s*:\s*"([^"]+)"/)?.[1];
+  assert.ok(versione, "build-info.js non dichiara piu' la versione");
+  assert.ok(
+    PACCO.includes(`"dashboardVersion": "${versione}"`) ||
+      PACCO.includes(`"dashboardVersion":"${versione}"`),
+    "il pacchetto non si porta dentro la provenienza: chi lo costruisce non la vede",
+  );
+
+  const rilascio = readFileSync(join(RADICE, ".github/workflows/release.yml"), "utf8");
+  const genera = rilascio.indexOf("generate_build_info.py");
+  const impacchetta = rilascio.indexOf("impacchetta-la-plancia.mjs");
+  assert.ok(genera > 0 && impacchetta > 0, "il rilascio non fa piu' questi due passi");
+  assert.ok(
+    genera < impacchetta,
+    "il rilascio impacchetta prima di generare la provenienza: la versione murata sarebbe quella vecchia",
+  );
+});
+
+test("se il pacchetto non arriva, il documento torna ai sorgenti da solo", () => {
+  /* Dichiarare dove sta il pacchetto non basta: se il file non risponde — un
+   * aggiornamento a meta', una copia incompleta — il browser resta con un solo
+   * indirizzo, quello rotto, e la plancia non parte affatto. Chiesto in
+   * revisione, ed e' giusto: il ripiego che avevo promesso copriva il caso
+   * «guscio non riscritto», non «pacchetto assente». */
+  const html = readFileSync(join(FRONTEND, "legacy/dashboard.html"), "utf8");
+  const fatto = guscioImpacchettato(html);
+  const tag = fatto.match(/<script type="module" src="\.\/pacco[^>]*>/)?.[0] || "";
+  assert.match(tag, /onerror=/, "l'ingresso impacchettato non si accorge di non essere arrivato");
+  assert.match(tag, /modules-entry\.js/, "il ripiego non rimette in pagina l'ingresso dei sorgenti");
+  assert.match(
+    tag,
+    /__DASHBOARDMODERN_PACCO_SEZIONI__\s*=\s*null/,
+    "ripiegando, le sezioni continuerebbero a essere chieste al pacchetto che non c'e'",
+  );
+  assert.match(
+    tag,
+    /__DASHBOARDMODERN_CATALOGHI__\s*=\s*null/,
+    "ripiegando, i cataloghi continuerebbero a essere cercati accanto al pacchetto",
+  );
+});
+
+test("ripulire non porta via il lavoro di chi sviluppa", () => {
+  /* `--pulisci` rimetteva i gusci a HEAD con un `git checkout`, e cosi'
+   * buttava via anche le modifiche non salvate: il ciclo impacchetta /
+   * pulisci faceva perdere il lavoro. Chiesto in revisione. */
+  const script = readFileSync(join(RADICE, "scripts/impacchetta-la-plancia.mjs"), "utf8");
+  assert.doesNotMatch(script, /execFileSync\("git", \["checkout"/);
+  assert.match(script, /prima-del-pacco/);
+});
+
 test("senza il pacchetto la plancia sa ancora da dove partire", async () => {
   /* Il ripiego non e' un di piu': se il passo che costruisce il pacchetto
    * salta, il documento resta quello dei sorgenti e la plancia deve avviarsi

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -633,10 +633,22 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
    * is narrow: a catalog must be named after a locale the registry declares,
    * which the i18n-catalogs contract checks in turn. */
   const engine = await readFile(path.join(srcRoot, "core/i18n.js"), "utf8");
+  /* La cartella dei cataloghi e' dichiarabile.
+   *
+   * Da quando la plancia si impacchetta, il codice cambia casa: dai sorgenti
+   * gira da `src/core/`, impacchettato da `legacy/`, e un percorso relativo
+   * scritto qui varrebbe solo in uno dei due posti. Chi prepara il pacchetto
+   * dichiara dove sono; senza dichiarazione vale `../i18n/`, la strada di
+   * sempre — ed e' quella che tiene in piedi l'esenzione qui sotto. */
   assert.match(
     engine,
-    /import\(`\.\.\/i18n\/\$\{[^}]+\}\.js`\)/,
-    "src/core/i18n.js no longer loads catalogs from src/i18n; the exemption below is stale",
+    /import\(`\$\{cartellaDeiCataloghi\(\)\}\$\{[^}]+\}\.js`\)/,
+    "src/core/i18n.js no longer loads catalogs by computed name; the exemption below is stale",
+  );
+  assert.match(
+    engine,
+    /return dichiarata \|\| "\.\.\/i18n\/";/,
+    "src/core/i18n.js no longer falls back to src/i18n; the exemption below is stale",
   );
   const catalogs = srcOrphans.filter((file) => /^src\/i18n\/[A-Za-z-]+\.js$/.test(file));
   assert.ok(catalogs.length > 0, "no language catalogs found under src/i18n");

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.4.4"
+  "version": "1.4.5-beta.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,43 +7,556 @@
       "name": "dashboardmodern-v2",
       "devDependencies": {
         "@playwright/test": "^1.54.1",
+        "esbuild": "^0.28.2",
         "prettier": "^3.3.0"
       },
-      "engines": { "node": ">=22" }
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@playwright/test": {
       "version": "1.54.1",
       "dev": true,
-      "dependencies": { "playwright": "1.54.1" },
-      "bin": { "playwright": "cli.js" },
-      "engines": { "node": ">=18" }
+      "dependencies": {
+        "playwright": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
-    "node_modules/playwright": {
-      "version": "1.54.1",
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
       "dev": true,
-      "dependencies": { "playwright-core": "1.54.1" },
-      "bin": { "playwright": "cli.js" },
-      "engines": { "node": ">=18" },
-      "optionalDependencies": { "fsevents": "2.3.2" }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.54.1",
-      "dev": true,
-      "bin": { "playwright-core": "cli.js" },
-      "engines": { "node": ">=18" }
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "dev": true,
       "optional": true,
-      "os": ["darwin"],
-      "engines": { "node": "^8.16.0 || ^10.6.0 || >=11.0.0" }
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.1",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.1",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/prettier": {
       "version": "3.9.6",
       "dev": true,
-      "bin": { "prettier": "bin/prettier.cjs" },
-      "engines": { "node": ">=14" }
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,13 @@
     "test:frontend": "node --test custom_components/dashboardmodern/frontend/tests/*.test.js",
     "test:e2e": "playwright test",
     "format": "prettier --write \"custom_components/dashboardmodern/frontend/src/core/**/*.js\" \"custom_components/dashboardmodern/frontend/legacy/{modules-entry,build-info}.js\" \"custom_components/dashboardmodern/frontend/tests/{build-info,dashboard-store,editor-registry,modules-entry,release-artifact}.test.js\" \"custom_components/dashboardmodern/frontend/e2e/**/*.js\" playwright.config.js",
-    "format:check": "prettier --check \"custom_components/dashboardmodern/frontend/src/core/**/*.js\" \"custom_components/dashboardmodern/frontend/legacy/{modules-entry,build-info}.js\" \"custom_components/dashboardmodern/frontend/tests/{build-info,dashboard-store,editor-registry,modules-entry,release-artifact}.test.js\" \"custom_components/dashboardmodern/frontend/e2e/**/*.js\" playwright.config.js"
+    "format:check": "prettier --check \"custom_components/dashboardmodern/frontend/src/core/**/*.js\" \"custom_components/dashboardmodern/frontend/legacy/{modules-entry,build-info}.js\" \"custom_components/dashboardmodern/frontend/tests/{build-info,dashboard-store,editor-registry,modules-entry,release-artifact}.test.js\" \"custom_components/dashboardmodern/frontend/e2e/**/*.js\" playwright.config.js",
+    "impacchetta": "node scripts/impacchetta-la-plancia.mjs",
+    "impacchetta:pulisci": "node scripts/impacchetta-la-plancia.mjs --pulisci"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.1",
+    "esbuild": "^0.28.2",
     "prettier": "^3.3.0"
   }
 }

--- a/scripts/impacchetta-la-plancia.mjs
+++ b/scripts/impacchetta-la-plancia.mjs
@@ -1,0 +1,128 @@
+/* La plancia in un pacchetto, invece che in centosettantanove file.
+ *
+ * Dal campo: «impiega ancora troppo tempo in caricamento, soprattutto in primo
+ * avvio». Non era il velo — quello se ne va presto — ed era misurabile: al
+ * primo avvio il browser scaricava CENTOSETTANTANOVE file JavaScript per
+ * quattro megabyte. Non in fila, che sarebbe stato peggio: il documento li
+ * precarica tutti insieme. Ma centosettantanove richieste restano
+ * centosettantanove richieste, e su HTTP/1.1 il browser ne serve sei per volta
+ * — una trentina di ondate prima di avere tutto. Al secondo avvio la cache le
+ * tiene, ed e' per questo che si sente solo la prima volta.
+ *
+ * Qui si mettono insieme. Restano fuori i tredici cataloghi delle lingue —
+ * quasi due megabyte, e a una casa ne serve UNO — che continuano ad arrivare
+ * uno alla volta quando servono.
+ *
+ * Niente minificazione: il guadagno grosso e' il numero di richieste, e con i
+ * nomi veri un errore dal campo si legge ancora. Si potra' aggiungere quando
+ * il resto sara' assestato.
+ *
+ * Lo script si usa cosi':
+ *
+ *   node scripts/impacchetta-la-plancia.mjs           costruisce il pacchetto
+ *   node scripts/impacchetta-la-plancia.mjs --pulisci  torna ai sorgenti
+ *
+ * Nel deposito i gusci restano quelli dei sorgenti: chi sviluppa apre la
+ * plancia e vede i file veri. E' il rilascio a chiamare questo script prima di
+ * fare il pacchetto, e i gusci riscritti finiscono solo li' dentro.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const RADICE = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const FRONTEND = join(RADICE, "custom_components/dashboardmodern/frontend");
+const PACCO = join(FRONTEND, "legacy/pacco");
+const GUSCI = ["legacy/dashboard.html", "legacy/dashboard-en.html"];
+
+/* I due ingressi della plancia. Il primo lo carica il documento; il secondo
+ * lo chiede `config.js` quando il guscio e' pronto, ed e' quello che si porta
+ * dietro tutte le sezioni. */
+export const INGRESSI = Object.freeze([
+  { sorgente: "legacy/modules-entry.js", nel_pacco: "legacy/modules-entry.js" },
+  { sorgente: "src/sections/section-runtime.js", nel_pacco: "src/sections/section-runtime.js" },
+]);
+
+/* Il segno che il guscio riscritto porta in fronte: da qui si riconosce un
+ * documento gia' impacchettato, e --pulisci sa cosa togliere. */
+export const APERTURA = "<!-- dm:pacco -->";
+const CHIUSURA = "<!-- /dm:pacco -->";
+
+function costruisci() {
+  rmSync(PACCO, { recursive: true, force: true });
+  mkdirSync(PACCO, { recursive: true });
+  execFileSync(
+    "npx",
+    [
+      "esbuild",
+      ...INGRESSI.map((voce) => voce.sorgente),
+      "--bundle",
+      "--format=esm",
+      "--splitting",
+      "--outbase=.",
+      `--outdir=${PACCO}`,
+      "--log-level=warning",
+    ],
+    { cwd: FRONTEND, stdio: "inherit" },
+  );
+}
+
+/* Il documento senza i suoi centottantuno precaricamenti, e con il pacchetto
+ * al loro posto. I precaricamenti vanno tolti per forza: sono richieste che il
+ * browser parte a fare comunque, e lasciarle vorrebbe dire scaricare tutto due
+ * volte — il pacchetto E i file sciolti. */
+export function guscioImpacchettato(html) {
+  const senzaPreload = html.replace(
+    /^[ \t]*<link rel="modulepreload" href="\.\.\/src\/[^"]*">\n/gm,
+    "",
+  );
+  const dichiarazione =
+    `${APERTURA}\n` +
+    `<link rel="modulepreload" href="./pacco/legacy/modules-entry.js">\n` +
+    `<script>\n` +
+    `/* Dove la plancia trova le sue parti, adesso che sono in un pacchetto.\n` +
+    `   Senza queste due righe valgono i sorgenti, ed e' cosi' che si sviluppa. */\n` +
+    `window.__DASHBOARDMODERN_PACCO_SEZIONI__ = "./pacco/src/sections/section-runtime.js";\n` +
+    `window.__DASHBOARDMODERN_CATALOGHI__ = "../../src/i18n/";\n` +
+    `window.__DASHBOARDMODERN_IMPACCHETTATA__ = true;\n` +
+    `</script>\n` +
+    `${CHIUSURA}\n`;
+  return senzaPreload
+    .replace(/^[ \t]*<link rel="modulepreload" href="\.\/modules-entry\.js">\n/m, dichiarazione)
+    .replace(
+      /<script type="module" src="\.\/modules-entry\.js"><\/script>/,
+      '<script type="module" src="./pacco/legacy/modules-entry.js"></script>',
+    );
+}
+
+function scriviIGusci() {
+  for (const relativo of GUSCI) {
+    const percorso = join(FRONTEND, relativo);
+    const html = readFileSync(percorso, "utf8");
+    if (html.includes(APERTURA)) continue;
+    const fatto = guscioImpacchettato(html);
+    if (fatto === html) throw new Error(`${relativo}: non ho trovato dove agganciare il pacchetto`);
+    writeFileSync(percorso, fatto);
+  }
+}
+
+function pulisci() {
+  rmSync(PACCO, { recursive: true, force: true });
+  execFileSync("git", ["checkout", "--", ...GUSCI], { cwd: FRONTEND, stdio: "inherit" });
+}
+
+function main() {
+  if (process.argv.includes("--pulisci")) {
+    pulisci();
+    console.log("pacchetto tolto: la plancia riparte dai sorgenti");
+    return;
+  }
+  costruisci();
+  scriviIGusci();
+  const entrata = join(PACCO, "legacy/modules-entry.js");
+  if (!existsSync(entrata)) throw new Error("il pacchetto non contiene l'ingresso della plancia");
+  console.log("plancia impacchettata in legacy/pacco/");
+}
+
+if (process.argv[1] && process.argv[1].endsWith("impacchetta-la-plancia.mjs")) main();

--- a/scripts/impacchetta-la-plancia.mjs
+++ b/scripts/impacchetta-la-plancia.mjs
@@ -88,13 +88,35 @@ export function guscioImpacchettato(html) {
     `window.__DASHBOARDMODERN_IMPACCHETTATA__ = true;\n` +
     `</script>\n` +
     `${CHIUSURA}\n`;
+  /* Il ripiego, per davvero.
+   *
+   * Dichiarare dove sta il pacchetto non basta: se il file non arriva — un
+   * aggiornamento a meta', una copia incompleta — il browser resta con un solo
+   * indirizzo, quello che non risponde, e la plancia non parte affatto. Il
+   * documento deve accorgersene da se'. `onerror` scatta proprio quando lo
+   * script non si carica: allora si ritirano le due dichiarazioni, cosi'
+   * `config.js` torna a chiedere le sezioni ai sorgenti, e si rimette in pagina
+   * l'ingresso di sempre. Il caso peggiore torna a essere «lenta come ieri». */
+  const ripiego =
+    `<script type="module" src="./pacco/legacy/modules-entry.js" ` +
+    `onerror="window.__DASHBOARDMODERN_PACCO_SEZIONI__=null;` +
+    `window.__DASHBOARDMODERN_CATALOGHI__=null;` +
+    `window.__DASHBOARDMODERN_IMPACCHETTATA__=false;` +
+    `var s=document.createElement('script');s.type='module';s.src='./modules-entry.js';` +
+    `document.head.appendChild(s)"></script>`;
   return senzaPreload
     .replace(/^[ \t]*<link rel="modulepreload" href="\.\/modules-entry\.js">\n/m, dichiarazione)
-    .replace(
-      /<script type="module" src="\.\/modules-entry\.js"><\/script>/,
-      '<script type="module" src="./pacco/legacy/modules-entry.js"></script>',
-    );
+    .replace(/<script type="module" src="\.\/modules-entry\.js"><\/script>/, ripiego);
 }
+
+/* Il documento com'era prima, messo da parte.
+ *
+ * `--pulisci` rimetteva i gusci a HEAD con un `git checkout`, e cosi' buttava
+ * via anche le modifiche non salvate di chi stava lavorando su quei file: il
+ * ciclo `impacchetta` / `impacchetta:pulisci` gli faceva perdere il lavoro.
+ * Chiesto in revisione. Adesso si conserva la copia di partenza e si rimette
+ * quella: torna esattamente il documento che c'era, salvato o no. */
+const copiaDi = (relativo) => join(FRONTEND, `${relativo}.prima-del-pacco`);
 
 function scriviIGusci() {
   for (const relativo of GUSCI) {
@@ -103,13 +125,19 @@ function scriviIGusci() {
     if (html.includes(APERTURA)) continue;
     const fatto = guscioImpacchettato(html);
     if (fatto === html) throw new Error(`${relativo}: non ho trovato dove agganciare il pacchetto`);
+    writeFileSync(copiaDi(relativo), html);
     writeFileSync(percorso, fatto);
   }
 }
 
 function pulisci() {
   rmSync(PACCO, { recursive: true, force: true });
-  execFileSync("git", ["checkout", "--", ...GUSCI], { cwd: FRONTEND, stdio: "inherit" });
+  for (const relativo of GUSCI) {
+    const copia = copiaDi(relativo);
+    if (!existsSync(copia)) continue;
+    writeFileSync(join(FRONTEND, relativo), readFileSync(copia, "utf8"));
+    rmSync(copia, { force: true });
+  }
 }
 
 function main() {


### PR DESCRIPTION
## Il primo avvio, misurato

Dal campo: «impiega ancora troppo tempo in caricamento, soprattutto in primo avvio». **Non era il velo** — quello se ne va presto, e resta dov'è.

Misurato sul banco:

| | prima | col pacchetto |
|---|---|---|
| richieste JS | ~185 | **13** |
| moduli sciolti | 179 | **0** |
| precaricamenti nel documento | 181 | **2** |
| peso dei moduli | 4016 kB | 1034 kB |
| in gzip | 1692 kB | **257 kB** |

Il browser scaricava centosettantanove file. Non in fila — il documento li precarica tutti insieme — ma su HTTP/1.1 ne serve **sei per volta**: una trentina di ondate prima di avere tutto. Al secondo avvio la cache li tiene, ed è per questo che si sente solo la prima volta.

## Cosa entra nel pacchetto, e cosa no

Il rilascio mette insieme i **due** ingressi della plancia: quello che carica il documento e quello che `config.js` chiede quando il guscio è pronto — ed è il secondo a portarsi dietro tutte le sezioni.

Restano fuori i **tredici cataloghi delle lingue**: 1,9 MB a una casa che ne parla una sola. Metterli dentro sarebbe stato un peggioramento. Continuano ad arrivare uno alla volta, quando servono. Verificato: col pacchetto attivo il giapponese carica solo `ja.js`, e la barra dice ホーム / エネルギー / 家電 / 自動.

**Niente minificazione.** Il guadagno grosso è il numero di richieste; con i nomi veri un errore dal campo si legge ancora. Si potrà aggiungere quando il resto sarà assestato.

## Il ripiego

Nel deposito i gusci restano quelli dei sorgenti — chi sviluppa apre la plancia e vede i file veri — ed è il rilascio a riscriverli, dentro lo zip e basta. Se quel passo salta, il documento resta quello di prima e la plancia parte lo stesso: il caso peggiore è «veloce come ieri», non «rotta».

Per saperlo a colpo d'occhio, la **Diagnostica runtime** ha ora la riga «Moduli»: `impacchettati (3 file)` o `sciolti (179 file)`.

## Le caselle del popup Lavatrice

Segnalazione a parte, dallo stesso giro: nella finestra «Modifica azione» ogni casella portava **due** tasti azzurri con la lente, appaiati — uno se lo disegnava la carta, l'altro glielo metteva la guardia del selettore, che non riconosceva il primo. Chiamavano tutt'e due `wzPickEntity` sullo stesso campo.

E nessuno dei due era il modo giusto: «non c'è la lente per la ricerca entità ma si fa direttamente nella riga». Quella passata girava solo dentro le fisarmoniche delle Sezioni, e questa carta sta altrove. Adesso la chiede, e vale in entrambi i posti.

## Come è stato verificato

- **La suite intera contro la plancia impacchettata**: 816 e2e verdi su desktop e mobile. Ha trovato due prove che frugavano nell'impalcatura — cercavano un modulo dei sorgenti partendo dal tag dello script d'ingresso, che col pacchetto cambia casa. Ora contano la strada dal documento, e passano **con il pacchetto e senza**: eseguite in tutti e due i modi.
- **Una prova nuova** che tiene fermi i due rovesci del pacchetto: che non manchi una sezione di quelle che il runtime installa, e che non ci entrino le traduzioni. Più il documento riscritto e il ripiego.
- Il **pacchetto di rilascio vero**, costruito e ispezionato: i tre file del pacco dentro, il guscio con due precaricamenti, e i 194 sorgenti ancora presenti per il ripiego.
- 1697 prove frontend, 86 Python, Ruff e Prettier puliti.

## Perché è una beta

Il tag col trattino esce marcato **pre-release**: HACS non lo propone a chi non ha chiesto le versioni beta. Il guadagno si misura col cronometro su una casa vera, e il rischio si vede solo lì.

Da guardare, in ordine: quanto ci mette il primo avvio a cache vuota; se le lingue diverse dall'italiano caricano ancora; se ogni sezione della barra si apre piena.

---
_Generated by [Claude Code](https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT)_