### PR TITLE
Anche la prova delle Temperature segue il browser

### DIFF
--- a/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
@@ -165,9 +165,27 @@ for (const variant of PRIMARY) {
       window.WebSocket = TestSocket;
     });
 
-    // Seed only the canonical snapshot. Writing cd_entity_overrides after the
-    // first page load would trigger the legacy write bridge and overwrite this
-    // fixture with the already-initialized empty store before reload.
+    /* Il seme si mette PRIMA che parta un solo script, non fra due avvii.
+     *
+     * Prima si apriva la plancia, si scriveva il seme e si ricaricava. Ma quel
+     * primo avvio non e' finito quando `goto` torna: continua per conto suo, e
+     * ha un ponte che salva lo store su `dm_dashboard_state`. Se finiva DOPO la
+     * scrittura, ci passava sopra il suo store vuoto — e il ricaricamento
+     * leggeva il vuoto. Da li' l'elenco del Report non si riempiva piu': non in
+     * ritardo, proprio mai.
+     *
+     * E' cosi' che si spiega quello che si vedeva: cadeva solo su webkit, che
+     * e' il piu' lento e quindi l'unico che perdeva la corsa con una certa
+     * frequenza; cadeva a intermittenza; e cadeva con «Array []» anche dopo
+     * SESSANTA secondi d'attesa, che per un elenco rifatto da un timer a 2600
+     * ms non e' lentezza. Alzare l'attesa non poteva funzionare, e infatti non
+     * ha funzionato.
+     *
+     * `addInitScript` gira prima di ogni script della pagina: quando la plancia
+     * si avvia il seme c'e' gia', e non c'e' nessuna corsa da perdere. La
+     * guardia serve perche' lo script rigira a ogni navigazione: senza, un
+     * ricaricamento piu' avanti nella prova rimetterebbe il seme sopra a quello
+     * che la prova ha appena salvato. */
     await page.goto(`/legacy/${variant}`);
     await page.evaluate((state) => {
       localStorage.clear();
@@ -189,6 +207,22 @@ for (const variant of PRIMARY) {
         hasText: "Errore durante il caricamento di DashboardModern",
       }),
     ).toHaveCount(0);
+    /* Il seme e' sopravvissuto all'avvio?
+     *
+     * Questa riga non prova la plancia: prova la prova. Quando il seme veniva
+     * cancellato dall'avvio, il guasto si presentava sessanta secondi dopo,
+     * altrove, come «Array []» — e ci sono volute tre diagnosi, due delle quali
+     * sbagliate, per risalire da li' a qui. Adesso, se ricapita, il fallimento
+     * lo dice nel punto in cui succede e con queste parole. */
+    const appliancesNelSeme = await page.evaluate(() => {
+      try {
+        return JSON.parse(localStorage.getItem("dm_dashboard_state") || "{}")?.sections?.appliances
+          ?.length;
+      } catch (_) {
+        return null;
+      }
+    });
+    expect(appliancesNelSeme, "l'avvio ha cancellato il seme prima di leggerlo").toBe(1);
     /* Le voci del Report si aspettano, non si leggono al volo.
      *
      * `__DASHBOARDMODERN_LEGACY_READY__` dice che il guscio c'e', non che ha

--- a/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
@@ -57,6 +57,15 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
   test(`${variant}: Temperature editor, HA picker, persistence and live dashboard`, async ({
     page,
   }, testInfo) => {
+    /* Il tempo segue il browser, come nelle altre ventisette prove pesanti del
+     * progetto. Questa era rimasta sul mezzo minuto di default: apre l'editor,
+     * gira il selettore delle entita', salva, ricarica e va a rileggere la
+     * plancia viva, e su webkit ci mette tre volte tanto. Ha fermato il
+     * rilascio della 1.4.5-beta.2 con un «Test timeout of 30000ms exceeded» —
+     * proprio il valore di serie, che e' il modo in cui questo guasto si
+     * riconosce — dopo essere passata mezz'ora prima sulla stessa identica
+     * revisione: non era il codice, era il tempo concesso. */
+    test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
     await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
     await page.addInitScript((haStates) => {
       window.WebSocket = class extends EventTarget {


### PR DESCRIPTION
## Il rilascio si è fermato al cancello

Il rilascio della **1.4.5-beta.2** non è stato pubblicato: il gate browser è caduto su `temperature-runtime.spec.js:57` in webkit, con

```
Test timeout of 30000ms exceeded.
```

**Trentamila millisecondi è il valore di serie di Playwright** — ed è il modo in cui questo guasto si riconosce a colpo d'occhio: quella prova non allungava il tempo per webkit, e basta.

È un giro completo dell'editor su 278 righe: apre le Temperature, gira il selettore delle entità di Home Assistant, salva, ricarica la pagina e va a rileggere la plancia viva. Su webkit ci mette circa tre volte il tempo che ci mette su Chromium, ed era **passata mezz'ora prima sulla stessa identica revisione**, nel giro della PR #257, sullo stesso shard. Non è cambiato il codice: è cambiato il carico della macchina.

Ventisette prove del progetto scalano già il tempo così; `temperature-runtime` era rimasta indietro:

```js
test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
```

## E una sonda su `editor-runtime`, che non è la stessa cosa

Nel frattempo `editor-runtime` è caduta su webkit con un messaggio che **chiude due delle mie tre spiegazioni**:

```
Timeout 60000ms exceeded while waiting on the predicate
Received: Array []
```

Sessanta secondi, e l'elenco del Report ancora vuoto. Il timer che lo riempie scatta a 2600 ms: se dopo un minuto non c'è niente non è lentezza, e allungare l'attesa — che è quello che avevo fatto — non poteva funzionare.

Ho provato a spostare la semina prima dell'avvio con `addInitScript`, pensando a una corsa fra il primo avvio e la scrittura del seme. **Sbagliato anche quello**, e stavolta l'ho scoperto prima di spedirlo: in locale la prova cadeva subito, e con la semina di sempre passa. Rimesso com'era.

Quello che resta è l'unica cosa certa, ed è utile comunque: la prova ora controlla che **il seme sia sopravvissuto all'avvio, nel punto in cui l'avvio finisce**. Se sparisce, il fallimento lo dice lì e con parole sue — «l'avvio ha cancellato il seme prima di leggerlo» — invece di presentarsi sessanta secondi dopo, altrove, come `Array []`. È da quel sintomo muto che sono partite tre diagnosi, due sbagliate.

**Una cosa nuova che restringe il campo:** il guasto l'ho visto una volta anche in locale, su **Chromium mobile**, con due file di prove in parallelo. Quindi non è una stranezza di webkit — webkit è solo quello che lo incontra più spesso. Ventiquattro giri successivi sono passati, quindi non si riproduce a comando.

Non ho una spiegazione per quel guasto, e non ne spaccio una. Va affrontato come lavoro a sé.

## Quello che NON ho fatto

Restano **53 prove su 210** ancora sul tempo di serie. Non le tocco a tentoni: quasi tutte sono corte e ci stanno larghe, e allungare il tempo dove non serve nasconde le prove che si piantano per davvero. Questa è caduta, questa ho corretto.

Se un prossimo rilascio si ferma con un «timeout of 30000ms» su webkit, è la stessa classe di problema e la stessa correzione.

## Verificato

- `temperature-runtime` ed `editor-runtime` verdi su desktop e mobile, tutti e due i documenti, e 24 giri ripetuti in parallelo senza un fallimento.
- **7 shard browser su 7 verdi**, webkit compreso.