### PR TITLE
Versione 1.4.5-beta.3: la Diagnostica misura invece di dedurre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.4.5-beta.3
+
+La compressione della beta.2 funziona — confermato dal campo: `content-encoding:
+br`, 366 kB al posto di 2007. Ed e' ancora lento. Quindi ne' le richieste ne' i
+byte erano la causa, e questa versione non prova a indovinare la terza: misura.
+
+### Corretto
+
+- **La riga «Transfer» non dichiara piu' cose che non ha misurato.** Diceva «non
+  compressi» di una plancia che arrivava compressa: il peso del corpo com'e'
+  arrivato non e' sempre disponibile, e quel vuoto finiva nel ramo sbagliato. E'
+  il modo in cui una diagnostica fa cercare il guasto dalla parte sbagliata, che
+  e' peggio del non averla. Adesso, quando quel dato manca, lo dice — e
+  soprattutto va a CHIEDERE al server come e' arrivato davvero il file, invece
+  di dedurlo: la riga si completa da sola con «servito br» o «servito in
+  chiaro».
+
+### Nuovo
+
+- **La Diagnostica dice quando la plancia e' pronta, e dove va il tempo.** La
+  riga «Boot» mostra quanto ci mette il velo ad andarsene, quando e' arrivato
+  l'ultimo file, e quanto tempo passa DOPO che la rete ha finito. Se il grosso
+  sta prima e' la rete; se sta dopo sono analisi ed esecuzione, dove ne' il
+  pacchetto ne' la compressione arrivano. Serve a smettere di tirare a
+  indovinare su una macchina che non e' la mia.
+
 ## 1.4.5-beta.2
 
 La beta di prima aveva ridotto le richieste da centosettantanove a tre, e dal

--- a/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
@@ -165,28 +165,36 @@ for (const variant of PRIMARY) {
       window.WebSocket = TestSocket;
     });
 
-    /* Il seme si mette PRIMA che parta un solo script, non fra due avvii.
+    /* Il seme si scrive quando il primo avvio ha gia' scritto il suo.
      *
-     * Prima si apriva la plancia, si scriveva il seme e si ricaricava. Ma quel
-     * primo avvio non e' finito quando `goto` torna: continua per conto suo, e
-     * ha un ponte che salva lo store su `dm_dashboard_state`. Se finiva DOPO la
-     * scrittura, ci passava sopra il suo store vuoto — e il ricaricamento
-     * leggeva il vuoto. Da li' l'elenco del Report non si riempiva piu': non in
-     * ritardo, proprio mai.
+     * Questa e' la corsa che ha fatto cadere la prova per mezza giornata, e
+     * l'ha nominata la sonda qui sotto invece di una mia deduzione: «l'avvio ha
+     * cancellato il seme prima di leggerlo».
      *
-     * E' cosi' che si spiega quello che si vedeva: cadeva solo su webkit, che
-     * e' il piu' lento e quindi l'unico che perdeva la corsa con una certa
-     * frequenza; cadeva a intermittenza; e cadeva con «Array []» anche dopo
-     * SESSANTA secondi d'attesa, che per un elenco rifatto da un timer a 2600
-     * ms non e' lentezza. Alzare l'attesa non poteva funzionare, e infatti non
-     * ha funzionato.
+     * `goto` torna quando il documento e' pronto, non quando la plancia ha
+     * finito di avviarsi. Quel primo avvio continua per conto suo e a un certo
+     * punto salva il proprio store — vuoto — su `dm_dashboard_state`. Se lo
+     * faceva DOPO che la prova aveva scritto il seme, ci passava sopra, e il
+     * ricaricamento leggeva il vuoto: da li' l'elenco del Report non si
+     * riempiva piu'. Non in ritardo — proprio mai, ed e' per questo che
+     * aspettare di piu' non poteva funzionare, e infatti non ha funzionato.
      *
-     * `addInitScript` gira prima di ogni script della pagina: quando la plancia
-     * si avvia il seme c'e' gia', e non c'e' nessuna corsa da perdere. La
-     * guardia serve perche' lo script rigira a ogni navigazione: senza, un
-     * ricaricamento piu' avanti nella prova rimetterebbe il seme sopra a quello
-     * che la prova ha appena salvato. */
+     * Su Chromium quel salvataggio arriva quasi sempre prima, e la prova
+     * passava; su webkit, che ci mette tre volte tanto, arrivava dopo, e
+     * cadeva. Stessa corsa, esito diverso a seconda di chi corre.
+     *
+     * Adesso si aspetta che quel salvataggio sia avvenuto — la chiave esiste —
+     * e solo allora si scrive il seme: dopo, non c'e' piu' nessuno che possa
+     * passarci sopra.
+     *
+     * Anticipare il seme con `addInitScript`, cioe' metterlo prima ancora del
+     * primo avvio, l'ho provato e non funziona: quel primo avvio lo cancella
+     * comunque. E' una cosa che vale la pena sapere di questa plancia, e sta
+     * scritta qui perche' non la riprovi qualcun altro. */
     await page.goto(`/legacy/${variant}`);
