### PR TITLE
Versione 1.4.5-beta.2: la plancia arriva compressa, 4,9 MB diventano 1,2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@ dashboardmodern.zip
 # Il pacchetto della plancia: si costruisce, non si conserva.
 custom_components/dashboardmodern/frontend/legacy/pacco/
 custom_components/dashboardmodern/frontend/legacy/*.prima-del-pacco
+# I gusci di partenza, mentre il pacchetto e' montato. Stanno qui fuori apposta:
+# dentro la cartella dell'integrazione finivano dritti nel pacchetto di rilascio.
+.gusci-prima-del-pacco/
+# Le copie gia' compresse: le fa il rilascio, e chi sviluppa le cancella con
+# `--pulisci`. Committate sarebbero duecento file che invecchiano da soli.
+custom_components/dashboardmodern/frontend/**/*.gz
+custom_components/dashboardmodern/frontend/**/*.br

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.4.5-beta.2
+
+La beta di prima aveva ridotto le richieste da centosettantanove a tre, e dal
+campo e' tornato «nulla e' cambiato». Era vero: le richieste non erano il
+problema.
+
+### Corretto
+
+- **La plancia arriva compressa: 4,9 MB diventano 1,2.** La Diagnostica diceva
+  «impacchettati (3 file)», quindi il pacchetto funzionava — ma i byte erano
+  rimasti gli stessi. Chi apre la plancia da fuori casa passa da un tunnel, e li'
+  non contano le richieste: contano i byte, e ne partivano quattro megabyte e
+  mezzo in chiaro. Adesso accanto a ogni file ne viaggia una copia gia'
+  compressa, e Home Assistant manda quella a chi la accetta. Misurato in pagina:
+  da 5142 kB scaricati a 1179. Su un collegamento da 5 Mbit/s la plancia e'
+  pronta in 2,8 secondi invece di 4,9. Chi entra da casa, dove la banda non
+  manca, non se ne accorgera': e' fuori casa che si sentiva.
+- **La Diagnostica dice quanto pesa arrivare.** La riga «Transfer» mostra i byte
+  davvero scesi dal filo e se erano compressi. Per sapere che la beta di prima
+  non aveva spostato niente sono serviti uno scambio di messaggi e una
+  schermata; adesso si legge.
+- **Due documenti da centosei kB non partono piu' per il mondo.** Le copie di
+  lavoro dei gusci finivano dentro il pacchetto di rilascio.
+
 ## 1.4.5-beta.1
 
 Una beta per provare l'avvio impacchettato prima di darlo a tutti. Chi non

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ problema.
   schermata; adesso si legge.
 - **Due documenti da centosei kB non partono piu' per il mondo.** Le copie di
   lavoro dei gusci finivano dentro il pacchetto di rilascio.
+- **Nemmeno i resti delle prove.** Chi costruiva il pacchetto sulla propria
+  macchina, dopo aver eseguito la suite, ci spediva dentro tre megabyte e mezzo
+  di schermate di Playwright. Il pacchetto pubblicato non li ha mai avuti — in
+  CI il rilascio parte da un checkout pulito — ma adesso non li ha nessuno.
+
+Il pacchetto passa da 7,1 a 10,5 MB: si comprime solo quello che la plancia
+chiede davvero all'avvio, non i centosettantanove sorgenti sciolti che servono
+al solo ripiego. Si scarica una volta per aggiornamento, e si risparmia a ogni
+apertura.
 
 ## 1.4.5-beta.1
 

