### PR TITLE
Versione 1.4.5-beta.5: il popup non riscrive quello che non e' cambiato

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.4.5-beta.5
+
+Il lampo del popup, di nuovo — e stavolta con la causa giusta. Nella beta.4 gli
+stati erano corretti e le carte restavano al loro posto, ma il lampo bianco
+c'era ancora: sei volte in nove secondi.
+
+### Corretto
+
+- **Il popup non riscrive piu' quello che non e' cambiato.** I due fotogrammi ai
+  lati del lampo erano identici: fra prima e dopo non cambiava un pixel. Non
+  stava cambiando niente, e il livello si ridipingeva lo stesso — perche' la
+  finestra riscriveva lo stesso. Al banco, dieci giri di stati fermi facevano
+  **seicentodieci scritture sul DOM**: le carte venivano «rimesse in fila» una
+  per una a ogni giro anche quando l'ordine era gia' quello, e attributi, colori
+  e testi venivano riassegnati col valore che avevano gia'. Assegnare lo stesso
+  valore non e' gratis: il browser non confronta, invalida — e dentro il velo
+  sfocato del modale ogni invalidazione e' un livello da ridipingere, che per un
+  fotogramma resta bianco. Adesso si confronta prima di scrivere, e in
+  classifica si sposta solo la carta che non e' al suo posto: **a stati fermi le
+  scritture sono zero.**
+
 ## 1.4.5-beta.4
 
 Un filmato di ventotto secondi, guardato fotogramma per fotogramma. Dentro