+    await page.waitForFunction(() => !!localStorage.getItem("dm_dashboard_state"), {
+      timeout: 30_000,
+    });
     await page.evaluate((state) => {
       localStorage.clear();
       localStorage.setItem("dm_dashboard_state", JSON.stringify(state));

--- a/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
@@ -292,9 +292,14 @@ for (const variant of PRIMARY) {
      * i byte erano rimasti gli stessi, ed e' quello che si sentiva da fuori
      * casa.
      *
+     * E a quattordici quando i byte sono scesi a un quarto — confermato dal
+     * campo, `content-encoding: br` — ed era ancora lento. Le prime due righe
+     * dicono COSA e' arrivato; la quarta dice QUANDO, e quanto del tempo sta
+     * dopo la rete, dove ne' il pacchetto ne' la compressione arrivano.
+     *
      * Chi aggiunge una voce alza questo numero E la nomina qui sotto: cosi'
      * la prossima volta il conto si legge invece di sembrare capriccio. */
-    await expect(page.locator("[data-runtime-diagnostics] .ed-row")).toHaveCount(13);
+    await expect(page.locator("[data-runtime-diagnostics] .ed-row")).toHaveCount(14);
     await expect(page.locator("[data-runtime-diagnostics]")).toContainText("Integration version");
     /* La dodicesima e la tredicesima. La prima si controlla dal valore, che
      * vale in tutti gli stati: la riga dice quale dei due, non presume.
@@ -307,6 +312,7 @@ for (const variant of PRIMARY) {
      * che non lo e'. */
     await expect(page.locator("[data-runtime-diagnostics]")).toContainText(/impacchettati|sciolti/);
     await expect(page.locator("[data-runtime-diagnostics]")).toContainText("Transfer");
+    await expect(page.locator("[data-runtime-diagnostics]")).toContainText("Boot");
     await page.evaluate(() => window.editorSwitch("sez1"));
     await expect(page.locator('#ed-body[data-renderer="energy"]')).toBeVisible();
     await page.screenshot({ path: `test-results/${testInfo.project.name}-${variant}-energy.png` });

--- a/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/editor-runtime.spec.js
@@ -165,9 +165,27 @@ for (const variant of PRIMARY) {
       window.WebSocket = TestSocket;
     });
 
-    // Seed only the canonical snapshot. Writing cd_entity_overrides after the
-    // first page load would trigger the legacy write bridge and overwrite this
-    // fixture with the already-initialized empty store before reload.
+    /* Il seme si mette PRIMA che parta un solo script, non fra due avvii.
+     *
+     * Prima si apriva la plancia, si scriveva il seme e si ricaricava. Ma quel
+     * primo avvio non e' finito quando `goto` torna: continua per conto suo, e
+     * ha un ponte che salva lo store su `dm_dashboard_state`. Se finiva DOPO la
+     * scrittura, ci passava sopra il suo store vuoto — e il ricaricamento
+     * leggeva il vuoto. Da li' l'elenco del Report non si riempiva piu': non in
+     * ritardo, proprio mai.
+     *
+     * E' cosi' che si spiega quello che si vedeva: cadeva solo su webkit, che
+     * e' il piu' lento e quindi l'unico che perdeva la corsa con una certa
+     * frequenza; cadeva a intermittenza; e cadeva con «Array []» anche dopo
+     * SESSANTA secondi d'attesa, che per un elenco rifatto da un timer a 2600
+     * ms non e' lentezza. Alzare l'attesa non poteva funzionare, e infatti non
+     * ha funzionato.
+     *
+     * `addInitScript` gira prima di ogni script della pagina: quando la plancia
+     * si avvia il seme c'e' gia', e non c'e' nessuna corsa da perdere. La
+     * guardia serve perche' lo script rigira a ogni navigazione: senza, un
+     * ricaricamento piu' avanti nella prova rimetterebbe il seme sopra a quello
+     * che la prova ha appena salvato. */
     await page.goto(`/legacy/${variant}`);
     await page.evaluate((state) => {
       localStorage.clear();
@@ -189,6 +207,22 @@ for (const variant of PRIMARY) {
         hasText: "Errore durante il caricamento di DashboardModern",
       }),
     ).toHaveCount(0);
+    /* Il seme e' sopravvissuto all'avvio?
+     *
+     * Questa riga non prova la plancia: prova la prova. Quando il seme veniva
+     * cancellato dall'avvio, il guasto si presentava sessanta secondi dopo,
+     * altrove, come «Array []» — e ci sono volute tre diagnosi, due delle quali
+     * sbagliate, per risalire da li' a qui. Adesso, se ricapita, il fallimento
+     * lo dice nel punto in cui succede e con queste parole. */
+    const appliancesNelSeme = await page.evaluate(() => {
+      try {
+        return JSON.parse(localStorage.getItem("dm_dashboard_state") || "{}")?.sections?.appliances
+          ?.length;
+      } catch (_) {
+        return null;
+      }
+    });
+    expect(appliancesNelSeme, "l'avvio ha cancellato il seme prima di leggerlo").toBe(1);
     /* Le voci del Report si aspettano, non si leggono al volo.
      *
      * `__DASHBOARDMODERN_LEGACY_READY__` dice che il guscio c'e', non che ha

--- a/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/temperature-runtime.spec.js
@@ -57,6 +57,15 @@ for (const variant of ["dashboard.html", "dashboard-en.html"]) {
   test(`${variant}: Temperature editor, HA picker, persistence and live dashboard`, async ({
     page,
   }, testInfo) => {
+    /* Il tempo segue il browser, come nelle altre ventisette prove pesanti del
+     * progetto. Questa era rimasta sul mezzo minuto di default: apre l'editor,
+     * gira il selettore delle entita', salva, ricarica e va a rileggere la
+     * plancia viva, e su webkit ci mette tre volte tanto. Ha fermato il
+     * rilascio della 1.4.5-beta.2 con un «Test timeout of 30000ms exceeded» —
+     * proprio il valore di serie, che e' il modo in cui questo guasto si
+     * riconosce — dopo essere passata mezz'ora prima sulla stessa identica
+     * revisione: non era il codice, era il tempo concesso. */
+    test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
     await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
     await page.addInitScript((haStates) => {
       window.WebSocket = class extends EventTarget {

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5-beta.2","dashboardVersion":"1.4.5-beta.2","moduleVersion":14,"schemaVersion":4,"date":"2026-09-01T11:13:52+00:00","commit":"81a36a03535080c508503a9040ff4f7c1ac13463","assetHash":"e39baae43450a50a"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5-beta.3","dashboardVersion":"1.4.5-beta.3","moduleVersion":14,"schemaVersion":4,"date":"2026-09-01T13:34:38+00:00","commit":"b39fe62aa5367cd8619682cd124744538697e8a0","assetHash":"9911506c4dda14dd"});

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard-runtime-en.js
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard-runtime-en.js
@@ -5126,6 +5126,12 @@ function _cdFogliPronti() {
 function _cdPlanciaPronta() { return _cdModuliPronti() && _cdFogliPronti(); }
 function _cdTogliIlVelo() {
     if (_cdBootDone) return; _cdBootDone = true;
+    // Il momento che conta per chi guarda, segnato dove succede davvero.
+    // `__DASHBOARDMODERN_READY__` lo alza cdHideBoot PRIMA di aspettare i
+    // moduli e i fogli: leggere quello vorrebbe dire dichiarare pronta una
+    // plancia ancora coperta dal velo, e sottostimare proprio il tempo che si
+    // sente. Chiesto in revisione. La Diagnostica legge questo.
+    try { window.__DASHBOARDMODERN_VELO_VIA__ = performance.now(); } catch(_) {}
     const o = document.getElementById('cd-boot-overlay');
     if (o) { o.style.opacity = '0'; setTimeout(() => { if (o.parentNode) o.remove(); }, 260); }
 }

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard-runtime-it.js
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard-runtime-it.js
@@ -5168,6 +5168,12 @@ function _cdFogliPronti() {
 function _cdPlanciaPronta() { return _cdModuliPronti() && _cdFogliPronti(); }
 function _cdTogliIlVelo() {
     if (_cdBootDone) return; _cdBootDone = true;
+    // Il momento che conta per chi guarda, segnato dove succede davvero.
+    // `__DASHBOARDMODERN_READY__` lo alza cdHideBoot PRIMA di aspettare i
+    // moduli e i fogli: leggere quello vorrebbe dire dichiarare pronta una
+    // plancia ancora coperta dal velo, e sottostimare proprio il tempo che si
+    // sente. Chiesto in revisione. La Diagnostica legge questo.
+    try { window.__DASHBOARDMODERN_VELO_VIA__ = performance.now(); } catch(_) {}
     const o = document.getElementById('cd-boot-overlay');
     if (o) { o.style.opacity = '0'; setTimeout(() => { if (o.parentNode) o.remove(); }, 260); }
 }

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -615,54 +615,41 @@ function mountReportEditor(_tab, target) {
  * al posto di 2007. Ed e' ancora lento. Quindi il tempo se ne va in un posto
  * che finora non ho misurato, e ho gia' sbagliato due volte a indovinarlo.
  *
- * Questo lo segna: dal momento in cui la plancia comincia a caricarsi a quando
- * il velo se ne va. Il resto — quando e' arrivato l'ultimo file — si legge a
- * posteriori dai tempi delle risorse, quindi non serve segnarlo. La differenza
- * fra i due dice tutto: se il grosso sta PRIMA, e' la rete; se sta DOPO, e'
- * analisi ed esecuzione, e la compressione non la tocca nemmeno.
+ * Il momento del velo lo segna chi lo toglie: `_cdTogliIlVelo` scrive
+ * `__DASHBOARDMODERN_VELO_VIA__`, e qui si legge. La prima stesura guardava
+ * `__DASHBOARDMODERN_READY__`, ed era la cosa sbagliata: `cdHideBoot` alza
+ * quella bandiera PRIMA di mettersi ad aspettare moduli e fogli, quindi la
+ * plancia risultava «pronta» mentre il velo era ancora li'. Sottostimava
+ * proprio il tempo che si sente. Chiesto in revisione, ed era vero.
  *
- * Niente orologio che guarda: si intercetta l'assegnazione. Chi toglie il velo
- * scrive `__DASHBOARDMODERN_READY__ = true`, e quella scrittura passa di qui —
- * il momento e' esatto invece che arrotondato al giro di sondaggio, e non
- * arriva un `setInterval` in piu' nel grafo di produzione, dove ogni intervallo
- * e' elencato uno per uno apposta perche' non ne entri uno di nascosto.
+ * L'altra meta' — quando la rete ha finito — si legge dai tempi delle risorse,
+ * con due accortezze che la prima stesura non aveva, tutt'e due segnalate:
  *
- * Si arma solo dove c'e' una pagina: le prove che importano questo modulo da
- * Node non devono trovarsi un accessore piantato su un globale. */
-let prontaDopo = null;
-if (typeof document !== "undefined") {
-  if (globalThis.__DASHBOARDMODERN_READY__) prontaDopo = performance.now();
-  else {
-    let acceso = false;
-    try {
-      Object.defineProperty(globalThis, "__DASHBOARDMODERN_READY__", {
-        configurable: true,
-        get: () => acceso,
-        set: (nuovo) => {
-          acceso = nuovo;
-          if (nuovo && prontaDopo === null) prontaDopo = performance.now();
-        },
-      });
-    } catch (_) {
-      /* Se il globale non si lascia intercettare, la riga dira' di non averlo
-       * misurato: meglio di un numero inventato. */
-    }
-  }
-}
-
+ *   - si contano solo le risorse arrivate PRIMA che il velo se ne andasse. Chi
+ *     riapre la Diagnostica fa partire la richiesta di `panel.js` qui sotto, e
+ *     quella diventerebbe «l'ultimo file» — minuti dopo l'avvio — schiacciando
+ *     a zero il tempo dopo la rete. La misura si corromperebbe da sola guardando
+ *     se stessa, e lo stesso farebbe qualunque risorsa caricata dopo;
+ *   - si conta anche il documento. Il guscio non e' una «risorsa»: sta nella
+ *     voce di navigazione, e sono centosei kB. Lasciarlo fuori vorrebbe dire
+ *     contare il suo scaricamento come lavoro del browser dopo la rete.
+ */
 export function tempoDiAvvio() {
   try {
+    const veloVia = globalThis.__DASHBOARDMODERN_VELO_VIA__;
     const casa = `${import.meta.url.split("/legacy/")[0]}/`;
-    const nostre = performance
+    const finiteEntro = (fine) => (veloVia ? fine <= veloVia : true);
+    const fini = performance
       .getEntriesByType("resource")
-      .filter((risorsa) => risorsa.name.startsWith(casa));
+      .filter((risorsa) => risorsa.name.startsWith(casa))
+      .map((risorsa) => risorsa.responseEnd || 0)
+      .filter(finiteEntro);
+    const documento = performance.getEntriesByType("navigation")[0]?.responseEnd || 0;
+    if (documento && finiteEntro(documento)) fini.push(documento);
     const s = (v) => `${(v / 1000).toFixed(1)} s`;
-    const ultimo = nostre.length
-      ? Math.max(...nostre.map((risorsa) => risorsa.responseEnd || 0))
-      : 0;
-    if (!prontaDopo) return ultimo ? `ultimo file a ${s(ultimo)} — velo non misurato` : "?";
-    const dopoLaRete = Math.max(0, prontaDopo - ultimo);
-    return `pronta in ${s(prontaDopo)} · ultimo file a ${s(ultimo)} · ${s(dopoLaRete)} dopo la rete`;
+    const ultimo = fini.length ? Math.max(...fini) : 0;
+    if (!veloVia) return ultimo ? `ultimo file a ${s(ultimo)} — velo non misurato` : "?";
+    return `velo via a ${s(veloVia)} · ultimo file a ${s(ultimo)} · ${s(Math.max(0, veloVia - ultimo))} dopo la rete`;
   } catch (_) {
     return "?";
   }

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -645,12 +645,46 @@ export function pesoScaricato() {
     const disteso = somma("decodedBodySize");
     if (!disteso) return "?";
     const mb = (v) => `${(v / 1048576).toFixed(1)} MB`;
-    const come = codificato && codificato / disteso < 0.9 ? "compressi" : "non compressi";
+    /* Senza `encodedBodySize` non si sa: dirlo e' l'unica risposta onesta.
+     * Prima un valore mancante — che vale zero — finiva nel ramo «non
+     * compressi», e la riga dichiarava una cosa che non aveva misurato. E' il
+     * modo in cui questa riga puo' far cercare il guasto dalla parte
+     * sbagliata, che e' peggio del non averla. */
+    const come = !codificato
+      ? "peso codificato non disponibile"
+      : codificato / disteso < 0.9
+        ? "compressi"
+        : "non compressi";
     return dalFilo
       ? `${mb(dalFilo)} di ${mb(disteso)} — ${come}`
       : `${mb(disteso)} dalla cache — ${come}`;
   } catch (_) {
     return "?";
+  }
+}
+
+/* E poi lo si chiede al server, invece di dedurlo.
+ *
+ * I conti qui sopra sono una deduzione: dicono quanto pesa quello che e'
+ * arrivato, non come e' arrivato. `fetch` invece la risposta ce l'ha scritta —
+ * `content-encoding` e' esposto per le risorse di casa propria, verificato con
+ * un browser vero — e una risposta letta batte una dedotta.
+ *
+ * `panel.js` sta in cima alla cartella servita, c'e' sempre, e pesa poco: e'
+ * il campione buono. La riga si scrive subito col peso e si completa da sola
+ * quando il server ha risposto; se la richiesta non riesce, resta quella che
+ * era. */
+async function chiediComeArrivano(target) {
+  const nodo = target.querySelector('[data-dm-voce="Transfer"]');
+  if (!nodo) return;
+  try {
+    const casa = `${import.meta.url.split("/legacy/")[0]}/`;
+    const risposta = await fetch(`${casa}panel.js`, { cache: "reload" });
+    if (!risposta.ok) return;
+    const come = risposta.headers.get("content-encoding");
+    nodo.textContent = `${nodo.textContent} · servito ${come || "in chiaro"}`;
+  } catch (_) {
+    /* Una diagnostica che non riesce a misurare non rompe la diagnostica. */
   }
 }
 
@@ -672,8 +706,9 @@ function renderDiagnostics(target) {
     Modules: globalThis.__DASHBOARDMODERN_IMPACCHETTATA__ ? "impacchettati (3 file)" : "sciolti (179 file)",
     Transfer: pesoScaricato(),
   };
-  target.innerHTML = `<div class="ed-sec-title">🩺 ${t("diagnostics")}</div><div class="ed-list">${Object.entries(rows).map(([key, value]) => `<div class="ed-row"><div class="ed-row-main"><div class="ed-row-new">${esc(key)}</div><div class="ed-row-old mono">${esc(value)}</div></div></div>`).join("")}</div>`;
+  target.innerHTML = `<div class="ed-sec-title">🩺 ${t("diagnostics")}</div><div class="ed-list">${Object.entries(rows).map(([key, value]) => `<div class="ed-row"><div class="ed-row-main"><div class="ed-row-new">${esc(key)}</div><div class="ed-row-old mono" data-dm-voce="${esc(key)}">${esc(value)}</div></div></div>`).join("")}</div>`;
   target.dataset.runtimeDiagnostics = "true";
+  chiediComeArrivano(target);
 }
 
 export const EDITOR_TAB_ALIASES = Object.freeze({

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -608,6 +608,66 @@ function mountReportEditor(_tab, target) {
   if (entityInputs !== pickers) throw new Error(`Entity picker invariant failed: ${entityInputs} inputs / ${pickers} pickers`);
 }
 
+/* Quando il velo se ne va, misurato mentre succede.
+ *
+ * Le richieste sono scese da centosettantanove a tre. I byte da 4,9 MB a 1,2,
+ * e la compressione e' confermata dal campo — `content-encoding: br`, 366 kB
+ * al posto di 2007. Ed e' ancora lento. Quindi il tempo se ne va in un posto
+ * che finora non ho misurato, e ho gia' sbagliato due volte a indovinarlo.
+ *
+ * Questo lo segna: dal momento in cui la plancia comincia a caricarsi a quando
+ * il velo se ne va. Il resto — quando e' arrivato l'ultimo file — si legge a
+ * posteriori dai tempi delle risorse, quindi non serve segnarlo. La differenza
+ * fra i due dice tutto: se il grosso sta PRIMA, e' la rete; se sta DOPO, e'
+ * analisi ed esecuzione, e la compressione non la tocca nemmeno.
+ *
+ * Niente orologio che guarda: si intercetta l'assegnazione. Chi toglie il velo
+ * scrive `__DASHBOARDMODERN_READY__ = true`, e quella scrittura passa di qui —
+ * il momento e' esatto invece che arrotondato al giro di sondaggio, e non
+ * arriva un `setInterval` in piu' nel grafo di produzione, dove ogni intervallo
+ * e' elencato uno per uno apposta perche' non ne entri uno di nascosto.
+ *
+ * Si arma solo dove c'e' una pagina: le prove che importano questo modulo da
+ * Node non devono trovarsi un accessore piantato su un globale. */
+let prontaDopo = null;
+if (typeof document !== "undefined") {
+  if (globalThis.__DASHBOARDMODERN_READY__) prontaDopo = performance.now();
+  else {
+    let acceso = false;
+    try {
+      Object.defineProperty(globalThis, "__DASHBOARDMODERN_READY__", {
+        configurable: true,
+        get: () => acceso,
+        set: (nuovo) => {
+          acceso = nuovo;
+          if (nuovo && prontaDopo === null) prontaDopo = performance.now();
+        },
+      });
+    } catch (_) {
+      /* Se il globale non si lascia intercettare, la riga dira' di non averlo
+       * misurato: meglio di un numero inventato. */
+    }
+  }
+}
+
+export function tempoDiAvvio() {
+  try {
+    const casa = `${import.meta.url.split("/legacy/")[0]}/`;
+    const nostre = performance
+      .getEntriesByType("resource")
+      .filter((risorsa) => risorsa.name.startsWith(casa));
+    const s = (v) => `${(v / 1000).toFixed(1)} s`;
+    const ultimo = nostre.length
+      ? Math.max(...nostre.map((risorsa) => risorsa.responseEnd || 0))
+      : 0;
+    if (!prontaDopo) return ultimo ? `ultimo file a ${s(ultimo)} — velo non misurato` : "?";
+    const dopoLaRete = Math.max(0, prontaDopo - ultimo);
+    return `pronta in ${s(prontaDopo)} · ultimo file a ${s(ultimo)} · ${s(dopoLaRete)} dopo la rete`;
+  } catch (_) {
+    return "?";
+  }
+}
+
 /* Quanti byte sono arrivati davvero, e se sono arrivati compressi.
  *
  * Dal campo, dopo un rilascio che aveva ridotto le richieste da 179 a 3:
@@ -705,6 +765,7 @@ function renderDiagnostics(target) {
      * vedere a colpo d'occhio invece di indovinarlo dal cronometro. */
     Modules: globalThis.__DASHBOARDMODERN_IMPACCHETTATA__ ? "impacchettati (3 file)" : "sciolti (179 file)",
     Transfer: pesoScaricato(),
+    Boot: tempoDiAvvio(),
   };
   target.innerHTML = `<div class="ed-sec-title">🩺 ${t("diagnostics")}</div><div class="ed-list">${Object.entries(rows).map(([key, value]) => `<div class="ed-row"><div class="ed-row-main"><div class="ed-row-new">${esc(key)}</div><div class="ed-row-old mono" data-dm-voce="${esc(key)}">${esc(value)}</div></div></div>`).join("")}</div>`;
   target.dataset.runtimeDiagnostics = "true";

--- a/custom_components/dashboardmodern/frontend/tests/il-peso-scaricato-dice-il-vero.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/il-peso-scaricato-dice-il-vero.test.js
@@ -99,6 +99,21 @@ test("tutto dalla cache si dice, non si finge", () => {
   assert.match(detto, /dalla cache/, `la riga non dice che non ha viaggiato: «${detto}»`);
 });
 
+test("senza il peso codificato non si dichiara nulla, si dice che manca", () => {
+  /* Il campo che dice quanto pesava il corpo com'e' arrivato non c'e' sempre.
+   * Quando manca vale zero, e zero finiva nel ramo «non compressi»: la riga
+   * dichiarava una cosa che non aveva misurato, ed e' cosi' che una
+   * diagnostica fa cercare il guasto dalla parte sbagliata — peggio che non
+   * averla. Il peso disteso invece si sa, e si dice. */
+  const detto = conQuesteRisorse(
+    [risorsa({ nome: "legacy/a.js", dalFilo: 0, codificato: 0, disteso: 5 * MB })],
+    pesoScaricato,
+  );
+  assert.doesNotMatch(detto, /non compressi/, `dichiara senza aver misurato: «${detto}»`);
+  assert.match(detto, /non disponibile/, `non dice che il dato manca: «${detto}»`);
+  assert.match(detto, /5\.0 MB/, `perde il peso che invece conosce: «${detto}»`);
+});
+
 test("dove il browser non riempie quei campi, la riga non inventa", () => {
   /* Non tutti i browser danno `encodedBodySize` e `transferSize`. Dire «?» e'
    * la risposta onesta; inventare uno zero direbbe «non compressi» di una

--- a/custom_components/dashboardmodern/frontend/tests/il-peso-scaricato-dice-il-vero.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/il-peso-scaricato-dice-il-vero.test.js
@@ -124,3 +124,76 @@ test("dove il browser non riempie quei campi, la riga non inventa", () => {
   );
   assert.equal(detto, "?");
 });
+
+/* La riga «Boot» dice quando il velo se ne va, e non si corrompe da sola.
+ *
+ * Tre punti, tutti e tre segnalati in revisione e tutti e tre veri:
+ *
+ *   - `__DASHBOARDMODERN_READY__` non e' il velo. `cdHideBoot` alza quella
+ *     bandiera PRIMA di mettersi ad aspettare moduli e fogli, e il velo puo'
+ *     restare li' per secondi: misurarla sottostima proprio il tempo che si
+ *     sente. Adesso il momento lo segna chi il velo lo toglie davvero;
+ *   - la Diagnostica, aprendosi, chiede `panel.js` per sapere come arrivano i
+ *     file. Quella richiesta e' una risorsa come le altre, e minuti dopo
+ *     l'avvio diventerebbe «l'ultimo file», schiacciando a zero il tempo dopo
+ *     la rete: la misura si corromperebbe guardando se stessa;
+ *   - il documento non e' una «risorsa»: sta nella voce di navigazione. Sono
+ *     centosei kB, e lasciarli fuori vorrebbe dire contarne lo scaricamento
+ *     come lavoro del browser.
+ */
+const { tempoDiAvvio } = await import(`../legacy/modules-entry.js?boot=${Date.now()}`);
+
+function conQuestoAvvio({ risorse = [], navigazione = null, veloVia }, prova) {
+  const prima = performance.getEntriesByType;
+  const primaVelo = globalThis.__DASHBOARDMODERN_VELO_VIA__;
+  performance.getEntriesByType = (tipo) =>
+    tipo === "resource" ? risorse : tipo === "navigation" ? (navigazione ? [navigazione] : []) : [];
+  if (veloVia === undefined) delete globalThis.__DASHBOARDMODERN_VELO_VIA__;
+  else globalThis.__DASHBOARDMODERN_VELO_VIA__ = veloVia;
+  try {
+    return prova();
+  } finally {
+    performance.getEntriesByType = prima;
+    if (primaVelo === undefined) delete globalThis.__DASHBOARDMODERN_VELO_VIA__;
+    else globalThis.__DASHBOARDMODERN_VELO_VIA__ = primaVelo;
+  }
+}
+
+const fine = (nome, responseEnd) => ({ name: `${CASA}${nome}`, responseEnd });
+
+test("il tempo e' quello del velo, non quello della bandiera", () => {
+  const detto = conQuestoAvvio(
+    { risorse: [fine("legacy/a.js", 2000)], veloVia: 6000 },
+    tempoDiAvvio,
+  );
+  assert.match(detto, /velo via a 6\.0 s/, `non misura il velo: «${detto}»`);
+  assert.match(detto, /4\.0 s dopo la rete/, `il conto dopo la rete non torna: «${detto}»`);
+});
+
+test("la richiesta della Diagnostica non diventa «l'ultimo file»", () => {
+  /* `panel.js` chiesto quando si apre il pannello, molto dopo l'avvio. */
+  const detto = conQuestoAvvio(
+    { risorse: [fine("legacy/a.js", 2000), fine("panel.js", 300000)], veloVia: 6000 },
+    tempoDiAvvio,
+  );
+  assert.match(detto, /ultimo file a 2\.0 s/, `si e' contata addosso: «${detto}»`);
+  assert.match(detto, /4\.0 s dopo la rete/, `il tempo dopo la rete e' sparito: «${detto}»`);
+});
+
+test("il documento conta come rete, non come lavoro del browser", () => {
+  const detto = conQuestoAvvio(
+    { risorse: [fine("legacy/a.js", 1000)], navigazione: { responseEnd: 5000 }, veloVia: 6000 },
+    tempoDiAvvio,
+  );
+  assert.match(detto, /ultimo file a 5\.0 s/, `il guscio non e' contato: «${detto}»`);
+  assert.match(
+    detto,
+    /1\.0 s dopo la rete/,
+    `il guscio finisce fra il lavoro del browser: «${detto}»`,
+  );
+});
+
+test("senza il segno del velo non si inventa un tempo", () => {
+  const detto = conQuestoAvvio({ risorse: [fine("legacy/a.js", 2000)] }, tempoDiAvvio);
+  assert.match(detto, /velo non misurato/, `dichiara un avvio che non ha visto: «${detto}»`);
+});

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.4.5-beta.2"
+  "version": "1.4.5-beta.3"
 }

--- a/misura-tmp.mjs
+++ b/misura-tmp.mjs
@@ -1,0 +1,16 @@
+import { chromium } from "@playwright/test";
+const browser = await chromium.launch();
+const page = await (await browser.newContext()).newPage();
+await page.goto("http://127.0.0.1:4174/legacy/dashboard.html");
+const esito = await page.evaluate(async () => {
+  const r = await fetch("/legacy/dashboard-runtime-it.js", { cache: "reload" });
+  const testo = await r.text();
+  return {
+    contentEncoding: r.headers.get("content-encoding"),
+    contentLength: r.headers.get("content-length"),
+    tutteLeIntestazioni: [...r.headers.keys()],
+    corpoDisteso: testo.length,
+  };
+});
+console.log(JSON.stringify(esito, null, 1));
+await browser.close();


### PR DESCRIPTION
## La compressione funziona. Ed è ancora lento.

Dal campo, misurato sull'impianto vero con la beta.2 installata:

```
content-encoding: br — byte: 366117
```

`section-runtime.js` scende da 2 007 000 a 366 117 byte. Home Assistant **sta servendo la copia compressa**.

| | prima | ora |
|---|---|---|
| richieste JS | ~185 | 13 |
| byte scaricati | 4,9 MB | 1,2 MB |
| **percezione** | lento | **lento** |

Né le richieste né i byte erano la causa. **Due tentativi, due volte l'asse sbagliato.** Questa versione non prova a indovinare il terzo: mette gli strumenti per saperlo.

## La riga «Transfer» mentiva

Diceva `non compressi` di una plancia che arrivava compressa — ed è per quello che si è cercato un guasto nella catena di compressione, che invece funzionava.

`encodedBodySize` non è sempre disponibile; nel riquadro dove gira la plancia non lo era. Quando manca vale **zero**, e zero finiva dritto nel ramo «non compressi». La riga dichiarava una cosa che non aveva misurato — il modo in cui una diagnostica fa cercare dalla parte sbagliata, peggio del non averla.

Adesso, quando quel dato manca lo dice; e soprattutto smette di dedurre e va a **chiedere al server**. `fetch` espone `content-encoding` per le risorse di casa propria — verificato con un browser vero contro un server costruito come quello di HA, che ha risposto `br`.

## La riga «Boot», nuova — e le tre correzioni della revisione

```
Boot: velo via a 4.2 s · ultimo file a 3.6 s · 0.6 s dopo la rete
```

Se il grosso sta prima è la rete; se sta dopo è il lavoro del browser, dove né il pacchetto né la compressione arrivano.

La prima stesura aveva tre difetti, tutti segnalati in revisione e tutti veri:

- **misurava la bandiera, non il velo.** `cdHideBoot()` alza `__DASHBOARDMODERN_READY__` come prima riga e solo *dopo* aspetta moduli e fogli: avrebbe dichiarato pronta una plancia ancora coperta, sottostimando esattamente il tempo che si percepisce. Ora il momento lo segna `_cdTogliIlVelo()`, dove il velo se ne va davvero;
- **si guardava addosso.** La Diagnostica, aprendosi, chiede `panel.js`: quella richiesta diventava «l'ultimo file» e azzerava il tempo dopo la rete. Ora si contano solo le risorse finite prima che il velo se ne andasse;
- **il guscio non è una risorsa.** Sta nella voce di navigazione: i suoi 106 kB finivano contati come lavoro del browser. Ora entra nel conto della rete.

## E la sonda ha nominato un guasto vero

L'asserzione «l'avvio ha cancellato il seme prima di leggerlo», aggiunta per non dover più dedurre, è **scattata su webkit** — e ha chiuso una cosa che ha bloccato quattro giri di CI.

`goto` torna quando il documento è pronto, non quando la plancia ha finito di avviarsi. Quel primo avvio salva poi il proprio store **vuoto**: se lo faceva dopo che la prova aveva scritto il seme, ci passava sopra, e da lì l'elenco del Report non si riempiva **mai più**. Non in ritardo — mai: ecco perché portare l'attesa a sessanta secondi non poteva funzionare, e non ha funzionato.

Su Chromium quel salvataggio arriva quasi sempre prima; su webkit, tre volte più lento, arrivava dopo. Stessa corsa, esito diverso a seconda di chi corre — ed è per questo che sembrava una stranezza di webkit.

Ora si aspetta che quel salvataggio sia avvenuto, e solo allora si scrive. Nel commento resta scritto anche cosa **non** funziona (anticipare il seme con `addInitScript`: il primo avvio lo cancella lo stesso), perché non lo riprovi qualcun altro.

## Verificato

- **Quattro diagnosi, tre sbagliate**, e quella buona l'ha trovata la sonda invece del ragionamento. È il motivo per cui la sonda vale più della toppa.
- Otto prove nuove; tutte quelle che rispondono a un difetto sono state eseguite **anche contro la versione precedente**, e cadono.
- **1718 prove frontend** verdi, **7 shard browser su 7** verdi, webkit compreso.