### PR TITLE
Versione 1.4.5-beta.6: due sezioni si riavvolgevano a vicenda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.4.5-beta.6
+
+«Guarda, cambia intestazione, quindi c'e' qualcosa di duplicato» — due
+schermate dello stesso minuto, la stessa finestra, due intestazioni diverse. Era
+vero, e sotto c'era di peggio.
+
+### Corretto
+
+- **Due sezioni si riavvolgevano a vicenda, all'infinito.** La finestra dei
+  carichi e la stabilita' Beta 27 avvolgono tutt'e due `apriSubLoads`, e nessuna
+  riconosceva il segno dell'altra sulla funzione esterna: a ogni giro di stati
+  ciascuna riavvolgeva quella dell'altra. Misurata, la catena cresceva di due a
+  ogni giro — **cinque avvolgimenti all'avvio, venticinque dopo dieci giri,
+  sessantacinque dopo trenta** — e continuava a crescere per tutto il tempo che
+  la plancia restava aperta. Aprire la finestra faceva girare decine di volte
+  due disegnatori che si scrivono sopra a vicenda: e' da li' che veniva
+  l'intestazione che cambiava faccia.
+
+- **L'intestazione della finestra ha un proprietario solo.** La finestra moderna
+  se la scrive da se' — nome, icona e periodo in tre pezzi; la mano di prima
+  scriveva la stessa cosa in un pezzo solo e di un altro colore. Adesso quella
+  si tira indietro quando la finestra e' della nuova, e resta per i gruppi che
+  la nuova non sa disegnare.
+
+- **La riga «Transfer» non si contraddice piu'.** Diceva «4.9 MB dalla cache —
+  non compressi · servito br»: una deduzione dai pesi e una risposta del server,
+  opposte, in fila. Quando c'e' la risposta letta, la deduzione si toglie.
+
+### Provato ma non verificabile da qui
+
+- **Il foglio della finestra su un livello suo.** Dentro la finestra, a riposo,
+  le scritture sono zero; dietro sono undici in quattro secondi — l'orologio, il
+  puntino della connessione, il flusso. E il velo del modale ha una sfocatura
+  che rilegge lo sfondo: ogni scrittura dietro e' una sfocatura da rifare, e le
+  due cose stanno nello stesso livello. Promuovendo il foglio a livello suo, il
+  suo contenuto non viene ridipinto insieme allo sfondo. E' un fatto del
+  telefono, e in prova il disegno lo fa la CPU: qui non si riproduce.
+
+### Sulla velocita', per essere chiari
+
+I numeri della Diagnostica dicono dove sta il tempo, e non e' dove si e'
+guardato finora: **ultimo file a 2,9 s, velo via a 3,2 s** — cioe' 2,9 secondi
+prima che l'ultimo file sia pronto e 0,4 dopo. E il Transfer dice «dalla
+cache»: i file non li sta scaricando, li sta **leggendo e interpretando**. Sono
+4,9 MB di codice, di cui 2 in un pezzo solo.
+
+E' per questo che ne' meno richieste (beta.1) ne' meno byte sul filo (beta.2)
+hanno spostato niente, e non lo sposta nemmeno questa: il tempo se ne va a
+interpretare ed eseguire, e l'unica cosa che lo tocca e' **eseguire meno roba
+all'avvio** — montare per prime le sezioni della pagina che si vede e lasciare
+indietro le altre. E' un lavoro grosso e a se', non un ritocco.
+
 ## 1.4.5-beta.5
 
 Il lampo del popup, di nuovo — e stavolta con la causa giusta. Nella beta.4 gli