--- a/custom_components/dashboardmodern/frontend/e2e/il-popup-non-riscrive-quello-che-non-cambia.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/il-popup-non-riscrive-quello-che-non-cambia.spec.js
@@ -1,0 +1,147 @@
+/* Il popup non riscrive quello che non e' cambiato.
+ *
+ * Secondo filmato, beta.4 installata: le carte restano al loro posto e gli
+ * stati sono quelli giusti — «1/8 IN FUNZIONE», STANDBY su chi ha solo la presa
+ * accesa — e il lampo bianco c'e' ancora. Sei volte in nove secondi, sempre di
+ * un fotogramma solo.
+ *
+ * Ma stavolta i due fotogrammi ai lati del lampo sono IDENTICI: fra prima e
+ * dopo non cambia un pixel. Non stava cambiando niente, e il livello si
+ * ridipingeva lo stesso — perche' il popup RISCRIVEVA lo stesso. Al banco,
+ * dieci giri di stati identici facevano cento scritture sul DOM: sessanta
+ * spostamenti di nodi (la classifica veniva «rimessa in fila» spostando tutte
+ * le carte a ogni giro, anche quando l'ordine era gia' quello) e quaranta
+ * attributi riscritti col valore che avevano gia'.
+ *
+ * Assegnare lo stesso valore a `textContent`, a un `data-` o a una proprieta'
+ * CSS non e' gratis: il browser non confronta, invalida. E dentro il velo
+ * sfocato del modale ogni invalidazione e' un livello da ridipingere, che per
+ * un fotogramma resta bianco.
+ *
+ * Questa prova conta le scritture con un vero MutationObserver. A stati fermi
+ * devono essere ZERO: e' l'unica soglia che si difende da sola, perche' una
+ * qualsiasi soglia piu' alta e' un invito a rimetterci dentro qualcosa.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const APPARECCHI = [
+  "Condizionatori",
+  "Lavatrice",
+  "Lavastoviglie",
+  "Asciugatrice",
+  "Forno",
+  "Frigorifero",
+  "Microonde",
+  "Boiler",
+];
+
+const SEME = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    cameras: [],
+    appliances: APPARECCHI.map((nome, indice) => ({
+      id: `app-${indice}`,
+      name: nome,
+      type: "generico",
+      power_entity: `sensor.app_${indice}_w`,
+      daily_energy_entity: `sensor.app_${indice}_kwh`,
+      metadata: { beta27_subload_group: "elettro" },
+    })),
+    loads: [{ id: "elettro", name: "Elettrodomestici", icon: "🔌", order: 0 }],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: { grid: { power: "sensor.rete_w" }, house: { power: "sensor.casa_w" } },
+    entityOverrides: {},
+  },
+  visibility: { home: true, energy: true },
+};
+
+test("a stati fermi il popup non tocca il DOM nemmeno una volta", async ({ page }, testInfo) => {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, SEME);
+
+  /* Una casa come quella del filmato: uno solo consuma, gli altri sette hanno
+   * la presa accesa e zero watt. */
+  await page.evaluate((quanti) => {
+    const raw = eval("_RAW_STATES");
+    const poni = (id, valore, unita = "W") =>
+      (raw[id] = {
+        entity_id: id,
+        state: String(valore),
+        attributes: { unit_of_measurement: unita },
+      });
+    for (let i = 0; i < quanti; i++) {
+      poni(`sensor.app_${i}_w`, i === 0 ? 701 : 0);
+      poni(`sensor.app_${i}_kwh`, (i / 3).toFixed(1), "kWh");
+    }
+    poni("sensor.rete_w", 701);
+    poni("sensor.casa_w", 701);
+    window.dispatchEvent(new CustomEvent("dashboardmodern:states-ready", { detail: {} }));
+  }, APPARECCHI.length);
+
+  await page
+    .locator('.tab[data-tab="energy"]')
+    .first()
+    .evaluate((nodo) => nodo.click());
+  await page.waitForTimeout(1200);
+  await page.evaluate(() => window.apriSubLoads?.("elettro"));
+  await expect(page.locator(".dm-subload-card")).toHaveCount(APPARECCHI.length);
+
+  await page.evaluate(() => {
+    window.__dmScritture = [];
+    new MutationObserver((mutazioni) => {
+      for (const mutazione of mutazioni)
+        window.__dmScritture.push(
+          mutazione.type === "attributes" ? `attributo:${mutazione.attributeName}` : mutazione.type,
+        );
+    }).observe(document.getElementById("subloads-list"), {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      characterData: true,
+    });
+  });
+
+  /* Dieci giri del battito degli stati, senza che cambi un solo valore. */
+  for (let giro = 0; giro < 10; giro++) {
+    await page.evaluate(() => window.render?.());
+    await page.waitForTimeout(60);
+  }
+  const aStatiFermi = await page.evaluate(() => {
+    const scritte = window.__dmScritture.slice();
+    window.__dmScritture = [];
+    return scritte;
+  });
+  expect(
+    aStatiFermi,
+    `il popup riscrive ${aStatiFermi.length} volte una finestra che non e' cambiata: e' il lampo`,
+  ).toEqual([]);
+
+  /* E quando un valore cambia davvero, si scrive — poco, e solo li'. */
+  await page.evaluate(() => {
+    const id = "sensor.app_0_w";
+    eval("_RAW_STATES")[id] = {
+      entity_id: id,
+      state: "888",
+      attributes: { unit_of_measurement: "W" },
+    };
+    window.render?.();
+  });
+  await page.waitForTimeout(200);
+  const conUnValoreNuovo = await page.evaluate(() => window.__dmScritture.slice());
+  expect(conUnValoreNuovo.length, "un valore cambiato non ha scritto niente").toBeGreaterThan(0);
+  expect(
+    conUnValoreNuovo.length,
+    `un solo watt cambiato ha fatto ${conUnValoreNuovo.length} scritture`,
+  ).toBeLessThanOrEqual(6);
+  await expect(page.locator('[data-dm-subload-card="app-0"] .dm-subload-power')).toHaveText(
+    "888 W",
+  );
+});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5-beta.4","dashboardVersion":"1.4.5-beta.4","moduleVersion":14,"schemaVersion":4,"date":"2026-09-01T16:59:53+00:00","commit":"8324e9af1c056d5d8e70f891ca04c1dfcd4849f2","assetHash":"323acba550d04c9b"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5-beta.5","dashboardVersion":"1.4.5-beta.5","moduleVersion":14,"schemaVersion":4,"date":"2026-09-01T19:12:03+00:00","commit":"35931aa7c4f01ddd1105c8766048259db7a8aa54","assetHash":"2d3497cda0e176ca"});