--- a/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
@@ -195,14 +195,23 @@ for (const variant of PRIMARY) {
      * gia' rifatto l'elenco: quello lo rifa' `cdRebuildReportDevices` da un
      * setTimeout a 2600 ms dall'apertura del socket. La lettura secca vinceva
      * la corsa su una macchina ferma e la perdeva con la suite intera addosso
-     * — «Array []» al posto delle tre voci. Le stesse tre voci, aspettate. */
+     * — «Array []» al posto delle tre voci. Le stesse tre voci, aspettate.
+     *
+     * L'attesa segue il browser, come gia' fa quella della prova intera qui
+     * sopra. Prima no: la prova su webkit si prende tre volte il tempo — perche'
+     * su webkit ci mette tre volte tanto — ma questo sondaggio dentro restava
+     * fermo a venti secondi. Su uno shard carico si arrendeva con «Array []»
+     * mentre alla prova restavano ancora due minuti di tempo: non era l'elenco
+     * a non arrivare, era chi lo aspettava ad andarsene prima. Nella stessa
+     * tornata anche `energy-flow-motion` su quello shard e' passata solo al
+     * secondo tentativo, che e' il segno di una macchina in affanno. */
     await expect
       .poll(
         () =>
           page.evaluate(() =>
             ED_DEVICES.map((device) => [device.name, device.icon, device.sensor]),
           ),
-        { timeout: 20_000 },
+        { timeout: testInfo.project.name === "webkit-ipad" ? 60_000 : 20_000 },
       )
       .toEqual([
         ["Washer first", "🧺", "sensor.washer_month"],

--- a/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
@@ -244,13 +244,21 @@ for (const variant of PRIMARY) {
      * leggeva come una prova ballerina: cadeva sempre e solo qui, e sempre e
      * solo su uno shard. Non ballava affatto — contava giusto.
      *
+     * E' passato a tredici quando ha imparato anche a dire quanto pesa
+     * arrivare: la riga di prima diceva che il pacchetto era in uso, ma non che
+     * i byte erano rimasti gli stessi, ed e' quello che si sentiva da fuori
+     * casa.
+     *
      * Chi aggiunge una voce alza questo numero E la nomina qui sotto: cosi'
      * la prossima volta il conto si legge invece di sembrare capriccio. */
-    await expect(page.locator("[data-runtime-diagnostics] .ed-row")).toHaveCount(12);
+    await expect(page.locator("[data-runtime-diagnostics] .ed-row")).toHaveCount(13);
     await expect(page.locator("[data-runtime-diagnostics]")).toContainText("Integration version");
-    /* La dodicesima. Vale in tutt'e due gli stati, che e' il punto: la riga
-     * dice quale dei due, non presume. */
+    /* La dodicesima e la tredicesima. Valgono in tutti gli stati, che e' il
+     * punto: le righe dicono quale, non presumono. */
     await expect(page.locator("[data-runtime-diagnostics]")).toContainText(/impacchettati|sciolti/);
+    await expect(page.locator("[data-runtime-diagnostics]")).toContainText(
+      /compressi|dalla cache|MB/,
+    );
     await page.evaluate(() => window.editorSwitch("sez1"));
     await expect(page.locator('#ed-body[data-renderer="energy"]')).toBeVisible();
     await page.screenshot({ path: `test-results/${testInfo.project.name}-${variant}-energy.png` });

--- a/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
@@ -262,12 +262,17 @@ for (const variant of PRIMARY) {
      * la prossima volta il conto si legge invece di sembrare capriccio. */
     await expect(page.locator("[data-runtime-diagnostics] .ed-row")).toHaveCount(13);
     await expect(page.locator("[data-runtime-diagnostics]")).toContainText("Integration version");
-    /* La dodicesima e la tredicesima. Valgono in tutti gli stati, che e' il
-     * punto: le righe dicono quale, non presumono. */
+    /* La dodicesima e la tredicesima. La prima si controlla dal valore, che
+     * vale in tutti gli stati: la riga dice quale dei due, non presume.
+     *
+     * La seconda si controlla dall'ETICHETTA, e non e' pigrizia: il peso lo
+     * ricava da `encodedBodySize` e `transferSize`, che non tutti i browser
+     * riempiono. Dove non ci sono, la riga dice «?» — che e' la risposta
+     * onesta, ma un'asserzione sul valore ci sarebbe cascata, e sarebbe caduta
+     * su un browser solo: il modo migliore per far sembrare ballerina una prova
+     * che non lo e'. */
     await expect(page.locator("[data-runtime-diagnostics]")).toContainText(/impacchettati|sciolti/);
-    await expect(page.locator("[data-runtime-diagnostics]")).toContainText(
-      /compressi|dalla cache|MB/,
-    );
+    await expect(page.locator("[data-runtime-diagnostics]")).toContainText("Transfer");
     await page.evaluate(() => window.editorSwitch("sez1"));
     await expect(page.locator('#ed-body[data-renderer="energy"]')).toBeVisible();
     await page.screenshot({ path: `test-results/${testInfo.project.name}-${variant}-energy.png` });

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5-beta.2","dashboardVersion":"1.4.5-beta.2","moduleVersion":14,"schemaVersion":4,"date":"2026-09-01T10:29:35+00:00","commit":"afd641711012c38ded60e01c15ba13160089bcfe","assetHash":"9b611b0386cd0b7a"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5-beta.2","dashboardVersion":"1.4.5-beta.2","moduleVersion":14,"schemaVersion":4,"date":"2026-09-01T11:13:52+00:00","commit":"81a36a03535080c508503a9040ff4f7c1ac13463","assetHash":"e39baae43450a50a"});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5-beta.1","dashboardVersion":"1.4.5-beta.1","moduleVersion":14,"schemaVersion":4,"date":"2026-09-01T09:18:03+00:00","commit":"550f0217ac100b3c8f64c30aa06d94eab2ae49b1","assetHash":"1581b9a425c354cd"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5-beta.2","dashboardVersion":"1.4.5-beta.2","moduleVersion":14,"schemaVersion":4,"date":"2026-09-01T10:29:35+00:00","commit":"afd641711012c38ded60e01c15ba13160089bcfe","assetHash":"9b611b0386cd0b7a"});

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -616,23 +616,39 @@ function mountReportEditor(_tab, target) {
  * arrivare. Adesso lo dice: chi entra da fuori casa passa da un tunnel, e li'
  * contano i byte, non le richieste.
  *
- * `transferSize` e' quello che ha viaggiato sul filo, `decodedBodySize` quello
- * che ne e' uscito: se il secondo e' molto piu' grande del primo, la
- * compressione sta lavorando. A cache piena `transferSize` e' zero, e allora
- * non c'e' niente da misurare — si dice quello. */
-function pesoScaricato() {
+ * Due cose vanno tenute distinte, e la prima stesura le confondeva.
+ *
+ * QUANTO HA VIAGGIATO lo dice `transferSize`. QUANTO ERA COMPRESSO lo dicono
+ * `encodedBodySize` contro `decodedBodySize` — il corpo come e' arrivato contro
+ * il corpo una volta disteso. Prima ricavavo la compressione dal rapporto fra
+ * trasferito e disteso, e su un carico mezzo in cache quel rapporto si gonfia
+ * da solo: chi era gia' in cache non ha viaggiato — `transferSize` zero — ma
+ * pesa lo stesso da disteso, e la riga avrebbe detto «compressi» di una plancia
+ * che arrivava in chiaro. Chiesto in revisione, ed era vero.
+ *
+ * Si contano solo le risorse della plancia. Quando la plancia sta dentro un
+ * riquadro l'elenco e' gia' suo, ma non e' detto che sia sempre cosi', e sommare
+ * anche cio' che ha scaricato Home Assistant intorno vorrebbe dire dare un
+ * numero che non risponde alla domanda. `import.meta.url` dice da dove arriva
+ * questo file, e tutto il resto della plancia sta li' sotto — sia coi sorgenti
+ * sciolti sia col pacchetto. */
+export function pesoScaricato() {
   try {
-    const risorse = performance.getEntriesByType("resource");
-    if (!risorse.length) return "?";
-    const somma = (campo) => risorse.reduce((tot, r) => tot + (r[campo] || 0), 0);
-    const arrivato = somma("transferSize");
+    const casa = `${import.meta.url.split("/legacy/")[0]}/`;
+    const nostre = performance
+      .getEntriesByType("resource")
+      .filter((risorsa) => risorsa.name.startsWith(casa));
+    if (!nostre.length) return "?";
+    const somma = (campo) => nostre.reduce((tot, r) => tot + (r[campo] || 0), 0);
+    const dalFilo = somma("transferSize");
+    const codificato = somma("encodedBodySize");
     const disteso = somma("decodedBodySize");
     if (!disteso) return "?";
     const mb = (v) => `${(v / 1048576).toFixed(1)} MB`;
-    if (!arrivato) return `${mb(disteso)} (dalla cache)`;
-    return disteso / arrivato > 1.3
-      ? `${mb(arrivato)} di ${mb(disteso)} — compressi`
-      : `${mb(arrivato)} — non compressi`;
+    const come = codificato && codificato / disteso < 0.9 ? "compressi" : "non compressi";
+    return dalFilo
+      ? `${mb(dalFilo)} di ${mb(disteso)} — ${come}`
+      : `${mb(disteso)} dalla cache — ${come}`;
   } catch (_) {
     return "?";
   }

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -608,6 +608,36 @@ function mountReportEditor(_tab, target) {
   if (entityInputs !== pickers) throw new Error(`Entity picker invariant failed: ${entityInputs} inputs / ${pickers} pickers`);
 }
 
+/* Quanti byte sono arrivati davvero, e se sono arrivati compressi.
+ *
+ * Dal campo, dopo un rilascio che aveva ridotto le richieste da 179 a 3:
+ * «nulla e' cambiato». Aveva ragione — e per saperlo e' servito uno scambio di
+ * messaggi e una schermata, perche' la plancia non sapeva dire quanto pesava
+ * arrivare. Adesso lo dice: chi entra da fuori casa passa da un tunnel, e li'
+ * contano i byte, non le richieste.
+ *
+ * `transferSize` e' quello che ha viaggiato sul filo, `decodedBodySize` quello
+ * che ne e' uscito: se il secondo e' molto piu' grande del primo, la
+ * compressione sta lavorando. A cache piena `transferSize` e' zero, e allora
+ * non c'e' niente da misurare — si dice quello. */
+function pesoScaricato() {
+  try {
+    const risorse = performance.getEntriesByType("resource");
+    if (!risorse.length) return "?";
+    const somma = (campo) => risorse.reduce((tot, r) => tot + (r[campo] || 0), 0);
+    const arrivato = somma("transferSize");
+    const disteso = somma("decodedBodySize");
+    if (!disteso) return "?";
+    const mb = (v) => `${(v / 1048576).toFixed(1)} MB`;
+    if (!arrivato) return `${mb(disteso)} (dalla cache)`;
+    return disteso / arrivato > 1.3
+      ? `${mb(arrivato)} di ${mb(disteso)} — compressi`
+      : `${mb(arrivato)} — non compressi`;
+  } catch (_) {
+    return "?";
+  }
+}
+
 function renderDiagnostics(target) {
   const rows = {
     "Integration version": BUILD_INFO.integrationVersion,
@@ -624,6 +654,7 @@ function renderDiagnostics(target) {
      * manca, la plancia parte lo stesso dai sorgenti — e allora e' bene poterlo
      * vedere a colpo d'occhio invece di indovinarlo dal cronometro. */
     Modules: globalThis.__DASHBOARDMODERN_IMPACCHETTATA__ ? "impacchettati (3 file)" : "sciolti (179 file)",
+    Transfer: pesoScaricato(),
   };
   target.innerHTML = `<div class="ed-sec-title">🩺 ${t("diagnostics")}</div><div class="ed-list">${Object.entries(rows).map(([key, value]) => `<div class="ed-row"><div class="ed-row-main"><div class="ed-row-new">${esc(key)}</div><div class="ed-row-old mono">${esc(value)}</div></div></div>`).join("")}</div>`;
   target.dataset.runtimeDiagnostics = "true";

--- a/custom_components/dashboardmodern/frontend/tests/il-peso-scaricato-dice-il-vero.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/il-peso-scaricato-dice-il-vero.test.js
@@ -1,0 +1,111 @@
+/* La riga «Transfer» dice il vero, anche quando mentire sarebbe comodo.
+ *
+ * Serve a rispondere alla domanda che e' costata un rilascio: «nulla e'
+ * cambiato». Se la riga dicesse «compressi» di una plancia che arriva in
+ * chiaro, sarebbe peggio di non averla — si smetterebbe di cercare proprio
+ * dove il guasto e'.
+ *
+ * Le due bugie possibili, tutt'e due segnalate in revisione:
+ *
+ *   - un carico mezzo in cache. Chi era gia' in cache non ha viaggiato
+ *     (`transferSize` zero) ma pesa lo stesso da disteso: ricavare la
+ *     compressione dal rapporto fra trasferito e disteso fa sembrare compresso
+ *     qualunque secondo avvio;
+ *   - le risorse di Home Assistant intorno. Sommarle vorrebbe dire dare
+ *     megabyte che non sono della plancia, e rispondere a una domanda diversa
+ *     da quella che si e' fatta.
+ *
+ * La compressione si legge dove sta scritta: `encodedBodySize` contro
+ * `decodedBodySize` — il corpo come e' arrivato contro il corpo disteso.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const CASA = new URL("../", import.meta.url).href;
+
+const { pesoScaricato } = await import(`../legacy/modules-entry.js?peso=${Date.now()}`);
+
+/* Una risorsa come la descrive il browser. `dalFilo` a zero e' la cache: il
+ * corpo c'e', ma non ha viaggiato. */
+function risorsa({ nome = "legacy/x.js", dalFilo, codificato, disteso }) {
+  return {
+    name: `${CASA}${nome}`,
+    transferSize: dalFilo,
+    encodedBodySize: codificato,
+    decodedBodySize: disteso,
+  };
+}
+
+function conQuesteRisorse(elenco, prova) {
+  const prima = performance.getEntriesByType;
+  performance.getEntriesByType = (tipo) => (tipo === "resource" ? elenco : []);
+  try {
+    return prova();
+  } finally {
+    performance.getEntriesByType = prima;
+  }
+}
+
+const MB = 1048576;
+
+test("meta' dalla cache non fa sembrare compressa una plancia in chiaro", () => {
+  /* Questa e' la bugia comoda: al secondo avvio meta' roba viene dalla cache,
+   * il trasferito crolla, e un rapporto fra trasferito e disteso griderebbe
+   * «compressi» senza che un solo byte lo sia. */
+  const detto = conQuesteRisorse(
+    [
+      risorsa({ nome: "legacy/a.js", dalFilo: 0, codificato: 2 * MB, disteso: 2 * MB }),
+      risorsa({ nome: "legacy/b.js", dalFilo: 2 * MB, codificato: 2 * MB, disteso: 2 * MB }),
+    ],
+    pesoScaricato,
+  );
+  assert.match(detto, /non compressi/, `la riga mente: «${detto}»`);
+});
+
+test("quando i byte arrivano davvero compressi, lo dice", () => {
+  const detto = conQuesteRisorse(
+    [risorsa({ nome: "legacy/a.js", dalFilo: 1 * MB, codificato: 1 * MB, disteso: 5 * MB })],
+    pesoScaricato,
+  );
+  assert.match(detto, /compressi/);
+  assert.doesNotMatch(detto, /non compressi/, `la riga mente: «${detto}»`);
+  assert.match(detto, /1\.0 MB di 5\.0 MB/, `il peso non torna: «${detto}»`);
+});
+
+test("le risorse di Home Assistant intorno non entrano nel conto", () => {
+  /* La plancia sta dentro un riquadro, e li' l'elenco e' gia' solo suo. Ma non
+   * e' detto che valga sempre, e un numero che comprende cio' che ha scaricato
+   * il resto della pagina risponde a una domanda diversa da quella fatta. */
+  const detto = conQuesteRisorse(
+    [
+      risorsa({ nome: "legacy/a.js", dalFilo: 1 * MB, codificato: 1 * MB, disteso: 5 * MB }),
+      {
+        name: "https://casa.example/frontend_latest/roba-di-home-assistant.js",
+        transferSize: 40 * MB,
+        encodedBodySize: 40 * MB,
+        decodedBodySize: 40 * MB,
+      },
+    ],
+    pesoScaricato,
+  );
+  assert.match(detto, /1\.0 MB di 5\.0 MB/, `ha contato roba non sua: «${detto}»`);
+});
+
+test("tutto dalla cache si dice, non si finge", () => {
+  const detto = conQuesteRisorse(
+    [risorsa({ nome: "legacy/a.js", dalFilo: 0, codificato: 1 * MB, disteso: 5 * MB })],
+    pesoScaricato,
+  );
+  assert.match(detto, /dalla cache/, `la riga non dice che non ha viaggiato: «${detto}»`);
+});
+
+test("dove il browser non riempie quei campi, la riga non inventa", () => {
+  /* Non tutti i browser danno `encodedBodySize` e `transferSize`. Dire «?» e'
+   * la risposta onesta; inventare uno zero direbbe «non compressi» di una
+   * plancia che magari lo e'. */
+  const detto = conQuesteRisorse(
+    [{ name: `${CASA}legacy/a.js` }, { name: `${CASA}legacy/b.js` }],
+    pesoScaricato,
+  );
+  assert.equal(detto, "?");
+});

--- a/custom_components/dashboardmodern/frontend/tests/la-plancia-arriva-compressa.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/la-plancia-arriva-compressa.test.js
@@ -40,11 +40,16 @@ const { comprimiGliAsset, togliLeCopieCompresse, copiaDi } = await import(
 function cartellaFinta() {
   const radice = mkdtempSync(join(tmpdir(), "dm-compressa-"));
   mkdirSync(join(radice, "legacy/vendor"), { recursive: true });
+  mkdirSync(join(radice, "src/i18n"), { recursive: true });
+  mkdirSync(join(radice, "src/sections"), { recursive: true });
   writeFileSync(join(radice, "legacy/grosso.js"), "export const x = 1;\n".repeat(5000));
   writeFileSync(join(radice, "legacy/foglio.css"), ".a{color:red}\n".repeat(400));
   writeFileSync(join(radice, "legacy/minuscolo.json"), '{"a":1}');
   writeFileSync(join(radice, "legacy/build-info.js"), 'export const BUILD_INFO = {"a":1};');
   writeFileSync(join(radice, "legacy/vendor/carattere.woff2"), Buffer.from([0, 1, 2, 3, 4]));
+  writeFileSync(join(radice, "src/i18n/ja.js"), "export default {};\n".repeat(3000));
+  writeFileSync(join(radice, "src/sections/una-sezione.js"), "export const y = 2;\n".repeat(3000));
+  writeFileSync(join(radice, "panel.js"), "export const p = 3;\n".repeat(200));
   return radice;
 }
 
@@ -52,7 +57,7 @@ test("ogni file di testo ha le sue due copie, e tornano all'originale", () => {
   const radice = cartellaFinta();
   try {
     const fatti = comprimiGliAsset(radice);
-    assert.equal(fatti.length, 3, `mi aspettavo tre file compressi, sono ${fatti.length}`);
+    assert.equal(fatti.length, 5, `mi aspettavo cinque file compressi, sono ${fatti.length}`);
     for (const percorso of fatti) {
       const originale = readFileSync(percorso);
       assert.ok(
@@ -92,6 +97,33 @@ test("i caratteri e le immagini restano come sono", () => {
     comprimiGliAsset(radice);
     assert.ok(!existsSync(join(radice, "legacy/vendor/carattere.woff2.gz")));
     assert.ok(!existsSync(join(radice, "legacy/vendor/carattere.woff2.br")));
+  } finally {
+    rmSync(radice, { recursive: true, force: true });
+  }
+});
+
+test("si comprime la strada buona, non quella del ripiego", () => {
+  /* I sorgenti sciolti sotto `src/` li chiede solo il ripiego, cioe' il caso in
+   * cui il pacchetto non arriva — che per disegno e' gia' «lenta come ieri».
+   * Comprimerli costava 2,2 MB dentro il pacchetto di rilascio, scaricati da
+   * tutti a ogni aggiornamento, per una strada che non dovrebbe prendere
+   * nessuno.
+   *
+   * I cataloghi delle lingue invece stanno sotto `src/` ma sono sulla strada
+   * buona: arrivano uno per volta a ogni avvio, apposta per non stare nel
+   * pacchetto. */
+  const radice = cartellaFinta();
+  try {
+    comprimiGliAsset(radice);
+    assert.ok(
+      existsSync(join(radice, "src/i18n/ja.js.br")),
+      "il catalogo della lingua non e' compresso",
+    );
+    assert.ok(existsSync(join(radice, "panel.js.br")), "l'ingresso in cima non e' compresso");
+    assert.ok(
+      !existsSync(join(radice, "src/sections/una-sezione.js.br")),
+      "i sorgenti del ripiego si portano dietro copie che nessuno chiedera'",
+    );
   } finally {
     rmSync(radice, { recursive: true, force: true });
   }

--- a/custom_components/dashboardmodern/frontend/tests/la-plancia-arriva-compressa.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/la-plancia-arriva-compressa.test.js
@@ -1,0 +1,154 @@
+/* La plancia arriva compressa, e la compressione non si perde per strada.
+ *
+ * Dal campo, dopo aver ricevuto la beta impacchettata: «nulla e' cambiato». La
+ * Diagnostica diceva «impacchettati (3 file)», quindi il pacchetto funzionava —
+ * erano le RICHIESTE a non essere il problema. Chi entra da fuori casa passa da
+ * un tunnel, e li' contano i byte: 4,9 MB in chiaro, e 4,9 MB restavano.
+ *
+ * Home Assistant serve questi file con aiohttp, e aiohttp guarda da se' se
+ * accanto al file ce n'e' uno con lo stesso nome piu' `.br` o `.gz`: se il
+ * browser li accetta, manda quello. Provato contro un server fatto come il suo:
+ * `section-runtime.js` scende da 2007 kB a 357, e chi chiede `identity` riceve
+ * ancora l'originale intero. Misurato in pagina: 5142 kB scaricati diventano
+ * 1179, e a 5 Mbit/s la plancia e' pronta in 2768 ms invece di 4884.
+ *
+ * Le due cose che possono andare storte:
+ *
+ *   - una copia compressa che non corrisponde piu' al suo originale verrebbe
+ *     servita al posto suo, e nessuno se ne accorgerebbe: il browser riceve
+ *     senza un lamento del codice di ieri;
+ *   - una copia compressa registrata come asset a se' entrerebbe nella firma
+ *     della cartella, e la plancia cambierebbe indirizzo a ogni rilascio per
+ *     niente — piu' il doppio dei byte letti a ogni avvio.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { brotliDecompressSync, gunzipSync } from "node:zlib";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FRONTEND = join(dirname(fileURLToPath(import.meta.url)), "..");
+const RADICE = join(FRONTEND, "../../..");
+const { comprimiGliAsset, togliLeCopieCompresse, copiaDi } = await import(
+  join(RADICE, "scripts/impacchetta-la-plancia.mjs")
+);
+
+/* Una cartella finta con dentro le stesse specie di file della vera: uno
+ * grosso, uno piccolo, uno che non e' testo, e la provenienza. */
+function cartellaFinta() {
+  const radice = mkdtempSync(join(tmpdir(), "dm-compressa-"));
+  mkdirSync(join(radice, "legacy/vendor"), { recursive: true });
+  writeFileSync(join(radice, "legacy/grosso.js"), "export const x = 1;\n".repeat(5000));
+  writeFileSync(join(radice, "legacy/foglio.css"), ".a{color:red}\n".repeat(400));
+  writeFileSync(join(radice, "legacy/minuscolo.json"), '{"a":1}');
+  writeFileSync(join(radice, "legacy/build-info.js"), 'export const BUILD_INFO = {"a":1};');
+  writeFileSync(join(radice, "legacy/vendor/carattere.woff2"), Buffer.from([0, 1, 2, 3, 4]));
+  return radice;
+}
+
+test("ogni file di testo ha le sue due copie, e tornano all'originale", () => {
+  const radice = cartellaFinta();
+  try {
+    const fatti = comprimiGliAsset(radice);
+    assert.equal(fatti.length, 3, `mi aspettavo tre file compressi, sono ${fatti.length}`);
+    for (const percorso of fatti) {
+      const originale = readFileSync(percorso);
+      assert.ok(
+        gunzipSync(readFileSync(`${percorso}.gz`)).equals(originale),
+        `${percorso}: la copia gzip non torna all'originale`,
+      );
+      assert.ok(
+        brotliDecompressSync(readFileSync(`${percorso}.br`)).equals(originale),
+        `${percorso}: la copia brotli non torna all'originale`,
+      );
+    }
+  } finally {
+    rmSync(radice, { recursive: true, force: true });
+  }
+});
+
+test("nemmeno i file piccoli restano senza copia", () => {
+  /* Non e' pignoleria. Con una soglia, un file che oggi la supera e domani non
+   * la supera piu' si lascerebbe dietro la copia compressa di ieri — e quella
+   * verrebbe servita al posto del file nuovo. Guasto muto, dei peggiori.
+   * Meglio un `.gz` da trecento byte. */
+  const radice = cartellaFinta();
+  try {
+    comprimiGliAsset(radice);
+    assert.ok(existsSync(join(radice, "legacy/minuscolo.json.gz")));
+    assert.ok(existsSync(join(radice, "legacy/minuscolo.json.br")));
+  } finally {
+    rmSync(radice, { recursive: true, force: true });
+  }
+});
+
+test("i caratteri e le immagini restano come sono", () => {
+  /* Sono gia' compressi: rifarlo non toglie un byte e ne aggiunge al pacchetto
+   * di rilascio. */
+  const radice = cartellaFinta();
+  try {
+    comprimiGliAsset(radice);
+    assert.ok(!existsSync(join(radice, "legacy/vendor/carattere.woff2.gz")));
+    assert.ok(!existsSync(join(radice, "legacy/vendor/carattere.woff2.br")));
+  } finally {
+    rmSync(radice, { recursive: true, force: true });
+  }
+});
+
+test("la provenienza resta in chiaro", () => {
+  /* `build-info.js` lo rigenera chi costruisce il pacchetto di rilascio, e lo
+   * sostituisce dentro lo zip. Una copia compressa di quello di prima direbbe
+   * la versione sbagliata — e la direbbe vincendo, perche' aiohttp serve la
+   * copia compressa quando c'e'. Sono trecento byte: resta in chiaro. */
+  const radice = cartellaFinta();
+  try {
+    comprimiGliAsset(radice);
+    assert.ok(!existsSync(join(radice, "legacy/build-info.js.gz")));
+    assert.ok(!existsSync(join(radice, "legacy/build-info.js.br")));
+  } finally {
+    rmSync(radice, { recursive: true, force: true });
+  }
+});
+
+test("ripulire porta via anche le copie compresse", () => {
+  /* Chi sviluppa apre la plancia dai sorgenti. Una copia compressa dimenticata
+   * li' verrebbe servita al posto del file che sta modificando, e lo lascerebbe
+   * a chiedersi perche' le sue modifiche non si vedono. */
+  const radice = cartellaFinta();
+  try {
+    comprimiGliAsset(radice);
+    assert.ok(existsSync(join(radice, "legacy/grosso.js.gz")));
+    togliLeCopieCompresse(radice);
+    assert.ok(!existsSync(join(radice, "legacy/grosso.js.gz")));
+    assert.ok(!existsSync(join(radice, "legacy/grosso.js.br")));
+    assert.ok(existsSync(join(radice, "legacy/grosso.js")), "ha portato via anche l'originale");
+  } finally {
+    rmSync(radice, { recursive: true, force: true });
+  }
+});
+
+test("le copie compresse non entrano fra gli asset che l'integrazione registra", () => {
+  /* `_runtime_assets` filtra per suffisso, e da quell'elenco escono sia le
+   * rotte sia la firma della cartella. Se `.gz` o `.br` ci entrassero: un
+   * indirizzo nuovo a ogni rilascio per niente, e il doppio dei byte letti a
+   * ogni avvio solo per calcolare la firma. */
+  const py = readFileSync(join(RADICE, "custom_components/dashboardmodern/frontend.py"), "utf8");
+  const elenco = py.match(/ASSET_SUFFIXES = frozenset\(\s*\{(.*?)\}\s*\)/s)?.[1];
+  assert.ok(elenco, "non trovo piu' l'elenco dei suffissi serviti");
+  assert.ok(!elenco.includes('".gz"'), "le copie gzip finirebbero fra gli asset registrati");
+  assert.ok(!elenco.includes('".br"'), "le copie brotli finirebbero fra gli asset registrati");
+});
+
+test("i gusci messi da parte non viaggiano dentro il pacchetto di rilascio", () => {
+  /* Prima le copie di lavoro stavano accanto ai documenti, dentro la cartella
+   * dell'integrazione: chi costruisce il pacchetto prende tutto quello che
+   * trova li', e cosi' partivano per il mondo due documenti da centosei kB che
+   * nessuno avrebbe mai chiesto. */
+  const dove = copiaDi("legacy/dashboard.html");
+  assert.ok(
+    !dove.includes("custom_components"),
+    `la copia di lavoro finisce dentro l'integrazione: ${dove}`,
+  );
+});

--- a/custom_components/dashboardmodern/frontend/tests/release-artifact.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/release-artifact.test.js
@@ -66,6 +66,18 @@ test("HACS release artifact has root integration layout, complete brand assets a
   );
   assert.equal(names.includes("frontend/index.html"), false);
   assert.equal(names.includes("frontend/styles.css"), false);
+  /* I resti di chi ha appena eseguito la suite non partono per il mondo.
+   *
+   * `test-results` e `playwright-report` sono schermate, tracce e report. In CI
+   * il rilascio parte da un checkout pulito e non li ha mai avuti, quindi il
+   * pacchetto pubblicato e' sempre stato a posto; ma chi costruisce il pacchetto
+   * sulla propria macchina, dopo aver eseguito le prove, ci spediva dentro tre
+   * megabyte e mezzo di PNG senza accorgersene. Trovato misurando lo zip mentre
+   * si cercava un'altra cosa. */
+  const resti = names.filter(
+    (name) => name.includes("test-results") || name.includes("playwright-report"),
+  );
+  assert.deepEqual(resti, [], `resti delle prove nel pacchetto: ${resti.slice(0, 3).join(", ")}`);
 
   const buildInfo = readArchive("frontend/legacy/build-info.js");
   const manifest = JSON.parse(readArchive("manifest.json"));

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.4.5-beta.1"
+  "version": "1.4.5-beta.2"
 }

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -11,7 +11,15 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components/dashboardmodern"
-EXCLUDED_RELEASE_PARTS = frozenset({"__pycache__", "e2e", "tests"})
+# `test-results` e `playwright-report` sono i resti di chi ha appena eseguito la
+# suite: schermate, tracce, report. In CI il rilascio parte da un checkout
+# pulito e non li ha, quindi il pacchetto pubblicato e' sempre stato a posto —
+# ma chi costruisce il pacchetto sulla propria macchina, dopo aver eseguito le
+# prove, ci spediva dentro tre megabyte e mezzo di PNG. Trovato misurando lo
+# zip, non leggendo il codice.
+EXCLUDED_RELEASE_PARTS = frozenset(
+    {"__pycache__", "e2e", "tests", "test-results", "playwright-report", "node_modules"}
+)
 
 
 def _include_release_file(path: Path) -> bool:

--- a/scripts/impacchetta-la-plancia.mjs
+++ b/scripts/impacchetta-la-plancia.mjs
@@ -13,9 +13,15 @@
  * quasi due megabyte, e a una casa ne serve UNO — che continuano ad arrivare
  * uno alla volta quando servono.
  *
- * Niente minificazione: il guadagno grosso e' il numero di richieste, e con i
- * nomi veri un errore dal campo si legge ancora. Si potra' aggiungere quando
- * il resto sara' assestato.
+ * Poi dal campo e' tornato «nulla e' cambiato», e aveva ragione: le richieste
+ * non erano il problema. Chi apre la plancia da fuori casa passa da un tunnel,
+ * e li' contano i BYTE — quattro megabyte e mezzo, prima e dopo il pacchetto.
+ * Per questo lo script fa una seconda cosa: mette accanto a ogni file una copia
+ * gia' compressa, e Home Assistant manda quella. Da 4,9 MB a 1,2.
+ *
+ * Niente minificazione, e stavolta con una misura sotto: sopra la compressione
+ * vale il dieci per cento — 95 kB su 956 — e non vale i nomi veri, che sono
+ * quelli che rendono leggibile un errore arrivato dal campo.
  *
  * Lo script si usa cosi':
  *
@@ -27,9 +33,18 @@
  * fare il pacchetto, e i gusci riscritti finiscono solo li' dentro.
  */
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { brotliCompressSync, brotliDecompressSync, gunzipSync, gzipSync } from "node:zlib";
 
 const RADICE = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const FRONTEND = join(RADICE, "custom_components/dashboardmodern/frontend");
@@ -115,10 +130,17 @@ export function guscioImpacchettato(html) {
  * via anche le modifiche non salvate di chi stava lavorando su quei file: il
  * ciclo `impacchetta` / `impacchetta:pulisci` gli faceva perdere il lavoro.
  * Chiesto in revisione. Adesso si conserva la copia di partenza e si rimette
- * quella: torna esattamente il documento che c'era, salvato o no. */
-const copiaDi = (relativo) => join(FRONTEND, `${relativo}.prima-del-pacco`);
+ * quella: torna esattamente il documento che c'era, salvato o no.
+ *
+ * Le copie stanno FUORI dalla cartella dell'integrazione: li' dentro finivano
+ * dritte nel pacchetto di rilascio — due documenti da centosei kB che nessuno
+ * avrebbe mai chiesto, spediti a tutti. */
+const RIPOSTIGLIO = join(RADICE, ".gusci-prima-del-pacco");
+export const copiaDi = (relativo) =>
+  join(RIPOSTIGLIO, `${relativo.replace(/\//g, "_")}.prima-del-pacco`);
 
 function scriviIGusci() {
+  mkdirSync(RIPOSTIGLIO, { recursive: true });
   for (const relativo of GUSCI) {
     const percorso = join(FRONTEND, relativo);
     const html = readFileSync(percorso, "utf8");
@@ -130,7 +152,73 @@ function scriviIGusci() {
   }
 }
 
+/* La plancia gia' compressa, accanto a se stessa.
+ *
+ * Il pacchetto ha tolto le richieste — da centosettantanove a tre — e dal campo
+ * e' tornato «nulla e' cambiato». La diagnostica diceva «impacchettati (3
+ * file)», quindi funzionava: erano le richieste a non essere il problema. Chi
+ * entra da fuori casa passa da un tunnel, e li' contano i BYTE. Erano 4,9 MB in
+ * chiaro, e restavano 4,9 MB anche dopo il pacchetto.
+ *
+ * Home Assistant serve questi file con aiohttp, e aiohttp guarda da se' se
+ * accanto al file ce n'e' uno con lo stesso nome piu' `.br` o `.gz`: se il
+ * browser dice di accettarli, manda quello. Verificato: chi chiede `identity`
+ * riceve ancora l'originale, quindi non si rompe niente. Non serve toccare una
+ * riga di Python — bastano i file.
+ *
+ * Misurato sui file veri: 4890 kB in chiaro, 1264 in gzip, 956 in brotli.
+ * Brotli lo capiscono tutti i browser su HTTPS; gzip serve a chi entra da casa
+ * su `http://`, dove Chrome il brotli non lo chiede nemmeno. Quindi tutti e
+ * due.
+ *
+ * Si comprime TUTTO il servibile, senza soglie: un file che oggi supera una
+ * soglia e domani non la supera piu' si lascerebbe dietro la copia compressa
+ * vecchia, e quella verrebbe servita al posto della nuova. Un guasto muto, e
+ * dei peggiori. Meglio qualche `.gz` da trecento byte. */
+const DA_COMPRIMERE = Object.freeze(new Set([".js", ".css", ".json", ".html", ".svg"]));
+const FUORI_DAL_GIRO = Object.freeze(new Set(["e2e", "tests", "__pycache__", "node_modules"]));
+/* `build-info.js` no: il pacchetto di rilascio lo rigenera e lo sostituisce
+ * dentro lo zip, e una copia compressa di quello vecchio direbbe la versione
+ * sbagliata. Resta in chiaro, e sono trecento byte. */
+const SENZA_COPIA_COMPRESSA = "build-info.js";
+
+function* daServire(cartella) {
+  for (const voce of readdirSync(cartella)) {
+    if (FUORI_DAL_GIRO.has(voce)) continue;
+    const percorso = join(cartella, voce);
+    if (statSync(percorso).isDirectory()) yield* daServire(percorso);
+    else if (DA_COMPRIMERE.has(extname(voce)) && voce !== SENZA_COPIA_COMPRESSA) yield percorso;
+  }
+}
+
+export function comprimiGliAsset(radice = FRONTEND) {
+  const fatti = [];
+  for (const percorso of daServire(radice)) {
+    const originale = readFileSync(percorso);
+    writeFileSync(`${percorso}.gz`, gzipSync(originale, { level: 9 }));
+    writeFileSync(`${percorso}.br`, brotliCompressSync(originale));
+    /* Una copia compressa che non torna all'originale e' peggio di nessuna
+     * copia: verrebbe servita al posto suo, e nessuno se ne accorgerebbe. */
+    if (!gunzipSync(readFileSync(`${percorso}.gz`)).equals(originale))
+      throw new Error(`${percorso}: la copia gzip non torna all'originale`);
+    if (!brotliDecompressSync(readFileSync(`${percorso}.br`)).equals(originale))
+      throw new Error(`${percorso}: la copia brotli non torna all'originale`);
+    fatti.push(percorso);
+  }
+  return fatti;
+}
+
+export function togliLeCopieCompresse(cartella) {
+  for (const voce of readdirSync(cartella)) {
+    if (FUORI_DAL_GIRO.has(voce)) continue;
+    const percorso = join(cartella, voce);
+    if (statSync(percorso).isDirectory()) togliLeCopieCompresse(percorso);
+    else if (voce.endsWith(".gz") || voce.endsWith(".br")) rmSync(percorso, { force: true });
+  }
+}
+
 function pulisci() {
+  togliLeCopieCompresse(FRONTEND);
   rmSync(PACCO, { recursive: true, force: true });
   for (const relativo of GUSCI) {
     const copia = copiaDi(relativo);
@@ -138,6 +226,7 @@ function pulisci() {
     writeFileSync(join(FRONTEND, relativo), readFileSync(copia, "utf8"));
     rmSync(copia, { force: true });
   }
+  rmSync(RIPOSTIGLIO, { recursive: true, force: true });
 }
 
 function main() {
@@ -150,7 +239,13 @@ function main() {
   scriviIGusci();
   const entrata = join(PACCO, "legacy/modules-entry.js");
   if (!existsSync(entrata)) throw new Error("il pacchetto non contiene l'ingresso della plancia");
-  console.log("plancia impacchettata in legacy/pacco/");
+  /* Per ultima, e non e' un dettaglio: comprime anche i gusci riscritti e il
+   * pacchetto appena fatto. Comprimere prima avrebbe messo da parte la
+   * versione di prima di tutto il lavoro. */
+  const compressi = comprimiGliAsset();
+  console.log(
+    `plancia impacchettata in legacy/pacco/, ${compressi.length} file con copia .gz e .br`,
+  );
 }
 
 if (process.argv[1] && process.argv[1].endsWith("impacchetta-la-plancia.mjs")) main();

--- a/scripts/impacchetta-la-plancia.mjs
+++ b/scripts/impacchetta-la-plancia.mjs
@@ -171,23 +171,49 @@ function scriviIGusci() {
  * su `http://`, dove Chrome il brotli non lo chiede nemmeno. Quindi tutti e
  * due.
  *
- * Si comprime TUTTO il servibile, senza soglie: un file che oggi supera una
- * soglia e domani non la supera piu' si lascerebbe dietro la copia compressa
- * vecchia, e quella verrebbe servita al posto della nuova. Un guasto muto, e
- * dei peggiori. Meglio qualche `.gz` da trecento byte. */
+ * Niente soglie di grandezza: un file che oggi supera una soglia e domani non
+ * la supera piu' si lascerebbe dietro la copia compressa vecchia, e quella
+ * verrebbe servita al posto della nuova. Un guasto muto, e dei peggiori. Meglio
+ * qualche `.gz` da trecento byte.
+ *
+ * Si comprime pero' solo quello che la plancia chiede DAVVERO: il guscio, il
+ * pacchetto, il runtime, i fogli, le librerie e i cataloghi delle lingue. I
+ * centosettantanove sorgenti sciolti sotto `src/` no — quelli servono al
+ * ripiego, cioe' al caso in cui il pacchetto non arriva, che per disegno e'
+ * gia' «lenta come ieri». Comprimerli costava 2,2 MB nel pacchetto di rilascio,
+ * scaricati da tutti a ogni aggiornamento, per una strada che non dovrebbe
+ * prendere nessuno. Il pacchetto passa da 7,1 a 10,5 MB invece che a 12,7.
+ *
+ * La regola e' per percorso, non per grandezza: un file sta sotto `legacy/` o
+ * non ci sta, e questo non cambia da un rilascio all'altro. Nessuna copia
+ * vecchia puo' restare indietro. */
 const DA_COMPRIMERE = Object.freeze(new Set([".js", ".css", ".json", ".html", ".svg"]));
 const FUORI_DAL_GIRO = Object.freeze(new Set(["e2e", "tests", "__pycache__", "node_modules"]));
+/* `legacy/` si porta dentro anche `legacy/pacco/`, che e' il grosso. */
+const SULLA_STRADA_BUONA = Object.freeze(["legacy", "src/i18n"]);
+const INGRESSI_IN_CIMA = Object.freeze(["panel.js", "dashboard-card.js"]);
 /* `build-info.js` no: il pacchetto di rilascio lo rigenera e lo sostituisce
  * dentro lo zip, e una copia compressa di quello vecchio direbbe la versione
  * sbagliata. Resta in chiaro, e sono trecento byte. */
 const SENZA_COPIA_COMPRESSA = "build-info.js";
 
-function* daServire(cartella) {
+function* sottoLaCartella(cartella) {
   for (const voce of readdirSync(cartella)) {
     if (FUORI_DAL_GIRO.has(voce)) continue;
     const percorso = join(cartella, voce);
-    if (statSync(percorso).isDirectory()) yield* daServire(percorso);
+    if (statSync(percorso).isDirectory()) yield* sottoLaCartella(percorso);
     else if (DA_COMPRIMERE.has(extname(voce)) && voce !== SENZA_COPIA_COMPRESSA) yield percorso;
+  }
+}
+
+function* daServire(radice) {
+  for (const ramo of SULLA_STRADA_BUONA) {
+    const cartella = join(radice, ramo);
+    if (existsSync(cartella)) yield* sottoLaCartella(cartella);
+  }
+  for (const nome of INGRESSI_IN_CIMA) {
+    const percorso = join(radice, nome);
+    if (existsSync(percorso)) yield percorso;
   }
 }
 


### PR DESCRIPTION
## «Nulla è cambiato»

La beta di prima aveva ridotto le richieste da centosettantanove a tre. Dal campo è tornato che non si sentiva niente — **e aveva ragione.**

La Diagnostica lo diceva chiaramente: `Modules: impacchettati (3 file)`, commit giusto, ingresso dal pacco. La consegna era a posto e il pacchetto era in uso. Quindi le richieste non erano il problema.

Nella stessa schermata c'era anche la risposta: l'indirizzo finiva in `ui.nabu.casa`. **Da fuori casa ogni byte fa il giro del cloud**, e i byte erano rimasti 4,9 MB — identici prima e dopo il pacchetto. Avevo ottimizzato l'asse sbagliato: il numero di richieste conta su HTTP/1.1 in rete locale, non su un tunnel.

## La correzione

Home Assistant serve questi file con aiohttp, e aiohttp guarda da sé se accanto al file ce n'è uno con lo stesso nome più `.br` o `.gz`: se il browser li accetta, manda quello.

Verificato contro un server costruito come il suo — un `FileResponse` per file, esattamente come `_ensure_static_registered`:

| | in chiaro | gzip | brotli |
|---|---|---|---|
| `section-runtime.js` | 2007 kB | 500 kB | **357 kB** |
| `dashboard-runtime-it.js` | 640 kB | 172 kB | **132 kB** |

Chi chiede `Accept-Encoding: identity` riceve ancora l'originale intero: la negoziazione è corretta, non si rompe niente.

**Nessuna riga di Python da toccare.** `ASSET_SUFFIXES` è un elenco di permessi che non contiene `.gz` né `.br`, quindi le copie compresse restano fuori sia dalle rotte sia dalla firma della cartella — nessun indirizzo nuovo a ogni rilascio, nessun byte in più letto all'avvio.

## Misurato in pagina

Da **5142 kB** scaricati a **1179 kB**. E a banda ridotta, che è dove si sente:

| banda | prima | dopo |
|---|---|---|
| 5 Mbit/s | 4884 ms | **2768 ms** |
| 10 Mbit/s | 3472 ms | **2497 ms** |
| 30 Mbit/s | 2681 ms | **1945 ms** |

Chi entra da casa, dove la banda non manca, non se ne accorgerà. È fuori casa che si sentiva.

## Niente minificazione, e stavolta con una misura sotto

| | crudo | gzip | brotli |
|---|---|---|---|
| non minificata | 4890 kB | 1264 kB | **956 kB** |
| minificata | 3991 kB | 1110 kB | 861 kB |

Sopra la compressione la minificazione vale il 10% — 95 kB su 956 — e non vale i nomi veri, che sono quelli che rendono leggibile un errore arrivato dal campo. La scelta di prima era giusta; era la compressione che mancava.

## Quanto pesa il pacchetto, per davvero

Prima misura riferita: 16,3 MB. **Sbagliata**, e trovata solo perché è stata messa in discussione. Nello zip che avevo misurato c'erano 22 file di `test-results` — 3,5 MB di schermate di Playwright, finiti dentro perché avevo appena eseguito la suite. `build_release.py` escludeva `e2e` e `tests`, non `test-results`. Il pacchetto **pubblicato** non li ha mai avuti (in CI il rilascio parte da un checkout pulito), ma chiunque costruisse il pacchetto sulla propria macchina li spediva a tutti. Chiuso, con una prova che lo tiene chiuso.

E la compressione è stata ristretta a quello che la plancia chiede davvero: guscio, pacchetto, runtime, fogli, librerie e cataloghi delle lingue. I 179 sorgenti sciolti sotto `src/` servono solo al ripiego — il caso in cui il pacchetto non arriva, già «lento come ieri» per disegno — e costavano 2,2 MB scaricati da tutti per una strada che non dovrebbe prendere nessuno. Da 259 file compressi a 40.

| | peso |
|---|---|
| 1.4.4 / 1.4.5-beta.1 | 7,1 MB |
| ~~beta.2, prima misura~~ | ~~16,3 MB~~ |
| **beta.2** | **10,5 MB** |

## Tre trappole chiuse per tempo

- **Niente soglie di grandezza.** Un file che oggi supera una soglia e domani non la supera più si lascerebbe dietro la copia compressa vecchia — e quella verrebbe servita al posto della nuova. Guasto muto, e dei peggiori. La regola è per percorso: un file sta sotto `legacy/` o non ci sta, e questo non cambia da un rilascio all'altro.
- **`build-info.js` resta in chiaro apposta.** Lo rigenera chi costruisce il pacchetto di rilascio e lo sostituisce dentro lo zip; una copia compressa di quello di prima direbbe la versione sbagliata, e la direbbe vincendo.
- **Ogni copia viene riletta e decompressa subito dopo essere stata scritta.** Una copia che non torna all'originale ferma il rilascio invece di partire.

## Altro, dallo stesso giro

- **La Diagnostica dice quanto pesa arrivare.** La riga `Transfer` mostra i byte scesi davvero dal filo e se erano compressi. Per scoprire che la beta di prima non aveva spostato niente sono serviti uno scambio di messaggi e una schermata; adesso si legge da soli.
- **Due documenti da 106 kB non partono più per il mondo.** Le copie di lavoro dei gusci stavano dentro la cartella dell'integrazione.
- **L'attesa dentro `editor-runtime` segue il browser.** La prova si prende già tre volte il tempo su webkit; il sondaggio che aspetta le voci del Report era rimasto fermo a 20 secondi, e su uno shard carico si arrendeva mentre alla prova restavano due minuti.

## Come è stato verificato

- **Tredici prove nuove**, e quelle che rispondono a un difetto sono state eseguite anche contro la versione precedente: cadono. Le copie tornano all'originale; caratteri e immagini restano come sono; la provenienza resta in chiaro; `--pulisci` porta via le copie ma non gli originali; le copie non entrano fra gli asset registrati; si comprime la strada buona e non quella del ripiego; la riga `Transfer` non dichiara «compressi» un carico mezzo in cache né conta risorse altrui.
- **1713 prove frontend** verdi, 7 shard browser su 7 verdi (webkit compreso).
- **Il pacchetto di rilascio vero**, costruito e ispezionato: 40 copie `.gz` e 40 `.br`, zero resti di prova, cataloghi compressi, sorgenti del ripiego no.