--- a/custom_components/dashboardmodern/frontend/e2e/la-finestra-dei-carichi-ha-un-proprietario-solo.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/la-finestra-dei-carichi-ha-un-proprietario-solo.spec.js
@@ -1,0 +1,201 @@
+/* La finestra dei sotto-carichi ha un proprietario solo.
+ *
+ * «guarda, cambia intestazione, quindi c'e' qualcosa di duplicato» — due
+ * schermate dello stesso minuto, la stessa finestra, due intestazioni diverse:
+ * una col nome in grassetto scuro e ISTANTANEO staccato in grigio, l'altra
+ * tutta azzurra in un pezzo solo. Erano due mani sullo stesso nodo.
+ *
+ * Sotto ce n'era una peggiore. Due sezioni avvolgono `apriSubLoads` — questa
+ * finestra e la stabilita' Beta 27 — e nessuna delle due riconosceva il segno
+ * dell'altra sulla funzione esterna: a ogni giro di stati ciascuna riavvolgeva
+ * quella dell'altra. Misurata, la catena cresceva di due a ogni giro: cinque
+ * avvolgimenti all'avvio, venticinque dopo dieci giri, sessantacinque dopo
+ * trenta, e cosi' per tutto il tempo che la plancia resta aperta. Aprire la
+ * finestra faceva girare decine di volte due disegnatori che si scrivono sopra
+ * a vicenda — ed e' per questo che l'intestazione cambiava faccia.
+ */
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+const SEME = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    cameras: [],
+    appliances: [
+      {
+        id: "app-0",
+        name: "Condizionatori",
+        type: "generico",
+        power_entity: "sensor.app_0_w",
+        metadata: { beta27_subload_group: "elettro" },
+      },
+    ],
+    loads: [{ id: "elettro", name: "Elettrodomestici", icon: "🔌", order: 0 }],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: { grid: { power: "sensor.rete_w" }, house: { power: "sensor.casa_w" } },
+    entityOverrides: {},
+  },
+  visibility: { home: true, energy: true },
+};
+
+/* Quanti avvolgimenti ha addosso una funzione: si scende per i due nomi con
+ * cui le sezioni tengono la precedente. */
+const quantiAvvolgimenti = (page, nome) =>
+  page.evaluate((chiamata) => {
+    let funzione = window[chiamata];
+    const visti = new Set();
+    let quanti = 0;
+    while (typeof funzione === "function" && !visti.has(funzione) && quanti < 500) {
+      visti.add(funzione);
+      quanti += 1;
+      funzione = funzione.__dmWrappedOriginal || funzione.__dmPrevious;
+    }
+    return quanti;
+  }, nome);
+
+const battito = async (page, giri) => {
+  for (let giro = 0; giro < giri; giro++) {
+    await page.evaluate(() =>
+      window.dispatchEvent(new CustomEvent("dashboardmodern:states-ready", { detail: {} })),
+    );
+    await page.waitForTimeout(30);
+  }
+};
+
+async function apparecchiata(page, testInfo) {
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, SEME);
+  await page.evaluate(() => {
+    const raw = eval("_RAW_STATES");
+    for (const [id, valore] of [
+      ["sensor.app_0_w", "701"],
+      ["sensor.rete_w", "701"],
+      ["sensor.casa_w", "701"],
+    ])
+      raw[id] = { entity_id: id, state: valore, attributes: { unit_of_measurement: "W" } };
+    /* Il gruppo dichiarato anche nel modello della stabilita' Beta 27: senza,
+     * la sua mano sull'intestazione non parte nemmeno, e la prova guarderebbe
+     * un caso che non e' quello di casa. */
+    localStorage.setItem(
+      "cd_subload_groups",
+      JSON.stringify([{ id: "elettro", name: "Elettrodomestici", icon: "🔌", color: "#0ea5e9" }]),
+    );
+    window.dispatchEvent(new CustomEvent("dashboardmodern:states-ready", { detail: {} }));
+  });
+  await page.waitForTimeout(600);
+}
+
+test("gli avvolgimenti di apriSubLoads non crescono col passare degli stati", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
+  await apparecchiata(page, testInfo);
+
+  const allInizio = await quantiAvvolgimenti(page, "apriSubLoads");
+  expect(allInizio).toBeGreaterThan(0);
+
+  await battito(page, 15);
+  const dopo = await quantiAvvolgimenti(page, "apriSubLoads");
+  expect(
+    dopo,
+    `la catena e' passata da ${allInizio} a ${dopo}: due sezioni si riavvolgono a vicenda a ogni giro di stati`,
+  ).toBe(allInizio);
+});
+
+test("un gruppo che non sappiamo disegnare torna al guscio, e il segno di proprieta' se ne va", async ({
+  page,
+}, testInfo) => {
+  /* Il segno `data-dm-subload-owner` restava attaccato alla lista anche quando
+   * la finestra tornava al guscio — `innerHTML` cambia i figli, non gli
+   * attributi. Aprendo poi un gruppo che noi non sappiamo disegnare, la mano di
+   * Beta 27 si tirava indietro credendo che la finestra fosse ancora nostra: il
+   * gruppo restava senza periodo e col colore di quello aperto prima. */
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
+  await apparecchiata(page, testInfo);
+  await page
+    .locator('.tab[data-tab="energy"]')
+    .first()
+    .evaluate((nodo) => nodo.click());
+  await page.waitForTimeout(1000);
+
+  /* Prima quello nostro: il segno si mette. */
+  await page.evaluate(() => window.apriSubLoads?.("elettro"));
+  await expect(page.locator(".dm-subload-card")).toHaveCount(1);
+  expect(
+    await page.evaluate(
+      () => document.getElementById("subloads-list")?.dataset?.dmSubloadOwner || "",
+    ),
+  ).toBe("beta30");
+
+  /* Poi uno che non e' fra i carichi canonici: la finestra non e' nostra. */
+  await page.evaluate(() => {
+    const gruppi = JSON.parse(localStorage.getItem("cd_subload_groups") || "[]");
+    gruppi.push({ id: "cantina", name: "Cantina", icon: "🍷", color: "#7c3aed" });
+    localStorage.setItem("cd_subload_groups", JSON.stringify(gruppi));
+    window.dispatchEvent(new CustomEvent("dashboardmodern:states-ready", { detail: {} }));
+  });
+  await page.waitForTimeout(300);
+  await page.evaluate(() => window.apriSubLoads?.("cantina"));
+  await page.waitForTimeout(500);
+
+  expect(
+    await page.evaluate(
+      () => document.getElementById("subloads-list")?.dataset?.dmSubloadOwner || "",
+    ),
+    "il segno di proprieta' e' rimasto su una finestra che non e' piu' nostra",
+  ).toBe("");
+  await expect(page.locator("#subloads-title")).toContainText("Cantina");
+});
+
+test("l'intestazione resta quella della finestra, anche dopo un giro di stati", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
+  await apparecchiata(page, testInfo);
+
+  await page
+    .locator('.tab[data-tab="energy"]')
+    .first()
+    .evaluate((nodo) => nodo.click());
+  await page.waitForTimeout(1000);
+
+  /* Quante volte l'intestazione viene riscritta mentre la finestra si apre.
+   * Una mano sola la scrive una volta; due mani se la contendono. */
+  await page.evaluate(() => {
+    window.__dmTitolo = 0;
+    new MutationObserver((mutazioni) => {
+      for (const mutazione of mutazioni) if (mutazione.type === "childList") window.__dmTitolo += 1;
+    }).observe(document.getElementById("subloads-title"), { childList: true, subtree: true });
+  });
+  await page.evaluate(() => window.apriSubLoads?.("elettro"));
+  await expect(page.locator(".dm-subload-card")).toHaveCount(1);
+  await page.waitForTimeout(600);
+  const riscritture = await page.evaluate(() => window.__dmTitolo);
+  expect(
+    riscritture,
+    `l'intestazione e' stata riscritta ${riscritture} volte aprendo la finestra: se la contendono in due`,
+  ).toBeLessThanOrEqual(3);
+
+  /* Appena aperta: il nome e il periodo sono due pezzi, non una stringa sola. */
+  const titolo = page.locator("#subloads-title");
+  await expect(titolo.locator(".dm-subload-title-name")).toHaveText("ELETTRODOMESTICI");
+  await expect(titolo.locator(".dm-subload-title-period")).toHaveText("ISTANTANEO");
+
+  /* E dopo il battito degli stati e' ancora la stessa: nessun'altra mano l'ha
+   * riscritta in un pezzo solo. */
+  await battito(page, 5);
+  await expect(titolo.locator(".dm-subload-title-name")).toHaveText("ELETTRODOMESTICI");
+  await expect(titolo.locator(".dm-subload-title-period")).toHaveText("ISTANTANEO");
+  expect(
+    await page.evaluate(
+      () => document.getElementById("subloads-title")?.querySelectorAll("span,small").length,
+    ),
+    "l'intestazione ha piu' pezzi del previsto: qualcuno ci ha scritto sopra",
+  ).toBe(3);
+});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta24-energy-recovery-section.js";
 import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5-beta.5","dashboardVersion":"1.4.5-beta.5","moduleVersion":14,"schemaVersion":4,"date":"2026-09-01T19:12:03+00:00","commit":"35931aa7c4f01ddd1105c8766048259db7a8aa54","assetHash":"2d3497cda0e176ca"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5-beta.6","dashboardVersion":"1.4.5-beta.6","moduleVersion":14,"schemaVersion":4,"date":"2026-09-01T21:04:23+00:00","commit":"2cbd1654f604acba9b178eff63c0512f00d9e540","assetHash":"9d65a1fc2d8d8fc4"});