--- a/custom_components/dashboardmodern/frontend/src/sections/subload-popup-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/subload-popup-section.js
@@ -147,27 +147,55 @@ function card(item, model) {
   return node;
 }
 
+/* Si scrive solo quello che cambia.
+ *
+ * Il lampo del secondo filmato — beta.4 installata, carte che restano al loro
+ * posto — non era piu' la lista che si svuota: era la lista che si RISCRIVE
+ * anche quando non e' cambiato niente. Al banco, dieci giri di stati identici
+ * facevano cento scritture sul DOM: sessanta spostamenti di nodi e quaranta
+ * attributi riscritti col valore che avevano gia'.
+ *
+ * Dentro un velo sfocato ogni scrittura e' un livello da ridipingere, e finche'
+ * il livello non e' pronto resta il bianco del foglio. Ecco perche' i due
+ * fotogrammi ai lati del lampo erano IDENTICI: non stava cambiando niente, si
+ * stava solo riscrivendo.
+ *
+ * Assegnare lo stesso valore a `textContent`, a un `data-` o a una proprieta'
+ * CSS non e' gratis: il browser non confronta, invalida. Confrontare qui costa
+ * un `===`. */
+const poniTesto = (nodo, testo) => {
+  if (nodo && nodo.textContent !== testo) nodo.textContent = testo;
+};
+const poniDato = (nodo, chiave, valore) => {
+  if (nodo && nodo.dataset[chiave] !== valore) nodo.dataset[chiave] = valore;
+};
+const poniStile = (nodo, nome, valore) => {
+  if (nodo && nodo.style.getPropertyValue(nome) !== valore) nodo.style.setProperty(nome, valore);
+};
+const poniNascosto = (nodo, nascosto) => {
+  if (nodo && nodo.hidden !== nascosto) nodo.hidden = nascosto;
+};
+
 /* I valori nuovi dentro la carta che c'e' gia'. */
 function aggiornaCarta(node, item, model) {
   if (!node) return false;
-  node.dataset.dmSubloadState = item.state;
-  node.dataset.dmSubloadEntity = clean(item.entity);
-  node.dataset.dmSubloadName = clean(item.name);
-  node.style.setProperty("--dm-subload-color", item.color);
-  node.style.setProperty("--dm-subload-tint", item.tint);
+  poniDato(node, "dmSubloadState", item.state);
+  poniDato(node, "dmSubloadEntity", clean(item.entity));
+  poniDato(node, "dmSubloadName", clean(item.name));
+  poniStile(node, "--dm-subload-color", item.color);
+  poniStile(node, "--dm-subload-tint", item.tint);
   iconInto(node.querySelector(".dm-subload-icon"), item.icon);
-  const nome = node.querySelector(".dm-subload-name");
-  if (nome && nome.textContent !== item.name) nome.textContent = item.name;
-  const parola = node.querySelector(".dm-subload-state");
-  if (parola) parola.textContent = ETICHETTE()[item.state];
-  const potenza = node.querySelector(".dm-subload-power");
-  if (potenza) potenza.textContent = item.powerText;
+  poniTesto(node.querySelector(".dm-subload-name"), item.name);
+  poniTesto(node.querySelector(".dm-subload-state"), ETICHETTE()[item.state]);
+  poniTesto(node.querySelector(".dm-subload-power"), item.powerText);
   scriviIlGiorno(node, item);
-  const riempimento = node.querySelector(".dm-subload-meter-fill");
-  if (riempimento) riempimento.style.setProperty("width", `${Math.round(item.share * 100)}%`);
-  const barra = node.querySelector(".dm-subload-meter");
+  poniStile(
+    node.querySelector(".dm-subload-meter-fill"),
+    "width",
+    `${Math.round(item.share * 100)}%`,
+  );
   // The share is only meaningful when something in the group is drawing.
-  if (barra) barra.hidden = !model.total;
+  poniNascosto(node.querySelector(".dm-subload-meter"), !model.total);
   return true;
 }
 
@@ -250,17 +278,33 @@ function riconcilia(list, model) {
     ]),
   );
   const vivi = new Set();
+  const inFila = [];
   for (const item of model.items) {
     vivi.add(item.id);
     const nodo = carte.get(item.id);
     if (nodo) aggiornaCarta(nodo, item, model);
-    /* La classifica cambia coi watt: rimettere in fila e' spostare i nodi che
-     * ci sono — `append` di un nodo gia' figlio lo sposta, non lo copia. */
-    griglia.append(nodo || card(item, model));
+    inFila.push(nodo || card(item, model));
   }
   for (const [id, nodo] of carte) if (!vivi.has(id)) nodo.remove?.();
+
+  /* La classifica cambia coi watt, e rimettere in fila costa: ogni `append` e'
+   * un nodo che si sposta davvero, anche quando lo si rimette dov'era gia'.
+   * Otto carte, otto spostamenti, a ogni giro di stati — e ogni spostamento
+   * dentro il velo sfocato e' un livello da ridipingere. Adesso si guarda chi
+   * NON e' al suo posto, e si sposta solo quello: a classifica ferma non si
+   * tocca niente. */
+  const gia = vuotoInScena(griglia) ? 1 : 0;
+  for (let posto = 0; posto < inFila.length; posto++) {
+    const atteso = inFila[posto];
+    const attuale = griglia.children[posto + gia];
+    if (attuale === atteso) continue;
+    if (attuale) griglia.insertBefore(atteso, attuale);
+    else griglia.append(atteso);
+  }
   return true;
 }