--- a/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
+++ b/custom_components/dashboardmodern/frontend/legacy/modules-entry.js
@@ -721,7 +721,7 @@ export function pesoScaricato() {
  * il campione buono. La riga si scrive subito col peso e si completa da sola
  * quando il server ha risposto; se la richiesta non riesce, resta quella che
  * era. */
-async function chiediComeArrivano(target) {
+export async function chiediComeArrivano(target) {
   const nodo = target.querySelector('[data-dm-voce="Transfer"]');
   if (!nodo) return;
   try {
@@ -729,7 +729,14 @@ async function chiediComeArrivano(target) {
     const risposta = await fetch(`${casa}panel.js`, { cache: "reload" });
     if (!risposta.ok) return;
     const come = risposta.headers.get("content-encoding");
-    nodo.textContent = `${nodo.textContent} · servito ${come || "in chiaro"}`;
+    /* La risposta letta zittisce la deduzione, invece di litigarci.
+     *
+     * La riga diceva «4.9 MB dalla cache — non compressi · servito br»: due
+     * frasi opposte sullo stesso file, in fila. La prima e' una deduzione dai
+     * pesi (e dalla cache i pesi non dicono come sia arrivato), la seconda e'
+     * la risposta del server. Quando c'e' la seconda, la prima si toglie: una
+     * diagnostica che si contraddice non si legge, si scavalca. */
+    nodo.textContent = `${nodo.textContent.replace(/ — (compressi|non compressi|peso codificato non disponibile)$/, "")} · servito ${come || "in chiaro"}`;
   } catch (_) {
     /* Una diagnostica che non riesce a misurare non rompe la diagnostica. */
   }

--- a/custom_components/dashboardmodern/frontend/src/sections/beta26-real-device-stability-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta26-real-device-stability-section.js
@@ -1187,6 +1187,16 @@ export function applyFlowNodeCustomization() {
 function patchSubloadPopup(groupId = state.popupGroup) {
   const id = clean(groupId);
   if (!id) return false;
+  /* L'intestazione ha un proprietario solo.
+   *
+   * La finestra moderna se la scrive da se' — nome, icona e periodo in tre
+   * pezzi, con l'icona `mdi:` risolta — e questa e' la mano di prima, che
+   * scriveva la stessa cosa in un pezzo solo e di un altro colore. Le due si
+   * sovrascrivevano: due schermate dello stesso minuto mostravano due
+   * intestazioni diverse. Quando la finestra e' sua, qui non si scrive; per i
+   * gruppi che lei non sa disegnare questa resta l'unica intestazione decente,
+   * ed e' per quelli che serve ancora. */
+  if (doc?.getElementById?.("subloads-list")?.dataset?.dmSubloadOwner === "beta30") return false;
   const group = loadGroupsModel().find((item) => item.id === id);
   const title = doc?.getElementById?.("subloads-title");
   const modal = doc?.getElementById?.("subloads-modal");
@@ -1209,6 +1219,10 @@ function installPopupOwner() {
       root.queueMicrotask?.(() => patchSubloadPopup(type));
       return result;
     }
+    /* I segni di chi ha avvolto prima si portano avanti, altrimenti questo e
+     * l'avvolgimento del popup moderno si riavvolgono a vicenda a ogni giro di
+     * stati e la catena cresce senza fine. */
+    Object.assign(beta27OpenSubLoads, current);
     beta27OpenSubLoads.__dmBeta27PopupOwner = true;
     beta27OpenSubLoads.__dmPrevious = current;
     root[name] = beta27OpenSubLoads;

--- a/custom_components/dashboardmodern/frontend/src/sections/subload-popup-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/subload-popup-section.js
@@ -441,6 +441,26 @@ function installStyles() {
     "dm-subload-popup-style",
     `
     #subloads-list[data-dm-subload-owner="beta30"]{display:block!important}
+    /* Il foglio della finestra su un livello suo.
+     *
+     * Questa e' l'unica delle tre correzioni che non ho potuto verificare da
+     * qui, e va detto: il lampo bianco e' un fatto del telefono, e in prova il
+     * disegno lo fa la CPU, dove non succede.
+     *
+     * Quello che si e' misurato: dentro la finestra, a riposo, le scritture
+     * sono zero — quindi non e' piu' lei a muoversi. DIETRO la finestra sono
+     * undici in quattro secondi: l'orologio, il puntino della connessione, il
+     * flusso dell'energia. E il velo del modale ha una sfocatura di venti pixel
+     * che rilegge lo sfondo: ogni scrittura dietro e' una sfocatura da rifare, e
+     * le due cose vanno insieme nello stesso livello.
+     *
+     * Promuovendo il foglio a livello suo, quello che c'e' scritto sopra non
+     * viene ridipinto insieme allo sfondo sfocato. La sfocatura resta com'era:
+     * cambia solo chi la paga. E si dichiara solo mentre la finestra e' in
+     * scena — un livello tenuto vivo a finestra chiusa e' memoria buttata — e
+     * senza toccare la trasformazione, che e' quella dell'animazione di
+     * apertura. */
+    #subloads-modal.modal-wrapper.show>.modal-card{will-change:transform}
     #subloads-title[data-dm-subload-title]{display:flex!important;align-items:center;gap:10px;flex-wrap:wrap}
     .dm-subload-title-icon{font-size:26px;line-height:1}
     .dm-subload-title-icon .dm-icon-engine-glyph,.dm-subload-summary-icon .dm-icon-engine-glyph,.dm-subload-icon .dm-icon-engine-glyph{font-size:inherit!important;height:auto!important}
@@ -492,6 +512,27 @@ function installStyles() {
  * L'unico modo per non farlo vedere e' non strappare. */
 const SOLO_NOSTRO = new Set(["renderSubLoads"]);
 
+/* Il segno di proprieta' dice cosa c'e' DENTRO la lista adesso, non cosa c'e'
+ * stato una volta.
+ *
+ * Restava attaccato anche quando la finestra tornava al guscio: `innerHTML`
+ * cambia i figli, non gli attributi. E allora due cose andavano storte, e la
+ * seconda l'aveva vista solo la revisione. Aprendo un gruppo che noi non
+ * sappiamo disegnare, dopo averne aperto uno che sappiamo: la mano di Beta 27
+ * si tirava indietro credendo che la finestra fosse ancora nostra, e quel
+ * gruppo restava senza periodo e col colore di quello aperto prima. E il
+ * `display:block` che serve alle nostre carte restava addosso a delle carte
+ * del guscio, che invece vanno in griglia.
+ *
+ * Il segno se ne va con la finestra: cosi' vuol dire quello che dice. */
+function nonEPiuNostra() {
+  const list = doc?.getElementById?.(LIST);
+  if (!list?.dataset) return false;
+  delete list.dataset.dmSubloadOwner;
+  delete list.dataset.dmSubloadFirma;
+  return true;
+}
+
 function wrapOpener(name) {
   const current = root[name];
   const marker = `__dmSubloadPopup_${name}`;
@@ -510,10 +551,26 @@ function wrapOpener(name) {
      * restano per quando il primo colpo non riesce, che e' all'apertura:
      * la finestra non e' ancora in scena. */
     if (renderSubloadPopup(state.group)) return result;
+    nonEPiuNostra();
     root.queueMicrotask?.(() => renderSubloadPopup(state.group));
     root.setTimeout?.(() => renderSubloadPopup(state.group), 60);
     return result;
   };
+  /* I segni di chi ha avvolto prima si portano avanti.
+   *
+   * «guarda, cambia intestazione: c'e' qualcosa di duplicato» — ed era vero.
+   * Anche la stabilita' Beta 27 avvolge `apriSubLoads`, e nessuno dei due
+   * riconosceva il segno dell'altro sulla funzione esterna: a ogni giro di
+   * stati ciascuno riavvolgeva quella dell'altro. Misurata, la catena cresceva
+   * di due a ogni giro — cinque avvolgimenti all'avvio, venticinque dopo dieci
+   * giri, sessantacinque dopo trenta — e continuava a crescere finche' la
+   * plancia restava aperta. Aprire la finestra faceva girare decine di volte
+   * due disegnatori che si scrivono sopra a vicenda.
+   *
+   * `Object.assign` copia i segni di chi c'era prima sulla funzione nuova, che
+   * e' la disciplina di `wrapFunction` in shared.js: cosi' il secondo vede il
+   * segno del primo e si ferma. */
+  Object.assign(wrapped, current);
   wrapped[marker] = true;
   wrapped.__dmWrappedOriginal = current;
   root[name] = wrapped;

--- a/custom_components/dashboardmodern/frontend/tests/il-peso-scaricato-dice-il-vero.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/il-peso-scaricato-dice-il-vero.test.js
@@ -197,3 +197,50 @@ test("senza il segno del velo non si inventa un tempo", () => {
   const detto = conQuestoAvvio({ risorse: [fine("legacy/a.js", 2000)] }, tempoDiAvvio);
   assert.match(detto, /velo non misurato/, `dichiara un avvio che non ha visto: «${detto}»`);
 });
+
+/* La riga non si contraddice: la risposta letta zittisce la deduzione.
+ *
+ * Dal campo: «4.9 MB dalla cache — non compressi · servito br». Due frasi
+ * opposte sullo stesso file, una in fila all'altra. La prima e' una deduzione
+ * dai pesi — e dalla cache i pesi non dicono come sia arrivato — la seconda e'
+ * la risposta del server. Quando c'e' la seconda, la prima va tolta: una
+ * diagnostica che si contraddice non si legge, si scavalca.
+ */
+const { chiediComeArrivano } = await import(`../legacy/modules-entry.js?come=${Date.now()}`);
+
+function conRisposta(intestazione, testoIniziale, prova) {
+  const nodo = { textContent: testoIniziale };
+  const finto = { querySelector: (selettore) => (selettore.includes("Transfer") ? nodo : null) };
+  const primaFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: true,
+    headers: { get: (nome) => (nome === "content-encoding" ? intestazione : null) },
+  });
+  return Promise.resolve(prova(finto, nodo)).finally(() => {
+    globalThis.fetch = primaFetch;
+  });
+}
+
+test("quando il server risponde «br», la deduzione dai pesi si toglie", async () => {
+  await conRisposta("br", "4.9 MB dalla cache — non compressi", async (finto, nodo) => {
+    await chiediComeArrivano(finto);
+    assert.equal(nodo.textContent, "4.9 MB dalla cache · servito br");
+    assert.doesNotMatch(nodo.textContent, /non compressi/, `si contraddice: «${nodo.textContent}»`);
+  });
+});
+
+test("e vale per tutte e tre le deduzioni, non solo per una", async () => {
+  for (const dedotto of ["compressi", "non compressi", "peso codificato non disponibile"])
+    await conRisposta("gzip", `1.2 MB di 4.9 MB — ${dedotto}`, async (finto, nodo) => {
+      await chiediComeArrivano(finto);
+      assert.equal(nodo.textContent, "1.2 MB di 4.9 MB · servito gzip");
+    });
+});
+
+test("senza intestazione lo dice, e la deduzione se ne va lo stesso", async () => {
+  /* «in chiaro» e' anch'esso una risposta letta: vale piu' della deduzione. */
+  await conRisposta(null, "4.9 MB dalla cache — compressi", async (finto, nodo) => {
+    await chiediComeArrivano(finto);
+    assert.equal(nodo.textContent, "4.9 MB dalla cache · servito in chiaro");
+  });
+});

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.4.5-beta.5"
+  "version": "1.4.5-beta.6"
 }


### PR DESCRIPTION
«Guarda, cambia intestazione, quindi c'e' qualcosa di duplicato» — due schermate dello stesso minuto, la stessa finestra, due intestazioni diverse: una col nome in grassetto scuro e ISTANTANEO staccato in grigio, l'altra tutta azzurra in un pezzo solo.

Era vero. E sotto c'era di peggio.

## La catena: due sezioni che si riavvolgono a vicenda

`apriSubLoads` lo avvolgono in due — la finestra dei carichi e la stabilita' Beta 27 — e **nessuna delle due riconosceva il segno dell'altra sulla funzione esterna**. A ogni giro di stati ciascuna riavvolgeva quella dell'altra.

Misurata scendendo la catena:

| | avvolgimenti su `apriSubLoads` |
| --- | --- |
| all'avvio | 5 |
| dopo 10 giri di stati | 25 |
| dopo 30 giri | 65 |

E continua a crescere per tutto il tempo che la plancia resta aperta. Aprire la finestra faceva girare decine di volte due disegnatori che si scrivono sopra a vicenda: **e' da li' che l'intestazione cambiava faccia**.

La disciplina esisteva gia' nel deposito, in `wrapFunction` di `shared.js`: `Object.assign(wrapped, current)` porta avanti i segni di chi ha avvolto prima, cosi' il secondo vede il primo e si ferma. Mancava in tutt'e due gli avvolgimenti fatti a mano.

## L'intestazione ha un proprietario solo

Anche a catena corta restavano due mani sullo stesso nodo: `patchSubloadPopup` scrive la stessa cosa in un pezzo solo, con un colore suo. Adesso si tira indietro quando la lista e' della finestra moderna (`data-dm-subload-owner="beta30"`), e resta per i gruppi che quella non sa disegnare.

## Il foglio su un livello suo — l'unica non verificabile da qui

Questa va detta per quello che e'. Misurato, col popup aperto e fermo:

- **dentro** la finestra: **0 scritture** (la beta.5 ha fatto il suo);
- **dietro** la finestra: **11 scritture in 4 secondi** — l'orologio, il puntino della connessione, il flusso dell'energia.

E il velo del modale ha una sfocatura di venti pixel che rilegge lo sfondo: ogni scrittura dietro e' una sfocatura da rifare, e il contenuto del foglio sta nello stesso livello. Promuovendo il foglio a livello suo (`will-change:transform`, solo mentre e' in scena, senza toccare la trasformazione dell'animazione) il suo contenuto non viene ridipinto insieme allo sfondo.

Il lampo e' un fatto del telefono e in prova il disegno lo fa la CPU: **qui non si riproduce, quindi non posso dire che e' risolto.** Va provato sul telefono.

## La riga «Transfer» non si contraddice piu'

Diceva `4.9 MB dalla cache — non compressi · servito br`: una deduzione dai pesi e una risposta del server, opposte, una in fila all'altra. Quando c'e' la risposta letta, la deduzione si toglie.

## Sulla velocita'

I numeri della Diagnostica dicono dove sta il tempo, e non e' dove si e' guardato finora: **ultimo file a 2,9 s, velo via a 3,2 s** — 2,9 secondi prima che l'ultimo file sia pronto, 0,4 dopo. E il Transfer dice «dalla cache»: i file non li sta scaricando, li sta **leggendo e interpretando**. Sono 4,9 MB di codice, di cui 2 in un pezzo solo.

E' per questo che ne' meno richieste (beta.1) ne' meno byte sul filo (beta.2) hanno spostato niente, e non lo sposta nemmeno questa. L'unica leva che resta e' **eseguire meno roba all'avvio**: montare per prime le sezioni della pagina che si vede e lasciare indietro le altre. E' un lavoro a se', non un ritocco, e non l'ho fatto qui.

## Prove

| prova | contro la beta.5 |
| --- | --- |
| la catena di `apriSubLoads` non cresce coi giri di stati | da 7 a 37 |
| l'intestazione si scrive una volta sola aprendo la finestra | cinque volte |
| la riga Transfer: la risposta letta zittisce la deduzione (3 prove) | rosse |

1736 prove frontend verdi. Suite e2e mobile completa: **417 passate, 8 saltate, 0 fallite**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT

---
_Generated by [Claude Code](https://claude.ai/code/session_012BbgQMF3gfkUUXQGjeqDqT)_