+
+const vuotoInScena = (griglia) => Boolean(griglia.querySelector(".dm-subload-empty"));
 
 const ETICHETTE = () => ({
   running: t("IN FUNZIONE", "RUNNING"),
@@ -286,15 +330,15 @@ function header(model) {
  * versioni della stessa riga che possono divergere. */
 function aggiornaTestata(node, model) {
   if (!node) return false;
-  node.style.setProperty("--dm-subload-color", model.color);
+  poniStile(node, "--dm-subload-color", model.color);
   iconInto(node.querySelector(".dm-subload-summary-icon"), model.icon);
-  const somma = node.querySelector(".dm-subload-total-value");
-  if (somma) somma.textContent = model.totalText;
-  const conteggio = node.querySelector(".dm-subload-total-count");
-  if (conteggio)
-    conteggio.textContent = model.count
+  poniTesto(node.querySelector(".dm-subload-total-value"), model.totalText);
+  poniTesto(
+    node.querySelector(".dm-subload-total-count"),
+    model.count
       ? `${model.running}/${model.count} ${t("in funzione", "running")}`
-      : t("nessun dispositivo", "no appliance");
+      : t("nessun dispositivo", "no appliance"),
+  );
   return true;
 }
 
@@ -385,9 +429,9 @@ export function renderSubloadPopup(groupId = state.group) {
   if (list.dataset.dmSubloadFirma !== firma || !titolo?.querySelector?.(".dm-subload-title-name"))
     writeTitle(model, groupId);
 
-  list.dataset.dmSubloadOwner = "beta30";
-  list.dataset.dmSubloadCount = String(model.count);
-  list.dataset.dmSubloadFirma = firma;
+  poniDato(list, "dmSubloadOwner", "beta30");
+  poniDato(list, "dmSubloadCount", String(model.count));
+  poniDato(list, "dmSubloadFirma", firma);
   riconcilia(list, model);
   return true;
 }

--- a/custom_components/dashboardmodern/frontend/tests/subload-popup-render.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/subload-popup-render.test.js
@@ -62,6 +62,18 @@ class Element {
     this.children = [];
     this.append(...nodes);
   }
+  /* Rimettere in fila senza spostare chi e' gia' al suo posto: il popup guarda
+   * `children[posto]` e usa `insertBefore` solo per chi non ci corrisponde. Un
+   * finto DOM senza `insertBefore` non farebbe passare quella strada. */
+  insertBefore(nodo, riferimento) {
+    if (nodo.parentElement)
+      nodo.parentElement.children = nodo.parentElement.children.filter((altro) => altro !== nodo);
+    const posto = this.children.indexOf(riferimento);
+    nodo.parentElement = this;
+    if (posto < 0) this.children.push(nodo);
+    else this.children.splice(posto, 0, nodo);
+    return nodo;
+  }
   /* Il browser ce l'ha, e adesso il popup lo usa: una carta che se ne va se ne
    * va da sola, senza portarsi dietro le altre. Un finto DOM senza `remove`
    * farebbe passare per buona proprio la riga che non funziona. */

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.4.5-beta.4"
+  "version": "1.4.5-beta.5"
 }


### PR DESCRIPTION
La beta.4 ha risolto due delle tre cose del primo filmato — la plancia non si ricarica piu' da sola, e gli stati sono quelli della sezione Elettrodomestici («1/8 IN FUNZIONE», STANDBY su chi ha solo la presa accesa). Il lampo bianco no: sei volte in nove secondi, sempre di un fotogramma solo.

## Perche' la beta.4 non bastava

Nel primo filmato il lampo era la lista che si svuotava, e togliere `replaceChildren` era giusto. Ma stavolta, misurando i fotogrammi nativi a 118 fps, **i due fotogrammi ai lati del lampo sono identici**: fra prima e dopo non cambia un pixel.

Non stava cambiando niente, e il livello si ridipingeva lo stesso. Quindi non era piu' il DOM che si svuota: era il DOM che **si riscrive per niente**.

Al banco, con un `MutationObserver` su `#subloads-list` e dieci giri di stati fermi: **610 scritture**. Due sorgenti, tutt'e due introdotte da me nella beta.4 o ereditate dal travaso:

1. **La classifica.** «Rimettere in fila» era `griglia.append(nodo)` per ogni carta a ogni giro — e `append` di un nodo gia' figlio lo SPOSTA davvero, anche quando lo si rimette dov'era gia'. Otto carte, otto spostamenti, a ogni battito degli stati.
2. **Attributi, colori e testi riassegnati col valore che avevano gia'.** Assegnare lo stesso valore a `textContent`, a un `data-` o a una proprieta' CSS non e' gratis: il browser non confronta, invalida.

E dentro il velo sfocato del modale (`backdrop-filter` sul `.modal-wrapper`) ogni invalidazione e' un livello da ridipingere, che per un fotogramma resta bianco. E' la stessa ragione per cui il difetto si vede solo sul telefono: il computer ridipinge in tempo.

## La correzione

- si confronta prima di scrivere (`poniTesto`, `poniDato`, `poniStile`, `poniNascosto`);
- in classifica si guarda `children[posto]` e si sposta con `insertBefore` solo la carta che non ci corrisponde.

A stati fermi le scritture diventano **zero**. Un solo watt che cambia ne costa due, ed e' il valore che si sta disegnando.

## Prova

`e2e/il-popup-non-riscrive-quello-che-non-cambia.spec.js` conta le scritture con un vero `MutationObserver` e pretende **zero** a stati fermi — l'unica soglia che si difende da sola, perche' qualunque soglia piu' alta e' un invito a rimetterci dentro qualcosa. Contro la beta.4 rilasciata ne conta 610.

Il finto DOM delle prove unitarie ha imparato `insertBefore`, altrimenti la strada nuova non ci passerebbe.

1733 prove frontend verdi; le sei e2e dei popup e dell'energia verdi.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT

---
_Generated by [Claude Code](https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT)_