### PR TITLE
Versione 1.4.5: la 1.4.5 esce dalle beta, con un cestino nella coda dell'assistenza e una chat che non resta ferma

### DIFF
--- a/.github/workflows/cleanup-releases.yml
+++ b/.github/workflows/cleanup-releases.yml
@@ -4,6 +4,11 @@
 # nell'interfaccia, con il rischio di togliere quello sbagliato. Qui si elenca
 # cosa conservare, si lancia prima in anteprima e solo dopo si esegue davvero.
 #
+# Tocca soltanto quello che non è una versione stabile: la numerazione pre-1.0
+# e ogni pre-release, beta e rc di qualunque versione. Le stabili non hanno il
+# trattino e questo workflow non sa cancellarle — è una garanzia, non una
+# dimenticanza, e chi la togliesse si prenderebbe il rischio che porta con sé.
+#
 # Si avvia da Actions → "Pulizia release" → Run workflow.
 #
 # Il file è volutamente autosufficiente: non dipende da nessuno script del
@@ -14,9 +19,9 @@ on:
   workflow_dispatch:
     inputs:
       keep:
-        description: "Tag da conservare, separati da spazi"
-        required: true
-        default: "v0.15.25 v1.0.0-rc.1 v1.0.0-rc.2 v1.0.0-rc.3"
+        description: "Tag da conservare, separati da spazi (vuoto = nessuno)"
+        required: false
+        default: ""
       apply:
         description: "Esegui davvero (senza spunta è solo un'anteprima)"
         type: boolean
@@ -51,21 +56,24 @@ jobs:
           declare -A KEEP=()
           for tag in $KEEP_LIST; do KEEP["$tag"]=1; done
 
-          # Tutto ciò che appartiene alla numerazione pre-1.0 e non è stato messo
-          # al riparo. La 1.0.0 e ogni versione successiva non corrispondono ai
-          # pattern, quindi non sono cancellabili nemmeno per errore di battitura.
+          # Cancellabile è soltanto ciò che non è una versione stabile: la
+          # numerazione pre-1.0, e ogni pre-release — beta e rc, di qualunque
+          # versione. Una versione stabile non ha il trattino, quindi non
+          # corrisponde a nessuno dei pattern e non è cancellabile nemmeno per
+          # errore di battitura: è la sola garanzia che questo workflow offre, e
+          # va tenuta. Chi volesse davvero togliere una stabile lo faccia a mano,
+          # una per una, guardandola in faccia.
           is_purgeable() {
             [ -n "${KEEP[$1]:-}" ] && return 1
             case "$1" in
               v0.*|0.*) return 0 ;;
-              v1.0.0-beta.*|1.0.0-beta.*) return 0 ;;
-              v1.0.0-rc.*|1.0.0-rc.*) return 0 ;;
+              *-beta.*|*-rc.*) return 0 ;;
               *) return 1 ;;
             esac
           }
 
           echo "Repository : $REPO"
-          echo "Conservo   : $KEEP_LIST"
+          echo "Conservo   : ${KEEP_LIST:-(niente)}"
           if [ "$APPLY" = "true" ]; then
             echo "Modalità   : ESECUZIONE (irreversibile)"
           else
@@ -116,7 +124,7 @@ jobs:
           {
             echo "## Pulizia release"
             echo
-            echo "- Conservati: \`$KEEP_LIST\`"
+            echo "- Conservati: \`${KEEP_LIST:-(niente)}\`"
             echo "- Release da eliminare: **${#targets_releases[@]}**"
             echo "- Tag da eliminare: **${#targets_tags[@]}**"
             echo "- Release stabili superstiti: **$survivors_stable**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
-## 1.4.5-beta.13
+## 1.4.5
 
-Due cose chieste guardando la chat funzionare: buttare via una conversazione
-dalla coda di chi risponde, e una finestra che non resta ferma mentre
-dall'altro capo qualcuno ha gia' risposto.
+Tredici passaggi di prova diventati una versione sola. Dentro ci sono cinque
+sezioni nuove — Musica, Agenda, Tapparelle rifatte, Sicurezza, MiniPC — le
+segnalazioni che nascono dalla plancia invece che da GitHub, il cruscotto di
+chi le riceve, la chat di assistenza privata col suo centralino, le sezioni
+vuote che non ingombrano piu' la barra, e una lunga fila di difetti visti su
+telefoni e tablet veri.
+
+Le note qui sotto sono quelle delle tredici prove, rimesse in fila per
+argomento invece che per data: quello che e' stato aggiunto, quello che e'
+cambiato, quello che e' stato tolto, quello che e' stato corretto.
 
 ### Aggiunto
 
@@ -32,38 +39,6 @@ dall'altro capo qualcuno ha gia' risposto.
   stesso, il secondo cancella — perche' una conversazione cancellata non si
   rimette a posto, e in un elenco dove si scorre col dito un cestino che
   cancella al primo tocco butta via prima o poi quella sbagliata.
-
-### Corretto
-
-- **La chat aperta si aggiorna da sola.**
-
-      «la risposta non si refresh devo uscire e rientrare»
-
-  La finestra leggeva una volta all'apertura e poi restava ferma: la risposta
-  arrivava solo chiudendo e riaprendo. Il giro dei cinque minuti del backend
-  c'era gia', ma quello serve al campanello — suona e basta, non ridisegna
-  niente.
-
-  Adesso guarda ogni quindici secondi, e ridisegna soltanto quando e' arrivato
-  davvero qualcosa: chi sta scrivendo non si vede rifare la casella sotto le
-  dita, e se ridisegna il cursore torna dov'era. Chiusa la finestra non chiede
-  piu' niente, cosi' una plancia accesa tutto il giorno in cucina non bussa al
-  centralino per una conversazione che nessuno sta guardando.
-
-- **Nella coda di chi risponde le bolle stavano dalla parte sbagliata.**
-
-  Le domande della casa comparivano a destra e in verde — come se se le fosse
-  scritte da solo chi stava leggendo — e le proprie risposte a sinistra e in
-  grigio: una conversazione letta al contrario. «Mio» dipende da chi guarda, e
-  questa finestra la guardano in due.
-
-## 1.4.5-beta.12
-
-Cinque richieste lette insieme e cinque sezioni nuove, le sezioni vuote che
-escono dalla barra, e la chat di assistenza — quella vera, che non passa da
-GitHub.
-
-### Aggiunto
 
 - **La Musica ha la sua sezione, e la copertina fa da sfondo.**
 
@@ -141,177 +116,6 @@ GitHub.
 
   Chi non vuole che la plancia parli con nessuno fuori di casa la spegne dalle
   opzioni, come le segnalazioni. Il progetto sta in `docs/CHAT.md`.
-
-### Cambiato
-
-- **La finestra di una tessera ha smesso di tremolare.** Non era un difetto di
-  disegno ma di composizione: la card e il velo sfocato stavano nello stesso
-  strato, e ogni valore che cambiava dietro obbligava il browser a rifare
-  l'intero riquadro sfocato. Il velo e' passato a uno pseudo-elemento — la card
-  gli e' sorella, non figlia — e le animazioni che restano dietro si mettono in
-  pausa mentre la finestra e' aperta.
-
-- **La stanza si mostra col suo nome, mai col suo identificativo.** «Verifica
-  inoltre perche' esce sotto room etc»: sotto «Tapparella salone» c'era scritto
-  «🏠 room_mt8vpz7m». La tendina salva l'id — e' l'unica cosa che regge un
-  rinominamento — ma gli elenchi del guscio stampano quello che trovano. E c'e'
-  la meta' che non si vedeva: con un id in mano la domanda «di che piano e'
-  questa stanza?» tornava «nessuno», e le tapparelle di una casa a due piani
-  finivano tutte nello stesso gruppo.
-
-- **Nella scheda Finestre la stanza sta in alto, accanto al nome**, con la sua
-  etichetta: stava in fondo, senza dire cosa fosse.
-
-- **Il MiniPC dice OFFLINE solo quando qualcuno gliel'ha detto.** Con tutto
-  configurato e l'internet acceso scriveva OFFLINE: le caselle equivalenti per
-  la connettivita' erano quattro e la card ne leggeva una sola. Adesso **ce n'e'
-  una**, si chiama Internet, accetta un `binary_sensor`, uno stato a parole o i
-  millisecondi di un ping — e quello che stava nelle altre tre e' stato
-  travasato dentro, non buttato. Lo stato sta in alto e la card apre lo storico.
-
-- **La pagina Gestione termica mostra le entita' configurate** (#274): solare,
-  scaldabagno e caldaia in una pagina sola, ognuna col suo blocco e i comandi
-  dove si vedono i valori.
-
-- **Il Cruscotto separa quelle prese in carico da quelle ancora ferme.**
-
-      «voglio un filtro anche con quelle in lavorazione, voglio capire cosa ho
-       preso in carico e quelle ancora da prendere in carico»
-
-  Le tre cifre in cima lo dicevano gia', ma erano numeri da leggere e basta:
-  l'unico filtro aperto era «Da lavorare», che le mette insieme. Adesso ci sono
-  «Nuove» e «In lavorazione», e sono esattamente quelle due cifre — stesso
-  nome, cosi' non si dubita che sia lo stesso numero.
-
-
-- **Una sezione vuota non sta nella barra.** «tutte le sezioni devono nascere
-  come nascoste, solo se si inserisce entita' in una sezione diventa visibile.»
-
-  Meta' della regola c'era gia' e funzionava: alla prima accensione le voci
-  nascono spente, e salvare in una scheda riaccende la sezione in cui si e'
-  appena messo qualcosa. Mancava l'altra meta', perche' quella derivazione
-  corre **una volta sola per chiave**: una sezione svuotata restava nella barra
-  per sempre, con la sua pagina vuota dentro, e una accesa da una versione che
-  accendeva tutto pure.
-
-  Adesso cosa riempie una sezione e' scritto in un posto solo, e lo leggono
-  tutti e due i versi. Lo spegnimento ha tre freni: non tocca una chiave che
-  non sa giudicare (Home, Agenda, Continuita', Cruscotto e le sezioni che si fa
-  l'utente restano dove sono — le ultime quattro si nascondono gia' da sole, e
-  Home e' la pagina dove si atterra); non spegne niente finche' la
-  configurazione condivisa non e' arrivata da Home Assistant, perche' prima che
-  arrivi ogni sezione sembra vuota; e non torna mai su una scelta fatta a mano.
-
-  Nel farlo l'elenco di cosa conta come «configurato» e' diventato piu'
-  completo: la caldaia, le porte dell'antifurto, i programmi della lavatrice, i
-  gruppi dell'energia. Erano sezioni che si potevano riempire senza che nessuno
-  se ne accorgesse, e adesso che il verso dello spegnimento esiste non
-  accorgersene vorrebbe dire farle sparire a chi le aveva configurate.
-
-- **Il Cruscotto non ha piu' l'interruttore.** La fascia verde offre una scelta
-  fra vedere una voce e non vederla. Quella voce compare solo a chi tiene la
-  repository — «solo a me esce il cruscotto nella navbar, ad utenti normali non
-  esce e quindi quel pulsante non ha senso» — e chi la tiene la vuole: era un
-  interruttore che una persona sola al mondo poteva toccare, per spegnersi da
-  sola la pagina che aveva chiesto. Chi la fascia l'aveva gia' toccata tiene la
-  sua preferenza: nessuno si ritrova la voce riaccesa dall'aggiornamento.
-
-### Rimosso
-
-- **La tessera d'avviso «Porte/Finestre».** «Viene gia' gestito da Finestre, se
-  li si mette il sensore finestra dice quale e' aperto, quindi e' un
-  duplicato»: la didascalia della tessera Finestre **nomina** le aperte, non le
-  conta soltanto. Se ne vanno con lei il suo gruppo negli avvisi, la sua riga
-  nel catalogo delle tessere e il rilevamento automatico che la riempiva.
-
-## 1.4.5-beta.11
-
-Tre cose viste su un telefono, e la piu' grossa e' che il cruscotto in una casa
-vera non e' mai comparso.
-
-### Corretto
-
-- **Il cruscotto non lo metteva nessuno.** La funzione che crea la voce nella
-  barra e la sua pagina era scritta, esportata e appesa a
-  `DashboardModernSegnalazioni.sistema` — e da li' la chiamava soltanto lo
-  script che fa le fotografie della galleria. Nelle foto il cruscotto c'era; in
-  una casa vera non compariva ne' nella barra ne' dentro la finestra delle
-  segnalazioni, che intanto la sua scheda «console» l'aveva persa. E' il modo
-  peggiore di sbagliare: la galleria che doveva far vedere il lavoro lo faceva
-  al posto dell'applicazione, e mostrava una cosa che non esisteva.
-
-  Adesso la mette `ricarica()`, appena sa chi sta guardando — prima di chiedere
-  la coda a GitHub, cosi' una rete lenta non la fa comparire in ritardo. E c'e'
-  una prova che pretende una chiamata vera dentro il modulo: toglierla di nuovo
-  costa una prova rossa invece di un giro di fotografie riuscito.
-
-- **La scheda «Segnalazioni» era illeggibile.** L'interruttore che nasconde il
-  cruscotto dalla barra stava dentro la scheda della configurazione, e quel
-  markup e' un `<button style="width:100%">` fatto per stare in cima a un
-  pannello dell'editor — e' cosi' che lo usano prese, robot, UPS e agenda.
-  Dentro una scheda, che e' una riga in orizzontale, quel «100%» diventava una
-  pretesa di tutta la larghezza: il testo accanto si stringeva a **una parola
-  per riga**. Si vedeva solo sul telefono di chi la console ce l'ha davvero,
-  cioe' su un dispositivo solo al mondo.
-
-  L'interruttore adesso sta nella finestra delle segnalazioni, che e' larga e
-  si apre dalla scheda: e' l'unico posto sempre raggiungibile anche quando la
-  voce e' nascosta. Dentro il cruscotto sarebbe stato un interruttore che,
-  spegnendosi, si porta via la strada per riaccenderlo.
-
-- **Il cerchio degli elettrodomestici segnava 0 mentre la sua finestra diceva
-  13,7 kWh.** Sullo stesso schermo, a un tocco di distanza. Il cerchio di
-  gruppo ha una regola: il contatore suo — la pinza sulla linea — vince sulla
-  somma di quello che ha dentro, perche' e' piu' preciso. E ne aveva una
-  seconda: nel Giorno e nel Mese uno zero del contatore vale come misura vera.
-
-  La seconda era stata scritta per non inventare numeri che il contatore del
-  gruppo non conferma, ed e' una preoccupazione giusta — solo che proteggeva
-  dal pericolo sbagliato. Quando il contatore dice zero e dentro ci sono
-  apparecchi che hanno consumato, quello zero non e' una misura: e' una casella
-  che non risponde, e il cerchio si mette a contraddire la propria finestra.
-  Adesso lo zero cede alla somma in tutti e tre i periodi, come gia' faceva nei
-  watt.
-
-  Il caso che la vecchia regola difendeva non aveva bisogno di una regola: il
-  carico che oggi non e' partito ha i figli a zero anche loro, la somma fa
-  zero, e zero resta.
-
-  E il paniere del Recorder adesso risolve anche gli apparecchi **nascosti dal
-  Report**. `show_in_report: false` dice «non voglio vederlo nel Report», e per
-  il Report va benissimo; ma un apparecchio nascosto li' puo' stare lo stesso
-  dentro un cerchio di gruppo, e se il suo unico strumento e' un contatore di
-  vita il periodo glielo puo' dare solo il Recorder. Erano due domande diverse
-  — «cosa disegna il Report» e «da dove leggo i periodi del flusso» — infilate
-  in una risposta sola. Il Report non se ne accorge: quello che si allarga sono
-  i valori, indicizzati per entita', non l'elenco che il Report disegna.
-
-  E il paniere del Recorder risolve anche gli apparecchi, non i soli
-  carichi: i figli di un cerchio di gruppo sono apparecchi, e cercarli in un
-  paniere che contiene solo i carichi voleva dire una somma che non trovava
-  niente.
-
-- **La coda che non arriva adesso lo dice.** Il giro zitto — quello che la Home
-  fa da sola per la tessera — inghiottiva l'errore per non mettere un avviso
-  rosso in faccia a chi non aveva chiesto niente. Giusto, ma «zitto» era
-  diventato «fai finta di niente»: il cruscotto restava una pagina vuota e la
-  tessera in Home non compariva, tutte e due senza una parola sul perche'.
-  Adesso il motivo si scrive comunque, e il cruscotto lo mostra invece di
-  restare bianco.
-
-## 1.4.5-beta.10
-
-«Basta che quando arriva un messaggio sulla chat parte una notifica di Home
-Assistant.» Ecco il campanello — e, gia' che il filo doveva diventare una
-conversazione vera, la meta' che mancava: da qui adesso si risponde.
-
-«Mi metti un filtro tra bug e features nel mio cruscotto.» C'era gia', e non
-serviva a niente.
-
-E due cose viste dal vero: otto elettrodomestici con otto prese uguali al posto
-del loro disegno, e un'apertura che spariva senza dire perche'.
-
-### Nuovo
 
 - **Quando qualcuno scrive, Home Assistant lo dice.** Ogni cinque minuti la
   plancia va a vedere se sotto una segnalazione e' comparso un messaggio, e se
@@ -419,79 +223,6 @@ del loro disegno, e un'apertura che spariva senza dire perche'.
   Home, ad alta voce per la console — dove qualcuno sta guardando e un guasto
   va detto.
 
-### Tolto
-
-- **Il campo «come ricontattarti».** Diceva il vero — «resta in casa», e nella
-  pagina pubblica non finiva davvero — ma in casa non lo leggeva nessuno: la
-  console del manutentore legge GitHub, dove quel campo non arriva mai.
-  Chiedere un indirizzo e-mail per poi non farne niente e' la peggiore delle
-  tre strade possibili: si conserva un dato personale, non serve a nessuno, e
-  chi lo scrive crede di essere raggiungibile. La risposta arriva sotto la
-  segnalazione, dove adesso si scrive nei due sensi, e il campanello avvisa
-  quando c'e'.
-
-  I recapiti gia' scritti spariscono dal disco alla prima accensione: toglierlo
-  dal modulo non sarebbe bastato, perche' quello che era gia' stato scritto
-  sarebbe rimasto li' finche' quel ticket non cadeva dal fondo dello store.
-
-### Corretto
-
-- **La risposta della console non partiva piu'.** Da quando il cruscotto e'
-  una pagina della barra invece di una finestra, il campo del testo veniva
-  cercato dentro la finestra — dove non c'e' piu' — e «Rispondi» usciva alla
-  riga dopo senza dire niente. I tasti che chiudevano e basta continuavano a
-  funzionare, il che rendeva il guasto ancora piu' difficile da vedere.
-
-- **«In lavorazione» era una supposizione.** Lo stato si deduceva dal fatto che
-  qualcuno avesse commentato, perche' un segno vero non c'era, e sbagliava nel
-  verso peggiore: bastava una domanda di chiarimento per far risultare presa in
-  carico una segnalazione che nessuno aveva ancora guardato. Adesso il segno lo
-  scrive il tasto, e i commenti tornano a essere commenti.
-
-- **Le segnalazioni aperte dalla plancia adesso hanno la loro etichetta.**
-  Arrivavano nude accanto a quelle dei moduli di GitHub, che l'etichetta se la
-  prendono da sole. Non era una dimenticanza: GitHub le scarta quando a
-  scriverle e' chi sulla repository non ha i permessi — cioe' esattamente chi
-  segnala — e mandarle sarebbe stato scrivere una riga che non arriva. Adesso
-  le mette un workflow della repository, che i permessi ce li ha: legge il
-  prefisso del titolo e applica `bug`, `enhancement` o `question`. Chi
-  un'etichetta ce l'ha gia' non si tocca.
-
-- **Le risposte si vedono aprendo la finestra, senza premere niente.** Aprirla
-  leggeva solo quello che c'era in casa: le risposte scritte su GitHub
-  arrivavano premendo «Aggiorna», o al giro di mezz'ora. Chi apriva le proprie
-  segnalazioni per vedere se c'era una risposta — cioe' l'unico motivo per cui
-  uno le apre — trovava quello che gia' sapeva, e doveva chiudere e riaprire la
-  plancia. Adesso l'apertura se le va a riprendere da sola, al massimo una
-  volta al minuto, senza rotella e senza avvisi se la rete e' giu': chi ha solo
-  aperto una finestra non ha chiesto niente.
-
-- **Quando GitHub rifiuta, adesso si legge perche'.** Un `403` usciva come
-  «permessi o limite orario»: due strade opposte dietro una frase sola — una si
-  risolve con un'installazione, l'altra aspettando — e a chi legge restava il
-  compito di indovinare. Con ogni rifiuto GitHub manda un `message` che quasi
-  sempre e' esatto («Resource not accessible by integration»), e veniva buttato
-  via. Adesso arriva fino alla riga sotto la segnalazione.
-
-- **La tessera compariva per caso, o non compariva.** La Home si disegna mentre
-  la richiesta verso GitHub e' ancora per aria, e a quel punto il sommario e'
-  nullo: la tessera non veniva messa, e restava fuori fino al primo evento che
-  facesse ridisegnare la griglia per un'altra ragione. Adesso l'arrivo della
-  coda e' esso stesso l'evento.
-
-- **E i suoi conti restavano fermi.** La soglia dei dieci minuti era un freno,
-  non un orologio: diceva «non richiedere se hai gia' chiesto da poco», e in una
-  plancia lasciata aperta su un tablet nessuno chiedeva piu' niente. Adesso c'e'
-  un battito che quei dieci minuti li conta — solo per chi ha la console, e
-  fermo mentre la pagina non si vede.
-
-- **«Apri il cruscotto» sembrava non fare niente.** Le due finestre stanno sullo
-  stesso piano e la piu' giovane copre l'altra: il cruscotto si apriva dietro
-  quella della tessera. Adesso la tessera chiude la propria prima che l'altra
-  si apra.
-
-### Il cruscotto
-
 - **Non e' piu' una finestra: e' una pagina, con la sua voce nella barra.** La
   coda del manutentore non e' una cosa che si sbircia — si legge un titolo, si
   apre il filo, si guarda una foto, si scrive una risposta — e tutto questo
@@ -546,8 +277,6 @@ del loro disegno, e un'apertura che spariva senza dire perche'.
 - **Il messaggio di coda vuota dice chi sta tagliando.** Col tipo acceso il
   vuoto e' quasi sempre colpa sua, non dello stato: dirlo evita di guardare una
   coda vuota chiedendosi dove siano finite le altre trentanove.
-
-### Nuovo
 
 - **Le entità del clima si raggruppano per stanza.** «Ho sette termosifoni con
   valvola smart, ognuna con una o più entità VTherm: almeno si raddoppiano,
@@ -637,7 +366,490 @@ del loro disegno, e un'apertura che spariva senza dire perche'.
   posto c'è un tasto **Prova**, che scarica un quadratino vero e dice se è
   arrivato.
 
+- **Il modulo non chiede piu' niente prima di lasciarti scrivere.** Il blocco
+  «Collega GitHub» stava in cima, prima che uno avesse messo giu' una riga. Era
+  una serratura davanti alla vetrina: chi la trovava pensava «vabbe', vado su
+  GitHub», ed e' esattamente il contrario di quello che questa finestra serve a
+  evitare. La segnalazione da fare la si perdeva li'.
+
+  Adesso l'ordine e' l'unico che regge. Tipo, titolo, descrizione, invia — e
+  alla pressione la segnalazione **e' gia' salvata in casa**. Solo a quel
+  punto, se manca la firma, compare il codice, con scritto perche': «Salvata.
+  Manca solo la firma: autorizza GitHub e parte.» L'autorizzazione arriva
+  quando ha un motivo, col lavoro gia' al sicuro. Chi si ferma li' non perde
+  niente: la bozza resta e parte da sola al primo collegamento.
+
+  Chi vuole collegarsi prima di scrivere puo' ancora farlo: la riga sta in
+  fondo a «Le mie», dove si guarda chi si e', non dove si scrive.
+
+- **Il codice si digita una volta sola, e non torna piu'.** Il gettone resta
+  nel deposito di Home Assistant — un utente di HA, un account GitHub — e
+  sopravvive ai riavvii, alle ricariche e agli aggiornamenti. Non scade,
+  perche' l'App e' registrata per non farlo scadere.
+
+- **Il cruscotto guarda tutta la repository.** Mostrava le sole segnalazioni
+  nate dalla plancia, riconosciute da una riga invisibile nel corpo. Su questa
+  repository sono cinquantuno issue, e quelle nate dalla plancia erano zero: il
+  cruscotto era una stanza vuota accanto a una casa piena, e restavano due
+  posti da guardare invece di uno.
+
+  Adesso arrivano tutte, e da dove viene ognuna resta scritto — 🏠 dalla
+  plancia, 🐙 da GitHub. Non cambia cosa ci si puo' fare: si risponde e si
+  chiude identico sulle due. Cambia una cosa sola, ed e' quella che vale la
+  pena sapere prima di scrivere: la risposta a una nata dalla plancia torna
+  **dentro** la dashboard di chi ha segnalato, quella a una issue aperta su
+  GitHub resta dove e' stata scritta.
+
+- **Il filtro «Chiuse», accanto a «Da lavorare».** Due meta' che non perdono
+  niente per strada — una prova lo tiene fermo, perche' quello che sfuggisse a
+  tutti e due sarebbe uno stato sparito senza che nessuno se ne accorga.
+
+- **Il tipo si legge dal titolo e dall'etichetta.** Non e' un campo di GitHub,
+  e si deduce da due posti che qui esistono da prima della plancia: il prefisso
+  che i moduli mettono da soli — `[Bug]`, `[Feature]`, `[Aiuto]` — e
+  l'etichetta messa a mano, `bug` o `enhancement`. Sulle cinquantuno di oggi
+  funzionano tutte e due. Quando nessuno dei due dice niente il tipo resta
+  vuoto, con una pastiglia grigia: chiamarle tutte «difetto» sarebbe comodo e
+  falso. Il prefisso poi sparisce dal titolo, perche' accanto c'e' gia' la
+  pastiglia che lo dice.
+
+- **L'Agenda ha la sua scheda nella configurazione.** «Calendario, per
+  configurarlo devi toglierlo dalla parte widget: crea una sezione a se' nel
+  menu e metti calendario e cose da fare. Nei widget deve esserci solo
+  l'interruttore.» I calendari e le liste ToDo erano finiti nella scheda dei
+  widget, che risponde a una domanda sola — quali tessere vedere in Home e in
+  che ordine — e per configurare l'agenda bisognava passare di li'. Adesso hanno
+  la loro, «📅 Agenda», con i due elenchi uno sotto l'altro; nella scheda dei
+  widget restano gli interruttori delle tessere e basta. (#259)
+- **E la Continuita' pure.** Le caselle dell'UPS erano una coda della scheda
+  «Energia»: «nel config manca completamente la parte per configurare il gruppo
+  di continuita'». Non mancava, ma stava dove nessuno la cercava — e senza una
+  scheda sua non poteva avere il suo interruttore, perche' la fascia verde
+  dell'Energia e' dell'Energia. (#256)
+- **La Gestione termica si configura una macchina alla volta.** «La sezione
+  solare termico non e' suddivisa con le altre cose aggiunte, caldaia e
+  scaldabagno: nel config voglio le sottosezioni per configurare quelle, non
+  creare confusione.» Era una colonna sola — tredici caselle di pannelli
+  solari, poi lo scaldabagno, poi la caldaia — e chi cercava la sua macchina
+  scorreva quelle degli altri. In cima ci sono adesso le stesse linguette che
+  ha la pagina, una per macchina spuntata, e sotto c'e' soltanto quella accesa.
+  (#253)
+
+- **La finestra puo' avere anche l'inferriata.** «La card delle finestre e'
+  fantastica, ma non riesco ad adattarla alla mia situazione perche' non ho le
+  tapparelle. Sarebbe possibile una card che consideri due sensori di contatto,
+  uno per le inferriate esterne e uno per gli infissi interni?» Accanto al
+  sensore dell'infisso c'e' adesso quello dell'inferriata, e la card li disegna
+  tutti e due: la grata sta davanti al vetro e si impacchetta di lato, l'infisso
+  sta dietro e rientra verso i cardini. I quattro stati si distinguono a colpo
+  d'occhio — tutto chiuso, grata aperta, finestra aperta, tutto aperto — e la
+  pastiglia dice quale, perche' «Aperta» da solo non rispondeva alla domanda per
+  cui si sono messi due sensori. Chi non ha inferriate non vede niente di nuovo:
+  la casella vuota lascia la card esattamente com'era. (#254)
+- **E una riga con le sole grate si salva.** Valeva gia' per il solo contatto
+  dell'infisso — «ho le persiane manuali, pero' ho i sensori di apertura» — e
+  vale per lo stesso motivo: la riga non comanda niente, ma ha qualcosa da dire.
+- **In Home i due contatti sono due righe.** Una grata lasciata aperta e una
+  finestra lasciata aperta non sono la stessa notizia, e uscendo di casa e'
+  proprio quella la differenza che si vuole leggere.
+- **Il verso girato vale per entrambi.** Chi ha un contatto che sta a ON da
+  chiuso (#244) lo elenca come sempre: il verso e' un fatto del filo, non del
+  tipo di apertura.
+- **Lo scaldabagno elettrico ha la sua tessera.** «Ho un impianto fotovoltaico
+  ed ho sfruttato uno scaldabagno per l'acqua calda sanitaria. La card attuale
+  e' fantastica ma pensata per il solare termico.» Adesso c'e' la sua: le
+  quattro caselle chieste — interruttore, temperatura dell'acqua, obiettivo,
+  consumo — piu' l'energia di oggi. Il numero grande e' l'acqua, l'anello dice
+  quanto manca all'obiettivo, e la tessera si accende mentre la resistenza
+  lavora. La differenza col solare non e' la forma della card: li' il calore
+  arriva dal sole e si guarda il salto fra le sonde, qui arriva da una
+  resistenza che si paga e si guarda quando ci sara' l'acqua calda. (#253)
+- **E con un `water_heater` di Home Assistant non c'e' niente da compilare.**
+  Basta la prima casella: stato, temperatura e obiettivo li dichiara l'entita'
+  stessa, e «Rileva da Home Assistant» la trova da sola. Le altre restano per
+  chi lo scaldabagno se l'e' messo insieme da un rele' e due sonde.
+- **L'obiettivo si legge anche da un termostato.** «Target preso dall'entita'
+  del termostato»: li' l'obiettivo non e' lo stato — lo stato e' la modalita' —
+  ma un attributo, e la casella lo cerca in tutti e due i posti.
+- **La sezione termica ha tre anime, non una.** Si chiamava «Solare termico» e
+  disegnava un impianto solo: pannello sul tetto, pompa, accumulo. Ma l'acqua
+  calda in casa la fanno tre macchine diverse — il sole, una resistenza, una
+  caldaia a gas — e quasi nessuno ne ha una sola: chi ha il fotovoltaico e lo
+  scaldabagno apriva quella pagina e ci trovava un pannello che non ha. Adesso
+  nella scheda Solare si spunta quello che si ha davvero, e la pagina prende la
+  forma di quello che si e' spuntato. Con due o tre compaiono in alto le
+  linguette, le stesse di Freddo e Caldo nella pagina Clima. (#253)
+- **Due scene nuove, nella stessa lingua della prima.** Lo scaldabagno ha il
+  suo serbatoio in piedi, con l'acqua calda che sale dal fondo — l'altezza del
+  riempimento e' quanto manca all'obiettivo — e le tre spire della resistenza
+  che si accendono quando lavora. La caldaia ha la scocca a muro con la fiamma
+  nell'oblo', la mandata e il ritorno che corrono al radiatore e il salto fra i
+  due, che e' la misura che dice se l'impianto sta davvero cedendo calore.
+- **La pressione bassa si vede prima di accorgersene.** Sotto il bar la
+  targhetta batte e compare la riga che dice perche': e' l'unica cosa di quella
+  pagina che ogni tanto chiede di alzarsi dal divano.
+- **La pagina si chiama come la macchina che si sta guardando.** «Impianto
+  solare termico» sopra una caldaia era il nome di un'altra macchina.
+- **Chi non sceglie non perde niente.** Una plancia gia' configurata col solare
+  continua a mostrarlo esattamente come prima: la domanda e' nuova, e le
+  risposte di ieri valgono ancora.
+- **La sezione si chiama «Gestione termica».** Il nome vecchio era quello di
+  una delle tre macchine: chi ha solo la caldaia trovava la sua dentro una voce
+  che parlava di pannelli solari. Cambia nella barra in basso e nella scheda
+  della configurazione; chi la sezione se l'era rinominata a mano tiene il nome
+  che ha scelto.
+- **Anche la caldaia ha la sua tessera e la sua finestra.** Il numero grande e'
+  la mandata, la didascalia il salto fra mandata e ritorno — che e' la misura
+  per cui si guarda una caldaia — e la pressione sotto il bar accende la
+  tessera e la fa comparire fra quelle che chiedono attenzione. La finestra
+  dice perche': «l'acqua gira senza cedere calore» quando mandata e ritorno
+  sono quasi uguali, «sotto il minimo, la caldaia puo' bloccarsi» quando manca
+  pressione.
+- **Con tutti e tre gli impianti le tessere sono tre**, ognuna con la sua
+  finestra, e tutte e tre portano alla stessa sezione: da li' si passa
+  dall'una all'altra con le linguette.
+- **Senza sonde funziona lo stesso, ed e' una scelta libera.** «Prevedi sia per
+  la caldaia che per lo scaldabagno anche il semplice utilizzo senza sonde di
+  temperatura.» Nessuna casella e' obbligatoria. Con il solo interruttore lo
+  scaldabagno dice acceso e spento, il serbatoio si riempie tutto e parla il
+  colore — caldo mentre la resistenza lavora, acciaio quando e' ferma —
+  invece di mostrarsi vuoto, che sarebbe dire «non c'e' acqua calda». Con il
+  solo stato la caldaia accende il suo oblo' e mostra il circuito che si
+  scalda.
+- **E le targhette senza numero non si disegnano.** Cinque riquadri con «--»
+  non sono una scheda spoglia: sono cinque promesse non mantenute. Le caselle
+  che non ci sono non lasciano un buco, lasciano posto.
+- **La pastiglia nomina quello che sta davvero leggendo.** Chi mappa il
+  bruciatore legge «bruciatore acceso»; chi mappa solo lo stato legge «caldaia
+  accesa», perche' un bruciatore che nessuno ha mappato non si puo' citare.
+
+- **Segnala un difetto, proponi un'idea, chiedi aiuto — dalla Configurazione.**
+  Fino a ieri, per segnalare qualcosa, bisognava uscire da Home Assistant,
+  aprire GitHub, farsi un account se non ce l'aveva, e compilare un modulo che
+  chiede la versione dell'integrazione — che chi segnala non sa, e che la
+  plancia invece conosce benissimo.
+
+  Adesso c'e' una tessera in Configurazione. Il modulo e' in tre passi, e il
+  primo e' la domanda che conta: **di che si tratta**. Tre schede con la loro
+  spiegazione — «Non funziona», «Vorrei che facesse», «Non ci riesco» — perche'
+  la differenza fra un difetto e un'idea la sa chi scrive solo se gliela si
+  racconta, e una segnalazione ben incasellata e' meta' del lavoro di chi la
+  legge. Titolo e descrizione cambiano suggerimento col tipo scelto: a chi
+  chiede aiuto non si domanda «cosa ti aspettavi».
+
+- **La diagnostica la compila la plancia.** Versione dell'integrazione,
+  versione di Home Assistant, lingua, pagina, browser: le cose che lei sa e chi
+  segnala no. Si vedono tutte prima di premere invia, sotto «cosa parte» —
+  quello che esce di casa non e' una cosa da far scoprire dopo.
+
+- **Serve il tuo account GitHub, ed e' quello che hai gia'.** La plancia si
+  scarica da HACS, e HACS un account GitHub lo chiede gia' — con la stessa
+  identica autorizzazione, il codice da digitare su `github.com/login/device`.
+  Chi e' arrivato fin qui quel giro l'ha gia' fatto una volta.
+
+  Il gettone resta nel backend di Home Assistant e non passa mai dal browser.
+  Si scollega dalla plancia, e si revoca del tutto da GitHub.
+
+- **La risposta torna dentro la plancia.** La segnalazione diventa una issue a
+  tuo nome; quando arriva una risposta, lo stato cambia da solo — «presa in
+  carico», «risolta», «archiviata» — e la risposta si legge da «Le mie», senza
+  chiedere niente a nessuno.
+
+- **Foto e video.** GitHub non ha un'API per allegarli a una issue, e non e'
+  una svista: e' una scelta loro, per contenere gli abusi. Quindi la plancia
+  non finge di spedirli — appena la segnalazione e' aperta, un tasto porta alla
+  sua pagina, dove si trascinano nel riquadro della risposta. Il momento e'
+  quello giusto: chi ha appena scritto ha ancora il file sotto mano.
+
+- **Una issue e' una pagina pubblica, e la plancia lo dice** sopra il tasto
+  invia, non dopo. L'unica cosa che non parte mai e' il recapito: chi scrive il
+  proprio indirizzo lo scrive a una persona, non a una pagina indicizzata.
+
+- **La Diagnostica dice quando la plancia e' pronta, e dove va il tempo.** La
+  riga «Boot» mostra quanto ci mette il velo ad andarsene, quando e' arrivato
+  l'ultimo file, e quanto tempo passa DOPO che la rete ha finito. Se il grosso
+  sta prima e' la rete; se sta dopo sono analisi ed esecuzione, dove ne' il
+  pacchetto ne' la compressione arrivano. Serve a smettere di tirare a
+  indovinare su una macchina che non e' la mia.
+
+- **La plancia arriva in un pacchetto, non in centosettantanove file.** «Impiega
+  ancora troppo tempo in caricamento, soprattutto in primo avvio.» Non era il
+  velo: al primo avvio il browser scaricava centosettantanove file JavaScript
+  per quattro megabyte. Non in fila — il documento li precarica tutti insieme —
+  ma su HTTP/1.1 il browser ne serve sei per volta, ed erano una trentina di
+  ondate prima di avere tutto. Adesso sono tre file. Restano fuori i tredici
+  cataloghi delle lingue, quasi due megabyte a una casa che ne parla una sola:
+  arriva solo quella che serve. Se il pacchetto manca, la plancia parte lo
+  stesso dai sorgenti — e la Diagnostica runtime dice quale delle due strade sta
+  usando.
+
+### Cambiato
+
+- **La finestra di una tessera ha smesso di tremolare.** Non era un difetto di
+  disegno ma di composizione: la card e il velo sfocato stavano nello stesso
+  strato, e ogni valore che cambiava dietro obbligava il browser a rifare
+  l'intero riquadro sfocato. Il velo e' passato a uno pseudo-elemento — la card
+  gli e' sorella, non figlia — e le animazioni che restano dietro si mettono in
+  pausa mentre la finestra e' aperta.
+
+- **La stanza si mostra col suo nome, mai col suo identificativo.** «Verifica
+  inoltre perche' esce sotto room etc»: sotto «Tapparella salone» c'era scritto
+  «🏠 room_mt8vpz7m». La tendina salva l'id — e' l'unica cosa che regge un
+  rinominamento — ma gli elenchi del guscio stampano quello che trovano. E c'e'
+  la meta' che non si vedeva: con un id in mano la domanda «di che piano e'
+  questa stanza?» tornava «nessuno», e le tapparelle di una casa a due piani
+  finivano tutte nello stesso gruppo.
+
+- **Nella scheda Finestre la stanza sta in alto, accanto al nome**, con la sua
+  etichetta: stava in fondo, senza dire cosa fosse.
+
+- **Il MiniPC dice OFFLINE solo quando qualcuno gliel'ha detto.** Con tutto
+  configurato e l'internet acceso scriveva OFFLINE: le caselle equivalenti per
+  la connettivita' erano quattro e la card ne leggeva una sola. Adesso **ce n'e'
+  una**, si chiama Internet, accetta un `binary_sensor`, uno stato a parole o i
+  millisecondi di un ping — e quello che stava nelle altre tre e' stato
+  travasato dentro, non buttato. Lo stato sta in alto e la card apre lo storico.
+
+- **La pagina Gestione termica mostra le entita' configurate** (#274): solare,
+  scaldabagno e caldaia in una pagina sola, ognuna col suo blocco e i comandi
+  dove si vedono i valori.
+
+- **Il Cruscotto separa quelle prese in carico da quelle ancora ferme.**
+
+      «voglio un filtro anche con quelle in lavorazione, voglio capire cosa ho
+       preso in carico e quelle ancora da prendere in carico»
+
+  Le tre cifre in cima lo dicevano gia', ma erano numeri da leggere e basta:
+  l'unico filtro aperto era «Da lavorare», che le mette insieme. Adesso ci sono
+  «Nuove» e «In lavorazione», e sono esattamente quelle due cifre — stesso
+  nome, cosi' non si dubita che sia lo stesso numero.
+
+
+- **Una sezione vuota non sta nella barra.** «tutte le sezioni devono nascere
+  come nascoste, solo se si inserisce entita' in una sezione diventa visibile.»
+
+  Meta' della regola c'era gia' e funzionava: alla prima accensione le voci
+  nascono spente, e salvare in una scheda riaccende la sezione in cui si e'
+  appena messo qualcosa. Mancava l'altra meta', perche' quella derivazione
+  corre **una volta sola per chiave**: una sezione svuotata restava nella barra
+  per sempre, con la sua pagina vuota dentro, e una accesa da una versione che
+  accendeva tutto pure.
+
+  Adesso cosa riempie una sezione e' scritto in un posto solo, e lo leggono
+  tutti e due i versi. Lo spegnimento ha tre freni: non tocca una chiave che
+  non sa giudicare (Home, Agenda, Continuita', Cruscotto e le sezioni che si fa
+  l'utente restano dove sono — le ultime quattro si nascondono gia' da sole, e
+  Home e' la pagina dove si atterra); non spegne niente finche' la
+  configurazione condivisa non e' arrivata da Home Assistant, perche' prima che
+  arrivi ogni sezione sembra vuota; e non torna mai su una scelta fatta a mano.
+
+  Nel farlo l'elenco di cosa conta come «configurato» e' diventato piu'
+  completo: la caldaia, le porte dell'antifurto, i programmi della lavatrice, i
+  gruppi dell'energia. Erano sezioni che si potevano riempire senza che nessuno
+  se ne accorgesse, e adesso che il verso dello spegnimento esiste non
+  accorgersene vorrebbe dire farle sparire a chi le aveva configurate.
+
+- **Il Cruscotto non ha piu' l'interruttore.** La fascia verde offre una scelta
+  fra vedere una voce e non vederla. Quella voce compare solo a chi tiene la
+  repository — «solo a me esce il cruscotto nella navbar, ad utenti normali non
+  esce e quindi quel pulsante non ha senso» — e chi la tiene la vuole: era un
+  interruttore che una persona sola al mondo poteva toccare, per spegnersi da
+  sola la pagina che aveva chiesto. Chi la fascia l'aveva gia' toccata tiene la
+  sua preferenza: nessuno si ritrova la voce riaccesa dall'aggiornamento.
+
+- **Un secondo e sei decimi in meno all'avvio.** Profilando la partenza con la
+  CPU rallentata quattro volte — un telefono di fascia media — **una sola
+  funzione si mangiava 789 millisecondi su 6800**, dentro un modulo che scrive
+  tre variabili CSS e non disegna niente.
+
+  Non era il suo codice: erano quindici chiamate a cinquantadue millisecondi
+  l'una. Il giro era, per ogni pagina: guarda dove va l'intestazione, scrivila,
+  rileggi quanto e' larga. Ogni scrittura invalida lo stile, e ogni lettura che
+  le viene dietro obbliga il browser a **ricalcolarlo tutto** prima di
+  rispondere. Nove pagine, nove ricalcoli completi.
+
+  Adesso i quattro tempi si fanno per tutte le pagine prima di passare al
+  successivo — si legge dove vanno tutte, si scrivono tutte, si misurano tutte,
+  si applicano tutte: **due ricalcoli invece di nove**, e la spesa non cresce
+  piu' col numero delle pagine. Misurato sullo stesso banco, tre giri per parte:
+  **da 6693 a 5060 millisecondi**. Il modulo passa da 789 a 53.
+
+- **Il flusso dell'energia tace, quando non c'e' niente da dire.** E' la cosa
+  piu' indaffarata della plancia: gira piu' di una volta al secondo, per tre
+  viste, e riscriveva gli attributi di ogni bolla e di ogni linea **col valore
+  che avevano gia'**. Un `data-` riscritto uguale e' comunque una scrittura:
+  sveglia ogni osservatore della pagina e invalida lo stile del nodo.
+
+  Contate col popup dell'Auto aperto e gli stati fermi: **1777 scritture in
+  quattro secondi**, tutte dietro il velo. Adesso sono 297, e quelle che restano
+  non sono piu' del flusso.
+
+### Rimosso
+
+- **La tessera d'avviso «Porte/Finestre».** «Viene gia' gestito da Finestre, se
+  li si mette il sensore finestra dice quale e' aperto, quindi e' un
+  duplicato»: la didascalia della tessera Finestre **nomina** le aperte, non le
+  conta soltanto. Se ne vanno con lei il suo gruppo negli avvisi, la sua riga
+  nel catalogo delle tessere e il rilevamento automatico che la riempiva.
+
+- **Il campo «come ricontattarti».** Diceva il vero — «resta in casa», e nella
+  pagina pubblica non finiva davvero — ma in casa non lo leggeva nessuno: la
+  console del manutentore legge GitHub, dove quel campo non arriva mai.
+  Chiedere un indirizzo e-mail per poi non farne niente e' la peggiore delle
+  tre strade possibili: si conserva un dato personale, non serve a nessuno, e
+  chi lo scrive crede di essere raggiungibile. La risposta arriva sotto la
+  segnalazione, dove adesso si scrive nei due sensi, e il campanello avvisa
+  quando c'e'.
+
+  I recapiti gia' scritti spariscono dal disco alla prima accensione: toglierlo
+  dal modulo non sarebbe bastato, perche' quello che era gia' stato scritto
+  sarebbe rimasto li' finche' quel ticket non cadeva dal fondo dello store.
+
 ### Corretto
+
+- **La chat aperta si aggiorna da sola.**
+
+      «la risposta non si refresh devo uscire e rientrare»
+
+  La finestra leggeva una volta all'apertura e poi restava ferma: la risposta
+  arrivava solo chiudendo e riaprendo. Il giro dei cinque minuti del backend
+  c'era gia', ma quello serve al campanello — suona e basta, non ridisegna
+  niente.
+
+  Adesso guarda ogni quindici secondi, e ridisegna soltanto quando e' arrivato
+  davvero qualcosa: chi sta scrivendo non si vede rifare la casella sotto le
+  dita, e se ridisegna il cursore torna dov'era. Chiusa la finestra non chiede
+  piu' niente, cosi' una plancia accesa tutto il giorno in cucina non bussa al
+  centralino per una conversazione che nessuno sta guardando.
+
+- **Nella coda di chi risponde le bolle stavano dalla parte sbagliata.**
+
+  Le domande della casa comparivano a destra e in verde — come se se le fosse
+  scritte da solo chi stava leggendo — e le proprie risposte a sinistra e in
+  grigio: una conversazione letta al contrario. «Mio» dipende da chi guarda, e
+  questa finestra la guardano in due.
+
+- **Il cruscotto non lo metteva nessuno.** La funzione che crea la voce nella
+  barra e la sua pagina era scritta, esportata e appesa a
+  `DashboardModernSegnalazioni.sistema` — e da li' la chiamava soltanto lo
+  script che fa le fotografie della galleria. Nelle foto il cruscotto c'era; in
+  una casa vera non compariva ne' nella barra ne' dentro la finestra delle
+  segnalazioni, che intanto la sua scheda «console» l'aveva persa. E' il modo
+  peggiore di sbagliare: la galleria che doveva far vedere il lavoro lo faceva
+  al posto dell'applicazione, e mostrava una cosa che non esisteva.
+
+  Adesso la mette `ricarica()`, appena sa chi sta guardando — prima di chiedere
+  la coda a GitHub, cosi' una rete lenta non la fa comparire in ritardo. E c'e'
+  una prova che pretende una chiamata vera dentro il modulo: toglierla di nuovo
+  costa una prova rossa invece di un giro di fotografie riuscito.
+
+- **La scheda «Segnalazioni» era illeggibile.** L'interruttore che nasconde il
+  cruscotto dalla barra stava dentro la scheda della configurazione, e quel
+  markup e' un `<button style="width:100%">` fatto per stare in cima a un
+  pannello dell'editor — e' cosi' che lo usano prese, robot, UPS e agenda.
+  Dentro una scheda, che e' una riga in orizzontale, quel «100%» diventava una
+  pretesa di tutta la larghezza: il testo accanto si stringeva a **una parola
+  per riga**. Si vedeva solo sul telefono di chi la console ce l'ha davvero,
+  cioe' su un dispositivo solo al mondo.
+
+  L'interruttore adesso sta nella finestra delle segnalazioni, che e' larga e
+  si apre dalla scheda: e' l'unico posto sempre raggiungibile anche quando la
+  voce e' nascosta. Dentro il cruscotto sarebbe stato un interruttore che,
+  spegnendosi, si porta via la strada per riaccenderlo.
+
+- **Il cerchio degli elettrodomestici segnava 0 mentre la sua finestra diceva
+  13,7 kWh.** Sullo stesso schermo, a un tocco di distanza. Il cerchio di
+  gruppo ha una regola: il contatore suo — la pinza sulla linea — vince sulla
+  somma di quello che ha dentro, perche' e' piu' preciso. E ne aveva una
+  seconda: nel Giorno e nel Mese uno zero del contatore vale come misura vera.
+
+  La seconda era stata scritta per non inventare numeri che il contatore del
+  gruppo non conferma, ed e' una preoccupazione giusta — solo che proteggeva
+  dal pericolo sbagliato. Quando il contatore dice zero e dentro ci sono
+  apparecchi che hanno consumato, quello zero non e' una misura: e' una casella
+  che non risponde, e il cerchio si mette a contraddire la propria finestra.
+  Adesso lo zero cede alla somma in tutti e tre i periodi, come gia' faceva nei
+  watt.
+
+  Il caso che la vecchia regola difendeva non aveva bisogno di una regola: il
+  carico che oggi non e' partito ha i figli a zero anche loro, la somma fa
+  zero, e zero resta.
+
+  E il paniere del Recorder adesso risolve anche gli apparecchi **nascosti dal
+  Report**. `show_in_report: false` dice «non voglio vederlo nel Report», e per
+  il Report va benissimo; ma un apparecchio nascosto li' puo' stare lo stesso
+  dentro un cerchio di gruppo, e se il suo unico strumento e' un contatore di
+  vita il periodo glielo puo' dare solo il Recorder. Erano due domande diverse
+  — «cosa disegna il Report» e «da dove leggo i periodi del flusso» — infilate
+  in una risposta sola. Il Report non se ne accorge: quello che si allarga sono
+  i valori, indicizzati per entita', non l'elenco che il Report disegna.
+
+  E il paniere del Recorder risolve anche gli apparecchi, non i soli
+  carichi: i figli di un cerchio di gruppo sono apparecchi, e cercarli in un
+  paniere che contiene solo i carichi voleva dire una somma che non trovava
+  niente.
+
+- **La coda che non arriva adesso lo dice.** Il giro zitto — quello che la Home
+  fa da sola per la tessera — inghiottiva l'errore per non mettere un avviso
+  rosso in faccia a chi non aveva chiesto niente. Giusto, ma «zitto» era
+  diventato «fai finta di niente»: il cruscotto restava una pagina vuota e la
+  tessera in Home non compariva, tutte e due senza una parola sul perche'.
+  Adesso il motivo si scrive comunque, e il cruscotto lo mostra invece di
+  restare bianco.
+
+- **La risposta della console non partiva piu'.** Da quando il cruscotto e'
+  una pagina della barra invece di una finestra, il campo del testo veniva
+  cercato dentro la finestra — dove non c'e' piu' — e «Rispondi» usciva alla
+  riga dopo senza dire niente. I tasti che chiudevano e basta continuavano a
+  funzionare, il che rendeva il guasto ancora piu' difficile da vedere.
+
+- **«In lavorazione» era una supposizione.** Lo stato si deduceva dal fatto che
+  qualcuno avesse commentato, perche' un segno vero non c'era, e sbagliava nel
+  verso peggiore: bastava una domanda di chiarimento per far risultare presa in
+  carico una segnalazione che nessuno aveva ancora guardato. Adesso il segno lo
+  scrive il tasto, e i commenti tornano a essere commenti.
+
+- **Le segnalazioni aperte dalla plancia adesso hanno la loro etichetta.**
+  Arrivavano nude accanto a quelle dei moduli di GitHub, che l'etichetta se la
+  prendono da sole. Non era una dimenticanza: GitHub le scarta quando a
+  scriverle e' chi sulla repository non ha i permessi — cioe' esattamente chi
+  segnala — e mandarle sarebbe stato scrivere una riga che non arriva. Adesso
+  le mette un workflow della repository, che i permessi ce li ha: legge il
+  prefisso del titolo e applica `bug`, `enhancement` o `question`. Chi
+  un'etichetta ce l'ha gia' non si tocca.
+
+- **Le risposte si vedono aprendo la finestra, senza premere niente.** Aprirla
+  leggeva solo quello che c'era in casa: le risposte scritte su GitHub
+  arrivavano premendo «Aggiorna», o al giro di mezz'ora. Chi apriva le proprie
+  segnalazioni per vedere se c'era una risposta — cioe' l'unico motivo per cui
+  uno le apre — trovava quello che gia' sapeva, e doveva chiudere e riaprire la
+  plancia. Adesso l'apertura se le va a riprendere da sola, al massimo una
+  volta al minuto, senza rotella e senza avvisi se la rete e' giu': chi ha solo
+  aperto una finestra non ha chiesto niente.
+
+- **Quando GitHub rifiuta, adesso si legge perche'.** Un `403` usciva come
+  «permessi o limite orario»: due strade opposte dietro una frase sola — una si
+  risolve con un'installazione, l'altra aspettando — e a chi legge restava il
+  compito di indovinare. Con ogni rifiuto GitHub manda un `message` che quasi
+  sempre e' esatto («Resource not accessible by integration»), e veniva buttato
+  via. Adesso arriva fino alla riga sotto la segnalazione.
+
+- **La tessera compariva per caso, o non compariva.** La Home si disegna mentre
+  la richiesta verso GitHub e' ancora per aria, e a quel punto il sommario e'
+  nullo: la tessera non veniva messa, e restava fuori fino al primo evento che
+  facesse ridisegnare la griglia per un'altra ragione. Adesso l'arrivo della
+  coda e' esso stesso l'evento.
+
+- **E i suoi conti restavano fermi.** La soglia dei dieci minuti era un freno,
+  non un orologio: diceva «non richiedere se hai gia' chiesto da poco», e in una
+  plancia lasciata aperta su un tablet nessuno chiedeva piu' niente. Adesso c'e'
+  un battito che quei dieci minuti li conta — solo per chi ha la console, e
+  fermo mentre la pagina non si vede.
+
+- **«Apri il cruscotto» sembrava non fare niente.** Le due finestre stanno sullo
+  stesso piano e la piu' giovane copre l'altra: il cruscotto si apriva dietro
+  quella della tessera. Adesso la tessera chiude la propria prima che l'altra
+  si apra.
 
 - **Le finestre Giornaliera e Mensile mostrano il periodo, non l'istante.** «I
   popup giornaliera e mensile non riportano i dati corretti: portano quelli
@@ -731,16 +943,6 @@ del loro disegno, e un'apertura che spariva senza dire perche'.
   «Elettrodom.» sta per «Elettrodomestici»; in testa alla sezione il nome resta
   per esteso.
 
-## 1.4.5-beta.9
-
-Il cruscotto della beta.8 si apriva e diceva «Risposta illeggibile», con tre
-zeri e nessuna segnalazione. Non era GitHub: era la plancia che leggeva male.
-
-E l'Agenda diceva «—» sopra una riga che diceva «Domani 12:00»: negava a
-caratteri grandi quello che affermava a caratteri piccoli.
-
-### Corretto
-
 - **Un appuntamento per domani non e' un trattino.** «Ho creato un appuntamento
   per domani ma sia nel widget che nel popup esce un —.» Il numero grande
   dell'Agenda contava soltanto oggi, e a oggi vuoto si arrendeva: un trattino —
@@ -787,96 +989,6 @@ caratteri grandi quello che affermava a caratteri piccoli.
   domani finiva contato fra quelli piu' in la'. Cioe' proprio il trattino da
   cui questa tessera era partita, che sarebbe ricomparso due volte l'anno.
   Adesso i giorni si contano come li conta il calendario.
-
-### Sulle prove
-
-- Due prove nuove percorrono la lettura per davvero, con un corpo che arriva a
-  pezzi come arriva sul filo. Nessuna prova poteva prendere questo guasto
-  prima: tutte sostituiscono la chiamata di rete in blocco — che e' giusto,
-  provano cosa il modulo chiede e cosa ne fa — e cosi' la lettura non veniva
-  mai percorsa. Falliscono tutte e due sul codice di prima.
-
-## 1.4.5-beta.8
-
-Le segnalazioni sono arrivate nella beta.7. Questa e' la versione che le mette
-alla prova su quello che c'e' davvero: cinquantuno issue gia' aperte, e un
-modulo che chiedeva un'autorizzazione prima ancora di sapere cosa uno voleva
-scrivere.
-
-### Le segnalazioni, seconda mano
-
-- **Il modulo non chiede piu' niente prima di lasciarti scrivere.** Il blocco
-  «Collega GitHub» stava in cima, prima che uno avesse messo giu' una riga. Era
-  una serratura davanti alla vetrina: chi la trovava pensava «vabbe', vado su
-  GitHub», ed e' esattamente il contrario di quello che questa finestra serve a
-  evitare. La segnalazione da fare la si perdeva li'.
-
-  Adesso l'ordine e' l'unico che regge. Tipo, titolo, descrizione, invia — e
-  alla pressione la segnalazione **e' gia' salvata in casa**. Solo a quel
-  punto, se manca la firma, compare il codice, con scritto perche': «Salvata.
-  Manca solo la firma: autorizza GitHub e parte.» L'autorizzazione arriva
-  quando ha un motivo, col lavoro gia' al sicuro. Chi si ferma li' non perde
-  niente: la bozza resta e parte da sola al primo collegamento.
-
-  Chi vuole collegarsi prima di scrivere puo' ancora farlo: la riga sta in
-  fondo a «Le mie», dove si guarda chi si e', non dove si scrive.
-
-- **Il codice si digita una volta sola, e non torna piu'.** Il gettone resta
-  nel deposito di Home Assistant — un utente di HA, un account GitHub — e
-  sopravvive ai riavvii, alle ricariche e agli aggiornamenti. Non scade,
-  perche' l'App e' registrata per non farlo scadere.
-
-- **Il cruscotto guarda tutta la repository.** Mostrava le sole segnalazioni
-  nate dalla plancia, riconosciute da una riga invisibile nel corpo. Su questa
-  repository sono cinquantuno issue, e quelle nate dalla plancia erano zero: il
-  cruscotto era una stanza vuota accanto a una casa piena, e restavano due
-  posti da guardare invece di uno.
-
-  Adesso arrivano tutte, e da dove viene ognuna resta scritto — 🏠 dalla
-  plancia, 🐙 da GitHub. Non cambia cosa ci si puo' fare: si risponde e si
-  chiude identico sulle due. Cambia una cosa sola, ed e' quella che vale la
-  pena sapere prima di scrivere: la risposta a una nata dalla plancia torna
-  **dentro** la dashboard di chi ha segnalato, quella a una issue aperta su
-  GitHub resta dove e' stata scritta.
-
-- **Il filtro «Chiuse», accanto a «Da lavorare».** Due meta' che non perdono
-  niente per strada — una prova lo tiene fermo, perche' quello che sfuggisse a
-  tutti e due sarebbe uno stato sparito senza che nessuno se ne accorga.
-
-- **Il tipo si legge dal titolo e dall'etichetta.** Non e' un campo di GitHub,
-  e si deduce da due posti che qui esistono da prima della plancia: il prefisso
-  che i moduli mettono da soli — `[Bug]`, `[Feature]`, `[Aiuto]` — e
-  l'etichetta messa a mano, `bug` o `enhancement`. Sulle cinquantuno di oggi
-  funzionano tutte e due. Quando nessuno dei due dice niente il tipo resta
-  vuoto, con una pastiglia grigia: chiamarle tutte «difetto» sarebbe comodo e
-  falso. Il prefisso poi sparisce dal titolo, perche' accanto c'e' gia' la
-  pastiglia che lo dice.
-
-### Le schede della configurazione
-
-- **L'Agenda ha la sua scheda nella configurazione.** «Calendario, per
-  configurarlo devi toglierlo dalla parte widget: crea una sezione a se' nel
-  menu e metti calendario e cose da fare. Nei widget deve esserci solo
-  l'interruttore.» I calendari e le liste ToDo erano finiti nella scheda dei
-  widget, che risponde a una domanda sola — quali tessere vedere in Home e in
-  che ordine — e per configurare l'agenda bisognava passare di li'. Adesso hanno
-  la loro, «📅 Agenda», con i due elenchi uno sotto l'altro; nella scheda dei
-  widget restano gli interruttori delle tessere e basta. (#259)
-- **E la Continuita' pure.** Le caselle dell'UPS erano una coda della scheda
-  «Energia»: «nel config manca completamente la parte per configurare il gruppo
-  di continuita'». Non mancava, ma stava dove nessuno la cercava — e senza una
-  scheda sua non poteva avere il suo interruttore, perche' la fascia verde
-  dell'Energia e' dell'Energia. (#256)
-- **La Gestione termica si configura una macchina alla volta.** «La sezione
-  solare termico non e' suddivisa con le altre cose aggiunte, caldaia e
-  scaldabagno: nel config voglio le sottosezioni per configurare quelle, non
-  creare confusione.» Era una colonna sola — tredici caselle di pannelli
-  solari, poi lo scaldabagno, poi la caldaia — e chi cercava la sua macchina
-  scorreva quelle degli altri. In cima ci sono adesso le stesse linguette che
-  ha la pagina, una per macchina spuntata, e sotto c'e' soltanto quella accesa.
-  (#253)
-
-### Corretto
 
 - **Le sezioni che non si potevano nascondere.** «Verifica tutta la repository e
   vedi dove nella sezione c'e' il tasto "visibile e nascondi": lo deve
@@ -940,189 +1052,6 @@ scrivere.
 - **La pastiglia del tipo si fa leggere.** Era `aria-hidden`: chi non distingue
   i colori non aveva modo di sapere se una riga fosse un difetto o un'idea.
 
-### Sulle prove
-
-- Le anteprime delle segnalazioni entrano in galleria per davvero. I bersagli
-  c'erano gia' nello script, ma gli scatti non erano mai stati committati: chi
-  apriva `docs/preview` trovava tutte le sezioni tranne queste. Trentasei file,
-  nove schermate per due temi e due formati.
-- Una prova prende il ripiego dell'immagine dal markup e lo esegue davvero su
-  un'immagine che si stacca: sul codice di prima fallisce.
-- 1865 prove frontend, 197 pytest.
-
-## 1.4.5-beta.7
-
-«Come velocita' non e' migliorato nulla, siamo sempre uguali.» Aveva ragione, e
-questa volta il tempo si e' andato a cercare col profilatore invece che a
-indovinarlo. Non stava dove si era guardato per sei versioni.
-
-E arriva anche il modo di dirlo senza uscire dalla plancia.
-
-### Nuovo
-
-- **La finestra puo' avere anche l'inferriata.** «La card delle finestre e'
-  fantastica, ma non riesco ad adattarla alla mia situazione perche' non ho le
-  tapparelle. Sarebbe possibile una card che consideri due sensori di contatto,
-  uno per le inferriate esterne e uno per gli infissi interni?» Accanto al
-  sensore dell'infisso c'e' adesso quello dell'inferriata, e la card li disegna
-  tutti e due: la grata sta davanti al vetro e si impacchetta di lato, l'infisso
-  sta dietro e rientra verso i cardini. I quattro stati si distinguono a colpo
-  d'occhio — tutto chiuso, grata aperta, finestra aperta, tutto aperto — e la
-  pastiglia dice quale, perche' «Aperta» da solo non rispondeva alla domanda per
-  cui si sono messi due sensori. Chi non ha inferriate non vede niente di nuovo:
-  la casella vuota lascia la card esattamente com'era. (#254)
-- **E una riga con le sole grate si salva.** Valeva gia' per il solo contatto
-  dell'infisso — «ho le persiane manuali, pero' ho i sensori di apertura» — e
-  vale per lo stesso motivo: la riga non comanda niente, ma ha qualcosa da dire.
-- **In Home i due contatti sono due righe.** Una grata lasciata aperta e una
-  finestra lasciata aperta non sono la stessa notizia, e uscendo di casa e'
-  proprio quella la differenza che si vuole leggere.
-- **Il verso girato vale per entrambi.** Chi ha un contatto che sta a ON da
-  chiuso (#244) lo elenca come sempre: il verso e' un fatto del filo, non del
-  tipo di apertura.
-- **Lo scaldabagno elettrico ha la sua tessera.** «Ho un impianto fotovoltaico
-  ed ho sfruttato uno scaldabagno per l'acqua calda sanitaria. La card attuale
-  e' fantastica ma pensata per il solare termico.» Adesso c'e' la sua: le
-  quattro caselle chieste — interruttore, temperatura dell'acqua, obiettivo,
-  consumo — piu' l'energia di oggi. Il numero grande e' l'acqua, l'anello dice
-  quanto manca all'obiettivo, e la tessera si accende mentre la resistenza
-  lavora. La differenza col solare non e' la forma della card: li' il calore
-  arriva dal sole e si guarda il salto fra le sonde, qui arriva da una
-  resistenza che si paga e si guarda quando ci sara' l'acqua calda. (#253)
-- **E con un `water_heater` di Home Assistant non c'e' niente da compilare.**
-  Basta la prima casella: stato, temperatura e obiettivo li dichiara l'entita'
-  stessa, e «Rileva da Home Assistant» la trova da sola. Le altre restano per
-  chi lo scaldabagno se l'e' messo insieme da un rele' e due sonde.
-- **L'obiettivo si legge anche da un termostato.** «Target preso dall'entita'
-  del termostato»: li' l'obiettivo non e' lo stato — lo stato e' la modalita' —
-  ma un attributo, e la casella lo cerca in tutti e due i posti.
-- **La sezione termica ha tre anime, non una.** Si chiamava «Solare termico» e
-  disegnava un impianto solo: pannello sul tetto, pompa, accumulo. Ma l'acqua
-  calda in casa la fanno tre macchine diverse — il sole, una resistenza, una
-  caldaia a gas — e quasi nessuno ne ha una sola: chi ha il fotovoltaico e lo
-  scaldabagno apriva quella pagina e ci trovava un pannello che non ha. Adesso
-  nella scheda Solare si spunta quello che si ha davvero, e la pagina prende la
-  forma di quello che si e' spuntato. Con due o tre compaiono in alto le
-  linguette, le stesse di Freddo e Caldo nella pagina Clima. (#253)
-- **Due scene nuove, nella stessa lingua della prima.** Lo scaldabagno ha il
-  suo serbatoio in piedi, con l'acqua calda che sale dal fondo — l'altezza del
-  riempimento e' quanto manca all'obiettivo — e le tre spire della resistenza
-  che si accendono quando lavora. La caldaia ha la scocca a muro con la fiamma
-  nell'oblo', la mandata e il ritorno che corrono al radiatore e il salto fra i
-  due, che e' la misura che dice se l'impianto sta davvero cedendo calore.
-- **La pressione bassa si vede prima di accorgersene.** Sotto il bar la
-  targhetta batte e compare la riga che dice perche': e' l'unica cosa di quella
-  pagina che ogni tanto chiede di alzarsi dal divano.
-- **La pagina si chiama come la macchina che si sta guardando.** «Impianto
-  solare termico» sopra una caldaia era il nome di un'altra macchina.
-- **Chi non sceglie non perde niente.** Una plancia gia' configurata col solare
-  continua a mostrarlo esattamente come prima: la domanda e' nuova, e le
-  risposte di ieri valgono ancora.
-- **La sezione si chiama «Gestione termica».** Il nome vecchio era quello di
-  una delle tre macchine: chi ha solo la caldaia trovava la sua dentro una voce
-  che parlava di pannelli solari. Cambia nella barra in basso e nella scheda
-  della configurazione; chi la sezione se l'era rinominata a mano tiene il nome
-  che ha scelto.
-- **Anche la caldaia ha la sua tessera e la sua finestra.** Il numero grande e'
-  la mandata, la didascalia il salto fra mandata e ritorno — che e' la misura
-  per cui si guarda una caldaia — e la pressione sotto il bar accende la
-  tessera e la fa comparire fra quelle che chiedono attenzione. La finestra
-  dice perche': «l'acqua gira senza cedere calore» quando mandata e ritorno
-  sono quasi uguali, «sotto il minimo, la caldaia puo' bloccarsi» quando manca
-  pressione.
-- **Con tutti e tre gli impianti le tessere sono tre**, ognuna con la sua
-  finestra, e tutte e tre portano alla stessa sezione: da li' si passa
-  dall'una all'altra con le linguette.
-- **Senza sonde funziona lo stesso, ed e' una scelta libera.** «Prevedi sia per
-  la caldaia che per lo scaldabagno anche il semplice utilizzo senza sonde di
-  temperatura.» Nessuna casella e' obbligatoria. Con il solo interruttore lo
-  scaldabagno dice acceso e spento, il serbatoio si riempie tutto e parla il
-  colore — caldo mentre la resistenza lavora, acciaio quando e' ferma —
-  invece di mostrarsi vuoto, che sarebbe dire «non c'e' acqua calda». Con il
-  solo stato la caldaia accende il suo oblo' e mostra il circuito che si
-  scalda.
-- **E le targhette senza numero non si disegnano.** Cinque riquadri con «--»
-  non sono una scheda spoglia: sono cinque promesse non mantenute. Le caselle
-  che non ci sono non lasciano un buco, lasciano posto.
-- **La pastiglia nomina quello che sta davvero leggendo.** Chi mappa il
-  bruciatore legge «bruciatore acceso»; chi mappa solo lo stato legge «caldaia
-  accesa», perche' un bruciatore che nessuno ha mappato non si puo' citare.
-
-### Nuovo: le segnalazioni
-
-- **Segnala un difetto, proponi un'idea, chiedi aiuto — dalla Configurazione.**
-  Fino a ieri, per segnalare qualcosa, bisognava uscire da Home Assistant,
-  aprire GitHub, farsi un account se non ce l'aveva, e compilare un modulo che
-  chiede la versione dell'integrazione — che chi segnala non sa, e che la
-  plancia invece conosce benissimo.
-
-  Adesso c'e' una tessera in Configurazione. Il modulo e' in tre passi, e il
-  primo e' la domanda che conta: **di che si tratta**. Tre schede con la loro
-  spiegazione — «Non funziona», «Vorrei che facesse», «Non ci riesco» — perche'
-  la differenza fra un difetto e un'idea la sa chi scrive solo se gliela si
-  racconta, e una segnalazione ben incasellata e' meta' del lavoro di chi la
-  legge. Titolo e descrizione cambiano suggerimento col tipo scelto: a chi
-  chiede aiuto non si domanda «cosa ti aspettavi».
-
-- **La diagnostica la compila la plancia.** Versione dell'integrazione,
-  versione di Home Assistant, lingua, pagina, browser: le cose che lei sa e chi
-  segnala no. Si vedono tutte prima di premere invia, sotto «cosa parte» —
-  quello che esce di casa non e' una cosa da far scoprire dopo.
-
-- **Serve il tuo account GitHub, ed e' quello che hai gia'.** La plancia si
-  scarica da HACS, e HACS un account GitHub lo chiede gia' — con la stessa
-  identica autorizzazione, il codice da digitare su `github.com/login/device`.
-  Chi e' arrivato fin qui quel giro l'ha gia' fatto una volta.
-
-  Il gettone resta nel backend di Home Assistant e non passa mai dal browser.
-  Si scollega dalla plancia, e si revoca del tutto da GitHub.
-
-- **La risposta torna dentro la plancia.** La segnalazione diventa una issue a
-  tuo nome; quando arriva una risposta, lo stato cambia da solo — «presa in
-  carico», «risolta», «archiviata» — e la risposta si legge da «Le mie», senza
-  chiedere niente a nessuno.
-
-- **Foto e video.** GitHub non ha un'API per allegarli a una issue, e non e'
-  una svista: e' una scelta loro, per contenere gli abusi. Quindi la plancia
-  non finge di spedirli — appena la segnalazione e' aperta, un tasto porta alla
-  sua pagina, dove si trascinano nel riquadro della risposta. Il momento e'
-  quello giusto: chi ha appena scritto ha ancora il file sotto mano.
-
-- **Una issue e' una pagina pubblica, e la plancia lo dice** sopra il tasto
-  invia, non dopo. L'unica cosa che non parte mai e' il recapito: chi scrive il
-  proprio indirizzo lo scrive a una persona, non a una pagina indicizzata.
-
-### Piu' veloce
-
-- **Un secondo e sei decimi in meno all'avvio.** Profilando la partenza con la
-  CPU rallentata quattro volte — un telefono di fascia media — **una sola
-  funzione si mangiava 789 millisecondi su 6800**, dentro un modulo che scrive
-  tre variabili CSS e non disegna niente.
-
-  Non era il suo codice: erano quindici chiamate a cinquantadue millisecondi
-  l'una. Il giro era, per ogni pagina: guarda dove va l'intestazione, scrivila,
-  rileggi quanto e' larga. Ogni scrittura invalida lo stile, e ogni lettura che
-  le viene dietro obbliga il browser a **ricalcolarlo tutto** prima di
-  rispondere. Nove pagine, nove ricalcoli completi.
-
-  Adesso i quattro tempi si fanno per tutte le pagine prima di passare al
-  successivo — si legge dove vanno tutte, si scrivono tutte, si misurano tutte,
-  si applicano tutte: **due ricalcoli invece di nove**, e la spesa non cresce
-  piu' col numero delle pagine. Misurato sullo stesso banco, tre giri per parte:
-  **da 6693 a 5060 millisecondi**. Il modulo passa da 789 a 53.
-
-- **Il flusso dell'energia tace, quando non c'e' niente da dire.** E' la cosa
-  piu' indaffarata della plancia: gira piu' di una volta al secondo, per tre
-  viste, e riscriveva gli attributi di ogni bolla e di ogni linea **col valore
-  che avevano gia'**. Un `data-` riscritto uguale e' comunque una scrittura:
-  sveglia ogni osservatore della pagina e invalida lo stile del nodo.
-
-  Contate col popup dell'Auto aperto e gli stati fermi: **1777 scritture in
-  quattro secondi**, tutte dietro il velo. Adesso sono 297, e quelle che restano
-  non sono piu' del flusso.
-
-### Corretto
-
 - **La scala del clima la dichiara il termostato, non la plancia.** «Ho una
   pompa di calore Samsung, il sensore mi gestisce la temperatura di uscita
   dell'acqua dai 40 gradi fino a 70 massimo. Quando vado a inserire nel menu
@@ -1185,31 +1114,6 @@ E arriva anche il modo di dirlo senza uscire dalla plancia.
   mai stato suo, e adesso vale per tutte e undici. Nessuna di loro ha figli
   fissi che un livello nuovo strapperebbe alla finestra del browser: verificato
   aprendole una per una.
-### Sulle prove
-
-Le segnalazioni portano **cinquantasei prove nuove** fra backend e finestra.
-Due meritano di essere raccontate, perche' sorvegliano cose che si vedrebbero
-tardi e male: che ognuno dei comandi che la finestra manda sia fra quelli che
-il ponte lascia passare — un tipo dimenticato la' e' un refuso che si scopre
-solo in un browser vero — e che la diagnostica sia una **lista chiusa**, con un
-controllo che nessuna delle sue chiavi somigli a un dato di casa. Quella lista
-va riletta ogni volta che qualcuno la allarga, ed e' l'unica cosa che decide
-cosa esce di casa.
-
-La prova che sorvegliava la bolla della batteria **cadeva due volte su otto gia'
-prima di questa versione**, e restava verde solo perche' i controlli hanno due
-tentativi di riserva. Non stava aspettando un ritardo: aspettava una passata che
-non sarebbe mai arrivata. Chiusa la corsa, passa sedici volte su sedici, e una
-prova nuova la sorveglia in modo secco — senza la correzione cade quattro volte
-su quattro.
-
-## 1.4.5-beta.6
-
-«Guarda, cambia intestazione, quindi c'e' qualcosa di duplicato» — due
-schermate dello stesso minuto, la stessa finestra, due intestazioni diverse. Era
-vero, e sotto c'era di peggio.
-
-### Corretto
 
 - **Due sezioni si riavvolgevano a vicenda, all'infinito.** La finestra dei
   carichi e la stabilita' Beta 27 avvolgono tutt'e due `apriSubLoads`, e nessuna
@@ -1231,38 +1135,6 @@ vero, e sotto c'era di peggio.
   non compressi · servito br»: una deduzione dai pesi e una risposta del server,
   opposte, in fila. Quando c'e' la risposta letta, la deduzione si toglie.
 
-### Provato ma non verificabile da qui
-
-- **Il foglio della finestra su un livello suo.** Dentro la finestra, a riposo,
-  le scritture sono zero; dietro sono undici in quattro secondi — l'orologio, il
-  puntino della connessione, il flusso. E il velo del modale ha una sfocatura
-  che rilegge lo sfondo: ogni scrittura dietro e' una sfocatura da rifare, e le
-  due cose stanno nello stesso livello. Promuovendo il foglio a livello suo, il
-  suo contenuto non viene ridipinto insieme allo sfondo. E' un fatto del
-  telefono, e in prova il disegno lo fa la CPU: qui non si riproduce.
-
-### Sulla velocita', per essere chiari
-
-I numeri della Diagnostica dicono dove sta il tempo, e non e' dove si e'
-guardato finora: **ultimo file a 2,9 s, velo via a 3,2 s** — cioe' 2,9 secondi
-prima che l'ultimo file sia pronto e 0,4 dopo. E il Transfer dice «dalla
-cache»: i file non li sta scaricando, li sta **leggendo e interpretando**. Sono
-4,9 MB di codice, di cui 2 in un pezzo solo.
-
-E' per questo che ne' meno richieste (beta.1) ne' meno byte sul filo (beta.2)
-hanno spostato niente, e non lo sposta nemmeno questa: il tempo se ne va a
-interpretare ed eseguire, e l'unica cosa che lo tocca e' **eseguire meno roba
-all'avvio** — montare per prime le sezioni della pagina che si vede e lasciare
-indietro le altre. E' un lavoro grosso e a se', non un ritocco.
-
-## 1.4.5-beta.5
-
-Il lampo del popup, di nuovo — e stavolta con la causa giusta. Nella beta.4 gli
-stati erano corretti e le carte restavano al loro posto, ma il lampo bianco
-c'era ancora: sei volte in nove secondi.
-
-### Corretto
-
 - **Il popup non riscrive piu' quello che non e' cambiato.** I due fotogrammi ai
   lati del lampo erano identici: fra prima e dopo non cambiava un pixel. Non
   stava cambiando niente, e il livello si ridipingeva lo stesso — perche' la
@@ -1275,13 +1147,6 @@ c'era ancora: sei volte in nove secondi.
   fotogramma resta bianco. Adesso si confronta prima di scrivere, e in
   classifica si sposta solo la carta che non e' al suo posto: **a stati fermi le
   scritture sono zero.**
-
-## 1.4.5-beta.4
-
-Un filmato di ventotto secondi, guardato fotogramma per fotogramma. Dentro
-c'erano tre cose, e nessuna delle tre era quella che si cercava da tre beta.
-
-### Corretto
 
 - **La plancia non si ricarica piu' da sola.** A quattro secondi dall'apertura
   lo schermo diventa bianco, il velo di avvio torna su, e la plancia riparte
@@ -1338,26 +1203,6 @@ c'erano tre cose, e nessuna delle tre era quella che si cercava da tre beta.
   `off_delay_minutes` scade nessuno manda niente — e' il tempo che passa — e una
   finestra lasciata aperta sarebbe rimasta a dire IN FUNZIONE.
 
-### Da sapere
-
-- Le tre chiavi che le legge solo l'avvio — il marchio, i nomi delle luci, le
-  unita' clima — quando cambiano da un altro dispositivo fanno ancora ricaricare
-  la pagina: scriverle in memoria e lasciare lo schermo a dire la cosa di prima
-  sarebbe peggio. Sono i pochi casi rimasti, e la differenza con prima e' che
-  adesso il ricaricamento e' l'eccezione invece della regola.
-- Un apparecchio il cui unico segnale e' un binary_sensor generico acceso, a
-  zero watt, adesso dice STANDBY invece di IN FUNZIONE — la stessa parola che
-  dice gia' la sua carta. Per i cicli che passano da zero watt c'e'
-  `off_delay_minutes`, che adesso vale in tutt'e due i posti.
-
-## 1.4.5-beta.3
-
-La compressione della beta.2 funziona — confermato dal campo: `content-encoding:
-br`, 366 kB al posto di 2007. Ed e' ancora lento. Quindi ne' le richieste ne' i
-byte erano la causa, e questa versione non prova a indovinare la terza: misura.
-
-### Corretto
-
 - **La riga «Transfer» non dichiara piu' cose che non ha misurato.** Diceva «non
   compressi» di una plancia che arrivava compressa: il peso del corpo com'e'
   arrivato non e' sempre disponibile, e quel vuoto finiva nel ramo sbagliato. E'
@@ -1366,23 +1211,6 @@ byte erano la causa, e questa versione non prova a indovinare la terza: misura.
   soprattutto va a CHIEDERE al server come e' arrivato davvero il file, invece
   di dedurlo: la riga si completa da sola con «servito br» o «servito in
   chiaro».
-
-### Nuovo
-
-- **La Diagnostica dice quando la plancia e' pronta, e dove va il tempo.** La
-  riga «Boot» mostra quanto ci mette il velo ad andarsene, quando e' arrivato
-  l'ultimo file, e quanto tempo passa DOPO che la rete ha finito. Se il grosso
-  sta prima e' la rete; se sta dopo sono analisi ed esecuzione, dove ne' il
-  pacchetto ne' la compressione arrivano. Serve a smettere di tirare a
-  indovinare su una macchina che non e' la mia.
-
-## 1.4.5-beta.2
-
-La beta di prima aveva ridotto le richieste da centosettantanove a tre, e dal
-campo e' tornato «nulla e' cambiato». Era vero: le richieste non erano il
-problema.
-
-### Corretto
 
 - **La plancia arriva compressa: 4,9 MB diventano 1,2.** La Diagnostica diceva
   «impacchettati (3 file)», quindi il pacchetto funzionava — ma i byte erano
@@ -1409,31 +1237,73 @@ chiede davvero all'avvio, non i centosettantanove sorgenti sciolti che servono
 al solo ripiego. Si scarica una volta per aggiornamento, e si risparmia a ogni
 apertura.
 
-## 1.4.5-beta.1
-
-Una beta per provare l'avvio impacchettato prima di darlo a tutti. Chi non
-chiede le versioni beta non la riceve.
-
-### Nuovo
-
-- **La plancia arriva in un pacchetto, non in centosettantanove file.** «Impiega
-  ancora troppo tempo in caricamento, soprattutto in primo avvio.» Non era il
-  velo: al primo avvio il browser scaricava centosettantanove file JavaScript
-  per quattro megabyte. Non in fila — il documento li precarica tutti insieme —
-  ma su HTTP/1.1 il browser ne serve sei per volta, ed erano una trentina di
-  ondate prima di avere tutto. Adesso sono tre file. Restano fuori i tredici
-  cataloghi delle lingue, quasi due megabyte a una casa che ne parla una sola:
-  arriva solo quella che serve. Se il pacchetto manca, la plancia parte lo
-  stesso dai sorgenti — e la Diagnostica runtime dice quale delle due strade sta
-  usando.
-
-### Corretto
-
 - **Le caselle del popup Lavatrice si scelgono dalla riga.** Nella finestra
   «Modifica azione» ogni casella portava due tasti azzurri con la lente,
   appaiati, e nessuno dei due era il modo giusto: in tutta la plancia
   un'entita' si sceglie dalla riga stessa. Quella passata pero' girava solo
   dentro le fisarmoniche delle Sezioni, e questa carta sta altrove.
+
+### Da sapere
+
+- Due prove nuove percorrono la lettura per davvero, con un corpo che arriva a
+  pezzi come arriva sul filo. Nessuna prova poteva prendere questo guasto
+  prima: tutte sostituiscono la chiamata di rete in blocco — che e' giusto,
+  provano cosa il modulo chiede e cosa ne fa — e cosi' la lettura non veniva
+  mai percorsa. Falliscono tutte e due sul codice di prima.
+
+- Le anteprime delle segnalazioni entrano in galleria per davvero. I bersagli
+  c'erano gia' nello script, ma gli scatti non erano mai stati committati: chi
+  apriva `docs/preview` trovava tutte le sezioni tranne queste. Trentasei file,
+  nove schermate per due temi e due formati.
+- Una prova prende il ripiego dell'immagine dal markup e lo esegue davvero su
+  un'immagine che si stacca: sul codice di prima fallisce.
+- 1865 prove frontend, 197 pytest.
+
+Le segnalazioni portano **cinquantasei prove nuove** fra backend e finestra.
+Due meritano di essere raccontate, perche' sorvegliano cose che si vedrebbero
+tardi e male: che ognuno dei comandi che la finestra manda sia fra quelli che
+il ponte lascia passare — un tipo dimenticato la' e' un refuso che si scopre
+solo in un browser vero — e che la diagnostica sia una **lista chiusa**, con un
+controllo che nessuna delle sue chiavi somigli a un dato di casa. Quella lista
+va riletta ogni volta che qualcuno la allarga, ed e' l'unica cosa che decide
+cosa esce di casa.
+
+La prova che sorvegliava la bolla della batteria **cadeva due volte su otto gia'
+prima di questa versione**, e restava verde solo perche' i controlli hanno due
+tentativi di riserva. Non stava aspettando un ritardo: aspettava una passata che
+non sarebbe mai arrivata. Chiusa la corsa, passa sedici volte su sedici, e una
+prova nuova la sorveglia in modo secco — senza la correzione cade quattro volte
+su quattro.
+
+- **Il foglio della finestra su un livello suo.** Dentro la finestra, a riposo,
+  le scritture sono zero; dietro sono undici in quattro secondi — l'orologio, il
+  puntino della connessione, il flusso. E il velo del modale ha una sfocatura
+  che rilegge lo sfondo: ogni scrittura dietro e' una sfocatura da rifare, e le
+  due cose stanno nello stesso livello. Promuovendo il foglio a livello suo, il
+  suo contenuto non viene ridipinto insieme allo sfondo. E' un fatto del
+  telefono, e in prova il disegno lo fa la CPU: qui non si riproduce.
+
+I numeri della Diagnostica dicono dove sta il tempo, e non e' dove si e'
+guardato finora: **ultimo file a 2,9 s, velo via a 3,2 s** — cioe' 2,9 secondi
+prima che l'ultimo file sia pronto e 0,4 dopo. E il Transfer dice «dalla
+cache»: i file non li sta scaricando, li sta **leggendo e interpretando**. Sono
+4,9 MB di codice, di cui 2 in un pezzo solo.
+
+E' per questo che ne' meno richieste (beta.1) ne' meno byte sul filo (beta.2)
+hanno spostato niente, e non lo sposta nemmeno questa: il tempo se ne va a
+interpretare ed eseguire, e l'unica cosa che lo tocca e' **eseguire meno roba
+all'avvio** — montare per prime le sezioni della pagina che si vede e lasciare
+indietro le altre. E' un lavoro grosso e a se', non un ritocco.
+
+- Le tre chiavi che le legge solo l'avvio — il marchio, i nomi delle luci, le
+  unita' clima — quando cambiano da un altro dispositivo fanno ancora ricaricare
+  la pagina: scriverle in memoria e lasciare lo schermo a dire la cosa di prima
+  sarebbe peggio. Sono i pochi casi rimasti, e la differenza con prima e' che
+  adesso il ricaricamento e' l'eccezione invece della regola.
+- Un apparecchio il cui unico segnale e' un binary_sensor generico acceso, a
+  zero watt, adesso dice STANDBY invece di IN FUNZIONE — la stessa parola che
+  dice gia' la sua carta. Per i cicli che passano da zero watt c'e'
+  `off_delay_minutes`, che adesso vale in tutt'e due i posti.
 
 ## 1.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## Non rilasciato
+
+### Aggiunto
+
+- **Le conversazioni dell'assistenza si possono buttare via.**
+
+      «si ma mi devi dare la possibilita' di eliminare anche la
+       conversazione»
+
+  Nella scheda «Conversazioni» ogni riga ha un cestino, e ce n'e' uno anche
+  sopra il filo aperto. Cancella davvero e per tutti e due: la linea sparisce
+  dal centralino e con lei quello che si erano detti, quindi sparisce anche
+  dalla plancia di quella casa.
+
+  Serve perche' una coda dove non si butta via niente si riempie di prove, di
+  domande gia' risolte e di righe aperte per sbaglio, finche' quella vera non
+  si trova piu'. Ed e' il verso giusto della promessa fatta prima della prima
+  riga: quello che si scrive li' non resta in giro per sempre.
+
+  Due tocchi e non uno — il primo arma il cestino e chiede conferma sul tasto
+  stesso, il secondo cancella — perche' una conversazione cancellata non si
+  rimette a posto, e in un elenco dove si scorre col dito un cestino che
+  cancella al primo tocco butta via prima o poi quella sbagliata.
+
+### Corretto
+
+- **La chat aperta si aggiorna da sola.**
+
+      «la risposta non si refresh devo uscire e rientrare»
+
+  La finestra leggeva una volta all'apertura e poi restava ferma: la risposta
+  arrivava solo chiudendo e riaprendo. Il giro dei cinque minuti del backend
+  c'era gia', ma quello serve al campanello — suona e basta, non ridisegna
+  niente.
+
+  Adesso guarda ogni quindici secondi, e ridisegna soltanto quando e' arrivato
+  davvero qualcosa: chi sta scrivendo non si vede rifare la casella sotto le
+  dita, e se ridisegna il cursore torna dov'era. Chiusa la finestra non chiede
+  piu' niente, cosi' una plancia accesa tutto il giorno in cucina non bussa al
+  centralino per una conversazione che nessuno sta guardando.
+
+- **Nella coda di chi risponde le bolle stavano dalla parte sbagliata.**
+
+  Le domande della casa comparivano a destra e in verde — come se se le fosse
+  scritte da solo chi stava leggendo — e le proprie risposte a sinistra e in
+  grigio: una conversazione letta al contrario. «Mio» dipende da chi guarda, e
+  questa finestra la guardano in due.
+
 ## 1.4.5-beta.12
 
 Cinque richieste lette insieme e cinque sezioni nuove, le sezioni vuote che

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ telefoni e tablet veri.
 
 Le note qui sotto sono quelle delle tredici prove, rimesse in fila per
 argomento invece che per data: quello che e' stato aggiunto, quello che e'
-cambiato, quello che e' stato tolto, quello che e' stato corretto.
+cambiato, quello che e' stato tolto, quello che e' stato corretto. In cima a
+«Corretto» ci sono anche cinque difetti visti sull'ultima beta e sistemati
+senza passare da una beta loro: il radar, i conti degli elettrodomestici e
+della Wallbox, lo storico della connettivita' e i filtri del cruscotto.
 
 ### Aggiunto
 
@@ -706,6 +709,115 @@ cambiato, quello che e' stato tolto, quello che e' stato corretto.
   sarebbe rimasto li' finche' quel ticket non cadeva dal fondo dello store.
 
 ### Corretto
+
+- **Il radar meteo usciva anche senza essere stato configurato, e
+  configurato non diceva la verita'.**
+
+      «radar da errore quando non configurato non deve uscire proprio e anche
+       quando configurato da errore»
+
+  Due difetti nello stesso riquadro, e il secondo nascondeva il primo.
+
+  Senza configurazione il blocco nasceva comunque e poi si metteva `hidden` —
+  che non basta: `hidden` e' l'ultima riga del foglio del browser, e sopra
+  c'era una regola nostra col `display` che la batte. Dentro le previsioni
+  restava un rettangolo grigio con l'immagine rotta e scritto «il radar non
+  sta rispondendo»: un errore per una cosa che nessuno aveva chiesto. Adesso
+  il posto dove disegnare non si fabbrica nemmeno.
+
+  Configurato, il blocco si diceva «vivo» contando le immagini **create**, che
+  e' un'altra cosa da quelle **arrivate**: se il servizio non risponde i
+  quadratini se ne vanno uno per uno, il riquadro resta vuoto, e la frase che
+  spiegherebbe restava nascosta perche' il blocco si dichiarava sano. Adesso
+  si contano i caricamenti veri: finche' sono in volo non si mostra ne'
+  l'immagine rotta ne' la frase, al primo che arriva il radar e' vivo, e se
+  non arriva nessuno lo dice — e si prepara a riprovare al giro dopo.
+
+- **Il cerchio di un carico diceva 0,2 kWh e la sua finestra 12,0.** Lo stesso
+  difetto della beta.11, tornato con un numero al posto dello zero.
+
+      «calcolo energia giornaliera e mensile su elettrodomestici di nuovo
+       sbagliata»
+
+  La regola scritta allora guardava lo zero, e 0,2 non e' zero. Ma zero non
+  era la cosa da guardare: una pinza sulla linea, per come e' fatta, misura
+  tutto quello che le passa sotto, e il suo numero **non puo' essere piu'
+  piccolo della somma di cio' che ha dentro**. Se lo e', quella casella non
+  sta misurando il gruppo — sta misurando altro, di solito un apparecchio solo
+  finito li' per sbaglio.
+
+  Adesso vince la somma, che e' il numero che la finestra mostra. Con un
+  margine del cinque per cento, perche' la pinza e i contatori dei figli non
+  leggono nello stesso istante e senza margine il cerchio ballerebbe avanti e
+  indietro per qualche secondo di ritardo.
+
+- **Sulla riga della Wallbox due numeri si contraddicevano guardandosi.**
+
+      «valori wallbox nel report sballati»
+
+  In Attivita' dispositivi: «1188,7 kWh dal sole e 184,0 dalla rete» e, tre
+  centimetri a destra sulla stessa riga, «0,0 kWh». Millequattrocento
+  chilowattora in un mese, per un'auto che in quel mese non aveva caricato.
+
+  Il guscio disegna il numero a destra e la quota sotto dallo stesso valore, e
+  finche' li scrive lui sono d'accordo. Poi la plancia riscriveva **meta'
+  riga**: correggeva il numero a destra col valore del Recorder e lasciava la
+  quota calcolata sul contatore di vita della colonnina. Adesso chi possiede
+  il numero possiede la riga.
+
+- **Lo storico della connettivita' diceva «Failed to fetch».**
+
+      «storico internet da errore»
+
+  «Failed to fetch» non e' una risposta: non e' un 401 e non e' un 404, e' una
+  richiesta che non e' mai arrivata da nessuna parte. Sulla stessa richiesta
+  c'erano tre guasti, e ognuno da solo bastava.
+
+  Home Assistant ospita la plancia in una cornice che eredita l'origine di chi
+  la contiene ma non il suo indirizzo: da li' la plancia **non sa dove sta**, e
+  il guscio, per costruire l'indirizzo a cui chiedere, indovina. Misurato
+  dentro la cornice: `http://homeassistant.local:8123` — il nome giusto in una
+  casa su cento, e in tutte le altre un host che non esiste, o che parla in
+  chiaro mentre la pagina viaggia in https, e allora il browser blocca senza
+  nemmeno provarci. Poi: la plancia ospitata non ha un gettone ma un segnale
+  che dice «i cookie bastano», e spedirlo come credenziale si prende un 401 su
+  una richiesta che sarebbe passata da sola. E infine la domanda nominava una
+  **casella della plancia** invece dell'entita' che ci sta dentro, che il
+  Recorder non conosce.
+
+  Adesso le domande a Home Assistant partono da casa: l'indirizzo si risolve
+  contro il documento che ospita — che e' il motivo per cui tutto il resto
+  della plancia ha sempre funzionato — l'autorizzazione finta non parte, e la
+  casella diventa la sua entita'. Una plancia che il suo indirizzo ce l'ha, o
+  che e' stata aperta da un file su disco, non viene toccata.
+
+  Lo stesso rimedio ripara un'altra chiamata rotta dalla stessa causa: quella
+  che trasforma i contatori di vita in «oggi» e «questo mese». Falliva in
+  silenzio, ed e' da li' che arrivavano i chilowattora della Wallbox.
+
+- **Nel cruscotto i filtri non si selezionavano.**
+
+      «tab nel cruscotto tiket non funziona non mi fa selezionare difetti etc e
+       nemmeno in lavorazione»
+
+  I tasti erano collegati e il tocco arrivava. Ma il ridisegno cominciava
+  cercando la finestra delle segnalazioni e, non trovandola, tornava indietro
+  prima di arrivare alla riga che ridisegna il cruscotto. Quella finestra la
+  costruisce chi apre la tessera in Configurazione: chi arriva al cruscotto
+  dalla barra non la tocca, quindi nel documento non c'e' — e non ci deve
+  essere. Il filtro non rispondeva **mai** a chi usava la pagina per quello per
+  cui esiste; rispondeva soltanto a chi, nella stessa sessione, avesse aperto e
+  chiuso la finestra almeno una volta.
+
+  E non erano solo i filtri: dietro lo stesso ridisegno ci sono il filo che si
+  apre, la risposta appena mandata, la segnalazione chiusa. Sul cruscotto
+  nessuna di quelle si vedeva finire. Adesso la finestra e la pagina sono due
+  disegni indipendenti, e chi non ha un posto dove stare non impedisce
+  all'altro di esistere.
+
+  Le fotografie della galleria non se ne erano accorte perche' seminavano il
+  filtro gia' scelto prima di far disegnare la pagina: nella foto il filtro era
+  acceso senza che nessuno l'avesse mai premuto. La prova nuova preme davvero.
 
 - **La chat aperta si aggiorna da sola.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -707,6 +707,85 @@ cambiato, quello che e' stato tolto, quello che e' stato corretto.
 
 ### Corretto
 
+- **Le foto si caricano in ogni formato tranne SVG.** Un SVG e' un
+  documento, non una bitmap, e puo' portare uno script: Home Assistant lo
+  serve da `/local/` sulla propria origine, dove stanno i gettoni di chi lo
+  apre. Da quello sportello passano solo formati che il browser disegna e non
+  esegue; quelli gia' in `www` restano elencati nel selettore.
+
+- **I comandi di configurazione rispettano la lista utenti della plancia
+  giusta.** Il profilo e' un campo libero: con due plance e due liste diverse,
+  chi era in lista sulla seconda poteva chiamare `config/get` e `config/set` a
+  mano col profilo della prima — leggerla, e azzerarla. Adesso il permesso si
+  chiede sulla plancia che quel profilo porta davvero.
+
+- **Aprire il filo di una segnalazione chiede lo stesso permesso degli altri
+  comandi.** Era l'unico senza: la issue e' pubblica, ma aprire il filo spegne
+  il pallino di tutta la casa, e chi non puo' usare la plancia non deve
+  spegnere i pallini degli altri.
+
+- **Un'entita' aggiunta a mano non spegne piu' la sua sezione.** La regola
+  delle sezioni vuote non leggeva `cd_entita_mie`: una sezione che viveva
+  solo di quelle risultava vuota, e il salvataggio dell'entita' appena
+  aggiunta la toglieva dalla barra — proprio la sezione dove la si era messa.
+
+- **Le porte non tengono in barra la scheda Sicurezza.** Dalla 1.4.5 si
+  disegnano nella loro pagina, che si accende e si spegne da sola; contarle
+  ancora come contenuto di Sicurezza lasciava una scheda vuota a chi ha solo
+  le porte.
+
+- **Il campanello delle segnalazioni non suona piu' per cose proprie.** Chi
+  aveva gia' una segnalazione e ne apriva un'altra si sentiva annunciare
+  «Nuova segnalazione» — la sua — perche' la consegna non lo diceva al
+  taccuino. E rispondere a una issue che il taccuino non conosceva alzava il
+  segno da zero: al giro dopo gli altri commenti suonavano come nuovi, per la
+  propria risposta. Adesso la consegna prende nota, chi apre il filo prende
+  nota, e chi risponde a una issue sconosciuta chiede il conto vero.
+
+- **Il filo legge gli ultimi commenti, non i primi trenta.** GitHub li da'
+  dal primo in poi, trenta per pagina: dal trentunesimo in poi la risposta
+  piu' recente non si vedeva mai, e lo stato dedotto dal commento del
+  manutentore restava fermo a settimane prima. Si chiede l'ultima pagina, e
+  se non basta anche quella prima.
+
+- **La sincronia delle segnalazioni gira su tutte.** Prendeva sempre le prime
+  venti: con ventuno aperte la ventunesima non veniva riletta mai. Ogni giro
+  riparte da dove si era fermato quello prima.
+
+- **La chat non scrive piu' su disco a ogni battito.** La finestra aperta
+  rilegge ogni quindici secondi, e il segnalibro si salvava lo stesso anche
+  quando non si era mosso: una scrittura ogni battito per dire quello che
+  c'era gia' scritto. Si salva solo quando cambia qualcosa.
+
+- **Il cestino della coda si disarma chiudendo la finestra.** Un cestino
+  armato sopravviveva alla chiusura: riaprendo, «Confermi?» era gia' acceso e
+  il primo tocco cancellava.
+
+- **«Domani» e la striscia dei sette giorni nel giorno del cambio d'ora.** La
+  tessera era gia' stata corretta; l'etichetta dei gruppi dell'Agenda e la
+  striscia sommavano ancora ventiquattro ore. Nel giorno che ne dura
+  venticinque «Domani» si chiamava con la sua data e la striscia mostrava oggi
+  due volte; in quello che ne dura ventitre' domani si saltava.
+
+- **L'ora d'inizio in inglese tiene il PM.** La didascalia della Home
+  tagliava l'intervallo al primo spazio: «02:30 PM – 03:30 PM» diventava
+  «02:30», e le due e mezza del pomeriggio si leggevano come le due di notte.
+
+- **Un'installazione dallo zip fallita a meta' non lascia una seconda
+  integrazione.** Con il disco pieno durante l'estrazione restava
+  `.dashboardmodern-nuovo` dentro `custom_components`, col manifest di questo
+  stesso dominio: al riavvio il caricatore poteva preferirla a quella vera.
+  La cartella d'appoggio se ne va prima dell'errore.
+
+- **Con due plance, togliere la primaria non lascia piu' un errore nel
+  registro.** L'erede ripartiva scoprendosi primaria e allo scarico chiedeva
+  di smontare l'avviso di aggiornamento che non aveva mai montato: «Config
+  entry was never loaded!» nel registro. Si scarica solo da chi l'ha montato.
+
+- **Due piccole cose del backend.** Un byte nullo nel percorso del selettore
+  delle foto non e' piu' un traceback ma una risposta come le altre; e
+  l'elenco delle plance legacy si legge nell'executor invece che nel loop.
+
 - **La chat aperta si aggiorna da sola.**
 
       «la risposta non si refresh devo uscire e rientrare»

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
-## Non rilasciato
+## 1.4.5-beta.13
+
+Due cose chieste guardando la chat funzionare: buttare via una conversazione
+dalla coda di chi risponde, e una finestra che non resta ferma mentre
+dall'altro capo qualcuno ha gia' risposto.
 
 ### Aggiunto
 

--- a/centralino/README.md
+++ b/centralino/README.md
@@ -134,7 +134,12 @@ incolla, e premi **Deploy**.
 
 **7. La pulizia automatica.** **Settings** → **Triggers** (o *Trigger Events*)
 → **Cron Triggers** → **Add** → `0 4 * * *`. E' il giro che cancella le linee
-ferme da sei mesi. Si puo' anche saltare: senza, quelle linee restano.
+ferme da sei mesi e raccoglie i messaggi rimasti senza linea.
+
+Metterlo conviene. Il `[triggers]` scritto in `wrangler.toml` vale solo per chi
+distribuisce con `wrangler`: chi ha incollato il codice dalla pagina di
+Cloudflare non ha nessun giro notturno finche' non lo aggiunge a mano, e senza
+quel giro la promessa dei sei mesi non la mantiene nessuno.
 
 **8. La prova.** Apri in una scheda del browser:
 

--- a/centralino/src/index.js
+++ b/centralino/src/index.js
@@ -317,6 +317,30 @@ async function sportelloDellaConsole(richiesta, env, url) {
     return json({ messaggio });
   }
 
+  /* Buttare via una conversazione, dalla parte di chi risponde.
+   *
+   * La casa puo' cancellare la propria da sempre; chi risponde non poteva
+   * cancellare niente, e una coda dove non si butta via nulla si riempie di
+   * prove, di domande gia' risolte e di righe aperte per sbaglio finche' quella
+   * vera non si trova piu'.
+   *
+   * Cancella tutto: la linea sparisce, e con lei quello che si erano detti.
+   * Non e' una scortesia verso la casa — la conversazione era gia' finita — ed
+   * e' l'unico modo di mantenere la promessa che sta scritta nella plancia:
+   * quello che si scrive qui non resta in giro per sempre.
+   *
+   * Su una linea che non c'e' piu' risponde di si' lo stesso, e non 404 come
+   * fa la risposta: chi cancella vuole che non ci sia, e se non c'e' gia' il
+   * risultato e' quello. Un errore, li', direbbe che qualcosa non ha
+   * funzionato mentre invece era gia' a posto. */
+  if (richiesta.method === "DELETE") {
+    await env.DB.batch([
+      env.DB.prepare("DELETE FROM messaggi WHERE linea = ?").bind(linea),
+      env.DB.prepare("DELETE FROM linee WHERE id = ?").bind(linea),
+    ]);
+    return json({ cancellata: true });
+  }
+
   if (richiesta.method !== "GET") return male(405, "metodo non previsto");
 
   const dopo = Number(url.searchParams.get("dopo") || 0) || 0;

--- a/centralino/src/index.js
+++ b/centralino/src/index.js
@@ -173,15 +173,35 @@ async function sfoltisci(env, id) {
     .run();
 }
 
+/* Scrivere una riga, e solo se la linea c'e' ancora.
+ *
+ * Il controllo sta DENTRO l'inserimento, e non e' pignoleria. Prima erano due
+ * momenti staccati — «la linea esiste?» e poi «scrivi» — e fra i due ci sta
+ * una cancellazione: chi risponde butta via la conversazione nell'istante in
+ * cui la casa sta scrivendo, e il messaggio finisce in archivio legato a una
+ * linea che non esiste piu'.
+ *
+ * Quella riga poi non se ne va mai: `messaggi.linea` non ha un vincolo verso
+ * `linee` — aggiungerlo adesso vorrebbe dire una migrazione su un archivio gia'
+ * in piedi — e la potatura notturna cerca i messaggi vecchi passando dalle
+ * linee, quindi un orfano non lo raggiunge nessuno. Parole di una persona,
+ * conservate per sempre in un servizio che promette il contrario.
+ *
+ * `INSERT … SELECT … WHERE EXISTS` invece e' un'istruzione sola: o la linea c'e'
+ * nel momento in cui si scrive, o non si scrive niente. Torna `null` in quel
+ * caso, e chi chiama lo dice a chi ha scritto. */
 async function scrivi(env, id, da, testo) {
   const adesso = Date.now();
   const messo = await env.DB.prepare(
-    "INSERT INTO messaggi (linea, da, testo, scritto_il) VALUES (?, ?, ?, ?) RETURNING id",
+    `INSERT INTO messaggi (linea, da, testo, scritto_il)
+     SELECT ?, ?, ?, ? WHERE EXISTS (SELECT 1 FROM linee WHERE id = ?)
+     RETURNING id`,
   )
-    .bind(id, da, testo, adesso)
+    .bind(id, da, testo, adesso, id)
     .first();
+  if (!messo) return null;
   await sfoltisci(env, id);
-  return { id: Number(messo?.id || 0), da, testo, scritto_il: adesso };
+  return { id: Number(messo.id || 0), da, testo, scritto_il: adesso };
 }
 
 async function messaggiDopo(env, id, dopo) {
@@ -231,7 +251,14 @@ async function sportelloDellaCasa(richiesta, env, url) {
       await aggiornaLeNote(env, id, note);
     }
     const messaggio = await scrivi(env, id, "casa", testo);
-    return json({ messaggio });
+    if (!messaggio) return male(404, "la conversazione non c'e' piu'");
+    /* «Nata adesso» e' un'informazione che serve dall'altra parte: se la casa
+     * aveva gia' una copia della conversazione e la linea e' rinata con questo
+     * messaggio, vuol dire che nel frattempo qualcuno l'aveva cancellata — e
+     * quella copia parla di un filo che non esiste piu'. Senza questo, la casa
+     * incollerebbe le frasi nuove in fondo alle vecchie e si vedrebbe una
+     * conversazione che chi risponde non ha. */
+    return json({ messaggio, nuova: stato === "assente" });
   }
 
   /* Da qui in giu' la linea deve esserci gia': non si legge e non si cancella
@@ -314,6 +341,7 @@ async function sportelloDellaConsole(richiesta, env, url) {
     const esiste = await env.DB.prepare("SELECT id FROM linee WHERE id = ?").bind(linea).first();
     if (!esiste) return male(404, "linea sconosciuta");
     const messaggio = await scrivi(env, linea, "console", testo);
+    if (!messaggio) return male(404, "linea sconosciuta");
     return json({ messaggio });
   }
 
@@ -384,6 +412,12 @@ export default {
         "DELETE FROM messaggi WHERE linea IN (SELECT id FROM linee WHERE vista_il < ?)",
       ).bind(limite),
       env.DB.prepare("DELETE FROM linee WHERE vista_il < ?").bind(limite),
+      /* E i messaggi che non appartengono piu' a nessuna linea. `scrivi` non
+       * ne fabbrica piu' — l'inserimento controlla la linea nella stessa
+       * istruzione — ma quelli nati prima di quel controllo sono li', e non li
+       * raggiunge nessun'altra query: la potatura di sopra passa dalle linee, e
+       * una linea che non c'e' non porta a niente. */
+      env.DB.prepare("DELETE FROM messaggi WHERE linea NOT IN (SELECT id FROM linee)"),
     ]);
   },
 };

--- a/centralino/test/centralino.test.js
+++ b/centralino/test/centralino.test.js
@@ -363,6 +363,67 @@ test("senza la chiave non si butta via niente", async () => {
   assert.equal(env.DB.interroga("SELECT COUNT(*) AS q FROM linee")[0].q, 1);
 });
 
+test("un messaggio non sopravvive alla linea che l'ha ospitato", async () => {
+  /* Fra «la linea esiste?» e «scrivi» ci sta una cancellazione: il messaggio
+   * finiva in archivio legato a una linea che non c'era più, e lì restava per
+   * sempre — la potatura notturna cerca i messaggi passando dalle linee, e un
+   * orfano non lo raggiunge nessuno. Parole di una persona, conservate per
+   * sempre in un servizio che promette il contrario. */
+  const env = ambiente();
+  await scrive(env, "una domanda");
+  // La linea sparisce sotto le mani di chi sta per scrivere.
+  env.DB.interroga("DELETE FROM linee WHERE id = ?", CASA);
+  const prima = env.DB.interroga("SELECT COUNT(*) AS q FROM messaggi")[0].q;
+
+  const risposta = await chiama(env, {
+    via: `/console/conversazioni/${CASA}`,
+    metodo: "POST",
+    chiave: CHIAVE_CONSOLE,
+    corpo: { testo: "una risposta che non ha più dove andare" },
+  });
+  assert.equal(risposta.stato, 404);
+  assert.equal(env.DB.interroga("SELECT COUNT(*) AS q FROM messaggi")[0].q, prima);
+});
+
+test("la potatura raccoglie anche gli orfani rimasti da prima", async () => {
+  /* `scrivi` non ne fabbrica più, ma quelli nati prima del controllo sono lì e
+   * non li raggiunge nessun'altra query. */
+  const env = ambiente();
+  await scrive(env, "una domanda");
+  env.DB.interroga(
+    "INSERT INTO messaggi (linea, da, testo, scritto_il) VALUES (?, 'casa', 'orfano', ?)",
+    `casa_${"f".repeat(32)}`,
+    Date.now(),
+  );
+  assert.equal(env.DB.interroga("SELECT COUNT(*) AS q FROM messaggi")[0].q, 2);
+
+  await centralino.scheduled({}, env);
+  const restati = env.DB.interroga("SELECT testo FROM messaggi");
+  assert.deepEqual(
+    restati.map((r) => r.testo),
+    ["una domanda"],
+  );
+});
+
+test("il primo messaggio dice che la linea è nata adesso", async () => {
+  /* Serve dall'altra parte: se la casa aveva già una copia della conversazione
+   * e la linea è rinata con questo messaggio, vuol dire che nel frattempo
+   * qualcuno l'aveva cancellata. */
+  const env = ambiente();
+  const primo = await scrive(env, "la prima");
+  assert.equal(primo.corpo.nuova, true);
+  const secondo = await scrive(env, "la seconda");
+  assert.equal(secondo.corpo.nuova, false);
+
+  await chiama(env, {
+    via: `/console/conversazioni/${CASA}`,
+    metodo: "DELETE",
+    chiave: CHIAVE_CONSOLE,
+  });
+  const dopo = await scrive(env, "e adesso ricomincio");
+  assert.equal(dopo.corpo.nuova, true);
+});
+
 test("buttare via una conversazione già andata non è un errore", async () => {
   /* Chi cancella vuole che non ci sia. Se non c'è già, il risultato è quello:
    * un 404 direbbe che qualcosa non ha funzionato mentre era a posto. */

--- a/centralino/test/centralino.test.js
+++ b/centralino/test/centralino.test.js
@@ -306,6 +306,75 @@ test("la console non risponde a una linea che non esiste", async () => {
   assert.equal(stato, 404);
 });
 
+test("chi risponde può buttare via una conversazione, per intero", async () => {
+  const env = ambiente();
+  await scrive(env, "era solo una prova");
+  await chiama(env, {
+    via: `/console/conversazioni/${CASA}`,
+    metodo: "POST",
+    chiave: CHIAVE_CONSOLE,
+    corpo: { testo: "va bene" },
+  });
+  const via = await chiama(env, {
+    via: `/console/conversazioni/${CASA}`,
+    metodo: "DELETE",
+    chiave: CHIAVE_CONSOLE,
+  });
+  assert.equal(via.stato, 200);
+  assert.equal(via.corpo.cancellata, true);
+  assert.equal(env.DB.interroga("SELECT COUNT(*) AS q FROM messaggi")[0].q, 0);
+  assert.equal(env.DB.interroga("SELECT COUNT(*) AS q FROM linee")[0].q, 0);
+});
+
+test("buttare via una conversazione non tocca quella di un'altra casa", async () => {
+  const env = ambiente();
+  await scrive(env, "la mia domanda");
+  await scrive(env, "la domanda dell'altra", ALTRA, `${SEGRETO}-altro`);
+  await chiama(env, {
+    via: `/console/conversazioni/${CASA}`,
+    metodo: "DELETE",
+    chiave: CHIAVE_CONSOLE,
+  });
+  const righe = env.DB.interroga("SELECT id FROM linee");
+  assert.deepEqual(
+    righe.map((r) => r.id),
+    [ALTRA],
+  );
+  assert.equal(
+    env.DB.interroga("SELECT COUNT(*) AS q FROM messaggi WHERE linea = ?", ALTRA)[0].q,
+    1,
+  );
+});
+
+test("senza la chiave non si butta via niente", async () => {
+  /* La cancellazione è la cosa che non si può rimettere a posto: se passasse
+   * senza chiave, chiunque conosca l'indirizzo del centralino potrebbe
+   * svuotare la coda di tutti. */
+  const env = ambiente();
+  await scrive(env, "una domanda che deve restare");
+  for (const chiave of ["", "sbagliata", `${CHIAVE_CONSOLE}x`]) {
+    const { stato } = await chiama(env, {
+      via: `/console/conversazioni/${CASA}`,
+      metodo: "DELETE",
+      chiave,
+    });
+    assert.equal(stato, 403, `"${chiave}" è passata`);
+  }
+  assert.equal(env.DB.interroga("SELECT COUNT(*) AS q FROM linee")[0].q, 1);
+});
+
+test("buttare via una conversazione già andata non è un errore", async () => {
+  /* Chi cancella vuole che non ci sia. Se non c'è già, il risultato è quello:
+   * un 404 direbbe che qualcosa non ha funzionato mentre era a posto. */
+  const { stato, corpo } = await chiama(ambiente(), {
+    via: `/console/conversazioni/${CASA}`,
+    metodo: "DELETE",
+    chiave: CHIAVE_CONSOLE,
+  });
+  assert.equal(stato, 200);
+  assert.equal(corpo.cancellata, true);
+});
+
 /* ─── Le linee che non parlano più ───────────────────────────────────────── */
 
 test("una linea ferma da sei mesi se ne va, conversazione compresa", async () => {

--- a/custom_components/dashboardmodern/__init__.py
+++ b/custom_components/dashboardmodern/__init__.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from .const import DOMAIN
+
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
@@ -20,6 +22,12 @@ if TYPE_CHECKING:
 # L'unica piattaforma e' l'avviso di aggiornamento, e la porta una plancia
 # sola: chi ne ha due non deve ritrovarsi due voci per la stessa versione.
 PLATFORMS: list[str] = ["update"]
+
+# Quale plancia ha montato la piattaforma. Si scarica solo da quella: chiederlo
+# a una voce che non l'ha mai montata fa sollevare a Home Assistant un
+# «Config entry was never loaded!» — succedeva all'erede, quando la primaria
+# veniva tolta e lei ripartiva scoprendosi primaria senza esserlo mai stata.
+DATA_UPDATE_ENTRY = "update_entry"
 
 
 def _primary_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -86,6 +94,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # spegne l'una puo' voler tenere accesa l'altra.
         await async_setup_chat(hass, entry)
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+        hass.data.setdefault(DOMAIN, {})[DATA_UPDATE_ENTRY] = entry.entry_id
     return True
 
 
@@ -120,7 +129,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Remove this entry's panel registration."""
     from .frontend import async_unregister_frontend_entry
 
-    if _primary_entry(hass, entry):
-        await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    scaricata = True
+    if domain_data.get(DATA_UPDATE_ENTRY) == entry.entry_id:
+        scaricata = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+        if scaricata:
+            domain_data.pop(DATA_UPDATE_ENTRY, None)
     await async_unregister_frontend_entry(hass, entry.entry_id)
-    return True
+    return scaricata

--- a/custom_components/dashboardmodern/chat.py
+++ b/custom_components/dashboardmodern/chat.py
@@ -149,12 +149,19 @@ async def async_conversazione(
             arrivati = await async_leggi(hass, identita, dopo=store.ultimo())
             await store.async_aggiungi(arrivati)
         except ChatError as errore:
-            # Il centralino giu' non deve voler dire una schermata vuota: la
-            # copia locale esiste apposta, e chi apre la chat la vede lo stesso.
-            # Il guasto si dice, ma accanto alla conversazione, non al posto suo:
-            # sollevare qui buttava via anche quello che c'era gia' letto.
-            guasto = str(errore)
-            _LOGGER.debug("Chat: rilettura non riuscita", exc_info=True)
+            if errore.code == "gone":
+                # La conversazione non esiste piu' nel centralino: l'ha
+                # cancellata chi risponde, o se ne sono andati i sei mesi di
+                # silenzio. Va via anche di qua, e non e' una perdita: e'
+                # esattamente quello che era stato promesso.
+                await store.async_dimentica()
+            else:
+                # Il centralino giu' non deve voler dire una schermata vuota: la
+                # copia locale esiste apposta, e chi apre la chat la vede lo
+                # stesso. Il guasto si dice accanto alla conversazione, non al
+                # posto suo: sollevare qui buttava via anche il gia' letto.
+                guasto = str(errore)
+                _LOGGER.debug("Chat: rilettura non riuscita", exc_info=True)
     if not zitta:
         await store.async_letto()
     return {
@@ -187,9 +194,16 @@ async def async_scrivi(
     # — nei cinque minuti fra un giro e l'altro ci sta benissimo — e quella
     # risposta non verrebbe chiesta mai piu': persa, in silenzio, per sempre.
     prima = store.ultimo()
-    messaggio = await async_manda(
-        hass, identita, testo, nome=store.nome(), lingua=lingua
-    )
+    esito = await async_manda(hass, identita, testo, nome=store.nome(), lingua=lingua)
+    messaggio = esito.get("messaggio") or {}
+    if esito.get("nuova") and store.messaggi():
+        # La linea e' nata con questo messaggio, ma una copia c'era gia': vuol
+        # dire che nel frattempo qualcuno l'ha cancellata dal centralino. Le
+        # frasi vecchie parlano di un filo che non esiste piu', e incollarci
+        # sotto quelle nuove darebbe a questa casa una conversazione che chi
+        # risponde non ha — con dentro le righe che erano state cancellate.
+        await store.async_dimentica()
+        prima = 0
     try:
         # Il centralino rida' anche il messaggio appena scritto, quindi questa
         # rilettura porta indietro sia le risposte in sospeso sia la propria
@@ -367,7 +381,17 @@ async def async_guarda(hass: HomeAssistant) -> list[dict[str, Any]]:
     if not store.aperta():
         return []
     identita = await store.async_identita()
-    arrivati = await async_leggi(hass, identita, dopo=store.ultimo())
+    try:
+        arrivati = await async_leggi(hass, identita, dopo=store.ultimo())
+    except ChatError as errore:
+        if errore.code != "gone":
+            raise
+        # Il giro dei cinque minuti e' anche il modo in cui questa casa scopre
+        # che la conversazione non c'e' piu': senza, la copia resterebbe li'
+        # finche' qualcuno non apre la finestra. Non suona niente — non e'
+        # arrivato niente da leggere.
+        await store.async_dimentica()
+        return []
     aggiunti = await store.async_aggiungi(arrivati)
     dalla_console = [riga for riga in aggiunti if riga.get("da") == "console"]
     if dalla_console:

--- a/custom_components/dashboardmodern/chat.py
+++ b/custom_components/dashboardmodern/chat.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any
 from .chat_client import (
     ChatError,
     async_cancella,
+    async_cestina,
     async_conversazioni,
     async_filo,
     async_leggi,
@@ -298,6 +299,23 @@ async def async_replica(hass: HomeAssistant, linea: str, testo: str) -> dict[str
     return await async_rispondi(hass, _chiave_di_chi_risponde(hass), linea, testo)
 
 
+async def async_butta(hass: HomeAssistant, linea: str) -> bool:
+    """Butta via una conversazione, dalla coda di chi risponde.
+
+    La casa la propria puo' cancellarla da sempre; chi risponde non poteva
+    cancellare niente, e una coda dove non si butta via nulla si riempie di
+    prove, di domande gia' risolte e di righe aperte per sbaglio, finche'
+    quella vera non si trova piu'.
+
+    Cancella davvero, e per tutti e due: la linea sparisce dal centralino e con
+    lei quello che si erano detti. Sparisce anche dalla plancia di quella casa
+    — la conversazione era finita — ed e' il verso giusto della promessa
+    scritta prima della prima riga: quello che si scrive li' non resta in giro
+    per sempre.
+    """
+    return await async_cestina(hass, _chiave_di_chi_risponde(hass), linea)
+
+
 # ─── Il campanello ───────────────────────────────────────────────────────────
 
 
@@ -395,6 +413,7 @@ __all__ = [
     "ChatError",
     "accesa",
     "async_apri",
+    "async_butta",
     "async_coda",
     "async_conversazione",
     "async_dimentica",

--- a/custom_components/dashboardmodern/chat_client.py
+++ b/custom_components/dashboardmodern/chat_client.py
@@ -180,7 +180,14 @@ async def async_manda(
     nome: str = "",
     lingua: str = "",
 ) -> dict[str, Any]:
-    """Manda un messaggio. Il primo apre la conversazione."""
+    """Manda un messaggio. Il primo apre la conversazione.
+
+    Torna due cose: il messaggio, e se la linea sia **nata con questo
+    messaggio**. La seconda serve a chi tiene la copia in casa: se una copia
+    c'era gia' e la linea e' rinata adesso, vuol dire che nel frattempo
+    qualcuno l'aveva cancellata, e quella copia parla di un filo che non esiste
+    piu'.
+    """
     pulito = str(testo or "").strip()[:CHAT_MAX_TESTO]
     if not pulito:
         raise ChatError("empty", "Non c'e' niente da mandare.")
@@ -196,7 +203,10 @@ async def async_manda(
         corpo={"testo": pulito, "nome": str(nome or "")},
     )
     messaggio = risposta.get("messaggio")
-    return messaggio if isinstance(messaggio, dict) else {}
+    return {
+        "messaggio": messaggio if isinstance(messaggio, dict) else {},
+        "nuova": bool(risposta.get("nuova")),
+    }
 
 
 async def async_leggi(
@@ -215,6 +225,17 @@ async def async_leggi(
         chiave=str(identita.get("segreto") or ""),
         intestazioni={"X-Casa": str(identita.get("casa") or ""), **await _note(hass)},
     )
+    # Il centralino dice anche se la linea e' ancora aperta, e qui e' un fatto
+    # che non si puo' buttare via. Questa funzione la chiama solo chi la chat
+    # l'ha gia' aperta: sentirsi rispondere «non c'e' nessuna linea» vuol dire
+    # una cosa sola — la conversazione non esiste piu', perche' chi risponde
+    # l'ha cancellata o perche' sono passati i sei mesi di silenzio.
+    #
+    # Ignorarlo, com'era prima, lasciava la copia in casa intatta per sempre:
+    # una conversazione cancellata da una parte e ancora li', leggibile, dopo
+    # che alla persona era stato promesso il contrario.
+    if risposta.get("aperta") is False:
+        raise ChatError("gone", "La conversazione non c'e' piu'.")
     righe = risposta.get("messaggi")
     return (
         [riga for riga in righe if isinstance(riga, dict)]

--- a/custom_components/dashboardmodern/chat_client.py
+++ b/custom_components/dashboardmodern/chat_client.py
@@ -270,6 +270,23 @@ async def async_filo(
     )
 
 
+async def async_cestina(hass: HomeAssistant, chiave: str, linea: str) -> bool:
+    """Butta via una conversazione, dalla parte di chi risponde.
+
+    Cancella tutto: la linea sparisce dal centralino, e con lei quello che si
+    erano detti. Il centralino risponde di si' anche su una linea che non c'e'
+    piu' — chi cancella vuole che non ci sia, e se non c'e' gia' il risultato
+    e' quello.
+    """
+    risposta = await _chiama(
+        hass,
+        "DELETE",
+        f"/console/conversazioni/{str(linea or '')}",
+        chiave=chiave,
+    )
+    return bool(risposta.get("cancellata"))
+
+
 async def async_rispondi(
     hass: HomeAssistant, chiave: str, linea: str, testo: str
 ) -> dict[str, Any]:
@@ -291,6 +308,7 @@ async def async_rispondi(
 __all__ = [
     "ChatError",
     "async_cancella",
+    "async_cestina",
     "async_conversazioni",
     "async_filo",
     "async_leggi",

--- a/custom_components/dashboardmodern/chat_store.py
+++ b/custom_components/dashboardmodern/chat_store.py
@@ -171,7 +171,14 @@ class ChatStore:
         arriva a chi risponde come una persona nuova, e la conversazione
         ripartirebbe da capo senza che nessuno l'abbia chiesto. Chi vuole
         sparire davvero passa dal centralino, e quel giro cancella tutti e due.
+
+        Una copia gia' vuota non si riscrive: il giro dei quindici secondi
+        passa di qui a ogni battito per una linea che non c'e' piu', e una
+        scrittura su disco per dire «niente» quattro volte al minuto e' il
+        modo di consumare la scheda di un Raspberry.
         """
+        if not self._dati.get("messaggi") and not self._dati.get("letto"):
+            return
         self._dati["messaggi"] = []
         self._dati["letto"] = 0
         await self._async_salva()
@@ -193,8 +200,17 @@ class ChatStore:
         ]
 
     async def async_letto(self) -> None:
-        """Aprire la chat e' averla letta."""
-        self._dati["letto"] = self.ultimo()
+        """Aprire la chat e' averla letta.
+
+        Si scrive su disco solo se il segnalibro si e' mosso davvero. La
+        finestra aperta rilegge ogni quindici secondi, e quasi sempre non e'
+        arrivato niente: salvare lo stesso voleva dire una scrittura ogni
+        battito per dire quello che c'era gia' scritto.
+        """
+        ultimo = self.ultimo()
+        if int(self._dati.get("letto") or 0) == ultimo:
+            return
+        self._dati["letto"] = ultimo
         await self._async_salva()
 
 

--- a/custom_components/dashboardmodern/config_store.py
+++ b/custom_components/dashboardmodern/config_store.py
@@ -282,6 +282,19 @@ class DashboardConfigStore:
     def _entry_profiles(self) -> dict[str, Any]:
         return self._data.setdefault("entry_profiles", {})
 
+    def entry_profiles(self) -> dict[str, str]:
+        """Quale profilo usa davvero ogni plancia, per chi deve risalire.
+
+        E' la memoria che segue i cambi di nome: chi controlla i permessi sul
+        profilo chiesto la guarda per non scambiare una plancia rinominata per
+        un profilo di nessuno.
+        """
+        return {
+            str(entry_id): str(profile)
+            for entry_id, profile in self._entry_profiles().items()
+            if profile
+        }
+
     def _resolve(self, profile: str, entry_id: str | None) -> tuple[str, str | None]:
         """Return the profile this config entry actually uses.
 

--- a/custom_components/dashboardmodern/frontend.py
+++ b/custom_components/dashboardmodern/frontend.py
@@ -181,14 +181,22 @@ def _panel_config(
     *,
     asset_version: str | None = None,
     static_url_path: str | None = None,
+    variants: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Build the panel config snapshot for one plancia."""
+    """Build the panel config snapshot for one plancia.
+
+    `variants` e' l'elenco delle plance legacy sul disco: chi lo ha gia' letto
+    nell'executor lo passa, cosi' questa funzione — che gira nel loop — non
+    tocca il disco. Senza, lo legge da se', ed e' il caso delle prove.
+    """
     from .config_flow import OPTION_ADMIN_ONLY, OPTION_REGISTER_LOVELACE
 
     if asset_version is None:
         asset_version = _frontend_asset_version()
     if static_url_path is None:
         static_url_path = f"{STATIC_URL_PATH}/{asset_version}"
+    if variants is None:
+        variants = legacy_variants()
     return {
         "entry_ids": [entry.entry_id],
         "instance_id": entry.entry_id,
@@ -196,7 +204,7 @@ def _panel_config(
         "title": entry.title or "DashboardModern",
         "primary": _entry_is_primary(hass, entry),
         "static_base": static_url_path,
-        "legacy_variants": legacy_variants(),
+        "legacy_variants": list(variants),
         "allowed_user_ids": _allowed_user_ids(entry),
         "register_lovelace_dashboard": bool(
             entry.options.get(OPTION_REGISTER_LOVELACE, True)
@@ -221,6 +229,7 @@ def _register_or_update_panel(
     update: bool,
     asset_version: str,
     static_url_path: str,
+    variants: list[str] | None = None,
 ) -> None:
     """Register or update the custom panel for one plancia."""
     from homeassistant.components import frontend
@@ -238,6 +247,7 @@ def _register_or_update_panel(
             entry,
             asset_version=asset_version,
             static_url_path=static_url_path,
+            variants=variants,
         ),
         require_admin=bool(entry.options.get(OPTION_ADMIN_ONLY, False)),
         show_in_sidebar=True,
@@ -343,6 +353,9 @@ async def async_register_frontend(hass: HomeAssistant, entry_id: str) -> None:
 
     asset_version = await hass.async_add_executor_job(_frontend_asset_version)
     static_url_path = f"{STATIC_URL_PATH}/{asset_version}"
+    # Anche l'elenco delle plance legacy e' una lettura del disco (`is_dir`,
+    # `glob`): si fa qui, fuori dal loop, e si passa giu' gia' letto.
+    variants = await hass.async_add_executor_job(legacy_variants)
 
     await _ensure_static_registered(hass, domain_data, static_url_path)
     _ensure_dashboard_card_registered(hass, domain_data, static_url_path)
@@ -360,6 +373,7 @@ async def async_register_frontend(hass: HomeAssistant, entry_id: str) -> None:
         update=old_path == new_path,
         asset_version=asset_version,
         static_url_path=static_url_path,
+        variants=variants,
     )
     paths[entry_id] = new_path
 

--- a/custom_components/dashboardmodern/frontend/e2e/i-tasti-del-cruscotto-si-premono.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/i-tasti-del-cruscotto-si-premono.spec.js
@@ -1,0 +1,179 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+/* «Tab nel cruscotto tiket non funziona, non mi fa selezionare difetti etc e
+ * nemmeno in lavorazione.»
+ *
+ * I tasti c'erano, il tocco arrivava, lo stato cambiava — e non si vedeva
+ * niente. `disegna()` cominciava cercando la finestra delle segnalazioni e,
+ * non trovandola, tornava indietro prima di arrivare alla riga che ridisegna
+ * il cruscotto. Ma il cruscotto e' una pagina della barra: chi ci arriva da li'
+ * la finestra non l'ha mai aperta, e nel documento non c'e'.
+ *
+ * Questa prova sta nel browser e non fra quelle senza schermo apposta: la cosa
+ * che si e' rotta e' un giro completo — tocco, stato, markup nuovo, tasto
+ * acceso — e a spezzarlo in pezzi provabili a tavolino ognuno dei pezzi
+ * risultava sano, che e' esattamente quello che e' successo.
+ *
+ * E le fotografie della galleria non se ne sono accorte perche' seminavano il
+ * filtro gia' scelto prima di far disegnare la pagina: il filtro nella foto era
+ * acceso senza che nessuno l'avesse mai premuto.
+ */
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  visibility: { home: true },
+};
+
+const CODA = [
+  {
+    number: 197,
+    type: "bug",
+    title: "La foto dell'auto torna quella di prima",
+    body: "Seleziono la vettura nuova, salvo, e ricompare quella vecchia.",
+    state: "inviato",
+    issue_url: "https://github.com/danigio15/dashboardmodern-v2/issues/197",
+    author: "marco-b",
+    origin: "plancia",
+    created_at: "2026-08-30T09:12:00Z",
+  },
+  {
+    number: 196,
+    type: "assistenza",
+    title: "Non trovo la pagina Piscina",
+    body: "Ho configurato le entita' ma la sezione non compare nella barra.",
+    state: "inviato",
+    issue_url: "https://github.com/danigio15/dashboardmodern-v2/issues/196",
+    author: "chiara-r",
+    origin: "plancia",
+    created_at: "2026-08-29T18:40:00Z",
+  },
+  {
+    number: 194,
+    type: "bug",
+    title: "Le tapparelle non si fermano a meta'",
+    body: "Premo stop e continuano a scendere fino in fondo.",
+    state: "in-carico",
+    issue_url: "https://github.com/danigio15/dashboardmodern-v2/issues/194",
+    author: "luca-p",
+    origin: "plancia",
+    assignees: ["danigio15"],
+    created_at: "2026-08-27T11:05:00Z",
+  },
+  {
+    number: 190,
+    type: "bug",
+    title: "Il meteo restava indietro di un'ora",
+    body: "Risolta nella beta precedente.",
+    state: "risolto",
+    issue_url: "https://github.com/danigio15/dashboardmodern-v2/issues/190",
+    author: "marco-b",
+    origin: "plancia",
+    created_at: "2026-08-20T07:30:00Z",
+  },
+];
+
+const voci = (page) => page.locator("#page-cruscotto .dm-tkt-voce");
+const titoli = (page) => page.locator("#page-cruscotto .dm-tkt-voce-tit");
+
+async function apriIlCruscotto(page, coda) {
+  await page.evaluate((elenco) => {
+    const stato = window.__DASHBOARDMODERN_SEGNALAZIONI__;
+    stato.console = true;
+    stato.queue = elenco;
+    /* Appena letta: il tocco sulla voce chiede la coda solo se quella che ha
+       e' vecchia, e qui non deve andare a cercare un Home Assistant che in
+       questa prova non c'e'. */
+    stato.queueAt = Date.now();
+    window.DashboardModernSegnalazioni.sistema();
+    /* Il cambio pagina si fa da qui e non con un tocco vero: sul tablet la
+       barra parte ferma, e quale sia il modo di arrivare al cruscotto non e'
+       la cosa che questa prova vuole provare. */
+    document.querySelector('.tab[data-tab="cruscotto"]').click();
+  }, coda);
+  await expect(page.locator("#page-cruscotto")).toHaveClass(/active/);
+}
+
+test.describe("i filtri del cruscotto rispondono al tocco", () => {
+  test("stato e tipo si premono anche senza aver mai aperto la finestra", async ({
+    page,
+  }, testInfo) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+    await apriIlCruscotto(page, CODA);
+
+    /* La condizione in cui il difetto viveva, scritta come tale: la finestra
+     * delle segnalazioni non esiste nel documento, e non deve esistere. Se un
+     * giorno qualcosa la costruisse all'avvio, questa prova passerebbe per il
+     * motivo sbagliato e non se ne accorgerebbe nessuno. */
+    await expect(page.locator("#dm-tkt-modal")).toHaveCount(0);
+
+    // Si parte da «Da lavorare»: le tre aperte, la chiusa no.
+    await expect(voci(page)).toHaveCount(3);
+    await expect(page.locator('#page-cruscotto [data-dm-filtro="aperte"]')).toHaveClass(/attivo/);
+
+    // «In lavorazione»: resta quella presa in carico.
+    await page.locator('#page-cruscotto [data-dm-filtro="in-carico"]').click();
+    await expect(page.locator('#page-cruscotto [data-dm-filtro="in-carico"]')).toHaveClass(
+      /attivo/,
+    );
+    await expect(page.locator('#page-cruscotto [data-dm-filtro="aperte"]')).not.toHaveClass(
+      /attivo/,
+    );
+    await expect(titoli(page)).toHaveText(["Le tapparelle non si fermano a meta'"]);
+
+    // «Nuove»: le due che nessuno ha ancora preso.
+    await page.locator('#page-cruscotto [data-dm-filtro="nuove"]').click();
+    await expect(page.locator('#page-cruscotto [data-dm-filtro="nuove"]')).toHaveClass(/attivo/);
+    await expect(voci(page)).toHaveCount(2);
+
+    // «Difetti» e' l'altro asse: si incrocia con lo stato, non lo scaccia.
+    await page.locator('#page-cruscotto [data-dm-tipo-coda="bug"]').click();
+    await expect(page.locator('#page-cruscotto [data-dm-tipo-coda="bug"]')).toHaveClass(/attivo/);
+    await expect(page.locator('#page-cruscotto [data-dm-filtro="nuove"]')).toHaveClass(/attivo/);
+    await expect(titoli(page)).toHaveText(["La foto dell'auto torna quella di prima"]);
+
+    // E il tipo resta scelto passando a «Chiuse».
+    await page.locator('#page-cruscotto [data-dm-filtro="chiuse"]').click();
+    await expect(titoli(page)).toHaveText(["Il meteo restava indietro di un'ora"]);
+
+    // «Ogni tipo» non vuol dire «senza tipo»: torna tutto quello dello stato.
+    await page.locator('#page-cruscotto [data-dm-filtro="tutte"]').click();
+    await page.locator('#page-cruscotto [data-dm-tipo-coda=""]').click();
+    await expect(voci(page)).toHaveCount(4);
+  });
+
+  test("il conto sotto i tasti del tipo si rifa' dentro lo stato scelto", async ({
+    page,
+  }, testInfo) => {
+    await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+    await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+    await apriIlCruscotto(page, CODA);
+
+    /* Il numero sotto «Difetti» dice quanti difetti ci sono DENTRO lo stato
+     * acceso. Se il tocco non ridisegna, quel numero resta quello di prima: e'
+     * il secondo modo, piu' silenzioso, in cui il difetto si vedeva. */
+    const difetti = page.locator('#page-cruscotto [data-dm-tipo-coda="bug"] .dm-tkt-quanti');
+    await expect(difetti).toHaveText("2");
+
+    await page.locator('#page-cruscotto [data-dm-filtro="in-carico"]').click();
+    await expect(difetti).toHaveText("1");
+
+    await page.locator('#page-cruscotto [data-dm-filtro="chiuse"]').click();
+    await expect(difetti).toHaveText("1");
+  });
+});

--- a/custom_components/dashboardmodern/frontend/e2e/la-barra-non-cambia-forma-sotto-gli-occhi.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/la-barra-non-cambia-forma-sotto-gli-occhi.spec.js
@@ -1,0 +1,122 @@
+import { expect, test } from "@playwright/test";
+import { bootNamespacedDashboard } from "./helpers/namespaced-dashboard.js";
+
+/* «Resta sempre la barra totale, per poi diventare come l'ho configurata: dura
+ * quattro o cinque secondi.»
+ *
+ * Il guscio applica la visibilita' delle voci a tempo — subito, a 1,5 s, poi
+ * ogni tre secondi — mentre la configurazione arriva quando arriva. Fra i due
+ * momenti la barra mostra forme che poi si rimangia: misurate dall'avvio, erano
+ * quattro, e tre di queste erano false.
+ *
+ * Il contratto che questa prova fissa e' uno solo, e non parla di tempi: da
+ * quando la barra si vede, la sua forma non cambia piu'. Che ci metta mezzo
+ * secondo o tre non e' affare di nessuno; che dica una cosa e poi un'altra si'.
+ */
+
+const seed = {
+  schema_version: 4,
+  sections: {
+    rooms: [{ id: "r1", name: "Salotto", entities: [] }],
+    cameras: [],
+    appliances: [],
+    loads: [],
+    lights: [],
+    climate: [],
+    ev: [],
+    covers: [],
+    pool: {},
+    irrigation: { zones: [] },
+    energy: {},
+    entityOverrides: {},
+  },
+  /* Due sezioni accese e tutte le altre spente: una barra che ha una forma
+   * ben diversa da quella di serie, cosi' una forma sbagliata si vede. */
+  visibility: {
+    home: true,
+    energy: true,
+    appliances: false,
+    ev: false,
+    boiler: false,
+    clima: false,
+    temp: false,
+    security: false,
+    server: false,
+    tapparelle: false,
+    irrigazione: false,
+    piscina: false,
+  },
+};
+
+/* Il campionatore parte col documento, prima che il guscio disegni: quello che
+ * si vuole cogliere succede nei primi due secondi. */
+async function guardaLaBarra(page) {
+  await page.addInitScript(() => {
+    window.__FORME_DELLA_BARRA__ = [];
+    const inizio = Date.now();
+    const giro = () => {
+      const barra = document.querySelector("nav.tabs.bottom-nav-bar");
+      const voci = [...document.querySelectorAll("nav.tabs .tab")];
+      if (barra && voci.length && getComputedStyle(barra).opacity !== "0") {
+        const firma = voci
+          .filter((nodo) => getComputedStyle(nodo).display !== "none")
+          .map((nodo) => nodo.dataset.tab)
+          .join(",");
+        const ultima = window.__FORME_DELLA_BARRA__[window.__FORME_DELLA_BARRA__.length - 1];
+        if (!ultima || ultima.firma !== firma) {
+          window.__FORME_DELLA_BARRA__.push({ ms: Date.now() - inizio, firma });
+        }
+      }
+      if (Date.now() - inizio < 8000) setTimeout(giro, 30);
+    };
+    setTimeout(giro, 0);
+  });
+}
+
+test("da quando si vede, la barra non cambia piu' forma", async ({ page }, testInfo) => {
+  test.setTimeout(120_000);
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await guardaLaBarra(page);
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+
+  /* Si aspetta che si sia assestata: la forma finale la decide la
+   * configurazione, e su questa casa non contiene ne' Sicurezza ne' MiniPC. */
+  const barra = page.locator("nav.tabs.bottom-nav-bar");
+  await expect(barra).not.toHaveCSS("opacity", "0");
+  await expect(page.locator('nav.tabs .tab[data-tab="security"]')).toBeHidden();
+  await expect(page.locator('nav.tabs .tab[data-tab="energy"]')).toBeVisible();
+  await page.waitForTimeout(4000);
+
+  const forme = await page.evaluate(() => window.__FORME_DELLA_BARRA__);
+  const elenco = forme.map((f) => `${f.ms}ms [${f.firma}]`).join("\n  ");
+  expect(forme.length, `la barra ha cambiato forma sotto gli occhi:\n  ${elenco}`).toBe(1);
+
+  /* E la forma unica e' quella configurata, non quella di serie. */
+  expect(forme[0].firma).not.toContain("security");
+  expect(forme[0].firma).toContain("home");
+  expect(forme[0].firma).toContain("energy");
+});
+
+test("una voce di una sezione spenta non compare nemmeno per un attimo", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(120_000);
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  await guardaLaBarra(page);
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, seed);
+  await expect(page.locator("nav.tabs.bottom-nav-bar")).not.toHaveCSS("opacity", "0");
+  await page.waitForTimeout(4000);
+
+  /* Le voci che mettono i moduli arrivano dopo quelle del guscio, e il guscio
+   * le filtrava al giro successivo: fra i due momenti la voce di una sezione
+   * spenta stava li' in mezzo alle altre. */
+  const forme = await page.evaluate(() => window.__FORME_DELLA_BARRA__);
+  for (const spenta of ["security", "server", "piscina", "irrigazione", "clima"]) {
+    for (const forma of forme) {
+      expect(
+        forma.firma.split(",").includes(spenta),
+        `«${spenta}» si e' vista a ${forma.ms}ms: [${forma.firma}]`,
+      ).toBe(false);
+    }
+  }
+});

--- a/custom_components/dashboardmodern/frontend/e2e/lo-storico-della-connettivita-dentro-la-cornice.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/lo-storico-della-connettivita-dentro-la-cornice.spec.js
@@ -1,0 +1,191 @@
+import { expect, test } from "@playwright/test";
+
+/* «Storico internet da errore.»
+ *
+ * Nella finestra della connettivita', al posto della cronologia dei sette
+ * giorni: «Storico non disponibile — Failed to fetch».
+ *
+ * Questa prova ricostruisce la sola topologia in cui il difetto esiste: Home
+ * Assistant che ospita la plancia dentro una cornice `srcdoc`. Aperta da sola,
+ * `dashboard.html` ha un `location.host` e l'indirizzo che il guscio costruisce
+ * e' giusto — il difetto e' invisibile, ed e' il motivo per cui nessuna prova
+ * l'aveva mai visto.
+ *
+ * Dentro la cornice `location.host` e' la stringa vuota, il guscio non sa dove
+ * sta e indovina `homeassistant.local:8123`. Qui quell'host non risponde
+ * apposta: se la richiesta ci va, la finestra scrive «Failed to fetch», che e'
+ * esattamente la schermata arrivata dal campo.
+ */
+
+/* La pagina che ospita, come la costruisce Home Assistant: una cornice
+ * `srcdoc`, e dentro i tre segnali che il preludio del pannello mette davvero
+ * — la plancia e' ospitata, il suo «gettone» e' un segnale che dice «i cookie
+ * bastano», e la connessione che le viene passata porta il `location.host`
+ * della cornice, che dentro `srcdoc` e' la stringa vuota. E' da li' che il
+ * guscio finisce a indovinare l'host. */
+const HOST_URL = "http://127.0.0.1:4173/dm-cornice-host.html";
+const HOST_PAGE = `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>body{margin:0;background:#eef2f7}iframe{width:100%;height:100vh;border:0;display:block}</style>
+</head><body>
+<iframe id="cornice"></iframe>
+<script type="module">
+const html = await (await fetch("/legacy/dashboard.html")).text();
+document.getElementById("cornice").srcdoc =
+  html.replace(
+    /<head(?:\\s[^>]*)?>/i,
+    (head) =>
+      head +
+      '<base href="/legacy/">' +
+      '<script>window.__DASHBOARDMODERN_HOSTED__=true;' +
+      'window.__DASHBOARDMODERN_REAL_TOKEN__="__dashboardmodern_hosted__";' +
+      'window.__DASHBOARDMODERN_CONNECTION__=' +
+      '{token:"__dashboardmodern_hosted__",local_ip:window.location.host,remote_url:""};' +
+      '<\\/script>',
+  );
+window.__DM_CORNICE_PRONTA__ = true;
+</script></body></html>`;
+
+const CASELLA = "dm.server_raggiungibilita_google";
+const ENTITA = "binary_sensor.internet_di_casa";
+
+const ora = Date.UTC(2026, 8, 3, 12, 0, 0);
+const quando = (oreFa) => new Date(ora - oreFa * 3600000).toISOString();
+const STORIA = [
+  [
+    { state: "on", last_changed: quando(72) },
+    { state: "off", last_changed: quando(30) },
+    { state: "on", last_changed: quando(29) },
+  ],
+];
+
+async function planciaNellaCornice(page) {
+  await page.addInitScript(() => {
+    class PonteFinto extends EventTarget {
+      static OPEN = 1;
+      readyState = 1;
+      constructor() {
+        super();
+        setTimeout(() => this.dispatchEvent(new Event("open")), 0);
+      }
+      send() {}
+      close() {}
+    }
+    window.WebSocket = PonteFinto;
+    try {
+      localStorage.clear();
+    } catch (_errore) {}
+  });
+  await page.route(`${HOST_URL}*`, (route) =>
+    route.fulfill({ status: 200, contentType: "text/html", body: HOST_PAGE }),
+  );
+  await page.goto("/dm-cornice-host.html");
+  await page.waitForFunction(() => window.__DM_CORNICE_PRONTA__ === true);
+  const cornice = page.frames().find((frame) => frame !== page.mainFrame());
+  await cornice.locator("body").waitFor();
+  /* Il guscio si carica dopo il corpo, e la finestra della connettivita' la
+     apre una sua funzione: si aspetta quella, che e' il segnale che il guscio
+     c'e' davvero. */
+  await cornice.waitForFunction(() => typeof window.apriSrvHistory === "function");
+  await cornice.waitForFunction(() => window.fetch.__dmIndirizzoDiCasa === true);
+  await cornice.waitForFunction(() => window.fetch.__dmIndirizzoDiCasa === true);
+  return cornice;
+}
+
+test.describe("lo storico della connettivita', dentro la cornice", () => {
+  test("la cronologia arriva: l'indirizzo torna a casa e la casella prende il suo nome", async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(120_000);
+
+    /* L'host indovinato non risponde: se la richiesta va li', la finestra
+     * scrive «Failed to fetch» e la prova cade dove e' caduta la casa vera. */
+    await page.route(
+      (url) => url.hostname === "homeassistant.local",
+      (route) => route.abort(),
+    );
+
+    const chieste = [];
+    await page.route("http://127.0.0.1:4173/api/history/period/**", (route) => {
+      chieste.push({
+        url: route.request().url(),
+        autorizzazione: route.request().headers().authorization ?? "",
+      });
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(STORIA),
+      });
+    });
+
+    const cornice = await planciaNellaCornice(page);
+
+    // Il guscio, dentro la cornice, non sa dove sta.
+    expect(await cornice.evaluate(() => location.host)).toBe("");
+    expect(await cornice.evaluate(() => HA_HTTP_URL)).toContain("homeassistant.local");
+
+    /* La casella della connettivita' mappata su un'entita' vera.
+     *
+     * La mappatura si mette nel magazzino e non solo con
+     * `cdApplyCanonicalOverrides`: quella funzione la richiamano anche le
+     * sezioni, passandole quello che il magazzino contiene, e una mappatura
+     * scritta soltanto a mano sparirebbe al primo giro. */
+    await cornice.evaluate(
+      ([casella, entita]) => {
+        window.DashboardModernModules?.store?.replaceSection?.("entityOverrides", {
+          [casella]: entita,
+        });
+        window.cdApplyCanonicalOverrides({ [casella]: entita });
+      },
+      [CASELLA, ENTITA],
+    );
+    await cornice.waitForFunction(
+      ([casella, entita]) => window.resolveEntity?.(casella) === entita,
+      [CASELLA, ENTITA],
+    );
+
+    await cornice.evaluate(() => window.apriSrvHistory("connettivita"));
+
+    const timeline = cornice.locator("#srv-hist-timeline");
+    await expect(timeline.locator(".srv-history-event")).toHaveCount(3);
+    await expect(timeline).not.toContainText("Storico non disponibile");
+    await expect(timeline).not.toContainText("Nessun dato storico");
+    await expect(timeline.locator(".srv-event-state").first()).toContainText("Online");
+
+    expect(chieste).toHaveLength(1);
+    // L'indirizzo e' quello di casa, e la domanda nomina l'entita' vera.
+    expect(chieste[0].url).toContain(`filter_entity_id=${ENTITA}`);
+    expect(chieste[0].url).not.toContain(CASELLA);
+    expect(chieste[0].url.startsWith("http://127.0.0.1:4173/api/history/period/")).toBe(true);
+    // E il gettone finto della plancia ospitata non parte: si prenderebbe un 401.
+    expect(chieste[0].autorizzazione).not.toContain("__dashboardmodern_hosted__");
+
+    await testInfo.attach("storico-connettivita.png", {
+      body: await cornice.locator("#srv-hist-overlay").screenshot(),
+      contentType: "image/png",
+    });
+  });
+
+  test("una casella senza entita' resta com'e', e la finestra lo dice", async ({ page }) => {
+    test.setTimeout(120_000);
+    await page.route(
+      (url) => url.hostname === "homeassistant.local",
+      (route) => route.abort(),
+    );
+    const chieste = [];
+    await page.route("http://127.0.0.1:4173/api/history/period/**", (route) => {
+      chieste.push(route.request().url());
+      return route.fulfill({ status: 200, contentType: "application/json", body: "[[]]" });
+    });
+
+    const cornice = await planciaNellaCornice(page);
+    await cornice.evaluate(() => window.apriSrvHistory("connettivita"));
+
+    /* La richiesta parte lo stesso e arriva a casa: quello che manca e' la
+     * mappatura, e la risposta vuota, li', e' la verita'. Sostituirla con
+     * l'entita' di un'altra casella sarebbe peggio del non rispondere. */
+    await expect(cornice.locator("#srv-hist-timeline")).toContainText("Nessun dato storico");
+    expect(chieste).toHaveLength(1);
+    expect(chieste[0]).toContain(`filter_entity_id=${CASELLA}`);
+  });
+});

--- a/custom_components/dashboardmodern/frontend/legacy/bridge-prelude.js
+++ b/custom_components/dashboardmodern/frontend/legacy/bridge-prelude.js
@@ -7,6 +7,43 @@
   var hasInstanceQuery = false;
   var hasHostQuery = false;
 
+  /* La tenda sulla barra, prima che la barra esista.
+   *
+   * «Resta sempre la barra totale, per poi diventare come l'ho configurata:
+   * dura quattro o cinque secondi.» Misurato sulla plancia vera: a 648 ms la
+   * barra si dipinge con tutte le voci del guscio e la configurazione non c'e'
+   * ancora; a 675 ms il guscio ne scrive una sua, ricavata da quali sezioni
+   * hanno contenuto — e in quel momento non ne ha nessuna; a 846 ms arriva
+   * quella vera; a 1431 ms compaiono le voci dei moduli, non filtrate. Quattro
+   * forme, e tre erano false.
+   *
+   * La regola sta qui, e qui per una ragione di tempo. Il foglio di stile della
+   * plancia il guscio lo carica apposta a bassa priorita' (`media="print"`
+   * finche' non e' arrivato), e misurando si vede che arriva DOPO che la barra
+   * si e' gia' dipinta: una tenda che cala dopo non copre niente. Questo
+   * preludio invece e' uno script che blocca, in cima al corpo del documento:
+   * e' il primo codice nostro che gira, prima del guscio e prima di qualunque
+   * modulo.
+   *
+   * Il segno lo mette la sezione della barra quando la configurazione della
+   * casa e' nota, o quando ha aspettato abbastanza. Se i moduli non
+   * arrivassero affatto la barra resterebbe coperta — ma in quel caso resta su
+   * anche il velo d'avvio, che i moduli li aspetta, e sotto non c'e' niente da
+   * vedere. */
+  function installaLaTendaDellaBarra() {
+    try {
+      if (document.getElementById("dm-tenda-barra")) return;
+      var stile = document.createElement("style");
+      stile.id = "dm-tenda-barra";
+      stile.textContent =
+        'html:not([data-dm-barra="pronta"]) nav.tabs.bottom-nav-bar{opacity:0!important}';
+      (document.head || document.documentElement).appendChild(stile);
+    } catch (_errore) {
+      /* Senza tenda si torna al difetto, non a qualcosa di peggio. */
+    }
+  }
+  installaLaTendaDellaBarra();
+
   function lightAddFormMarkup() {
     var isEnglish =
       document.documentElement.lang === "en" ||

--- a/custom_components/dashboardmodern/frontend/legacy/bridge-prelude.js
+++ b/custom_components/dashboardmodern/frontend/legacy/bridge-prelude.js
@@ -35,8 +35,13 @@
       if (document.getElementById("dm-tenda-barra")) return;
       var stile = document.createElement("style");
       stile.id = "dm-tenda-barra";
+      /* Invisibile e intoccabile. Un elemento con opacita' zero riceve i
+       * tocchi lo stesso, e la barra sta fissa in fondo allo schermo sopra a
+       * quello che c'e' sotto: senza questa riga, per il tempo della tenda un
+       * dito sul fondo della pagina finirebbe su una barra che non si vede. */
       stile.textContent =
-        'html:not([data-dm-barra="pronta"]) nav.tabs.bottom-nav-bar{opacity:0!important}';
+        'html:not([data-dm-barra="pronta"]) nav.tabs.bottom-nav-bar' +
+        "{opacity:0!important;pointer-events:none!important}";
       (document.head || document.documentElement).appendChild(stile);
     } catch (_errore) {
       /* Senza tenda si torna al difetto, non a qualcosa di peggio. */

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -13,4 +13,4 @@ import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
 import "../src/sections/segnalazioni-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5-beta.13","dashboardVersion":"1.4.5-beta.13","moduleVersion":14,"schemaVersion":4,"date":"2026-09-03T15:45:07+00:00","commit":"f8d879f2968b50bc8a3cb549864ef8ee3293b04f","assetHash":"325a8176e55c7527"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5","dashboardVersion":"1.4.5","moduleVersion":14,"schemaVersion":4,"date":"2026-09-03T15:51:41+00:00","commit":"66388fb10a8a14312029730acd990dc30b8f537a","assetHash":"325a8176e55c7527"});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -13,4 +13,4 @@ import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
 import "../src/sections/segnalazioni-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5-beta.12","dashboardVersion":"1.4.5-beta.12","moduleVersion":14,"schemaVersion":4,"date":"2026-09-03T04:51:01+00:00","commit":"35113d849ef28079897b6743de15cad54d8d242d","assetHash":"ebf8fef07f97bc9e"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.5-beta.13","dashboardVersion":"1.4.5-beta.13","moduleVersion":14,"schemaVersion":4,"date":"2026-09-03T15:45:07+00:00","commit":"f8d879f2968b50bc8a3cb549864ef8ee3293b04f","assetHash":"325a8176e55c7527"});

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
@@ -66,6 +66,7 @@ html[data-theme="dark"] #cd-boot-overlay b{color:#e2e8f0}
 <link rel="modulepreload" href="../src/core/i18n-dom.js">
 <link rel="modulepreload" href="../src/core/i18n.js">
 <link rel="modulepreload" href="../src/core/impianti-termici.js">
+<link rel="modulepreload" href="../src/core/indirizzo-di-casa.js">
 <link rel="modulepreload" href="../src/core/kiosk-undo.js">
 <link rel="modulepreload" href="../src/core/light-model.js">
 <link rel="modulepreload" href="../src/core/media-picker.js">
@@ -185,6 +186,7 @@ html[data-theme="dark"] #cd-boot-overlay b{color:#e2e8f0}
 <link rel="modulepreload" href="../src/sections/il-popup-della-lavatrice-section.js">
 <link rel="modulepreload" href="../src/sections/impianti-termici-editor-section.js">
 <link rel="modulepreload" href="../src/sections/impianti-termici-section.js">
+<link rel="modulepreload" href="../src/sections/indirizzo-di-casa-section.js">
 <link rel="modulepreload" href="../src/sections/le-strisce-di-linguette-section.js">
 <link rel="modulepreload" href="../src/sections/legacy-sections-registry.js">
 <link rel="modulepreload" href="../src/sections/lights-alerts-section.js">

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard.html
@@ -66,6 +66,7 @@ html[data-theme="dark"] #cd-boot-overlay b{color:#e2e8f0}
 <link rel="modulepreload" href="../src/core/i18n-dom.js">
 <link rel="modulepreload" href="../src/core/i18n.js">
 <link rel="modulepreload" href="../src/core/impianti-termici.js">
+<link rel="modulepreload" href="../src/core/indirizzo-di-casa.js">
 <link rel="modulepreload" href="../src/core/kiosk-undo.js">
 <link rel="modulepreload" href="../src/core/light-model.js">
 <link rel="modulepreload" href="../src/core/media-picker.js">
@@ -185,6 +186,7 @@ html[data-theme="dark"] #cd-boot-overlay b{color:#e2e8f0}
 <link rel="modulepreload" href="../src/sections/il-popup-della-lavatrice-section.js">
 <link rel="modulepreload" href="../src/sections/impianti-termici-editor-section.js">
 <link rel="modulepreload" href="../src/sections/impianti-termici-section.js">
+<link rel="modulepreload" href="../src/sections/indirizzo-di-casa-section.js">
 <link rel="modulepreload" href="../src/sections/le-strisce-di-linguette-section.js">
 <link rel="modulepreload" href="../src/sections/legacy-sections-registry.js">
 <link rel="modulepreload" href="../src/sections/lights-alerts-section.js">

--- a/custom_components/dashboardmodern/frontend/src/core/calendario-model.js
+++ b/custom_components/dashboardmodern/frontend/src/core/calendario-model.js
@@ -460,11 +460,13 @@ export function scadenzeDelleListe(blocchi) {
  *
  * `setDate` invece conta i giorni come li conta il calendario, e i mesi e gli
  * anni li fa girare da solo. */
-function ilGiornoDopo(istante) {
+export function giornoPiu(istante, giorni) {
   const quando = new Date(istante);
-  quando.setDate(quando.getDate() + 1);
+  quando.setDate(quando.getDate() + giorni);
   return quando;
 }
+
+const ilGiornoDopo = (istante) => giornoPiu(istante, 1);
 
 export function contoDellaTessera(eventi, scadenze, adesso = Date.now()) {
   const oggi = chiaveDelGiorno(adesso);
@@ -645,7 +647,9 @@ export function etichettaDelGiorno(
   const dette = { ...PAROLE_CALENDARIO, ...(parole || {}) };
   const oggi = chiaveDelGiorno(adesso);
   if (giorno === oggi) return dette.oggi;
-  const domani = chiaveDelGiorno(adesso + 86400000);
+  /* Non `+ 86400000`: nel giorno del cambio d'ora ventiquattro ore non sono
+   * un giorno, e «Domani» finiva per chiamarsi con la sua data. */
+  const domani = chiaveDelGiorno(ilGiornoDopo(adesso));
   if (giorno === domani) return dette.domani;
   const [anno, mese, numero] = clean(giorno).split("-").map(Number);
   if (!Number.isFinite(anno)) return clean(giorno);
@@ -661,7 +665,8 @@ export function etichettaDelGiorno(
   }
 }
 
-function orarioDi(istante, lingua) {
+/** L'ora di un istante, breve, nella lingua di chi guarda: «14:30», «02:30 PM». */
+export function orarioDi(istante, lingua) {
   try {
     return new Date(istante).toLocaleTimeString(lingua || undefined, {
       hour: "2-digit",

--- a/custom_components/dashboardmodern/frontend/src/core/contenuto-delle-sezioni.js
+++ b/custom_components/dashboardmodern/frontend/src/core/contenuto-delle-sezioni.js
@@ -35,6 +35,7 @@
  */
 
 import { sectionForEditorSlot } from "./editor-slots.js";
+import { CHIAVE_ENTITA_MIE, sezioniConEntita } from "./entita-mie.js";
 
 /** Un valore che somiglia a un'entita': `dominio.oggetto`. */
 const paresEntita = (valore) => typeof valore === "string" && valore.trim().includes(".");
@@ -84,7 +85,10 @@ export const MAGAZZINO_DELLE_SEZIONI = Object.freeze({
     testi: ["cd_ev_image"],
   }),
   boiler: Object.freeze({ chiavi: ["cd_caldaia", "cd_scaldabagni", "cd_impianti_termici"] }),
-  security: Object.freeze({ chiavi: ["cd_cameras", "cd_security_doors"] }),
+  /* Le porte non stanno piu' qui: dalla 1.4.5 si disegnano nella loro pagina,
+   * che si accende e si spegne da sola. Contarle ancora come contenuto di
+   * Sicurezza teneva in barra una scheda vuota a chi ha solo le porte. */
+  security: Object.freeze({ chiavi: ["cd_cameras"] }),
   /* Il MiniPC si configura solo dalle caselle dell'editor: nessuna chiave sua,
    * e le entita' arrivano tutte da `cd_entity_overrides`. */
   server: Object.freeze({ chiavi: [] }),
@@ -141,6 +145,14 @@ export function contenutoDelleSezioni(leggi) {
       const sezione = sectionForEditorSlot(String(casella));
       if (sezione && MAGAZZINO_DELLE_SEZIONI[sezione]) piene.add(sezione);
     }
+
+  /* Le entita' che uno si aggiunge dove vuole: stanno in una chiave sola, con
+   * dentro la sezione a cui appartengono. Senza questo giro una sezione che
+   * vive solo di quelle risultava vuota, e il salvataggio dell'entita' appena
+   * aggiunta la toglieva dalla barra — proprio la sezione dove la si era
+   * appena messa. */
+  for (const sezione of sezioniConEntita(leggi(CHIAVE_ENTITA_MIE)))
+    if (MAGAZZINO_DELLE_SEZIONI[sezione]) piene.add(sezione);
 
   const vuote = new Set(sezioniGovernate().filter((sezione) => !piene.has(sezione)));
   return { piene, vuote };

--- a/custom_components/dashboardmodern/frontend/src/core/energy-flow-topology.js
+++ b/custom_components/dashboardmodern/frontend/src/core/energy-flow-topology.js
@@ -409,8 +409,6 @@ export function readingFor(load, children, period, states, recorderValues) {
    * una regola apposta: il carico che oggi non e' partito ha i figli a zero
    * anche loro, la somma fa zero, e zero resta. Cambia soltanto il caso in cui
    * il contatore dice zero e chi sta dentro dice di no. */
-  if (own.value !== null && own.value !== 0)
-    return { ...own, source: "direct", children: children.length };
   if (!children.length) return { ...own, source: "direct", children: 0 };
   let total = null;
   for (const child of children) {
@@ -419,7 +417,43 @@ export function readingFor(load, children, period, states, recorderValues) {
     total = (total ?? 0) + value;
   }
   if (total === null || total === 0) return { ...own, source: "direct", children: children.length };
+  if (own.value !== null && !contatoreSottoIFigli(own.value, total))
+    return { ...own, source: "direct", children: children.length };
   return { entity: own.entity, value: total, source: "sum", children: children.length };
+}
+
+/* Un padre non consuma meno dei suoi figli.
+ *
+ * Lo zero era il caso facile, ed e' stato sistemato: una casella a zero con
+ * dentro apparecchi che hanno consumato non e' una misura, e' una casella che
+ * non risponde. Dal campo e' tornato lo stesso difetto un passo piu' in la',
+ * col numero al posto dello zero: cerchio a «0,2 kWh», finestra dello stesso
+ * cerchio a «12,0 kWh». Stessa schermata, stessa contraddizione, e la regola
+ * di prima non scattava perche' 0,2 non e' zero.
+ *
+ * Zero non era la cosa da guardare. La cosa da guardare e' che una pinza sulla
+ * linea, per come e' fatta, misura tutto quello che le passa sotto: il suo
+ * numero non puo' essere piu' piccolo della somma di cio' che ha dentro. Se lo
+ * e', quella casella non sta misurando il gruppo — sta misurando altro, di
+ * solito un apparecchio solo finito li' per sbaglio. E allora vince la somma,
+ * che e' il numero che la finestra mostra e che almeno e' un minimo vero.
+ *
+ * Il margine e' del cinque per cento e serve a non far ballare il cerchio: la
+ * pinza e i contatori dei figli non campionano nello stesso istante, e senza
+ * margine un ritardo di qualche secondo cambierebbe la sorgente avanti e
+ * indietro. Sotto quella soglia non e' piu' ritardo: e' un'altra grandezza.
+ *
+ * Il caso che la regola dello zero proteggeva resta protetto e non serve
+ * nominarlo: il gruppo fermo ha i figli a zero, la somma fa zero, e si esce
+ * prima di arrivare qui. */
+const MARGINE_DEL_CONTATORE = 0.95;
+
+export function contatoreSottoIFigli(proprio, somma) {
+  if (!Number.isFinite(proprio) || !Number.isFinite(somma)) return false;
+  /* Segni opposti non si confrontano per grandezza: un contatore con segno
+   * racconta un verso, e la somma dei figli un altro. */
+  if (somma <= 0) return false;
+  return proprio < somma * MARGINE_DEL_CONTATORE;
 }
 
 /* Only values the user actually saved override the canonical Load. The

--- a/custom_components/dashboardmodern/frontend/src/core/indirizzo-di-casa.js
+++ b/custom_components/dashboardmodern/frontend/src/core/indirizzo-di-casa.js
@@ -1,0 +1,176 @@
+/* L'indirizzo di casa, quando la plancia non sa dove sta.
+ *
+ * «Storico internet dà errore»: dentro la finestra della connettività, al
+ * posto della cronologia dei sette giorni, «❌ Storico non disponibile —
+ * Failed to fetch».
+ *
+ * «Failed to fetch» non è una risposta: non è un 401 e non è un 404, è una
+ * richiesta che non è mai arrivata da nessuna parte. E il motivo sta in come
+ * il guscio si costruisce l'indirizzo a cui chiedere:
+ *
+ *     host = location.host
+ *     if (!host) host = LOCAL_IP        // «homeassistant.local:8123»
+ *     HA_HTTP_URL = httpProto + '//' + host
+ *
+ * La plancia ospitata vive in una cornice `srcdoc`. Quella cornice eredita
+ * l'origine di chi la contiene — la memoria del browser è la stessa, ed è un
+ * fatto che questa casa conosce già — ma il suo `location` no: è
+ * `about:srcdoc`, e da lì `location.host` è la stringa vuota. Il guscio allora
+ * fa l'unica cosa che può fare senza sapere dove si trova: indovina, e
+ * indovina `homeassistant.local:8123`, che è il nome giusto in una casa su
+ * cento e in tutte le altre è un host che non esiste — o che esiste ma in
+ * chiaro, mentre la pagina viaggia in https, e allora il browser blocca la
+ * richiesta senza nemmeno provarci.
+ *
+ * Misurato dentro la cornice, con la plancia vera: `location.host` è "",
+ * `document.baseURI` è la pagina di Home Assistant, e `HA_HTTP_URL` è
+ * `http://homeassistant.local:8123`.
+ *
+ * Gli indirizzi RELATIVI invece funzionano, ed è il motivo per cui tutto il
+ * resto della plancia va: in un documento `srcdoc` si risolvono contro la base
+ * del padre, cioè contro Home Assistant. È la stessa cosa che le telecamere
+ * hanno imparato a suo tempo — «usa l'origine della plancia invece del vecchio
+ * HA_HTTP_URL» — e che in questa finestra non era arrivata.
+ *
+ * Questo modulo è l'aritmetica di quella riparazione, e sta nel nucleo perché
+ * è una domanda su delle stringhe: dato un indirizzo che qualcuno ha
+ * costruito, la base del documento e l'host che il documento ha (o non ha),
+ * qual è l'indirizzo giusto? Si prova senza rete e senza browser.
+ */
+
+const pulito = (valore) => String(valore ?? "").trim();
+
+const ASSOLUTO = /^https?:\/\//i;
+
+/* Un indirizzo che non porta da nessuna parte: lo schema c'è, l'host no.
+ *
+ * `new URL("http://")` lancia, e `new URL("http:///api/x")` non lancia ma
+ * legge «api» come host: si guarda la stringa, che è l'unica cosa che si
+ * comporta uguale dappertutto. */
+export function senzaHost(indirizzo) {
+  return /^https?:\/\/(?:\/|$)/i.test(pulito(indirizzo));
+}
+
+/** Se questo indirizzo chiede qualcosa a Home Assistant. */
+export function versoLApi(indirizzo) {
+  const valore = pulito(indirizzo);
+  if (!valore) return false;
+  if (valore.startsWith("/api/")) return true;
+  return /^https?:\/\/[^/]*\/api\//i.test(valore);
+}
+
+/* Il percorso, con la domanda attaccata: è la parte che si conserva.
+ *
+ * L'host senza host va tagliato a mano — `new URL` legge «api» come host — e
+ * quello con host si legge invece con `new URL`, che sa dove finisce. */
+function percorsoConDomanda(indirizzo) {
+  const valore = pulito(indirizzo);
+  if (senzaHost(valore)) {
+    const nudo = valore.replace(ASSOLUTO, "");
+    return nudo.startsWith("/") ? nudo : `/${nudo}`;
+  }
+  try {
+    const letto = new URL(valore);
+    return `${letto.pathname}${letto.search}${letto.hash}`;
+  } catch (_errore) {
+    return valore;
+  }
+}
+
+/**
+ * L'indirizzo da usare davvero.
+ *
+ * Torna `null` quando non c'è niente da riparare — chi chiama passa oltre
+ * senza toccare la richiesta, che è il caso normale e deve restare gratis.
+ *
+ * `hostDelDocumento` è il `location.host` di chi sta chiedendo, e la stringa
+ * vuota vuol dire «questo documento non ha un host suo»: è la cornice
+ * `srcdoc`, ed è l'unica condizione in cui il guscio ha dovuto indovinare. Un
+ * documento che il suo host ce l'ha non si tocca: lì `HA_HTTP_URL` è giusto, e
+ * dirottare una richiesta che qualcuno ha voluto sarebbe peggio del difetto
+ * che si sta correggendo.
+ *
+ * Senza una base contro cui risolvere non si inventa niente. Vale per la
+ * plancia aperta da un file su disco, che di host non ne ha e di base
+ * utilizzabile nemmeno: lì `LOCAL_IP` è l'unica risposta che esista, ed è
+ * giusto che resti.
+ */
+export function indirizzoRiparato(indirizzo, base = "", hostDelDocumento = "") {
+  const valore = pulito(indirizzo);
+  if (!valore || !versoLApi(valore)) return null;
+  /* Già relativo: parte da casa da solo, che è esattamente quello che serve. */
+  if (!ASSOLUTO.test(valore)) return null;
+  const rotto = senzaHost(valore);
+  if (!rotto && pulito(hostDelDocumento)) return null;
+  const percorso = percorsoConDomanda(valore);
+  const fondo = pulito(base);
+  /* Senza base resta il percorso, e solo per l'indirizzo che è rotto in sé: in
+   * una cornice si risolve da solo contro il padre, e comunque non può andare
+   * peggio di `http:///`. */
+  if (!fondo) return rotto ? percorso : null;
+  try {
+    return new URL(percorso, fondo).href;
+  } catch (_errore) {
+    return percorso;
+  }
+}
+
+/* Il gettone che non è un gettone.
+ *
+ * Nella plancia ospitata il guscio mette `__dashboardmodern_hosted__` al posto
+ * del gettone: è un segnale, non una credenziale, e vuol dire «i cookie
+ * bastano già». Spedirlo come `Bearer` è il modo di farsi rispondere 401 da
+ * una richiesta che sarebbe passata da sola. */
+export const GETTONE_FINTO = "__dashboardmodern_hosted__";
+
+export function autorizzazioneInutile(valore) {
+  const scritto = pulito(valore);
+  if (!scritto) return false;
+  const nudo = scritto.replace(/^Bearer\b\s*/i, "").trim();
+  return !nudo || nudo === GETTONE_FINTO || nudo === "undefined" || nudo === "null";
+}
+
+/* Il riferimento che il Recorder non conosce.
+ *
+ * Riparato l'indirizzo, la stessa finestra ha ancora un modo di non mostrare
+ * niente, più silenzioso del primo. La domanda che parte è:
+ *
+ *     /api/history/period/...?filter_entity_id=dm.server_raggiungibilita_google
+ *
+ * `dm.server_raggiungibilita_google` non è un'entità di Home Assistant: è una
+ * casella della plancia, e quale entità ci sia dentro lo sa la mappatura. Il
+ * Recorder non ha niente con quel nome, risponde con un elenco vuoto, e la
+ * finestra scrive «Nessun dato storico trovato per dm.…»: un errore che non
+ * sembra un errore.
+ *
+ * La mappatura è la stessa con cui la plancia legge lo stato di quella casella
+ * — `resolveEntity` — quindi qui non si inventa niente, si chiede a lei. Una
+ * casella non mappata resta com'è: in quel caso la risposta vuota è la verità,
+ * e sostituirla con un'altra entità sarebbe peggio.
+ */
+const RIFERIMENTO = /([?&]filter_entity_id=)([^&#]*)/i;
+
+const virtuale = (nome) => /^dm\./i.test(nome);
+
+export function conLEntitaVera(indirizzo, risolvi) {
+  const valore = pulito(indirizzo);
+  if (!valore || typeof risolvi !== "function") return null;
+  const trovato = valore.match(RIFERIMENTO);
+  if (!trovato) return null;
+  /* Più entità separate da virgola: è quello che l'API accetta, e basta una
+   * sola casella da tradurre perché valga la pena riscrivere. */
+  const prima = trovato[2].split(",");
+  const dopo = prima.map((pezzo) => {
+    const nome = pezzo.trim();
+    if (!virtuale(nome)) return pezzo;
+    let vero = "";
+    try {
+      vero = pulito(risolvi(nome));
+    } catch (_errore) {
+      return pezzo;
+    }
+    return vero && vero !== nome && !virtuale(vero) ? vero : pezzo;
+  });
+  if (dopo.every((pezzo, indice) => pezzo === prima[indice])) return null;
+  return valore.replace(RIFERIMENTO, (_tutto, capo) => `${capo}${dopo.join(",")}`);
+}

--- a/custom_components/dashboardmodern/frontend/src/i18n/ar.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ar.js
@@ -953,6 +953,7 @@ export default Object.freeze({
   "Confirm ✓": "أكّد ✓",
   "Confirm opening?": "تأكيد الفتح؟",
   "Confirm?": "تأكيد؟",
+  "Add an emoji": "أضف رمزًا تعبيريًا",
   "Connect GitHub": "ربط GitHub",
   Connected: "متصل",
   "Connected as": "متصل باسم",

--- a/custom_components/dashboardmodern/frontend/src/i18n/ar.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ar.js
@@ -952,6 +952,7 @@ export default Object.freeze({
   Confirm: "تأكيد",
   "Confirm ✓": "أكّد ✓",
   "Confirm opening?": "تأكيد الفتح؟",
+  "Confirm?": "تأكيد؟",
   "Connect GitHub": "ربط GitHub",
   Connected: "متصل",
   "Connected as": "متصل باسم",

--- a/custom_components/dashboardmodern/frontend/src/i18n/de.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/de.js
@@ -975,6 +975,7 @@ export default Object.freeze({
   Confirm: "Bestätigen",
   "Confirm ✓": "Bestätigen ✓",
   "Confirm opening?": "Öffnen bestätigen?",
+  "Confirm?": "Bestätigen?",
   "Connect GitHub": "GitHub verbinden",
   Connected: "Verbunden",
   "Connected as": "Verbunden als",

--- a/custom_components/dashboardmodern/frontend/src/i18n/de.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/de.js
@@ -976,6 +976,7 @@ export default Object.freeze({
   "Confirm ✓": "Bestätigen ✓",
   "Confirm opening?": "Öffnen bestätigen?",
   "Confirm?": "Bestätigen?",
+  "Add an emoji": "Emoji einfügen",
   "Connect GitHub": "GitHub verbinden",
   Connected: "Verbunden",
   "Connected as": "Verbunden als",

--- a/custom_components/dashboardmodern/frontend/src/i18n/es.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/es.js
@@ -969,6 +969,7 @@ export default Object.freeze({
   Confirm: "Confirmar",
   "Confirm ✓": "Confirmar ✓",
   "Confirm opening?": "¿Confirmas la apertura?",
+  "Confirm?": "¿Confirmas?",
   "Connect GitHub": "Conectar GitHub",
   Connected: "Conectado",
   "Connected as": "Conectado como",

--- a/custom_components/dashboardmodern/frontend/src/i18n/es.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/es.js
@@ -970,6 +970,7 @@ export default Object.freeze({
   "Confirm ✓": "Confirmar ✓",
   "Confirm opening?": "¿Confirmas la apertura?",
   "Confirm?": "¿Confirmas?",
+  "Add an emoji": "Añadir un emoji",
   "Connect GitHub": "Conectar GitHub",
   Connected: "Conectado",
   "Connected as": "Conectado como",

--- a/custom_components/dashboardmodern/frontend/src/i18n/fr.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/fr.js
@@ -975,6 +975,7 @@ export default Object.freeze({
   "Confirm ✓": "Confirmer ✓",
   "Confirm opening?": "Confirmer l'ouverture ?",
   "Confirm?": "Confirmer ?",
+  "Add an emoji": "Ajouter un emoji",
   "Connect GitHub": "Connecter GitHub",
   Connected: "Connecté",
   "Connected as": "Connecté en tant que",

--- a/custom_components/dashboardmodern/frontend/src/i18n/fr.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/fr.js
@@ -974,6 +974,7 @@ export default Object.freeze({
   Confirm: "Confirmer",
   "Confirm ✓": "Confirmer ✓",
   "Confirm opening?": "Confirmer l'ouverture ?",
+  "Confirm?": "Confirmer ?",
   "Connect GitHub": "Connecter GitHub",
   Connected: "Connecté",
   "Connected as": "Connecté en tant que",

--- a/custom_components/dashboardmodern/frontend/src/i18n/hi.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/hi.js
@@ -960,6 +960,7 @@ export default Object.freeze({
   "Confirm ✓": "पक्का करें ✓",
   "Confirm opening?": "खोलने की पुष्टि करें?",
   "Confirm?": "पुष्टि करें?",
+  "Add an emoji": "इमोजी जोड़ें",
   "Connect GitHub": "GitHub जोड़ें",
   Connected: "जुड़ा है",
   "Connected as": "इस रूप में जुड़े",

--- a/custom_components/dashboardmodern/frontend/src/i18n/hi.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/hi.js
@@ -959,6 +959,7 @@ export default Object.freeze({
   Confirm: "पुष्टि करें",
   "Confirm ✓": "पक्का करें ✓",
   "Confirm opening?": "खोलने की पुष्टि करें?",
+  "Confirm?": "पुष्टि करें?",
   "Connect GitHub": "GitHub जोड़ें",
   Connected: "जुड़ा है",
   "Connected as": "इस रूप में जुड़े",

--- a/custom_components/dashboardmodern/frontend/src/i18n/ja.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ja.js
@@ -967,6 +967,7 @@ export default Object.freeze({
   "Confirm ✓": "確定 ✓",
   "Confirm opening?": "開けてもよろしいですか？",
   "Confirm?": "確認しますか？",
+  "Add an emoji": "絵文字を追加",
   "Connect GitHub": "GitHub と連携",
   Connected: "接続済み",
   "Connected as": "接続中のアカウント",

--- a/custom_components/dashboardmodern/frontend/src/i18n/ja.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ja.js
@@ -966,6 +966,7 @@ export default Object.freeze({
   Confirm: "確認",
   "Confirm ✓": "確定 ✓",
   "Confirm opening?": "開けてもよろしいですか？",
+  "Confirm?": "確認しますか？",
   "Connect GitHub": "GitHub と連携",
   Connected: "接続済み",
   "Connected as": "接続中のアカウント",

--- a/custom_components/dashboardmodern/frontend/src/i18n/ko.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ko.js
@@ -961,6 +961,7 @@ export default Object.freeze({
   "Confirm ✓": "확인 ✓",
   "Confirm opening?": "열기를 확인할까요?",
   "Confirm?": "확인할까요?",
+  "Add an emoji": "이모지 넣기",
   "Connect GitHub": "GitHub 연결",
   Connected: "연결됨",
   "Connected as": "연결된 계정",

--- a/custom_components/dashboardmodern/frontend/src/i18n/ko.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ko.js
@@ -960,6 +960,7 @@ export default Object.freeze({
   Confirm: "확인",
   "Confirm ✓": "확인 ✓",
   "Confirm opening?": "열기를 확인할까요?",
+  "Confirm?": "확인할까요?",
   "Connect GitHub": "GitHub 연결",
   Connected: "연결됨",
   "Connected as": "연결된 계정",

--- a/custom_components/dashboardmodern/frontend/src/i18n/nl.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/nl.js
@@ -971,6 +971,7 @@ export default Object.freeze({
   "Confirm ✓": "Bevestigen ✓",
   "Confirm opening?": "Openen bevestigen?",
   "Confirm?": "Bevestigen?",
+  "Add an emoji": "Emoji toevoegen",
   "Connect GitHub": "GitHub koppelen",
   Connected: "Verbonden",
   "Connected as": "Verbonden als",

--- a/custom_components/dashboardmodern/frontend/src/i18n/nl.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/nl.js
@@ -970,6 +970,7 @@ export default Object.freeze({
   Confirm: "Bevestigen",
   "Confirm ✓": "Bevestigen ✓",
   "Confirm opening?": "Openen bevestigen?",
+  "Confirm?": "Bevestigen?",
   "Connect GitHub": "GitHub koppelen",
   Connected: "Verbonden",
   "Connected as": "Verbonden als",

--- a/custom_components/dashboardmodern/frontend/src/i18n/pl.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/pl.js
@@ -969,6 +969,7 @@ export default Object.freeze({
   "Confirm ✓": "Potwierdź ✓",
   "Confirm opening?": "Potwierdzić otwarcie?",
   "Confirm?": "Potwierdzić?",
+  "Add an emoji": "Dodaj emoji",
   "Connect GitHub": "Połącz GitHuba",
   Connected: "Połączono",
   "Connected as": "Połączono jako",

--- a/custom_components/dashboardmodern/frontend/src/i18n/pl.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/pl.js
@@ -968,6 +968,7 @@ export default Object.freeze({
   Confirm: "Potwierdź",
   "Confirm ✓": "Potwierdź ✓",
   "Confirm opening?": "Potwierdzić otwarcie?",
+  "Confirm?": "Potwierdzić?",
   "Connect GitHub": "Połącz GitHuba",
   Connected: "Połączono",
   "Connected as": "Połączono jako",

--- a/custom_components/dashboardmodern/frontend/src/i18n/pt.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/pt.js
@@ -969,6 +969,7 @@ export default Object.freeze({
   "Confirm ✓": "Confirmar ✓",
   "Confirm opening?": "Confirmar a abertura?",
   "Confirm?": "Confirmar?",
+  "Add an emoji": "Adicionar um emoji",
   "Connect GitHub": "Ligar o GitHub",
   Connected: "Ligado",
   "Connected as": "Ligado como",

--- a/custom_components/dashboardmodern/frontend/src/i18n/pt.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/pt.js
@@ -968,6 +968,7 @@ export default Object.freeze({
   Confirm: "Confirmar",
   "Confirm ✓": "Confirmar ✓",
   "Confirm opening?": "Confirmar a abertura?",
+  "Confirm?": "Confirmar?",
   "Connect GitHub": "Ligar o GitHub",
   Connected: "Ligado",
   "Connected as": "Ligado como",

--- a/custom_components/dashboardmodern/frontend/src/i18n/ru.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ru.js
@@ -968,6 +968,7 @@ export default Object.freeze({
   "Confirm ✓": "Подтвердить ✓",
   "Confirm opening?": "Подтвердить открытие?",
   "Confirm?": "Подтвердить?",
+  "Add an emoji": "Добавить эмодзи",
   "Connect GitHub": "Подключить GitHub",
   Connected: "Подключено",
   "Connected as": "Подключено как",

--- a/custom_components/dashboardmodern/frontend/src/i18n/ru.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ru.js
@@ -967,6 +967,7 @@ export default Object.freeze({
   Confirm: "Подтвердить",
   "Confirm ✓": "Подтвердить ✓",
   "Confirm opening?": "Подтвердить открытие?",
+  "Confirm?": "Подтвердить?",
   "Connect GitHub": "Подключить GitHub",
   Connected: "Подключено",
   "Connected as": "Подключено как",

--- a/custom_components/dashboardmodern/frontend/src/i18n/source-index.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/source-index.js
@@ -1383,6 +1383,7 @@ export const SOURCE_INDEX = Object.freeze({
   "Messaggio mandato.": "Message sent.",
   "Meteo": "Weather",
   "Meteo, avvisi, azioni rapide": "Weather, alerts, quick actions",
+  "Metti un'emoji": "Add an emoji",
   "Microonde": "Microwave",
   "Min": "Low",
   "MiniPC": "Server",

--- a/custom_components/dashboardmodern/frontend/src/i18n/source-index.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/source-index.js
@@ -736,6 +736,7 @@ export const SOURCE_INDEX = Object.freeze({
   "Conferma ✓": "Confirm ✓",
   "Conferma opzionale": "Optional confirmation",
   "Confermi l'apertura?": "Confirm opening?",
+  "Confermi?": "Confirm?",
   "Configura Entità": "Configure entities",
   "Configura le entità di ogni sezione con le": "Configure each section with",
   "Configura prima almeno una stanza nella sezione Stanze.": "Configure at least one room first in the Rooms section.",

--- a/custom_components/dashboardmodern/frontend/src/i18n/tr.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/tr.js
@@ -965,6 +965,7 @@ export default Object.freeze({
   Confirm: "Onayla",
   "Confirm ✓": "Onayla ✓",
   "Confirm opening?": "Açma onaylansın mı?",
+  "Confirm?": "Onaylansın mı?",
   "Connect GitHub": "GitHub'ı bağla",
   Connected: "Bağlı",
   "Connected as": "Şu hesapla bağlı",

--- a/custom_components/dashboardmodern/frontend/src/i18n/tr.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/tr.js
@@ -966,6 +966,7 @@ export default Object.freeze({
   "Confirm ✓": "Onayla ✓",
   "Confirm opening?": "Açma onaylansın mı?",
   "Confirm?": "Onaylansın mı?",
+  "Add an emoji": "Emoji ekle",
   "Connect GitHub": "GitHub'ı bağla",
   Connected: "Bağlı",
   "Connected as": "Şu hesapla bağlı",

--- a/custom_components/dashboardmodern/frontend/src/i18n/zh-Hans.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/zh-Hans.js
@@ -944,6 +944,7 @@ export default Object.freeze({
   "Confirm ✓": "确认 ✓",
   "Confirm opening?": "确认开门？",
   "Confirm?": "确认？",
+  "Add an emoji": "添加表情",
   "Connect GitHub": "连接 GitHub",
   Connected: "已连接",
   "Connected as": "已连接账号",

--- a/custom_components/dashboardmodern/frontend/src/i18n/zh-Hans.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/zh-Hans.js
@@ -943,6 +943,7 @@ export default Object.freeze({
   Confirm: "确认",
   "Confirm ✓": "确认 ✓",
   "Confirm opening?": "确认开门？",
+  "Confirm?": "确认？",
   "Connect GitHub": "连接 GitHub",
   Connected: "已连接",
   "Connected as": "已连接账号",

--- a/custom_components/dashboardmodern/frontend/src/legacy/bridge-socket.js
+++ b/custom_components/dashboardmodern/frontend/src/legacy/bridge-socket.js
@@ -98,6 +98,7 @@ export const ALLOWED_MESSAGE_TYPES = Object.freeze([
   "dashboardmodern/chat/queue",
   "dashboardmodern/chat/open",
   "dashboardmodern/chat/answer",
+  "dashboardmodern/chat/drop",
   "auth/sign_path",
 ]);
 

--- a/custom_components/dashboardmodern/frontend/src/sections/assistenza-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/assistenza-section.js
@@ -422,6 +422,9 @@ export function apri() {
   const modale = finestra();
   if (!modale) return;
   state.avviso = "";
+  /* Un cestino armato non sopravvive alla finestra: riaprirla e trovare
+   * «Confermi?» gia' acceso vorrebbe dire che il primo tocco cancella. */
+  state.daButtare = "";
   modale.classList.add("show");
   disegna();
   ricarica();
@@ -430,6 +433,7 @@ export function apri() {
 
 export function chiudi() {
   spegniIlGiro();
+  state.daButtare = "";
   doc?.getElementById?.("dm-chat-modal")?.classList.remove("show");
 }
 

--- a/custom_components/dashboardmodern/frontend/src/sections/assistenza-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/assistenza-section.js
@@ -187,6 +187,101 @@ export function filoMarkup(messaggi, dallaConsole = false) {
  * l'errore e sotto una casella pulita: chi aveva appena incollato mezzo file di
  * configurazione doveva riscriverlo per riprovare, che e' il modo piu' sicuro
  * di far smettere di riprovare. */
+/* ─── Le emoji ──────────────────────────────────────────────────────────
+ *
+ * «Ecco mancano le emoji :) :) :)»
+ *
+ * Una chat di assistenza le vuole per la ragione per cui le vuole qualunque
+ * chat: una frase scritta di corsa suona piu' secca di com'e' stata pensata, e
+ * chi legge dall'altra parte non ha il tono di voce per correggerla. Un pollice
+ * in su chiude uno scambio meglio di «ok».
+ *
+ * L'elenco e' corto e scelto, non un catalogo: in una finestra di assistenza
+ * servono facce, mani, e le cose di casa di cui si sta parlando. Un catalogo
+ * intero vorrebbe dire una ricerca, una tastiera e un pannello che copre la
+ * conversazione — e mille segni per trovarne cinque.
+ *
+ * Niente tonalita' di pelle e niente sequenze composte: un'emoji sola per
+ * segno, che e' quello che il campo e il centralino si passano senza sorprese.
+ */
+export const EMOJI_DELLA_CHAT = Object.freeze([
+  "🙂",
+  "😀",
+  "😅",
+  "😉",
+  "😊",
+  "🤔",
+  "😐",
+  "😕",
+  "😢",
+  "😱",
+  "👍",
+  "👎",
+  "🙏",
+  "👏",
+  "💪",
+  "🤝",
+  "👋",
+  "🤞",
+  "✅",
+  "❌",
+  "⚠️",
+  "❓",
+  "❗",
+  "💡",
+  "🔧",
+  "🔌",
+  "🔋",
+  "📷",
+  "📎",
+  "🏠",
+  "🚗",
+  "☀️",
+  "🌧️",
+  "🔥",
+  "❄️",
+  "💧",
+  "🎉",
+  "❤️",
+  "⏳",
+  "📅",
+]);
+
+/**
+ * Il testo con dentro l'emoji, e dove va a finire il cursore.
+ *
+ * Si mette dove sta il cursore e non in fondo: chi ha scritto una frase e
+ * torna indietro a metterci una faccia si aspetta che vada li'. Con del testo
+ * selezionato l'emoji lo sostituisce, che e' quello che fa qualunque campo.
+ *
+ * E il tetto si rispetta prima di scrivere, non dopo: il campo ha un massimo,
+ * e un'emoji che lo sfonda deve non entrare — non entrare a meta', che
+ * significherebbe spezzare un segno in due pezzi che non vogliono dire niente.
+ */
+export function conLEmoji(testo = "", emoji = "", inizio = null, fine = null, massimo = Infinity) {
+  const base = String(testo ?? "");
+  const segno = String(emoji ?? "");
+  const dentro = (valore, difetto) =>
+    Number.isInteger(valore) && valore >= 0 ? Math.min(valore, base.length) : difetto;
+  const da = dentro(inizio, base.length);
+  const a = Math.max(da, dentro(fine, da));
+  if (!segno) return { testo: base, cursore: a, pieno: false };
+  const prossimo = `${base.slice(0, da)}${segno}${base.slice(a)}`;
+  if (prossimo.length > massimo) return { testo: base, cursore: a, pieno: true };
+  return { testo: prossimo, cursore: da + segno.length, pieno: false };
+}
+
+function emojiMarkup() {
+  return `
+    <div class="dm-chat-emoji" data-dm-chat="emoji" hidden>
+      ${EMOJI_DELLA_CHAT.map(
+        (segno) =>
+          `<button type="button" class="dm-chat-emoji-uno" data-dm-emoji="${esc(segno)}"
+             tabindex="-1" aria-label="${esc(segno)}">${esc(segno)}</button>`,
+      ).join("")}
+    </div>`;
+}
+
 function casellaMarkup(dove) {
   const bozza = state.bozza || "";
   const rimasti = MAX_TESTO - bozza.length;
@@ -195,7 +290,11 @@ function casellaMarkup(dove) {
       <textarea id="${dove}" rows="3" maxlength="${MAX_TESTO}" placeholder="${esc(
         t("Scrivi il tuo messaggio…", "Write your message…"),
       )}">${esc(bozza)}</textarea>
+      ${emojiMarkup()}
       <div class="dm-chat-sotto">
+        <button type="button" class="dm-chat-emoji-apri" data-dm-chat="emoji-apri"
+          aria-expanded="false" aria-label="${esc(t("Metti un'emoji", "Add an emoji"))}"
+          title="${esc(t("Metti un'emoji", "Add an emoji"))}">🙂</button>
         <span class="dm-chat-rimasti" data-dm-chat="rimasti">${rimasti}</span>
         <button type="button" class="dm-chat-btn" data-dm-chat="manda"
           ${state.busy ? "disabled" : ""}>${esc(
@@ -516,7 +615,42 @@ function agganciaEventi(corpo) {
       state.name = clean(comeMiChiamo.value);
     });
   }
+  const pannello = corpo.querySelector('[data-dm-chat="emoji"]');
+  const apriEmoji = corpo.querySelector('[data-dm-chat="emoji-apri"]');
   const campo = corpo.querySelector("textarea");
+  if (pannello && apriEmoji && campo) {
+    apriEmoji.addEventListener("click", () => {
+      const chiuso = pannello.hidden;
+      pannello.hidden = !chiuso;
+      apriEmoji.setAttribute("aria-expanded", String(chiuso));
+      if (chiuso) campo.focus();
+    });
+    /* Un solo ascoltatore per tutte le emoji, e sul pannello: sono quaranta, e
+     * quaranta ascoltatori si rifanno a ogni ridisegno. */
+    pannello.addEventListener("mousedown", (evento) => {
+      /* Prima del `click`, cosi' la casella non perde il fuoco e il cursore
+       * resta dov'era: senza, l'emoji finirebbe sempre in fondo. */
+      if (evento.target.closest("[data-dm-emoji]")) evento.preventDefault();
+    });
+    pannello.addEventListener("click", (evento) => {
+      const scelta = evento.target.closest("[data-dm-emoji]");
+      if (!scelta) return;
+      const esito = conLEmoji(
+        campo.value,
+        scelta.dataset.dmEmoji,
+        campo.selectionStart,
+        campo.selectionEnd,
+        MAX_TESTO,
+      );
+      if (esito.pieno) return;
+      campo.value = esito.testo;
+      campo.setSelectionRange?.(esito.cursore, esito.cursore);
+      campo.focus();
+      /* Lo stesso evento che scrivere a mano fa partire: da li' passano la
+       * bozza tenuta da parte e il conto dei caratteri rimasti. */
+      campo.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
   if (campo) {
     campo.addEventListener("input", () => {
       state.bozza = campo.value;
@@ -843,6 +977,24 @@ const CSS = `
   font-size:13px; resize:vertical; }
 .dm-chat-sotto { display:flex; align-items:center; justify-content:space-between;
   gap:10px; margin-top:8px; }
+.dm-chat-emoji-apri { width:34px; height:34px; padding:0; flex:0 0 auto;
+  border-radius:50%; border:1px solid var(--card-border,#e2e8f0);
+  background:var(--surface-3,#f1f5f9); font-size:17px; line-height:1;
+  cursor:pointer; }
+.dm-chat-emoji-apri[aria-expanded="true"] { background:var(--accent,#22c55e);
+  border-color:transparent; }
+/* Il conto dei caratteri prende lo spazio in mezzo, cosi' il tasto delle
+   emoji resta a sinistra e «Manda» a destra dove sono sempre stati. */
+.dm-chat-sotto .dm-chat-rimasti { flex:1 1 auto; text-align:right; }
+.dm-chat-emoji { display:flex; flex-wrap:wrap; gap:4px; margin-top:8px;
+  padding:8px; border-radius:14px; background:var(--surface-3,#f1f5f9);
+  border:1px solid var(--card-border,#e2e8f0); max-height:148px;
+  overflow-y:auto; }
+.dm-chat-emoji[hidden] { display:none; }
+.dm-chat-emoji-uno { width:34px; height:34px; padding:0; border:0;
+  border-radius:10px; background:transparent; font-size:19px; line-height:1;
+  cursor:pointer; }
+.dm-chat-emoji-uno:hover { background:var(--surface-2,#fff); }
 .dm-chat-rimasti { font-size:11px; color:var(--text-dim,#64748b); }
 .dm-chat-btn { padding:9px 18px; border-radius:50px; cursor:pointer; border:0;
   background:var(--accent,#22c55e); color:#fff; font-size:13px; font-weight:700; }

--- a/custom_components/dashboardmodern/frontend/src/sections/assistenza-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/assistenza-section.js
@@ -36,6 +36,7 @@ const WS_FORGET = "dashboardmodern/chat/forget";
 const WS_QUEUE = "dashboardmodern/chat/queue";
 const WS_OPEN = "dashboardmodern/chat/open";
 const WS_ANSWER = "dashboardmodern/chat/answer";
+const WS_DROP = "dashboardmodern/chat/drop";
 
 /* Esportati perche' una prova li tenga accanto all'allowlist del ponte. Un
  * tipo non elencato la' non arriva a Home Assistant e la finestra risponde
@@ -49,6 +50,7 @@ export const WS_TYPES = Object.freeze([
   WS_QUEUE,
   WS_OPEN,
   WS_ANSWER,
+  WS_DROP,
 ]);
 
 /** Lo stesso tetto che il backend e il centralino applicano. */
@@ -68,6 +70,10 @@ const state = {
   tab: "mia",
   busy: false,
   avviso: "",
+  /* La conversazione col cestino gia' armato: il primo tocco arma, il secondo
+   * cancella. Una sola, perche' armarne due insieme vorrebbe dire due tasti
+   * rossi accanto e nessuno che sappia piu' quale stava per premere. */
+  daButtare: "",
   /* Quello che si sta scrivendo, perche' un ridisegno non se lo porti via. */
   bozza: "",
 };
@@ -128,8 +134,17 @@ export function avvertenzaMarkup() {
     </div>`;
 }
 
-export function messaggioMarkup(riga) {
-  const mio = clean(riga?.da) !== "console";
+/* Un messaggio, dalla parte giusta.
+ *
+ * «Mio» dipende da chi guarda, e questa finestra la guardano in due. Nella
+ * propria conversazione le proprie frasi sono quelle della casa; nella coda di
+ * chi risponde sono quelle della console — e li' il verso era rovesciato: le
+ * domande della casa comparivano a destra e in verde, come se se le fosse
+ * scritte da solo chi stava leggendo, e le proprie risposte a sinistra e in
+ * grigio. Una conversazione letta al contrario. */
+export function messaggioMarkup(riga, dallaConsole = false) {
+  const daConsole = clean(riga?.da) === "console";
+  const mio = dallaConsole ? daConsole : !daConsole;
   const ora = quando(riga?.scritto_il);
   return `
     <div class="dm-chat-riga ${mio ? "mia" : "sua"}">
@@ -144,7 +159,7 @@ export function messaggioMarkup(riga) {
  *
  * Il vuoto non e' una schermata bianca: e' l'invito a scrivere la prima riga,
  * perche' una chat vuota e una chat rotta si somigliano troppo. */
-export function filoMarkup(messaggi) {
+export function filoMarkup(messaggi, dallaConsole = false) {
   const righe = Array.isArray(messaggi) ? messaggi : [];
   if (!righe.length) {
     return `
@@ -159,7 +174,7 @@ export function filoMarkup(messaggi) {
       </div>`;
   }
   return `<div class="dm-chat-filo" data-dm-chat="filo">${righe
-    .map(messaggioMarkup)
+    .map((riga) => messaggioMarkup(riga, dallaConsole))
     .join("")}</div>`;
 }
 
@@ -238,14 +253,40 @@ function miaMarkup() {
   )}${cancella}`;
 }
 
-/* L'elenco, per chi risponde. */
-function codaMarkup() {
-  if (!state.conversazioni.length) {
+/* Il cestino di una conversazione, per chi risponde.
+ *
+ * Due tocchi e non uno. Una conversazione cancellata non si rimette a posto —
+ * sparisce dal centralino e dalla plancia di quella casa — e un cestino che
+ * cancella al primo tocco, in un elenco dove si scorre col dito, e' un cestino
+ * che prima o poi butta via la conversazione sbagliata. Il primo tocco arma e
+ * chiede conferma sul tasto stesso; il secondo cancella.
+ *
+ * `lungo` e' per quando il tasto sta da solo sopra un filo aperto, dove una
+ * paletta senza parole non direbbe di quale conversazione si parla. */
+function buttaMarkup(linea, lungo = false) {
+  const armato = state.daButtare === linea;
+  const titolo = t("Cancella la conversazione", "Delete the conversation");
+  const scritta = armato ? t("Confermi?", "Confirm?") : lungo ? titolo : "🗑";
+  return `
+    <button type="button" class="dm-chat-butta${armato ? " armato" : ""}${
+      lungo ? " lungo" : ""
+    }" data-dm-chat-butta="${esc(linea)}" ${state.busy ? "disabled" : ""}
+      title="${esc(titolo)}" aria-label="${esc(titolo)}">${esc(scritta)}</button>`;
+}
+
+/* L'elenco, per chi risponde.
+ *
+ * Prende le conversazioni invece di leggerle dallo stato — come `filoMarkup` —
+ * cosi' una prova puo' chiedergli una riga e guardare cosa ne esce senza dover
+ * far finta di avere una finestra aperta. */
+export function codaMarkup(conversazioni = state.conversazioni) {
+  const righe = Array.isArray(conversazioni) ? conversazioni : [];
+  if (!righe.length) {
     return `<div class="dm-chat-vuoto">${esc(
       t("Nessuna conversazione aperta.", "No open conversation."),
     )}</div>`;
   }
-  return `<div class="dm-chat-coda">${state.conversazioni
+  return `<div class="dm-chat-coda">${righe
     .map((voce) => {
       const linea = clean(voce?.id);
       const nome = clean(voce?.nome) || linea.slice(0, 12);
@@ -253,17 +294,23 @@ function codaMarkup() {
       const note = [clean(voce?.versione), clean(voce?.ha), clean(voce?.lingua)]
         .filter(Boolean)
         .join(" · ");
+      /* La riga non e' piu' un solo tasto: dentro ce ne stanno due, e un
+       * tasto dentro un tasto non e' markup valido — il browser lo srotola e
+       * il cestino finisce fuori dalla riga. Quindi un contenitore, e i due
+       * tasti dentro. */
       return `
-        <button type="button" class="dm-chat-voce${
-          state.linea === linea ? " aperta" : ""
-        }" data-dm-chat-linea="${esc(linea)}">
-          <div class="dm-chat-voce-testa">
-            <span class="dm-chat-voce-nm">${esc(nome)}</span>
-            ${nonLetti ? `<span class="dm-chat-segno">${nonLetti}</span>` : ""}
-          </div>
-          <div class="dm-chat-voce-ult">${esc(clean(voce?.ultimo))}</div>
-          ${note ? `<div class="dm-chat-voce-note">${esc(note)}</div>` : ""}
-        </button>`;
+        <div class="dm-chat-voce${state.linea === linea ? " aperta" : ""}">
+          <button type="button" class="dm-chat-voce-apri"
+            data-dm-chat-linea="${esc(linea)}">
+            <div class="dm-chat-voce-testa">
+              <span class="dm-chat-voce-nm">${esc(nome)}</span>
+              ${nonLetti ? `<span class="dm-chat-segno">${nonLetti}</span>` : ""}
+            </div>
+            <div class="dm-chat-voce-ult">${esc(clean(voce?.ultimo))}</div>
+            ${note ? `<div class="dm-chat-voce-note">${esc(note)}</div>` : ""}
+          </button>
+          ${buttaMarkup(linea)}
+        </div>`;
     })
     .join("")}</div>`;
 }
@@ -271,12 +318,13 @@ function codaMarkup() {
 function consoleMarkup() {
   if (!state.linea) return codaMarkup();
   return `
-    <div class="dm-chat-azioni">
+    <div class="dm-chat-azioni fra">
       <button type="button" class="dm-chat-btn chiaro" data-dm-chat="indietro">${esc(
         t("← Tutte le conversazioni", "← All conversations"),
       )}</button>
+      ${buttaMarkup(state.linea, true)}
     </div>
-    ${filoMarkup(state.filo)}
+    ${filoMarkup(state.filo, true)}
     ${casellaMarkup("dm-chat-console")}`;
 }
 
@@ -377,9 +425,11 @@ export function apri() {
   modale.classList.add("show");
   disegna();
   ricarica();
+  accendiIlGiro();
 }
 
 export function chiudi() {
+  spegniIlGiro();
   doc?.getElementById?.("dm-chat-modal")?.classList.remove("show");
 }
 
@@ -398,9 +448,32 @@ function disegna() {
   );
   modale.querySelector('[data-dm-chat="chiudi"]').textContent = t("Chiudi", "Close");
   const corpo = modale.querySelector('[data-dm-chat="corpo"]');
+  /* Dov'era il cursore, prima che il corpo venisse rifatto.
+   *
+   * Il giro che porta le risposte nuove ridisegna la finestra, e ridisegnarla
+   * vuol dire buttare via la casella e rifarla: senza questo, a chi stava
+   * scrivendo il cursore saltava fuori dal campo a meta' frase, ogni volta che
+   * dall'altra parte arrivava qualcosa. La bozza si teneva gia'; quello che si
+   * perdeva era il punto in cui si era. */
+  const attivo = doc?.activeElement;
+  const dovEro =
+    attivo?.id && corpo.contains(attivo) && typeof attivo.selectionStart === "number"
+      ? { id: attivo.id, da: attivo.selectionStart, a: attivo.selectionEnd }
+      : null;
   const dentro = state.console && state.tab === "coda" ? consoleMarkup() : miaMarkup();
   corpo.innerHTML = schedeMarkup() + avvisoMarkup() + dentro;
   agganciaEventi(corpo);
+  if (dovEro) {
+    const tornato = doc.getElementById(dovEro.id);
+    if (tornato) {
+      tornato.focus({ preventScroll: true });
+      try {
+        tornato.setSelectionRange(dovEro.da, dovEro.a);
+      } catch (_errore) {
+        /* Un campo che il cursore non lo tiene: basta avergli ridato il fuoco. */
+      }
+    }
+  }
   /* La chat si legge dal fondo: l'ultima frase e' quella che interessa, e
    * aprire una conversazione lunga in cima vorrebbe dire scorrere ogni volta
    * per arrivare al punto. */
@@ -413,6 +486,7 @@ function agganciaEventi(corpo) {
     bottone.addEventListener("click", () => {
       state.tab = bottone.dataset.dmChatTab;
       state.linea = "";
+      state.daButtare = "";
       disegna();
       if (state.tab === "coda") caricaCoda();
     });
@@ -420,11 +494,15 @@ function agganciaEventi(corpo) {
   corpo.querySelectorAll("[data-dm-chat-linea]").forEach((bottone) => {
     bottone.addEventListener("click", () => apriLinea(bottone.dataset.dmChatLinea));
   });
+  corpo.querySelectorAll("[data-dm-chat-butta]").forEach((bottone) => {
+    bottone.addEventListener("click", () => butta(bottone.dataset.dmChatButta));
+  });
   corpo
     .querySelector('[data-dm-chat="indietro"]')
     ?.addEventListener("click", () => {
       state.linea = "";
       state.filo = [];
+      state.daButtare = "";
       disegna();
       caricaCoda();
     });
@@ -454,6 +532,81 @@ function agganciaEventi(corpo) {
       }
     });
   }
+}
+
+/* ─── Il giro che tiene la finestra viva ────────────────────────────────── */
+
+/* Ogni quanto la finestra aperta va a vedere se e' arrivato qualcosa.
+ *
+ * «La risposta non si refresh, devo uscire e rientrare»: la finestra leggeva
+ * una volta all'apertura e poi restava ferma. Il giro dei cinque minuti del
+ * backend c'era gia', ma quello serve al campanello — suona e basta, non
+ * ridisegna niente — e cinque minuti davanti a una chat aperta sono
+ * un'eternita'.
+ *
+ * Quindici secondi, e solo mentre la finestra e' aperta: chiusa non chiede
+ * niente, perche' una plancia accesa tutto il giorno in cucina non deve
+ * bussare al centralino per una conversazione che nessuno sta guardando. */
+const RINFRESCO = 15000;
+
+let giro = 0;
+
+function accendiIlGiro() {
+  spegniIlGiro();
+  giro = root.setInterval?.(() => {
+    if (!doc?.getElementById?.("dm-chat-modal")?.classList.contains("show")) {
+      spegniIlGiro();
+      return;
+    }
+    rinfresca();
+  }, RINFRESCO);
+}
+
+function spegniIlGiro() {
+  if (giro) root.clearInterval?.(giro);
+  giro = 0;
+}
+
+/** Il segno di una lista: quanti sono e dov'e' arrivata. */
+const segno = (righe) =>
+  `${righe.length}:${Number(righe[righe.length - 1]?.id) || 0}`;
+
+/* Va a vedere, e ridisegna solo se c'e' qualcosa da ridisegnare.
+ *
+ * Il confronto non e' un risparmio di cicli: ridisegnare rifa' la casella, e
+ * rifare la casella quattro volte al minuto mentre qualcuno scrive e' il modo
+ * di rendere la finestra inusabile. Se non e' cambiato niente, non si tocca
+ * niente. */
+async function rinfresca() {
+  if (state.busy || !state.enabled) return;
+  try {
+    if (state.console && state.tab === "coda") {
+      if (state.linea) {
+        const filo = await chiedi(WS_OPEN, { line: state.linea });
+        const righe = Array.isArray(filo?.messages) ? filo.messages : [];
+        if (segno(righe) === segno(state.filo)) return;
+        state.filo = righe;
+      } else {
+        const coda = await chiedi(WS_QUEUE);
+        const righe = Array.isArray(coda?.conversations) ? coda.conversations : [];
+        if (JSON.stringify(righe) === JSON.stringify(state.conversazioni)) return;
+        state.conversazioni = righe;
+      }
+    } else {
+      const filo = await chiedi(WS_THREAD);
+      const righe = Array.isArray(filo?.messages) ? filo.messages : [];
+      if (segno(righe) === segno(state.messages)) return;
+      state.messages = righe;
+      state.unread = 0;
+      installaTessera();
+    }
+  } catch (_errore) {
+    /* Un giro automatico che non riesce non dice niente. Chi non ha chiesto
+     * niente non deve vedersi comparire un errore da solo, e al giro dopo il
+     * centralino magari risponde. */
+    return;
+  }
+  disegna();
 }
 
 /* ─── Le richieste ──────────────────────────────────────────────────────── */
@@ -503,6 +656,7 @@ async function apriLinea(linea) {
   if (!nome) return;
   state.linea = nome;
   state.filo = [];
+  state.daButtare = "";
   disegna();
   try {
     const filo = await chiedi(WS_OPEN, { line: nome });
@@ -552,6 +706,43 @@ async function manda() {
     state.busy = false;
     disegna();
   }
+}
+
+/* Buttare via una conversazione, dalla parte di chi risponde.
+ *
+ * Il primo tocco arma e basta. Il secondo cancella davvero, e cancella per
+ * tutti e due: la linea sparisce dal centralino, e con lei quello che si erano
+ * detti. La coda si rilegge subito dopo, perche' quello che si vede in elenco
+ * dev'essere quello che c'e' — non quello che questa finestra crede. */
+async function butta(linea) {
+  const nome = clean(linea);
+  if (!nome) return;
+  if (state.daButtare !== nome) {
+    state.daButtare = nome;
+    disegna();
+    return;
+  }
+  state.daButtare = "";
+  state.busy = true;
+  state.avviso = "";
+  disegna();
+  try {
+    await chiedi(WS_DROP, { line: nome });
+    state.conversazioni = state.conversazioni.filter(
+      (voce) => clean(voce?.id) !== nome,
+    );
+    if (state.linea === nome) {
+      state.linea = "";
+      state.filo = [];
+    }
+    state.avviso = t("Conversazione cancellata.", "Conversation deleted.");
+  } catch (errore) {
+    state.avviso = `!${clean(errore?.message) || t("Non riuscita.", "It did not work.")}`;
+  } finally {
+    state.busy = false;
+    disegna();
+  }
+  await caricaCoda();
 }
 
 async function cancella() {
@@ -629,7 +820,9 @@ const CSS = `
 .dm-chat-btn[disabled] { opacity:.6; cursor:default; }
 .dm-chat-btn.chiaro { background:var(--surface-3,#f1f5f9);
   color:var(--text-dim,#64748b); border:1px solid var(--card-border,#e2e8f0); }
-.dm-chat-azioni { display:flex; justify-content:flex-end; }
+.dm-chat-azioni { display:flex; justify-content:flex-end; align-items:center;
+  gap:10px; }
+.dm-chat-azioni.fra { justify-content:space-between; }
 
 .dm-chat-avviso { padding:9px 13px; border-radius:14px; font-size:12px;
   background:rgba(34,197,94,0.12); color:#15803d; }
@@ -638,16 +831,32 @@ const CSS = `
 /* L'elenco di chi risponde. */
 .dm-chat-coda { display:flex; flex-direction:column; gap:8px; max-height:52vh;
   overflow-y:auto; }
-.dm-chat-voce { display:grid; gap:3px; padding:11px 13px; border-radius:16px;
-  cursor:pointer; text-align:left; font:inherit;
-  border:1px solid var(--card-border,#e2e8f0); background:var(--surface-3,#f1f5f9);
-  color:var(--text,#0f172a); }
+.dm-chat-voce { display:flex; align-items:center; gap:8px; padding:11px 13px;
+  border-radius:16px; border:1px solid var(--card-border,#e2e8f0);
+  background:var(--surface-3,#f1f5f9); color:var(--text,#0f172a); }
 .dm-chat-voce.aperta { border-color:var(--accent,#22c55e); }
+/* Il tasto che apre prende tutta la riga tranne il cestino;
+   min-width:0 e' quello che lascia accorciare l'ultima frase invece di far
+   debordare la riga. */
+.dm-chat-voce-apri { flex:1 1 auto; min-width:0; display:grid; gap:3px; padding:0;
+  border:0; background:none; color:inherit; font:inherit; text-align:left;
+  cursor:pointer; }
 .dm-chat-voce-testa { display:flex; align-items:center; gap:8px; }
 .dm-chat-voce-nm { font-size:13px; font-weight:800; }
 .dm-chat-voce-ult { font-size:12px; color:var(--text-dim,#64748b);
   overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .dm-chat-voce-note { font-size:10px; color:var(--text-dim,#64748b); opacity:.8; }
+/* Il cestino: grigio finche' e' solo un tasto, rosso quando e' armato e il
+   tocco dopo cancella per davvero. */
+.dm-chat-butta { flex-shrink:0; padding:7px 11px; border-radius:12px;
+  cursor:pointer; font:inherit; font-size:12px; font-weight:700; line-height:1;
+  border:1px solid var(--card-border,#e2e8f0); background:var(--surface-2,#fff);
+  color:var(--text-dim,#64748b); }
+.dm-chat-butta.lungo { padding:9px 16px; border-radius:50px; }
+.dm-chat-butta.armato { background:rgba(239,68,68,0.12); color:#b91c1c;
+  border-color:rgba(239,68,68,0.35); }
+.dm-chat-butta[disabled] { opacity:.6; cursor:default; }
+
 .dm-chat-segno, .dm-chat-badge { min-width:18px; height:18px; padding:0 6px;
   border-radius:999px; background:var(--accent,#22c55e); color:#fff;
   font-size:10px; font-weight:900; display:inline-grid; place-items:center; }
@@ -679,6 +888,7 @@ export function installAssistenzaSection() {
 
 /** Seme per le prove: dimentica l'installazione e la finestra. */
 export function uninstallAssistenzaSection() {
+  spegniIlGiro();
   doc?.getElementById?.("dm-chat-modal")?.remove();
   doc?.getElementById?.("dm-chat-card")?.remove();
   state.installed = false;
@@ -689,6 +899,10 @@ export function uninstallAssistenzaSection() {
   state.linea = "";
   state.filo = [];
   state.tab = "mia";
+  state.daButtare = "";
+  state.busy = false;
+  state.avviso = "";
+  state.bozza = "";
 }
 
 installAssistenzaSection();

--- a/custom_components/dashboardmodern/frontend/src/sections/assistenza-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/assistenza-section.js
@@ -551,6 +551,14 @@ const RINFRESCO = 15000;
 
 let giro = 0;
 
+/* Un giro per volta, e mai due sovrapposti.
+ *
+ * Quindici secondi sono tanti finche' il centralino risponde. Il giorno che ci
+ * mette venti, il battito successivo parte mentre il primo e' ancora per aria:
+ * due richieste in volo, e vince quella che torna per ultima — che non e'
+ * detto sia la piu' recente. */
+let inVolo = false;
+
 function accendiIlGiro() {
   spegniIlGiro();
   giro = root.setInterval?.(() => {
@@ -558,6 +566,13 @@ function accendiIlGiro() {
       spegniIlGiro();
       return;
     }
+    /* Pagina nascosta, giro fermo. Non e' per risparmiare: leggere la propria
+     * conversazione vuol dire averla letta, e il segnalibro si sposta. Una
+     * finestra dimenticata aperta in una scheda in fondo si mangiava le
+     * risposte — le metteva in copia, le segnava lette, e il giro dei cinque
+     * minuti che deve suonare la campanella trovava che non era arrivato
+     * niente di nuovo. La risposta c'era, e nessuno lo sapeva. */
+    if (doc?.hidden) return;
     rinfresca();
   }, RINFRESCO);
 }
@@ -578,24 +593,36 @@ const segno = (righe) =>
  * di rendere la finestra inusabile. Se non e' cambiato niente, non si tocca
  * niente. */
 async function rinfresca() {
-  if (state.busy || !state.enabled) return;
+  if (state.busy || inVolo || !state.enabled) return;
+  /* Da dove si e' partiti. Fra la domanda e la risposta ci sta un dito che
+   * cambia scheda o apre un'altra conversazione: senza questo appunto, il filo
+   * di una casa finiva sotto il nome di un'altra — la richiesta era partita per
+   * A, ma quando torna la finestra sta mostrando B, e le frasi di A si
+   * scrivevano li' dentro come se fossero sue. */
+  const dovEro = { console: state.console, tab: state.tab, linea: state.linea };
+  const stessoPosto = () =>
+    state.console === dovEro.console &&
+    state.tab === dovEro.tab &&
+    state.linea === dovEro.linea;
+  inVolo = true;
   try {
-    if (state.console && state.tab === "coda") {
-      if (state.linea) {
-        const filo = await chiedi(WS_OPEN, { line: state.linea });
+    if (dovEro.console && dovEro.tab === "coda") {
+      if (dovEro.linea) {
+        const filo = await chiedi(WS_OPEN, { line: dovEro.linea });
         const righe = Array.isArray(filo?.messages) ? filo.messages : [];
-        if (segno(righe) === segno(state.filo)) return;
+        if (!stessoPosto() || segno(righe) === segno(state.filo)) return;
         state.filo = righe;
       } else {
         const coda = await chiedi(WS_QUEUE);
         const righe = Array.isArray(coda?.conversations) ? coda.conversations : [];
+        if (!stessoPosto()) return;
         if (JSON.stringify(righe) === JSON.stringify(state.conversazioni)) return;
         state.conversazioni = righe;
       }
     } else {
       const filo = await chiedi(WS_THREAD);
       const righe = Array.isArray(filo?.messages) ? filo.messages : [];
-      if (segno(righe) === segno(state.messages)) return;
+      if (!stessoPosto() || segno(righe) === segno(state.messages)) return;
       state.messages = righe;
       state.unread = 0;
       installaTessera();
@@ -605,6 +632,8 @@ async function rinfresca() {
      * niente non deve vedersi comparire un errore da solo, e al giro dopo il
      * centralino magari risponde. */
     return;
+  } finally {
+    inVolo = false;
   }
   disegna();
 }
@@ -889,6 +918,7 @@ export function installAssistenzaSection() {
 /** Seme per le prove: dimentica l'installazione e la finestra. */
 export function uninstallAssistenzaSection() {
   spegniIlGiro();
+  inVolo = false;
   doc?.getElementById?.("dm-chat-modal")?.remove();
   doc?.getElementById?.("dm-chat-card")?.remove();
   state.installed = false;

--- a/custom_components/dashboardmodern/frontend/src/sections/calendario-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/calendario-section.js
@@ -25,6 +25,7 @@ import {
   chiaveDelGiorno,
   etichettaDelGiorno,
   eventiDaQui,
+  giornoPiu,
   inCorso,
   oraDellEvento,
 } from "../core/calendario-model.js";
@@ -216,7 +217,9 @@ function fasciaMarkup(giorni, adesso, lingua, calendari) {
   const perChiave = new Map(giorni.map((voce) => [voce.giorno, voce.eventi]));
   const celle = [];
   for (let passo = 0; passo < GIORNI_NELLA_FASCIA; passo += 1) {
-    const quando = adesso + passo * 86400000;
+    /* Giorni di calendario, non multipli di ventiquattro ore: nel giorno del
+     * cambio d'ora la striscia mostrava oggi due volte e saltava il settimo. */
+    const quando = giornoPiu(adesso, passo).getTime();
     const chiave = chiaveDelGiorno(quando);
     const eventi = perChiave.get(chiave) || [];
     const data = new Date(quando);

--- a/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/config-persistence-section.js
@@ -592,6 +592,7 @@ export function sharedReconcileAction({
   localConfigured = false,
   pendingAt = 0,
   syncedRevision = 0,
+  chiaviDaTenere = [],
 } = {}) {
   const normalized = snapshot ? normalizeSharedSnapshot(snapshot) : null;
   if (!normalized) return localConfigured ? "push-local" : "none";
@@ -615,7 +616,46 @@ export function sharedReconcileAction({
     Number(syncedRevision) === Number(normalized.revision)
   )
     return "push-local";
+  /* La copia remota e' piu' avanti, ma qui c'e' una modifica appena fatta.
+   *
+   * «Metto l'entita', faccio salva, e non me la mette nella plancia»: prima si
+   * tornava «restore-remote», cioe' la copia remota — che quella modifica non
+   * ce l'ha — copriva tutto, in silenzio. E bastava che un'altra plancia della
+   * stessa casa avesse spinto qualcosa nel frattempo perche' succedesse: il
+   * telefono in mano e il tablet in cucina sono due dispositivi, e chi
+   * configura ne ha quasi sempre due aperti.
+   *
+   * Buttare via una modifica appena fatta e' il modo peggiore di risolvere un
+   * conflitto, perche' non lo risolve: lo nasconde. Adesso si fondono, e la
+   * regola e' quella che chiunque si aspetta — la copia remota vale per tutto,
+   * tranne dove questo dispositivo ha appena scritto. Poi si rispinge, cosi'
+   * anche gli altri vedono la modifica.
+   *
+   * Senza chiavi in sospeso non cambia niente: e' il caso di chi non ha toccato
+   * nulla, e li' la copia remota vince come prima. */
+  if (Number(pendingAt) > 0 && localConfigured && chiaviDaTenere.length > 0)
+    return "merge-local";
   return "restore-remote";
+}
+
+/**
+ * I valori da tenere: la copia remota, tranne dove questo dispositivo ha
+ * appena scritto.
+ *
+ * Solo le chiavi dichiarate, e solo quelle che qui hanno davvero un valore: una
+ * chiave in sospeso che localmente non esiste piu' vuol dire una cancellazione,
+ * e una cancellazione si rispetta togliendola anche dalla copia fusa.
+ */
+export function conLeModificheInSospeso(remoti = {}, locali = {}, daTenere = []) {
+  const uscita = { ...(remoti && typeof remoti === "object" ? remoti : {}) };
+  for (const chiave of Array.isArray(daTenere) ? daTenere : []) {
+    const nome = String(chiave || "");
+    if (!nome || !CONFIG_KEYS.includes(nome)) continue;
+    const mio = locali?.[nome];
+    if (mio === undefined || mio === null) delete uscita[nome];
+    else uscita[nome] = mio;
+  }
+  return uscita;
 }
 
 function readMeta(storage = root.localStorage) {
@@ -772,7 +812,26 @@ function sharedRestoreRevision(revision) {
  * flag, that decides whether those edits may overwrite the shared copy. Pushing
  * still waits for a successful read.
  */
-function markPending({ schedule = true } = {}) {
+/* QUALI chiavi sono in sospeso, non solo da quando.
+ *
+ * «Metto l'entita', faccio salva, e non me la mette nella plancia»: succedeva
+ * perche' una modifica locale fatta sopra una revisione che nel frattempo era
+ * cambiata perdeva per intero — `restore-remote` — e la copia remota, che
+ * quella modifica non ce l'ha, tornava sopra. In silenzio.
+ *
+ * Sapere quali chiavi ha toccato questo dispositivo permette di non buttarle:
+ * si prende la copia remota per tutto il resto e si tiene la propria dove si e'
+ * appena scritto. L'insieme e' piccolo per costruzione — sono le chiavi
+ * dichiarate — e si azzera appena la copia propria e' arrivata dall'altra
+ * parte. */
+function chiaviInSospeso(meta = readMeta()) {
+  const scritte = Array.isArray(meta.pending_keys) ? meta.pending_keys : [];
+  const vive = new Set(scritte.filter((chiave) => CONFIG_KEYS.includes(String(chiave))));
+  for (const chiave of state.dirtyKeys || []) vive.add(chiave);
+  return [...vive];
+}
+
+function markPending({ schedule = true, key = "" } = {}) {
   if (
     state.resetting ||
     state.hydrating ||
@@ -782,12 +841,20 @@ function markPending({ schedule = true } = {}) {
     return state.dirtyAt;
   const now = Date.now();
   state.dirtyAt = now;
-  writeMeta({ pending_at: now });
+  if (!state.dirtyKeys) state.dirtyKeys = new Set();
+  const nome = String(key || "");
+  if (nome && CONFIG_KEYS.includes(nome)) state.dirtyKeys.add(nome);
+  writeMeta({ pending_at: now, pending_keys: chiaviInSospeso() });
   if (schedule && state.hydrated && hostedBridge()) schedulePush();
   return now;
 }
 
-function queuePendingFromStorage() {
+function queuePendingFromStorage(key = "") {
+  const nome = String(key || "");
+  if (nome && CONFIG_KEYS.includes(nome)) {
+    if (!state.dirtyKeys) state.dirtyKeys = new Set();
+    state.dirtyKeys.add(nome);
+  }
   if (state.dirtyMarkTimer) return;
   state.dirtyMarkTimer =
     root.setTimeout?.(() => {
@@ -799,11 +866,13 @@ function queuePendingFromStorage() {
 
 function rememberSynced(revision, updatedAt) {
   state.dirtyAt = 0;
+  state.dirtyKeys = new Set();
   state.remoteRevision = Number(revision) || 0;
   writeMeta({
     synced_at: Number(updatedAt) || Date.now(),
     synced_revision: state.remoteRevision,
     pending_at: 0,
+    pending_keys: [],
   });
 }
 
@@ -1070,6 +1139,7 @@ async function hydrateShared() {
   state.remoteRevision = stored?.revision || 0;
   state.remoteConfigured = Boolean(stored && meaningfulConfigValues(stored.values));
   const localConfigured = state.hydrated ? meaningfulLocal(local) : state.localWasConfigured;
+  const daTenere = chiaviInSospeso(meta);
   const action = sharedReconcileAction({
     snapshot: stored,
     recoverable,
@@ -1077,10 +1147,19 @@ async function hydrateShared() {
     localConfigured,
     pendingAt,
     syncedRevision,
+    chiaviDaTenere: daTenere,
   });
 
   if (action === "push-local") return await pushShared();
   if (action === "restore-remote") return applySharedSnapshot(stored);
+  if (action === "merge-local") {
+    /* La copia remota per tutto, la propria dove si e' appena scritto — e poi
+     * si rispinge, cosi' la modifica arriva anche agli altri dispositivi
+     * invece di restare su questo. */
+    const fusi = conLeModificheInSospeso(stored.values, local, daTenere);
+    applySharedSnapshot({ ...stored, values: fusi });
+    return await pushShared();
+  }
   if (action === "auto-recover") {
     console.warn("[DashboardModern] shared configuration was empty; restoring the kept revision");
     const restored = await sharedRestoreRevision(recoverable[0].revision);
@@ -1233,7 +1312,7 @@ function installStorageMutationBridge() {
       !root.__DASHBOARDMODERN_PERSIST_RESTORE__ &&
       !root.__DASHBOARDMODERN_CONFIG_RESETTING__
     )
-      queuePendingFromStorage();
+      queuePendingFromStorage(key);
     return result;
   };
   storage.removeItem = function dashboardModernPersistentRemoveItem(key) {
@@ -1249,7 +1328,7 @@ function installStorageMutationBridge() {
       !root.__DASHBOARDMODERN_PERSIST_RESTORE__ &&
       !root.__DASHBOARDMODERN_CONFIG_RESETTING__
     )
-      queuePendingFromStorage();
+      queuePendingFromStorage(key);
     return result;
   };
   storage.__dmPersistenceMutationBridge = true;

--- a/custom_components/dashboardmodern/frontend/src/sections/energy-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/energy-section.js
@@ -640,6 +640,7 @@ function applyDeviceRows(bundle) {
     if (eur) eur.textContent = `${formatNumber(value * bundle.rates.importPrice, 2)} €`;
     const fill = row.querySelector(".ed-dev-bar-fill,.ed-dev-bar");
     if (fill) fill.style.width = `${Math.min(100, (value / maximum) * 100)}%`;
+    scriviLaQuota(row, splitFor(bundle.month, value));
     row.querySelectorAll(".ed-dev-live,.ed-dev-total-live,.ed-dev-name small").forEach((node) => {
       node.hidden = true;
     });
@@ -647,12 +648,39 @@ function applyDeviceRows(bundle) {
   setText("ed-dev-total", kwh(total));
 }
 
+/* La riga di sotto — «☀️ tot kWh 🔌 tot kWh» — parla dello stesso numero.
+ *
+ * «Valori wallbox nel report sballati»: sulla riga della Wallbox c'era scritto
+ * «☀️ 1188.7 kWh 🔌 184.0 kWh» e, tre centimetri a destra, «0,0 kWh». Due
+ * numeri sulla stessa riga che si contraddicono, e uno dei due era il
+ * contatore di vita della colonnina.
+ *
+ * La ragione e' che questa funzione si prendeva meta' riga. Il guscio disegna
+ * il numero a destra e la quota qui sotto dallo stesso valore, e finche' li
+ * scrive lui sono d'accordo; poi si passa di qui e si riscrive il numero a
+ * destra col valore del Recorder — che e' quello giusto, perche' il guscio nel
+ * mese corrente si perde il delta quando la sua chiamata allo storico
+ * fallisce. La quota pero' restava quella di prima, cioe' calcolata sul
+ * contatore intero.
+ *
+ * Chi possiede il numero possiede la riga: la quota si rifa' con la stessa
+ * spartizione che usa la scheda del dispositivo, sullo stesso valore. */
+export function scriviLaQuota(row, quota) {
+  const riga = row.querySelector(".ed-dev-name div");
+  if (!riga) return;
+  const pezzi = riga.querySelectorAll("span");
+  if (pezzi.length < 2) return;
+  pezzi[0].textContent = `☀️ ${formatNumber(quota.solar, 1)} kWh`;
+  pezzi[1].textContent = `🔌 ${formatNumber(quota.grid, 1)} kWh`;
+  riga.dataset.dmQuota = VERSION;
+}
+
 function valueFrom(values, entity) {
   const value = values instanceof Map ? values.get(entity) : values?.[entity];
   return Number.isFinite(Number(value)) ? Number(value) : null;
 }
 
-function splitFor(period, value) {
+export function splitFor(period, value) {
   const house = finite(period?.house);
   const grid = finite(period?.gridImport);
   const gridShare = house > 0 ? Math.max(0, Math.min(1, grid / house)) : 1;

--- a/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
@@ -76,6 +76,7 @@ import {
   minutiAllEvento,
   normalizzaCalendari,
   oraDellEvento,
+  orarioDi,
   parseCalendarApiEvents,
   parseCalendarEventsResponse,
   agendaPerGiorno,
@@ -609,7 +610,10 @@ function calendarioModel() {
     const titolo = clean(evento.summary) || t("Senza titolo", "Untitled");
     if (inCorso(evento, adesso)) return `${t("Adesso", "Now")} · ${titolo}`;
     const giorno = chiaveDelGiorno(evento.inizio);
-    const quando = evento.tuttoIlGiorno ? "" : oraDellEvento(evento, parole, lingua).split(" ")[0];
+    /* L'ora d'inizio si chiede da sola, non tagliando l'intervallo al primo
+     * spazio: in inglese «02:30 PM – 03:30 PM» perdeva il PM, e le 14:30
+     * si leggevano come le due di notte. */
+    const quando = evento.tuttoIlGiorno ? "" : orarioDi(evento.inizio, lingua);
     const dove =
       giorno === oggi
         ? quando

--- a/custom_components/dashboardmodern/frontend/src/sections/indirizzo-di-casa-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/indirizzo-di-casa-section.js
@@ -1,0 +1,127 @@
+/* Le domande a Home Assistant partono da casa, anche dentro la cornice.
+ *
+ * «Storico internet dà errore»: nella finestra della connettività, al posto
+ * della cronologia, «❌ Storico non disponibile — Failed to fetch».
+ *
+ * Il perché sta in `core/indirizzo-di-casa.js`, e in breve è questo: la
+ * plancia ospitata vive in una cornice `srcdoc`, il cui `location` è
+ * `about:srcdoc` e il cui `location.host` è vuoto. Il guscio costruisce
+ * `HA_HTTP_URL` da lì e, non sapendo dove sta, indovina: ne esce
+ * `http://homeassistant.local:8123`, che è un host che quasi nessuno ha — e
+ * che comunque parla in chiaro a una pagina che viaggia in https. La richiesta
+ * muore prima di arrivare da qualche parte. Gli indirizzi relativi invece
+ * funzionano — si risolvono contro la base del padre — ed è per questo che
+ * tutto il resto della plancia va.
+ *
+ * Il guscio non si tocca: si rigenera. E la riga sbagliata sta DENTRO la
+ * funzione che apre la finestra, quindi avvolgerla per nome non servirebbe a
+ * niente — quando la si chiama, l'indirizzo è già stato costruito.
+ *
+ * Allora si sta un gradino sotto, su `fetch`, dove la richiesta passa comunque.
+ *
+ * Lì si riparano tre cose, che sono tre guasti diversi sulla stessa richiesta
+ * e ognuno da solo bastava a non far vedere niente:
+ *
+ *   - l'indirizzo, che punta a un host indovinato invece che a casa;
+ *   - l'autorizzazione, perché la plancia ospitata non ha un gettone ma un
+ *     segnale che dice «i cookie bastano», e spedirlo come `Bearer` si prende
+ *     un 401 su una richiesta che sarebbe passata da sola;
+ *   - il nome dell'entità, perché la domanda nomina una casella della plancia
+ *     e non l'entità che ci sta dentro, e il Recorder quella casella non la
+ *     conosce.
+ *
+ * È il motivo per cui si riparano tutti e tre qui, dove la richiesta passa,
+ * invece che in tre posti diversi.
+ *
+ * Tutto il resto passa senza essere guardato due volte, e un documento che sa
+ * dove sta non si tocca: dirottare una richiesta che qualcuno ha voluto
+ * sarebbe peggio del difetto che si sta correggendo.
+ */
+import {
+  autorizzazioneInutile,
+  conLEntitaVera,
+  indirizzoRiparato,
+  versoLApi,
+} from "../core/indirizzo-di-casa.js";
+import { doc, root } from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_INDIRIZZO_DI_CASA__";
+const state = (root[KEY] ||= { installed: false });
+
+const DA_RETE = /^https?:\/\//i;
+
+/** La base contro cui risolvere: dentro la cornice è il documento del padre.
+ *
+ * Solo `http` e `https`. Una base `about:`, `file:` o `blob:` non è un posto
+ * da cui chiedere qualcosa a Home Assistant, e prenderla per buona vorrebbe
+ * dire trasformare un indirizzo sbagliato in un altro indirizzo sbagliato. */
+export function baseDelDocumento() {
+  const base = String(doc?.baseURI ?? "").trim();
+  if (DA_RETE.test(base)) return base;
+  const qui = String(root.location?.href ?? "").trim();
+  return DA_RETE.test(qui) ? qui : "";
+}
+
+/** L'host di chi sta chiedendo: vuoto dentro una cornice `srcdoc`. */
+export function hostDelDocumento() {
+  return String(root.location?.host ?? "").trim();
+}
+
+/* L'intestazione, qualunque forma abbia: `Headers`, array di coppie, oggetto
+ * semplice. Si torna sempre un oggetto semplice, che è quello che `fetch`
+ * accetta in ogni caso. */
+function intestazioniSemplici(init) {
+  const grezze = init?.headers;
+  if (!grezze) return null;
+  if (typeof grezze.forEach === "function" && typeof grezze.get === "function") {
+    const uscita = {};
+    grezze.forEach((valore, nome) => {
+      uscita[nome] = valore;
+    });
+    return uscita;
+  }
+  if (Array.isArray(grezze)) return Object.fromEntries(grezze);
+  if (typeof grezze === "object") return { ...grezze };
+  return null;
+}
+
+function nomeDellAutorizzazione(intestazioni) {
+  return Object.keys(intestazioni).find((nome) => nome.toLowerCase() === "authorization") || "";
+}
+
+/** L'`init` da usare: `null` quando non c'è niente da cambiare. */
+export function initRiparato(init) {
+  const intestazioni = intestazioniSemplici(init);
+  if (!intestazioni) return null;
+  const nome = nomeDellAutorizzazione(intestazioni);
+  if (!nome || !autorizzazioneInutile(intestazioni[nome])) return null;
+  delete intestazioni[nome];
+  return { ...(init || {}), headers: intestazioni };
+}
+
+export function installIndirizzoDiCasa() {
+  if (state.installed) return false;
+  const originale = root.fetch;
+  if (typeof originale !== "function" || originale.__dmIndirizzoDiCasa) return false;
+  state.installed = true;
+
+  const nostra = function fetch(risorsa, init) {
+    /* Solo le stringhe: una `Request` gia' costruita porta con se' il suo
+     * indirizzo risolto, e rifarla vorrebbe dire ricopiarne ogni pezzo. Il
+     * guscio passa stringhe. */
+    if (typeof risorsa !== "string" || !versoLApi(risorsa))
+      return originale.call(this, risorsa, init);
+    const riparato =
+      indirizzoRiparato(risorsa, baseDelDocumento(), hostDelDocumento()) || risorsa;
+    /* La mappatura si legge adesso e non all'installazione: la plancia parte
+       prima che la configurazione sia arrivata, e una copia presa allora
+       sarebbe vuota per sempre. */
+    const conNome = conLEntitaVera(riparato, (nome) => root.resolveEntity?.(nome));
+    const initNuovo = initRiparato(init);
+    return originale.call(this, conNome || riparato, initNuovo || init);
+  };
+  nostra.__dmIndirizzoDiCasa = true;
+  nostra.__dmPrevious = originale;
+  root.fetch = nostra;
+  return true;
+}

--- a/custom_components/dashboardmodern/frontend/src/sections/navigation-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/navigation-section.js
@@ -8,6 +8,8 @@ const state = (root[KEY] ||= {
   scroller: null,
   autoHide: 0,
   behaviour: false,
+  barraScoperta: false,
+  scadenza: 0,
 });
 
 /* The dock is sized on its content (`width:max-content`), so with every section
@@ -703,6 +705,110 @@ export function disegniNellaBarra(scope = doc) {
   return messi;
 }
 
+/* ── la barra non mostra una forma che poi si rimangia ──────────────────── */
+
+/* «Resta sempre la barra totale, per poi diventare come l'ho configurata: dura
+ * quattro o cinque secondi.»
+ *
+ * Misurato sulla plancia vera, dall'avvio. A 648 ms la barra si dipinge con
+ * tutte e nove le voci del guscio, e `cd_sections` non esiste ancora. A 675 ms
+ * il guscio ne scrive una sua — la ricava guardando quali sezioni hanno
+ * contenuto, e in quel momento non ne ha nessuna: «spegnile tutte». A 783 ms
+ * la barra diventa due voci. A 846 ms il magazzino proietta la configurazione
+ * vera, e a 983 ms la barra ne mostra tre. A 1431 ms arrivano le voci che
+ * mettono i moduli — Stanze, Luci, Prese, Robot — e arrivano non filtrate. A
+ * 1505 ms si assesta su quattro. Quattro forme, e tre erano false.
+ *
+ * Il perche': il guscio applica la visibilita' delle voci **a tempo** — subito,
+ * a 1,5 s, poi ogni tre secondi — mentre la configurazione arriva quando
+ * arriva. Le due cose non si aspettano.
+ *
+ * In locale non si vede, e per un motivo che spiega perche' nessuno se n'era
+ * accorto: il velo d'avvio resta su fino a 1731 ms e copre tutto
+ * l'assestamento. Ma il velo aspetta i moduli, i fogli di stile e gli stati —
+ * NON la configurazione — e in una casa dove la configurazione viene da Home
+ * Assistant sulla rete si alza prima, lasciando scoperta la barra sbagliata.
+ *
+ * Il velo non si tocca. Il momento in cui si alza e' quello che la Diagnostica
+ * misura e dichiara, e allungarlo vorrebbe dire peggiorare un numero vero per
+ * far sembrare risolta una cosa di un altro genere. Si copre la barra, che e'
+ * l'unica che sta mentendo, e la si scopre quando sa cosa mostrare.
+ */
+
+/* Passata questa, la barra si mostra com'e'. Una plancia che non riesce a
+ * leggere la sua configurazione deve avere una barra lo stesso: quella di serie
+ * e' meglio di nessuna. */
+export const ATTESA_MASSIMA_DELLA_BARRA = 2500;
+
+/* Se la configurazione della casa e' arrivata.
+ *
+ * Non basta che il magazzino esista: nasce con `visibility: {}` e `sections:
+ * {}`, e un magazzino appena nato risponde «tutto visibile» come risponderebbe
+ * una casa che non ha configurato niente. Le due cose vanno distinte, o si
+ * scopre la barra su un'ipotesi.
+ *
+ * Il segno e' che dentro ci sia qualcosa. Una casa configurata ha delle sezioni
+ * o delle preferenze di visibilita' — almeno una delle due, e quasi sempre
+ * tutte e due. Una casa che non ha ancora configurato niente non ha ne' l'una
+ * ne' l'altra, e li' la barra di serie e' la risposta giusta: si scopre subito,
+ * perche' non c'e' niente che possa smentirla. */
+export function laConfigurazioneSiConosce(magazzino = root.DashboardModernModules?.store) {
+  try {
+    const stato = magazzino?.getState?.();
+    if (!stato || typeof stato !== "object") return false;
+    const quante = (dentro) =>
+      dentro && typeof dentro === "object" ? Object.keys(dentro).length : 0;
+    return quante(stato.visibility) > 0 || quante(stato.sections) > 0;
+  } catch (_errore) {
+    return false;
+  }
+}
+
+/* La tenda e' gia' calata: `dashboard-runtime.css` copre la barra finche' il
+ * documento non porta il segno, e quel foglio il guscio lo carica dalla testa —
+ * cioe' prima che la barra esista. Qui si toglie il segno, e basta. */
+function scopriLaBarra() {
+  state.barraScoperta = true;
+  if (state.scadenza) {
+    root.clearTimeout?.(state.scadenza);
+    state.scadenza = 0;
+  }
+  if (doc?.documentElement) doc.documentElement.dataset.dmBarra = "pronta";
+}
+
+/** La visibilita' delle voci adesso, senza aspettare il giro del guscio. */
+function applicaLaVisibilita() {
+  try {
+    root.cdApplyNavVis?.();
+  } catch (_errore) {
+    /* Il guscio potrebbe non essere ancora arrivato: si riprova al prossimo
+       richiamo, che e' comunque prima del suo giro. */
+  }
+}
+
+function forseScopri() {
+  if (state.barraScoperta) return false;
+  if (!laConfigurazioneSiConosce()) return false;
+  applicaLaVisibilita();
+  scopriLaBarra();
+  return true;
+}
+
+function installaLAttesaDellaBarra() {
+  for (const evento of [
+    "dashboardmodern:legacy-ready",
+    "dashboardmodern:runtime-ready",
+    "dashboardmodern:persistence-restored",
+    "dashboardmodern:state-changed",
+  ])
+    root.addEventListener?.(evento, () => forseScopri());
+  state.scadenza = root.setTimeout?.(() => {
+    applicaLaVisibilita();
+    scopriLaBarra();
+  }, ATTESA_MASSIMA_DELLA_BARRA);
+  forseScopri();
+}
+
 function accodaDopo(nome) {
   const originale = root[nome];
   if (typeof originale !== "function" || originale.__dmConfigUltima) return false;
@@ -715,6 +821,30 @@ function accodaDopo(nome) {
     return esito;
   };
   avvolta.__dmConfigUltima = true;
+  root[nome] = avvolta;
+  return true;
+}
+
+/* Una voce appena messa si filtra subito, non al giro dopo.
+ *
+ * Le voci che aggiungono i moduli — Stanze, Luci, Prese, Robot, il cruscotto —
+ * arrivano dopo quelle del guscio, e il guscio le filtra al suo giro: misurato,
+ * comparivano non filtrate a 1431 ms e sparivano a 1505 ms. Settantaquattro
+ * millisecondi in cui la barra mostra la voce di una sezione spenta.
+ *
+ * L'aggancio e' `render`, che e' la funzione che rifa' la plancia e dentro cui
+ * quelle voci nascono: niente sorveglianti e niente timer, che e' la regola di
+ * questo modulo e di questa barra. */
+function filtraDopo(nome) {
+  const originale = root[nome];
+  if (typeof originale !== "function" || originale.__dmVisibilitaSubito) return false;
+  const avvolta = function (...argomenti) {
+    const esito = originale.apply(this, argomenti);
+    applicaLaVisibilita();
+    return esito;
+  };
+  avvolta.__dmVisibilitaSubito = true;
+  avvolta.__dmPrevious = originale;
   root[nome] = avvolta;
   return true;
 }
@@ -790,10 +920,19 @@ export function installNavigationSection() {
   /* E poco dopo l'avvio: il pannello di Home Assistant finisce di impaginarsi
    * dopo di noi, e una misura presa troppo presto è uno zero. */
   for (const attesa of [400, 1500]) root.setTimeout?.(() => misuraIlFondoDiSistema(), attesa);
+  /* Il foglio prima di tutto: la tenda e' una regola di stile, e metterla
+   * senza il foglio vorrebbe dire scriverla su un attributo che non tinge
+   * niente — la barra resterebbe scoperta proprio nei millisecondi che si
+   * volevano coprire. */
+  installStyles();
   applyNavbarMode();
+  installaLAttesaDellaBarra();
   configSempreUltima();
   accodaDopo("cdApplyNavOrder");
   accodaDopo("cdApplyNavVis");
+  filtraDopo("render");
+  for (const evento of ["dashboardmodern:legacy-ready", "dashboardmodern:runtime-ready"])
+    root.addEventListener?.(evento, () => filtraDopo("render"));
   /* La configurazione condivisa, arrivando, riscrive le chiavi: se quella
    * dell'altro dispositivo non la porta, qui resterebbe vuota e la barra
    * tornerebbe a scomparsa da sola. */
@@ -811,7 +950,6 @@ export function installNavigationSection() {
    * a quelle, senza sorveglianti ne' timer: e' la stessa regola con cui questo
    * modulo tiene il resto della barra. */
   disegniNellaBarra();
-  installStyles();
   installBarBehaviour();
   if (!installScroller()) {
     doc.addEventListener("DOMContentLoaded", () => installScroller(), { once: true });

--- a/custom_components/dashboardmodern/frontend/src/sections/radar-meteo-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/radar-meteo-section.js
@@ -123,6 +123,11 @@ function finestraAperta() {
   return modale.offsetParent !== null;
 }
 
+/* Il blocco che c'e' gia', senza fabbricarlo. */
+function bloccoEsistente() {
+  return finestra()?.querySelector?.(`.${BLOCCO}`) || null;
+}
+
 function blocco() {
   const modale = finestra();
   if (!modale) return null;
@@ -193,6 +198,26 @@ function daTessere(scelto, nodo) {
   /* Si ridisegna solo se il quadro e' cambiato davvero: rifare le immagini a
    * ogni giro le farebbe lampeggiare mentre si guarda. */
   const firma = `${luogo.lat},${luogo.lon},${finestraTessere.zoom},${misure.latoPx}x${misure.altoPx},${scelto.modello},${scelto.fondo}`;
+  let attesi = 0;
+  let arrivati = 0;
+  let persi = 0;
+  const segnala = (immagine, riuscito) => {
+    if (riuscito) arrivati += 1;
+    else {
+      persi += 1;
+      immagine.remove();
+    }
+    if (arrivati) {
+      nodo.dataset.dmRadar = "vivo";
+      return;
+    }
+    /* Nessuno arrivato e nessuno piu' in volo: il radar non risponde, e la
+     * firma si azzera perche' il giro dopo ci riprovi. */
+    if (persi >= attesi) {
+      nodo.dataset.dmRadar = "muto";
+      dove.dataset.dmFirma = "";
+    }
+  };
   if (dove.dataset.dmFirma !== firma) {
     dove.dataset.dmFirma = firma;
     const pezzi = [];
@@ -210,12 +235,27 @@ function daTessere(scelto, nodo) {
         immagine.style.cssText = `left:${tessera.sx}px;top:${tessera.sy}px;width:${tessera.lato}px;height:${tessera.lato}px`;
         /* Un quadratino che non arriva e' un buco, non un errore: il servizio
          * non copre tutto il mondo, e ai bordi manca per costruzione. */
-        immagine.addEventListener("error", () => immagine.remove(), { once: true });
+        immagine.addEventListener("error", () => segnala(immagine, false), { once: true });
+        immagine.addEventListener("load", () => segnala(immagine, true), { once: true });
         pezzi.push(immagine);
       }
     }
     dove.replaceChildren(...pezzi);
-    nodo.dataset.dmRadar = pezzi.length ? "vivo" : "muto";
+    /* «Vivo» quando un quadratino e' arrivato, non quando l'abbiamo chiesto.
+     *
+     * Qui si contavano le immagini create, che e' un'altra cosa: se il
+     * servizio non risponde le immagini se ne vanno una per una dal loro
+     * `error`, il riquadro resta vuoto — e il blocco continuava a dire
+     * «vivo», che nasconde la frase che spiega. Un radar configurato che non
+     * arriva mostrava un rettangolo grigio muto, senza una parola.
+     *
+     * E se non arriva nessuno si cancella la firma: senza, il giro
+     * successivo troverebbe lo stesso disegno e non riproverebbe mai piu'. */
+    attesi = pezzi.length;
+    arrivati = 0;
+    persi = 0;
+    nodo.dataset.dmRadar = pezzi.length ? "attesa" : "muto";
+    if (!pezzi.length) dove.dataset.dmFirma = "";
   }
 
   const nota = nodo.querySelector(".dm-radar-nota");
@@ -227,12 +267,24 @@ function daTessere(scelto, nodo) {
 
 export function disegnaRadar() {
   const scelto = radarScelto();
-  const nodo = blocco();
-  if (!nodo) return false;
+  /* Senza radar configurato non si disegna niente — e non si fabbrica
+   * nemmeno il posto dove disegnarlo.
+   *
+   * Prima il blocco nasceva comunque e poi si metteva `hidden`, e non
+   * bastava: `hidden` e' l'ultima riga del foglio del browser, e qui sopra
+   * c'e' una regola nostra con `display:grid` che la batte. Il risultato,
+   * in una casa che il radar non l'ha mai configurato, era un riquadro
+   * grigio dentro le previsioni con l'immagine rotta e scritto «il radar
+   * non sta rispondendo» — un errore per una cosa che nessuno aveva
+   * chiesto. Adesso se non c'e' niente da mostrare il blocco se ne va, e
+   * la regola col `display:none` che vince e' li' sotto per il caso in cui
+   * qualcuno lo lasci indietro. */
   if (!scelto) {
-    nodo.hidden = true;
+    bloccoEsistente()?.remove();
     return false;
   }
+  const nodo = blocco();
+  if (!nodo) return false;
   nodo.hidden = false;
   nodo.dataset.dmModo = scelto.modo;
   const nome = nodo.querySelector(".dm-radar-nome");
@@ -454,6 +506,13 @@ function installStyles() {
     "dm-radar-meteo",
     `
       #weather-modal .dm-radar-blocco{display:grid;gap:8px;margin-bottom:14px}
+      /* Una regola nostra col display batte l'attributo hidden del browser:
+         senza questa riga, nascondere il blocco non lo nascondeva. */
+      #weather-modal .dm-radar-blocco[hidden]{display:none!important}
+      /* Mentre i quadratini arrivano non si dice ne' l'una ne' l'altra cosa:
+         l'immagine rotta e la frase dell'errore restano tutte e due fuori. */
+      #weather-modal .dm-radar-blocco[data-dm-radar="attesa"] .dm-radar-img{display:none}
+      #weather-modal .dm-radar-blocco[data-dm-radar="attesa"] .dm-radar-muto{display:none}
       #weather-modal .dm-radar-testa{display:flex;align-items:baseline;gap:8px;flex-wrap:wrap}
       #weather-modal .dm-radar-testa strong{
         font-size:13px;font-weight:900;letter-spacing:.04em;text-transform:uppercase;

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -107,6 +107,7 @@ import { installEntitaMieEditor } from "./entita-mie-editor-section.js";
 import { installMediaPlayer } from "./media-player-section.js";
 import { installMediaEditor } from "./media-player-editor-section.js";
 import { installMediaInAzioni } from "./media-in-azioni-section.js";
+import { installIndirizzoDiCasa } from "./indirizzo-di-casa-section.js";
 import { installStanzePerNome } from "./stanze-per-nome-section.js";
 import { installRadarMeteo } from "./radar-meteo-section.js";
 import { installMinipcShowcaseSection } from "./minipc-showcase-section.js";
@@ -760,6 +761,11 @@ export function installSectionRuntime() {
 
   root[INSTALLING_KEY] = true;
   try {
+    /* Prima di tutto: una domanda a Home Assistant che parte con l'indirizzo
+     * sbagliato non arriva, e chi la fa non se ne accorge — «Failed to fetch»
+     * al posto dello storico. Si ripara la sola cosa che serve, e si ripara
+     * prima che qualcuno chieda. */
+    installIndirizzoDiCasa();
     // Language first: every section below reads its copy while it renders, so
     // the locale has to be settled before the first of them runs.
     installI18nSection();

--- a/custom_components/dashboardmodern/frontend/src/sections/segnalazioni-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/segnalazioni-section.js
@@ -1890,7 +1890,7 @@ function sottotitolo() {
   );
 }
 
-function disegna() {
+function disegnaLaFinestra() {
   const modale = doc?.getElementById?.("dm-tkt-modal");
   if (!modale) return;
   modale.querySelector('[data-dm-tkt="titolo"]').textContent = t("Segnalazioni", "Reports");
@@ -1901,9 +1901,34 @@ function disegna() {
   corpo.innerHTML = schede() + avvisoMarkup() + codiceMarkup() + pannello;
   agganciaEventi(corpo);
   if (state.tab === "nuova") mostraDiagnostica(corpo);
-  /* La pagina del cruscotto vive fuori da questa finestra, ma legge lo stesso
-   * stato: quando qui cambia qualcosa — una risposta pubblicata, la coda
-   * riletta — anche lei va rifatta, o le due mostrerebbero cose diverse. */
+}
+
+/* Ridisegnare vuol dire ridisegnare tutti e due i posti, e nessuno dei due
+ * comanda sull'altro.
+ *
+ * «Tab nel cruscotto non funziona, non mi fa selezionare Difetti e nemmeno In
+ * lavorazione.» I tasti erano collegati e il tocco arrivava: metteva
+ * `state.filtro` e chiamava questa. Ma questa cominciava cercando
+ * `#dm-tkt-modal` e, non trovandolo, tornava indietro alla riga dopo — mentre
+ * il cruscotto lo ridisegnava l’ultima riga, quella che non veniva mai
+ * eseguita.
+ *
+ * La finestra delle segnalazioni la costruisce `apri()`, che parte dalla
+ * tessera in Configurazione. Chi apre il cruscotto dalla barra quella tessera
+ * non la tocca: nel documento non c’è nessun `#dm-tkt-modal`, e non ci deve
+ * essere. Cioè il filtro non rispondeva mai a chi usava la pagina per quello
+ * per cui esiste; rispondeva soltanto a chi, nella stessa sessione, avesse
+ * aperto e chiuso la finestra almeno una volta.
+ *
+ * E il difetto era largo quanto la funzione: dietro `disegna()` ci stanno
+ * anche il filo che si apre, la risposta appena mandata, la segnalazione
+ * chiusa. Sul cruscotto nessuna di quelle si vedeva finire.
+ *
+ * Adesso la finestra e la pagina sono due disegni indipendenti: ciascuno
+ * guarda se ha un posto dove stare, e chi non ce l’ha non impedisce all’altro
+ * di esistere. */
+function disegna() {
+  disegnaLaFinestra();
   disegnaCruscotto();
 }
 

--- a/custom_components/dashboardmodern/frontend/tests/assistenza-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/assistenza-section.test.js
@@ -178,6 +178,13 @@ test("il cestino chiede conferma prima di cancellare", () => {
   );
   assert.match(sorgente, /state\.daButtare !== nome/);
   assert.match(sorgente, /Confermi\?/);
+  /* E un cestino armato non sopravvive alla finestra: riaprirla e trovare
+   * «Confermi?» gia' acceso vorrebbe dire che il primo tocco cancella. */
+  assert.match(sorgente, /state\.daButtare = "";\s*modale\.classList\.add\("show"\)/);
+  assert.match(
+    sorgente,
+    /export function chiudi\(\) \{\s*spegniIlGiro\(\);\s*state\.daButtare = "";/,
+  );
 });
 
 test("il nome di una casa non si porta dentro del markup nemmeno in coda", () => {

--- a/custom_components/dashboardmodern/frontend/tests/assistenza-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/assistenza-section.test.js
@@ -1,13 +1,16 @@
 /* La chat di assistenza: il contratto verso il backend e verso il ponte, e le
- * due cose che dal browser non si vedono finche' non e' tardi.
+ * cose che dal browser non si vedono finche' non e' tardi.
  *
  * Quello che si prova qui non e' il disegno — quello lo prova un browser vero
- * — ma tre cose che in casa d'altri si scoprirebbero male: un tipo di
- * messaggio non ammesso dal ponte, un modulo che nessuno importa e che quindi
- * non si carica mai, e il patto sulla riservatezza che sparisce da sotto la
- * casella dove si sta per raccontare un guaio di casa propria.
+ * — ma le cose che in casa d'altri si scoprirebbero male: un tipo di messaggio
+ * non ammesso dal ponte, un modulo che nessuno importa e che quindi non si
+ * carica mai, il patto sulla riservatezza che sparisce da sotto la casella
+ * dove si sta per raccontare un guaio di casa propria, una bolla dalla parte
+ * sbagliata quando a leggere e' chi risponde, e una finestra che resta ferma
+ * mentre dall'altro capo qualcuno ha gia' risposto.
  */
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
@@ -16,6 +19,7 @@ import {
   MAX_TESTO,
   WS_TYPES,
   avvertenzaMarkup,
+  codaMarkup,
   filoMarkup,
   messaggioMarkup,
   quando,
@@ -33,7 +37,7 @@ test("ogni messaggio che la chat manda passa dal ponte", () => {
   }
 });
 
-test("i sette comandi sono quelli che il backend registra", async () => {
+test("gli otto comandi sono quelli che il backend registra", async () => {
   const backend = await readFile(
     new URL("../../websocket_api.py", import.meta.url),
     "utf8",
@@ -45,7 +49,7 @@ test("i sette comandi sono quelli che il backend registra", async () => {
       `${tipo} non è registrato dal backend`,
     );
   }
-  assert.equal(WS_TYPES.length, 7);
+  assert.equal(WS_TYPES.length, 8);
 });
 
 test("nessun comando della chat porta un segreto", () => {
@@ -138,4 +142,112 @@ test("il tetto del messaggio è lo stesso del backend e del centralino", async (
     "utf8",
   );
   assert.match(centralino, new RegExp(`testo: ${MAX_TESTO},`));
+});
+
+test("ogni conversazione della coda si può buttare via", () => {
+  /* Una coda dove non si butta via niente si riempie di prove, di domande già
+   * risolte e di righe aperte per sbaglio, finché quella vera non si trova
+   * più. Il cestino deve stare su ogni riga, non solo sulla prima. */
+  const coda = codaMarkup([
+    { id: `casa_${"a".repeat(32)}`, nome: "Giovanni", ultimo: "test" },
+    { id: `casa_${"b".repeat(32)}`, ultimo: "un'altra" },
+  ]);
+  const cestini = coda.match(/data-dm-chat-butta="casa_/g) || [];
+  assert.equal(cestini.length, 2);
+});
+
+test("il tasto che apre e il cestino non sono uno dentro l'altro", () => {
+  /* Un <button> dentro un <button> non è markup valido: il browser lo srotola,
+   * e il cestino finisce fuori dalla riga — dove non lo trova nessuno. */
+  const coda = codaMarkup([{ id: `casa_${"c".repeat(32)}`, ultimo: "ciao" }]);
+  const apre = coda.indexOf("dm-chat-voce-apri");
+  const chiude = coda.indexOf("</button>", apre);
+  const cestino = coda.indexOf("data-dm-chat-butta");
+  assert.ok(apre > -1 && cestino > -1);
+  assert.ok(chiude < cestino, "il cestino sta dentro il tasto che apre la riga");
+});
+
+test("il cestino chiede conferma prima di cancellare", () => {
+  /* Una conversazione cancellata non si rimette a posto: sparisce dal
+   * centralino e dalla plancia di quella casa. In un elenco dove si scorre col
+   * dito, un cestino che cancella al primo tocco butta via prima o poi la
+   * conversazione sbagliata. */
+  const sorgente = readFileSync(
+    new URL("../src/sections/assistenza-section.js", import.meta.url),
+    "utf8",
+  );
+  assert.match(sorgente, /state\.daButtare !== nome/);
+  assert.match(sorgente, /Confermi\?/);
+});
+
+test("il nome di una casa non si porta dentro del markup nemmeno in coda", () => {
+  /* Il nome lo scrive un'altra casa: quello che una casa scrive non deve poter
+   * disegnare niente nella plancia di chi risponde. */
+  const coda = codaMarkup([
+    {
+      id: `casa_${"d".repeat(32)}`,
+      nome: '<img src=x onerror="alert(1)">',
+      ultimo: "<script>",
+    },
+  ]);
+  assert.ok(!coda.includes("<img"), "il nome è passato intero");
+  assert.ok(!coda.includes("<script>"), "l'ultima frase è passata intera");
+});
+
+test("nella coda di chi risponde le bolle stanno dalla parte giusta", () => {
+  /* «Mio» dipende da chi guarda, e questa finestra la guardano in due. Nella
+   * coda le domande della casa comparivano a destra e in verde — come se se le
+   * fosse scritte da solo chi stava leggendo — e le proprie risposte a
+   * sinistra: una conversazione letta al contrario. */
+  const domanda = { da: "casa", testo: "non mi si vede la temperatura" };
+  const risposta = { da: "console", testo: "guarda nella scheda Stanze" };
+  assert.match(messaggioMarkup(domanda), /dm-chat-riga mia/);
+  assert.match(messaggioMarkup(risposta), /dm-chat-riga sua/);
+  assert.match(messaggioMarkup(domanda, true), /dm-chat-riga sua/);
+  assert.match(messaggioMarkup(risposta, true), /dm-chat-riga mia/);
+});
+
+test("il filo di chi risponde passa il verso a ogni bolla", () => {
+  const filo = filoMarkup(
+    [
+      { da: "casa", testo: "una domanda" },
+      { da: "console", testo: "una risposta" },
+    ],
+    true,
+  );
+  assert.equal((filo.match(/dm-chat-riga sua/g) || []).length, 1);
+  assert.equal((filo.match(/dm-chat-riga mia/g) || []).length, 1);
+  assert.ok(filo.indexOf("dm-chat-riga sua") < filo.indexOf("dm-chat-riga mia"));
+});
+
+test("la finestra aperta si aggiorna da sola, e chiusa non chiede niente", () => {
+  /* «La risposta non si refresh, devo uscire e rientrare»: la finestra leggeva
+   * una volta all'apertura e poi restava ferma. Il giro dei cinque minuti del
+   * backend serve al campanello, non a ridisegnare — e cinque minuti davanti a
+   * una chat aperta sono un'eternità. */
+  const sorgente = readFileSync(
+    new URL("../src/sections/assistenza-section.js", import.meta.url),
+    "utf8",
+  );
+  assert.match(sorgente, /const RINFRESCO = \d+;/);
+  const quanto = Number(/const RINFRESCO = (\d+);/.exec(sorgente)?.[1]);
+  assert.ok(quanto >= 5000 && quanto <= 60000, `${quanto} non è un ritmo da chat`);
+  /* Aprire accende il giro, chiudere lo spegne: una plancia accesa tutto il
+   * giorno in cucina non deve bussare al centralino per una conversazione che
+   * nessuno sta guardando. */
+  assert.match(sorgente, /modale\.classList\.add\("show"\);[\s\S]{0,120}accendiIlGiro\(\)/);
+  assert.match(sorgente, /export function chiudi\(\) \{\s*spegniIlGiro\(\);/);
+});
+
+test("un giro che non trova niente di nuovo non ridisegna", () => {
+  /* Ridisegnare rifà la casella: farlo quattro volte al minuto mentre qualcuno
+   * scrive è il modo di rendere la finestra inusabile. */
+  const sorgente = readFileSync(
+    new URL("../src/sections/assistenza-section.js", import.meta.url),
+    "utf8",
+  );
+  assert.match(sorgente, /segno\(righe\) === segno\(state\.filo\)/);
+  assert.match(sorgente, /segno\(righe\) === segno\(state\.messages\)/);
+  /* E se ridisegna, il cursore torna dov'era. */
+  assert.match(sorgente, /setSelectionRange\(dovEro\.da, dovEro\.a\)/);
 });

--- a/custom_components/dashboardmodern/frontend/tests/assistenza-section.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/assistenza-section.test.js
@@ -251,3 +251,30 @@ test("un giro che non trova niente di nuovo non ridisegna", () => {
   /* E se ridisegna, il cursore torna dov'era. */
   assert.match(sorgente, /setSelectionRange\(dovEro\.da, dovEro\.a\)/);
 });
+
+test("la pagina nascosta ferma il giro", () => {
+  /* Leggere la propria conversazione vuol dire averla letta, e il segnalibro si
+   * sposta. Una finestra dimenticata aperta in una scheda in fondo si mangiava
+   * le risposte — le metteva in copia, le segnava lette — e il giro dei cinque
+   * minuti che deve suonare la campanella trovava che non era arrivato niente
+   * di nuovo. La risposta c'era, e nessuno lo sapeva. */
+  const sorgente = readFileSync(
+    new URL("../src/sections/assistenza-section.js", import.meta.url),
+    "utf8",
+  );
+  assert.match(sorgente, /if \(doc\?\.hidden\) return;/);
+});
+
+test("una risposta che arriva tardi non finisce sotto il nome sbagliato", () => {
+  /* Fra la domanda e la risposta ci sta un dito che apre un'altra
+   * conversazione: senza un appunto di dov'era partita, il filo di una casa
+   * finisce sotto il nome di un'altra. E due giri sovrapposti li vince quello
+   * che torna per ultimo, che non è detto sia il più recente. */
+  const sorgente = readFileSync(
+    new URL("../src/sections/assistenza-section.js", import.meta.url),
+    "utf8",
+  );
+  assert.match(sorgente, /const stessoPosto = \(\) =>/);
+  assert.match(sorgente, /if \(!stessoPosto\(\)/);
+  assert.match(sorgente, /if \(state\.busy \|\| inVolo \|\| !state\.enabled\) return;/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/energy-flow-topology.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/energy-flow-topology.test.js
@@ -975,3 +975,80 @@ test("il cerchio del gruppo non contraddice la propria finestra", () => {
   assert.equal(mese.nodes[0].source, "sum");
   assert.ok(Math.abs(mese.nodes[0].value - 28.6) < 1e-9, `mese: ${mese.nodes[0].value}`);
 });
+
+/* ── il contatore che dice meno dei suoi figli ──────────────────────────────
+ *
+ * «Calcolo energia giornaliera e mensile su elettrodomestici di nuovo
+ * sbagliata»: cerchio a «0,2 kWh», finestra dello stesso cerchio a «12,0 kWh»,
+ * sullo stesso schermo.
+ *
+ * E' lo stesso difetto dello zero, col numero al posto dello zero — e la
+ * regola di prima non scattava, perche' 0,2 non e' zero. Zero non era la cosa
+ * da guardare: una pinza sulla linea misura tutto quello che le passa sotto, e
+ * il suo numero non puo' essere piu' piccolo della somma di cio' che ha
+ * dentro. Se lo e', quella casella sta misurando altro.
+ */
+test("un contatore che dice meno dei suoi figli non sta misurando il gruppo", () => {
+  const gruppo = {
+    id: "elettro",
+    daily_energy_entity: "sensor.gruppo_oggi",
+    monthly_energy_entity: "sensor.gruppo_mese",
+  };
+  const figli = [
+    { id: "cond", daily_energy_entity: "sensor.cond_oggi", monthly_energy_entity: "sensor.cond_mese" },
+    { id: "lavast", daily_energy_entity: "sensor.lavast_oggi", monthly_energy_entity: "sensor.lavast_mese" },
+    { id: "frigo", daily_energy_entity: "sensor.frigo_oggi", monthly_energy_entity: "sensor.frigo_mese" },
+  ];
+  const kwh = (valore) => ({ state: String(valore), attributes: { unit_of_measurement: "kWh" } });
+  const stati = {
+    // Il numero visto dal vero: 0,2 fuori, 11,3 dentro.
+    "sensor.gruppo_oggi": kwh(0.2),
+    "sensor.cond_oggi": kwh(9.4),
+    "sensor.lavast_oggi": kwh(1.0),
+    "sensor.frigo_oggi": kwh(0.9),
+    "sensor.gruppo_mese": kwh(3.1),
+    "sensor.cond_mese": kwh(36.6),
+    "sensor.lavast_mese": kwh(4.2),
+    "sensor.frigo_mese": kwh(3.1),
+  };
+  const oggi = readingFor(gruppo, figli, "day", stati, null);
+  assert.ok(Math.abs(oggi.value - 11.3) < 1e-9, `giorno: ${oggi.value}`);
+  assert.equal(oggi.source, "sum");
+  const mese = readingFor(gruppo, figli, "month", stati, null);
+  assert.ok(Math.abs(mese.value - 43.9) < 1e-9, `mese: ${mese.value}`);
+  assert.equal(mese.source, "sum");
+});
+
+test("una pinza vera vince sulla somma, anche quando misura di piu'", () => {
+  /* E' il motivo per cui il contatore del gruppo esiste: prende anche quello
+   * che nessuno ha modellato come figlio. Finche' sta sopra, comanda lui. */
+  const gruppo = { id: "elettro", daily_energy_entity: "sensor.gruppo_oggi" };
+  const figli = [{ id: "cond", daily_energy_entity: "sensor.cond_oggi" }];
+  const kwh = (valore) => ({ state: String(valore), attributes: { unit_of_measurement: "kWh" } });
+  const letto = readingFor(
+    gruppo,
+    figli,
+    "day",
+    { "sensor.gruppo_oggi": kwh(14.2), "sensor.cond_oggi": kwh(9.4) },
+    null,
+  );
+  assert.equal(letto.value, 14.2);
+  assert.equal(letto.source, "direct");
+});
+
+test("il cerchio non balla per qualche secondo di ritardo fra i campioni", () => {
+  /* La pinza e i contatori dei figli non campionano nello stesso istante:
+   * senza margine, un contatore appena sotto la somma farebbe cambiare
+   * sorgente avanti e indietro a ogni giro. */
+  const gruppo = { id: "elettro", daily_energy_entity: "sensor.gruppo_oggi" };
+  const figli = [{ id: "cond", daily_energy_entity: "sensor.cond_oggi" }];
+  const kwh = (valore) => ({ state: String(valore), attributes: { unit_of_measurement: "kWh" } });
+  const letto = readingFor(
+    gruppo,
+    figli,
+    "day",
+    { "sensor.gruppo_oggi": kwh(11.9), "sensor.cond_oggi": kwh(12.0) },
+    null,
+  );
+  assert.equal(letto.source, "direct", "un pelo sotto e' ritardo, non un'altra grandezza");
+});

--- a/custom_components/dashboardmodern/frontend/tests/i18n-message-keys.js
+++ b/custom_components/dashboardmodern/frontend/tests/i18n-message-keys.js
@@ -693,6 +693,7 @@ export const MESSAGE_KEYS = Object.freeze([
   "Confirm",
   "Confirm ✓",
   "Confirm opening?",
+  "Confirm?",
   "Connect GitHub",
   "Connect GitHub to write under this report.",
   "Connected",

--- a/custom_components/dashboardmodern/frontend/tests/i18n-message-keys.js
+++ b/custom_components/dashboardmodern/frontend/tests/i18n-message-keys.js
@@ -367,6 +367,7 @@ export const MESSAGE_KEYS = Object.freeze([
   "Add a reply",
   "Add a second alarm area",
   "Add a second solar plant",
+  "Add an emoji",
   "Add appliance",
   "Add appliance button not found",
   "Add area",

--- a/custom_components/dashboardmodern/frontend/tests/il-calendario-dice-cosa-viene-dopo.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/il-calendario-dice-cosa-viene-dopo.test.js
@@ -22,12 +22,14 @@ import {
   chiaveDelGiorno,
   etichettaDelGiorno,
   eventiDaQui,
+  giornoPiu,
   inCorso,
   isCalendarEntity,
   istanteDi,
   minutiAllEvento,
   normalizzaCalendari,
   oraDellEvento,
+  orarioDi,
   PAROLE_CALENDARIO,
   ordinaEventi,
   parseCalendarEventsResponse,
@@ -942,4 +944,51 @@ test("la tessera e la pagina chiamano le liste e i calendari per nome", async ()
   );
   assert.doesNotMatch(pagina, /clean\(voce\.name\) \|\| voce\.entity/);
   assert.match(pagina, /nomeDellEntita\(voce\.entity, voce\.name\)/);
+});
+
+test("«Domani» resta domani anche nel giorno del cambio d'ora", () => {
+  /* La tessera era gia' stata corretta; l'etichetta dei gruppi e la striscia
+   * dei sette giorni sommavano ancora ventiquattro ore. Nel giorno che ne dura
+   * venticinque «Domani» si chiamava con la sua data e la striscia mostrava
+   * oggi due volte; in quello che ne dura ventitre' domani si saltava. */
+  const prima = process.env.TZ;
+  process.env.TZ = "America/New_York";
+  try {
+    // 2026-11-01 00:30 ora legale della costa est: quel giorno dura 25 ore.
+    const mezzanotteEMezza = Date.parse("2026-11-01T04:30:00Z");
+    assert.equal(etichettaDelGiorno("2026-11-02", mezzanotteEMezza), "Domani");
+    const striscia = Array.from({ length: 7 }, (_, passo) =>
+      chiaveDelGiorno(giornoPiu(mezzanotteEMezza, passo)),
+    );
+    assert.deepEqual(striscia, [
+      "2026-11-01",
+      "2026-11-02",
+      "2026-11-03",
+      "2026-11-04",
+      "2026-11-05",
+      "2026-11-06",
+      "2026-11-07",
+    ]);
+    // 2026-03-07 23:30: la notte dopo l'ora salta avanti, e domani e' l'8.
+    const primaDelSalto = Date.parse("2026-03-08T04:30:00Z");
+    assert.equal(chiaveDelGiorno(giornoPiu(primaDelSalto, 1)), "2026-03-08");
+  } finally {
+    if (prima === undefined) delete process.env.TZ;
+    else process.env.TZ = prima;
+  }
+});
+
+test("l'ora d'inizio in inglese tiene il PM", async () => {
+  /* La didascalia della Home tagliava l'intervallo al primo spazio: in
+   * inglese «02:30 PM – 03:30 PM» diventava «02:30», e le due e mezza del
+   * pomeriggio si leggevano come le due di notte. */
+  const dueEMezza = new Date(2026, 8, 1, 14, 30).getTime();
+  assert.equal(orarioDi(dueEMezza, "en-US"), "02:30 PM");
+  assert.equal(orarioDi(dueEMezza, "it-IT"), "14:30");
+  const sorgente = await readFile(
+    new URL("../src/sections/home-widgets-section.js", import.meta.url),
+    "utf8",
+  );
+  assert.doesNotMatch(sorgente, /oraDellEvento\([^)]*\)\.split\(/);
+  assert.match(sorgente, /orarioDi\(evento\.inizio, lingua\)/);
 });

--- a/custom_components/dashboardmodern/frontend/tests/il-radar-non-esce-se-non-lo-si-vuole.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/il-radar-non-esce-se-non-lo-si-vuole.test.js
@@ -1,0 +1,83 @@
+/* «Radar: da errore quando non configurato, non deve uscire proprio — e anche
+ * quando configurato da errore.»
+ *
+ * Sono due difetti nello stesso riquadro, e il primo si vede da chiunque non
+ * abbia mai aperto quella casella: dentro le previsioni compariva un rettangolo
+ * grigio con l'immagine rotta e scritto «il radar non sta rispondendo». Un
+ * errore per una cosa che nessuno aveva chiesto.
+ *
+ * Il blocco nasceva sempre e poi ci si metteva `hidden`, che sembra
+ * sufficiente e non lo e': `hidden` vale quanto una riga del foglio del
+ * browser, e sopra c'era una regola nostra con `display:grid` che la batte. Il
+ * blocco restava li', visibile, e senza `data-dm-radar` non si nascondevano
+ * nemmeno l'immagine vuota e la frase dell'errore — che infatti si vedevano
+ * tutte e due insieme.
+ *
+ * Il secondo e' del radar a tessere. «Vivo» si decideva contando i quadratini
+ * CREATI, ma un quadratino che non arriva si toglie da solo dal suo `error`:
+ * col servizio irraggiungibile il riquadro restava vuoto e il blocco
+ * continuava a dire «vivo», che e' proprio lo stato in cui la frase che
+ * spiegherebbe sta nascosta. E la firma del disegno non cambiava piu', quindi
+ * non si riprovava nemmeno.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+const sorgente = readFileSync(new URL("../src/sections/radar-meteo-section.js", import.meta.url), "utf8");
+
+test("senza radar configurato il blocco non si fabbrica nemmeno", () => {
+  /* Prima si guarda se c'e' qualcosa da mostrare, e solo dopo si cerca il
+   * posto dove mostrarlo: `blocco()` lo crea, e chiamarlo prima voleva dire
+   * fabbricare il riquadro per poi doverlo nascondere. */
+  const disegna = sorgente.slice(
+    sorgente.indexOf("export function disegnaRadar()"),
+    sorgente.indexOf("/* ── il giro, solo mentre si guarda ─"),
+  );
+  const doveScelto = disegna.indexOf("if (!scelto)");
+  const doveBlocco = disegna.indexOf("blocco()", disegna.indexOf("const nodo"));
+  assert.ok(doveScelto > 0, "il controllo sul radar scelto deve esserci");
+  assert.ok(doveBlocco > doveScelto, "il blocco si cerca dopo aver deciso che serve");
+  /* E quello eventualmente rimasto da prima se ne va. */
+  assert.match(disegna, /bloccoEsistente\(\)\?\.remove\(\)/);
+  assert.doesNotMatch(disegna, /nodo\.hidden = true/);
+});
+
+test("e se qualcuno lo lascia indietro, hidden lo nasconde davvero", () => {
+  /* La regola col display sta piu' in alto e batte l'attributo del browser:
+   * serve dirlo per esteso, una volta. */
+  assert.match(sorgente, /\.dm-radar-blocco\[hidden\]\{display:none!important\}/);
+});
+
+test("il radar a tessere dice «vivo» solo quando un quadratino e' arrivato", () => {
+  const tessere = sorgente.slice(
+    sorgente.indexOf("function daTessere("),
+    sorgente.indexOf("export function disegnaRadar()"),
+  );
+  /* Non si conta piu' quello che si e' chiesto. */
+  assert.doesNotMatch(tessere, /pezzi\.length \? "vivo"/);
+  /* Si ascoltano tutte e due le risposte, non solo il fallimento. */
+  assert.match(tessere, /addEventListener\("load", \(\) => segnala\(immagine, true\)/);
+  assert.match(tessere, /addEventListener\("error", \(\) => segnala\(immagine, false\)/);
+  /* Il primo che arriva accende; quando sono finiti e non e' arrivato
+   * nessuno, il blocco lo dice. */
+  assert.match(tessere, /if \(arrivati\) \{\s*nodo\.dataset\.dmRadar = "vivo";/);
+  assert.match(tessere, /if \(persi >= attesi\) \{\s*nodo\.dataset\.dmRadar = "muto";/);
+});
+
+test("un radar che non risponde riprova al giro dopo", () => {
+  /* La firma serve a non ridisegnare a vuoto mentre si guarda; ma se il
+   * disegno e' fallito, tenerla vuol dire non riprovare mai piu'. */
+  const tessere = sorgente.slice(
+    sorgente.indexOf("function daTessere("),
+    sorgente.indexOf("export function disegnaRadar()"),
+  );
+  const azzeramenti = [...tessere.matchAll(/dove\.dataset\.dmFirma = "";/g)];
+  assert.ok(azzeramenti.length >= 2, "si azzera sia a zero quadratini sia a zero arrivi");
+});
+
+test("mentre i quadratini arrivano non si mostra ne' il vuoto ne' l'errore", () => {
+  assert.match(sorgente, /\[data-dm-radar="attesa"\] \.dm-radar-img\{display:none\}/);
+  assert.match(sorgente, /\[data-dm-radar="attesa"\] \.dm-radar-muto\{display:none\}/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/il-report-non-si-contraddice-sulla-stessa-riga.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/il-report-non-si-contraddice-sulla-stessa-riga.test.js
@@ -1,0 +1,63 @@
+/* «Valori wallbox nel report sballati.»
+ *
+ * Sulla riga della Wallbox, in Attività dispositivi: «☀️ 1188.7 kWh 🔌 184.0
+ * kWh» e, tre centimetri a destra sulla stessa riga, «0,0 kWh». Due numeri che
+ * si contraddicono guardandosi, e il primo era il contatore di vita della
+ * colonnina — millequattrocento chilowattora in un mese, per un'auto che in
+ * quel mese non ha caricato.
+ *
+ * La riga la disegna il guscio, e i suoi due numeri nascono d'accordo perché
+ * nascono dallo stesso valore. Poi passa di qui la sezione e riscrive quello a
+ * destra col valore del Recorder — che è quello giusto: nel mese corrente il
+ * guscio sottrae la lettura d'inizio mese con una chiamata allo storico, e se
+ * quella chiamata fallisce si tiene il contatore intero. Ma si riscriveva
+ * mezza riga: la quota sotto restava calcolata sul contatore di vita.
+ *
+ * Chi possiede il numero possiede la riga.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { scriviLaQuota, splitFor } from "../src/sections/energy-section.js";
+
+/* Una riga come la disegna il guscio, ridotta a quello che serve. */
+function rigaFinta(solare, rete) {
+  const pezzi = [{ textContent: `☀️ ${solare} kWh` }, { textContent: `🔌 ${rete} kWh` }];
+  const dentro = { dataset: {}, querySelectorAll: (sel) => (sel === "span" ? pezzi : []) };
+  return {
+    pezzi,
+    dentro,
+    querySelector: (sel) => (sel === ".ed-dev-name div" ? dentro : null),
+  };
+}
+
+test("la quota si rifa' sullo stesso valore del numero a destra", () => {
+  const riga = rigaFinta("1188.7", "184.0");
+  /* Il mese vero: casa 100 kWh, dalla rete 20 — un quinto dalla rete. E la
+   * wallbox in quel mese ha caricato zero. */
+  scriviLaQuota(riga, splitFor({ house: 100, gridImport: 20 }, 0));
+  assert.equal(riga.pezzi[0].textContent, "☀️ 0,0 kWh");
+  assert.equal(riga.pezzi[1].textContent, "🔌 0,0 kWh");
+});
+
+test("e quando il dispositivo ha consumato, la quota segue la casa", () => {
+  const riga = rigaFinta("0.0", "0.0");
+  scriviLaQuota(riga, splitFor({ house: 100, gridImport: 20 }, 10));
+  assert.equal(riga.pezzi[0].textContent, "☀️ 8,0 kWh");
+  assert.equal(riga.pezzi[1].textContent, "🔌 2,0 kWh");
+});
+
+test("una riga senza quel pezzo non fa danni", () => {
+  const nuda = { querySelector: () => null };
+  assert.doesNotThrow(() => scriviLaQuota(nuda, { solar: 1, grid: 2 }));
+  const monca = {
+    querySelector: () => ({ dataset: {}, querySelectorAll: () => [{ textContent: "" }] }),
+  };
+  assert.doesNotThrow(() => scriviLaQuota(monca, { solar: 1, grid: 2 }));
+});
+
+test("senza produzione tutto viene dalla rete", () => {
+  const quota = splitFor({ house: 0, gridImport: 0 }, 5);
+  assert.equal(quota.grid, 5);
+  assert.equal(quota.solar, 0);
+});

--- a/custom_components/dashboardmodern/frontend/tests/il-salvataggio-appena-fatto-non-si-perde.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/il-salvataggio-appena-fatto-non-si-perde.test.js
@@ -1,0 +1,138 @@
+/* «Metto l'entita', faccio salva, e non me la mette nella plancia.»
+ *
+ * E poi, dallo stesso giorno: «se metti due calendari il primo te lo mette e
+ * l'altro no», «ora vedo gli stessi carichi sui due impianti diversi». Tre
+ * sezioni che non c'entrano niente l'una con l'altra, e un'unica forma: si
+ * salva, e il salvataggio non resta.
+ *
+ * La causa e' una sola, e sta nel modo in cui due plance della stessa casa si
+ * mettono d'accordo. Il conflitto si risolveva cosi': una modifica locale vince
+ * solo se e' stata fatta sopra la revisione che questo dispositivo aveva gia'
+ * visto; altrimenti `restore-remote`, e la copia remota — che quella modifica
+ * non ce l'ha — torna sopra. In silenzio.
+ *
+ * Basta che un'altra plancia abbia spinto qualcosa nel frattempo. Il telefono
+ * in mano e il tablet in cucina sono due dispositivi, e chi sta configurando ne
+ * ha quasi sempre due aperti.
+ *
+ * Buttare via una modifica appena fatta non risolve il conflitto: lo nasconde.
+ * Adesso si fondono.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  conLeModificheInSospeso,
+  sharedReconcileAction,
+} from "../src/sections/config-persistence-section.js";
+
+const PRESE_MIE = JSON.stringify([
+  { entity: "switch.lavatrice" },
+  { entity: "switch.asciugatrice" },
+  { entity: "switch.frigo" },
+]);
+const PRESE_LORO = JSON.stringify([
+  { entity: "switch.lavatrice" },
+  { entity: "switch.asciugatrice" },
+]);
+
+const remota = (revision, values) => ({
+  revision,
+  updated_at: 1_800_000_000_000,
+  keys_revision: 99,
+  writer_generation: 99,
+  values,
+});
+
+test("una modifica appena fatta non viene buttata dalla copia remota", () => {
+  /* La terza presa e' qui e non di la', e la revisione remota e' andata avanti
+   * perche' un altro dispositivo ha spinto qualcosa. Prima: «restore-remote»,
+   * cioe' la terza presa sparisce senza dirlo a nessuno. */
+  const scelta = sharedReconcileAction({
+    snapshot: remota(8, { cd_prese: PRESE_LORO }),
+    local: { cd_prese: PRESE_MIE },
+    localConfigured: true,
+    pendingAt: Date.now(),
+    syncedRevision: 7,
+    chiaviDaTenere: ["cd_prese"],
+  });
+  assert.equal(scelta, "merge-local");
+});
+
+test("chi non ha toccato niente prende la copia remota, come prima", () => {
+  /* Senza chiavi in sospeso non c'e' niente da difendere, e la regola resta
+   * quella di sempre: comanda chi e' piu' avanti. */
+  assert.equal(
+    sharedReconcileAction({
+      snapshot: remota(8, { cd_prese: PRESE_LORO }),
+      local: { cd_prese: PRESE_MIE },
+      localConfigured: true,
+      pendingAt: Date.now(),
+      syncedRevision: 7,
+      chiaviDaTenere: [],
+    }),
+    "restore-remote",
+  );
+});
+
+test("una modifica fatta sopra la revisione vista si spinge, come prima", () => {
+  assert.equal(
+    sharedReconcileAction({
+      snapshot: remota(7, { cd_prese: PRESE_LORO }),
+      local: { cd_prese: PRESE_MIE },
+      localConfigured: true,
+      pendingAt: Date.now(),
+      syncedRevision: 7,
+      chiaviDaTenere: ["cd_prese"],
+    }),
+    "push-local",
+  );
+});
+
+test("e chi non ha modifiche in sospeso non fonde niente", () => {
+  assert.equal(
+    sharedReconcileAction({
+      snapshot: remota(8, { cd_prese: PRESE_LORO }),
+      local: { cd_prese: PRESE_MIE },
+      localConfigured: true,
+      pendingAt: 0,
+      syncedRevision: 7,
+      chiaviDaTenere: ["cd_prese"],
+    }),
+    "restore-remote",
+  );
+});
+
+test("la fusione: la copia remota per tutto, la propria dove si e' scritto", () => {
+  const fusi = conLeModificheInSospeso(
+    { cd_prese: PRESE_LORO, cd_calendari: "[]", cd_stanze: '[{"id":"r1"}]' },
+    { cd_prese: PRESE_MIE, cd_calendari: '[{"entity":"calendar.lavoro"}]', cd_stanze: "[]" },
+    ["cd_prese"],
+  );
+  assert.equal(fusi.cd_prese, PRESE_MIE, "la modifica appena fatta e' andata persa");
+  assert.equal(fusi.cd_calendari, "[]", "una chiave non toccata ha vinto sulla remota");
+  assert.equal(fusi.cd_stanze, '[{"id":"r1"}]', "una chiave non toccata ha vinto sulla remota");
+});
+
+test("piu' chiavi toccate restano tutte", () => {
+  const fusi = conLeModificheInSospeso(
+    { cd_prese: PRESE_LORO, cd_calendari: "[]" },
+    { cd_prese: PRESE_MIE, cd_calendari: '[{"entity":"calendar.lavoro"}]' },
+    ["cd_prese", "cd_calendari"],
+  );
+  assert.equal(fusi.cd_prese, PRESE_MIE);
+  assert.equal(fusi.cd_calendari, '[{"entity":"calendar.lavoro"}]');
+});
+
+test("una chiave cancellata qui resta cancellata anche nella fusione", () => {
+  /* Se qui non c'e' piu' e' perche' e' stata tolta: rimetterla dalla copia
+   * remota vorrebbe dire far resuscitare quello che si e' appena eliminato. */
+  const fusi = conLeModificheInSospeso({ cd_prese: PRESE_LORO }, {}, ["cd_prese"]);
+  assert.equal("cd_prese" in fusi, false);
+});
+
+test("una chiave che non e' delle nostre non si tocca", () => {
+  const fusi = conLeModificheInSospeso({ cd_prese: PRESE_LORO }, { pippo: "x" }, ["pippo"]);
+  assert.equal(fusi.cd_prese, PRESE_LORO);
+  assert.equal("pippo" in fusi, false);
+});

--- a/custom_components/dashboardmodern/frontend/tests/la-barra-non-si-rimangia-la-forma.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/la-barra-non-si-rimangia-la-forma.test.js
@@ -1,0 +1,67 @@
+/* «Resta sempre la barra totale, per poi diventare come l'ho configurata: dura
+ * quattro o cinque secondi.»
+ *
+ * Misurato sulla plancia vera, dall'avvio: a 648 ms la barra si dipinge con
+ * tutte e nove le voci del guscio e `cd_sections` non esiste ancora; a 675 ms
+ * il guscio ne scrive una sua — ricavata da quali sezioni hanno contenuto, e in
+ * quel momento non ne ha nessuna — e a 783 ms la barra diventa due voci; a 846
+ * ms il magazzino proietta la configurazione vera; a 1431 ms arrivano le voci
+ * dei moduli, non filtrate; a 1505 ms si assesta. Quattro forme, e tre erano
+ * false.
+ *
+ * La decisione che questo modulo prende e' una sola, e si prova qui: la
+ * configurazione della casa e' arrivata, oppure no? Il resto — coprire,
+ * scoprire, filtrare una voce appena aggiunta — e' documento, e lo prova un
+ * browser.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { laConfigurazioneSiConosce } from "../src/sections/navigation-section.js";
+
+const magazzino = (stato) => ({ getState: () => stato });
+
+test("senza magazzino non si sa niente, e la barra aspetta", () => {
+  assert.equal(laConfigurazioneSiConosce(undefined), false);
+  assert.equal(laConfigurazioneSiConosce(null), false);
+  assert.equal(laConfigurazioneSiConosce({}), false);
+  assert.equal(laConfigurazioneSiConosce(magazzino(null)), false);
+});
+
+test("un magazzino appena nato non e' una configurazione", () => {
+  /* Nasce cosi', ed e' il caso che faceva scoprire la barra su un'ipotesi:
+   * `visibility: {}` risponde «tutto visibile» esattamente come una casa che
+   * non ha configurato niente. */
+  assert.equal(
+    laConfigurazioneSiConosce(magazzino({ schema_version: 4, sections: {}, visibility: {} })),
+    false,
+  );
+});
+
+test("basta una preferenza di visibilita'", () => {
+  assert.equal(
+    laConfigurazioneSiConosce(magazzino({ sections: {}, visibility: { energy: false } })),
+    true,
+  );
+});
+
+test("o una sezione configurata, anche senza preferenze", () => {
+  /* Una casa che ha delle stanze ma non ha mai toccato la visibilita' e' una
+   * casa configurata: la barra di serie e' la risposta giusta, e si puo'
+   * mostrare subito perche' non c'e' niente che la smentira'. */
+  assert.equal(
+    laConfigurazioneSiConosce(magazzino({ sections: { rooms: [] }, visibility: {} })),
+    true,
+  );
+});
+
+test("un magazzino che si arrabbia non blocca la barra per sempre", () => {
+  /* Torna «non lo so», e chi chiama ha la sua scadenza: meglio la barra di
+   * serie che nessuna barra. */
+  const rotto = {
+    getState() {
+      throw new Error("il magazzino non risponde");
+    },
+  };
+  assert.equal(laConfigurazioneSiConosce(rotto), false);
+});

--- a/custom_components/dashboardmodern/frontend/tests/le-emoji-nella-chat.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/le-emoji-nella-chat.test.js
@@ -1,0 +1,74 @@
+/* «Ecco mancano le emoji :) :) :)»
+ *
+ * Una frase scritta di corsa suona piu' secca di com'e' stata pensata, e chi
+ * legge dall'altra parte non ha il tono di voce per correggerla. Un pollice in
+ * su chiude uno scambio meglio di «ok».
+ *
+ * Qui si prova la sola cosa che ha delle regole: dove va a finire l'emoji, e
+ * dove va a finire il cursore dopo. Il pannello che si apre lo prova un
+ * browser.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { EMOJI_DELLA_CHAT, conLEmoji } from "../src/sections/assistenza-section.js";
+
+test("l'emoji va dove sta il cursore, non in fondo", () => {
+  /* Chi ha scritto una frase e torna indietro a metterci una faccia si aspetta
+   * che vada li'. */
+  const esito = conLEmoji("grazie mille", "🙏", 6, 6, 4000);
+  assert.equal(esito.testo, "grazie🙏 mille");
+  assert.equal(esito.cursore, 6 + "🙏".length);
+  assert.equal(esito.pieno, false);
+});
+
+test("senza cursore l'emoji va in fondo", () => {
+  assert.equal(conLEmoji("ci sono", "👍").testo, "ci sono👍");
+  assert.equal(conLEmoji("", "👍").testo, "👍");
+});
+
+test("con del testo selezionato l'emoji lo sostituisce", () => {
+  /* E' quello che fa qualunque campo quando si scrive sopra una selezione. */
+  assert.equal(conLEmoji("va bene cosi'", "👍", 0, 7, 4000).testo, "👍 cosi'");
+});
+
+test("il cursore resta dopo l'emoji, pronto a scrivere ancora", () => {
+  const esito = conLEmoji("ok", "🎉", 2, 2, 4000);
+  assert.equal(esito.testo.slice(esito.cursore), "");
+  assert.equal(conLEmoji("ok", "🎉", 0, 0, 4000).cursore, "🎉".length);
+});
+
+test("un'emoji che sfonda il tetto non entra, e non entra a meta'", () => {
+  /* Mezzo segno non vuol dire niente: o ci sta tutto o non ci sta. */
+  const pieno = "x".repeat(10);
+  const esito = conLEmoji(pieno, "🙂", 10, 10, 10);
+  assert.equal(esito.testo, pieno);
+  assert.equal(esito.pieno, true);
+  assert.equal(esito.cursore, 10);
+});
+
+test("posizioni impossibili non rompono niente", () => {
+  assert.equal(conLEmoji("ciao", "👋", 99, 99, 4000).testo, "ciao👋");
+  assert.equal(conLEmoji("ciao", "👋", -3, -3, 4000).testo, "ciao👋");
+  /* Una fine prima dell'inizio non e' una selezione: si tratta come un punto. */
+  assert.equal(conLEmoji("ciao", "👋", 2, 1, 4000).testo, "ci👋ao");
+  assert.equal(conLEmoji(null, null).testo, "");
+});
+
+test("senza emoji il testo non si tocca", () => {
+  assert.equal(conLEmoji("una frase", "", 3, 5, 4000).testo, "una frase");
+});
+
+test("l'elenco e' corto, scelto, e senza doppioni", () => {
+  /* Un catalogo intero vorrebbe dire una ricerca, una tastiera e un pannello
+   * che copre la conversazione — e mille segni per trovarne cinque. */
+  assert.ok(EMOJI_DELLA_CHAT.length >= 20, "troppo poche per servire");
+  assert.ok(EMOJI_DELLA_CHAT.length <= 60, "e' diventato un catalogo");
+  assert.equal(new Set(EMOJI_DELLA_CHAT).size, EMOJI_DELLA_CHAT.length, "ci sono doppioni");
+  for (const segno of EMOJI_DELLA_CHAT) {
+    assert.ok(segno.trim() === segno && segno.length > 0, `«${segno}» non e' pulita`);
+    /* Niente tonalita' di pelle: sono le sequenze che il campo e il centralino
+     * si passano peggio, e qui non servono a niente. */
+    assert.ok(!/[\u{1F3FB}-\u{1F3FF}]/u.test(segno), `«${segno}» porta una tonalita' di pelle`);
+  }
+});

--- a/custom_components/dashboardmodern/frontend/tests/lo-storico-parte-da-casa.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/lo-storico-parte-da-casa.test.js
@@ -1,0 +1,188 @@
+/* «Storico internet dà errore.»
+ *
+ * Nella finestra della connettività, al posto della cronologia dei sette
+ * giorni: «❌ Storico non disponibile — Failed to fetch».
+ *
+ * «Failed to fetch» non è una risposta. Non è un 401 e non è un 404: è una
+ * richiesta che non è mai arrivata da nessuna parte. Il perché sta in come il
+ * guscio si costruisce l'indirizzo a cui chiedere: parte da `location.host` e,
+ * quando quello è vuoto, indovina `LOCAL_IP`.
+ *
+ * La plancia ospitata vive in una cornice `srcdoc`. Quella cornice eredita
+ * l'origine di chi la contiene — la memoria del browser è la stessa, ed è un
+ * fatto che questa casa conosce già — ma il suo `location` no: è
+ * `about:srcdoc`, e `location.host` da lì è la stringa vuota. Misurato dentro
+ * la cornice con la plancia vera: `HA_HTTP_URL` diventa
+ * `http://homeassistant.local:8123`, che è il nome giusto in una casa su cento
+ * e in tutte le altre è un host che non esiste — o che esiste ma in chiaro,
+ * mentre la pagina viaggia in https, e allora il browser blocca la richiesta
+ * senza nemmeno provarci.
+ *
+ * Gli indirizzi relativi invece funzionano, ed è il motivo per cui tutto il
+ * resto della plancia va: in un documento `srcdoc` si risolvono contro la base
+ * del padre. Le telecamere l'avevano già imparato — «usa l'origine della
+ * plancia invece del vecchio HA_HTTP_URL» — e in questa finestra non era
+ * arrivato.
+ *
+ * La condizione che fa scattare la riparazione è UNA: il documento non ha un
+ * host suo. Un documento che sa dove sta non si tocca, perché lì `HA_HTTP_URL`
+ * è giusto e dirottare sarebbe peggio del difetto.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  autorizzazioneInutile,
+  conLEntitaVera,
+  indirizzoRiparato,
+  senzaHost,
+  versoLApi,
+} from "../src/core/indirizzo-di-casa.js";
+
+test("un indirizzo senza host si riconosce dalla stringa", () => {
+  assert.equal(senzaHost("http:///api/history/period/2026-09-03"), true);
+  assert.equal(senzaHost("http://"), true);
+  assert.equal(senzaHost("https://"), true);
+  assert.equal(senzaHost("http://casa.local/api/history/period/x"), false);
+  assert.equal(senzaHost("/api/history/period/x"), false);
+  assert.equal(senzaHost(""), false);
+});
+
+test("si ripara solo quello che va a Home Assistant", () => {
+  assert.equal(versoLApi("/api/history/period/x"), true);
+  assert.equal(versoLApi("http:///api/websocket"), true);
+  assert.equal(versoLApi("https://casa.local/api/states"), true);
+  assert.equal(versoLApi("https://tile.example/12/3/4.png"), false);
+  assert.equal(versoLApi("/local/foto.png"), false);
+});
+
+/* L'host che il guscio ha indovinato: è questo che arriva davvero dentro la
+ * cornice, misurato con la plancia vera. */
+const INDOVINATO =
+  "http://homeassistant.local:8123/api/history/period/2026-08-27T00:00:00.000Z" +
+  "?filter_entity_id=binary_sensor.internet&significant_changes_only=false";
+const CASA = "https://casa.duckdns.org/dashboardmodern-panel";
+
+test("dentro la cornice l'host indovinato torna a essere casa", () => {
+  assert.equal(
+    indirizzoRiparato(INDOVINATO, CASA, ""),
+    "https://casa.duckdns.org/api/history/period/2026-08-27T00:00:00.000Z" +
+      "?filter_entity_id=binary_sensor.internet&significant_changes_only=false",
+  );
+});
+
+test("un documento che sa dove sta non si tocca", () => {
+  /* La plancia aperta per conto suo: `HA_HTTP_URL` è giusto, e dirottare una
+   * richiesta che qualcuno ha voluto sarebbe peggio del difetto. */
+  assert.equal(indirizzoRiparato(INDOVINATO, CASA, "casa.duckdns.org"), null);
+  assert.equal(
+    indirizzoRiparato("https://altra.casa/api/states", CASA, "casa.duckdns.org"),
+    null,
+  );
+});
+
+test("anche l'indirizzo rotto in sé diventa quello di casa", () => {
+  /* Senza `LOCAL_IP` da indovinare ne esce `http://`, che non è nemmeno un
+   * indirizzo: quello si ripara ovunque, host del documento o no. */
+  assert.equal(
+    indirizzoRiparato("http:///api/states", CASA, "casa.duckdns.org"),
+    "https://casa.duckdns.org/api/states",
+  );
+});
+
+test("senza una base da cui partire resta il percorso, che basta", () => {
+  /* In una cornice `srcdoc` un percorso si risolve da solo contro la base del
+   * padre: è esattamente quello che fa funzionare tutto il resto. */
+  assert.equal(indirizzoRiparato("http:///api/states", "", ""), "/api/states");
+});
+
+test("la plancia aperta da un file su disco resta con il suo LOCAL_IP", () => {
+  /* Lì di host non ce n'è e di base utilizzabile nemmeno: `LOCAL_IP` è
+   * l'unica risposta che esista, ed è giusto che resti. La sezione lo
+   * garantisce non passando una base `file:`. */
+  assert.equal(indirizzoRiparato(INDOVINATO, "", ""), null);
+});
+
+test("un indirizzo già relativo, e uno che non va all'API, non si toccano", () => {
+  assert.equal(indirizzoRiparato("/api/history/period/x", CASA, ""), null);
+  assert.equal(indirizzoRiparato("https://tile.example/9/1/2.png", CASA, ""), null);
+});
+
+test("il gettone della plancia ospitata non è un gettone", () => {
+  /* `__dashboardmodern_hosted__` è un segnale che dice «i cookie bastano»:
+   * spedirlo come Bearer si prende un 401 su una richiesta che sarebbe
+   * passata da sola. */
+  assert.equal(autorizzazioneInutile("Bearer __dashboardmodern_hosted__"), true);
+  assert.equal(autorizzazioneInutile("__dashboardmodern_hosted__"), true);
+  assert.equal(autorizzazioneInutile("Bearer undefined"), true);
+  assert.equal(autorizzazioneInutile("Bearer "), true);
+  assert.equal(autorizzazioneInutile("Bearer eyJhbGciOi.vero.gettone"), false);
+  assert.equal(autorizzazioneInutile(""), false);
+});
+
+/* ─── E la domanda dice il nome giusto ────────────────────────────────────
+ *
+ * Riparato l'indirizzo, la stessa finestra ha ancora un modo di non mostrare
+ * niente: chiede al Recorder `dm.server_raggiungibilita_google`, che è una
+ * casella della plancia e non un'entità di Home Assistant. Torna un elenco
+ * vuoto e la finestra scrive «Nessun dato storico trovato per dm.…»: un errore
+ * che non sembra un errore, sulla stessa richiesta di prima.
+ */
+
+const MAPPA = {
+  "dm.server_raggiungibilita_google": "binary_sensor.internet_di_casa",
+  "dm.energy_stato_rete": "binary_sensor.inverter_in_rete",
+};
+const risolvi = (nome) => MAPPA[nome] || nome;
+
+test("la casella della plancia diventa l'entità che ci sta dentro", () => {
+  assert.equal(
+    conLEntitaVera(
+      "/api/history/period/2026-09-03?filter_entity_id=dm.server_raggiungibilita_google&end_time=x",
+      risolvi,
+    ),
+    "/api/history/period/2026-09-03?filter_entity_id=binary_sensor.internet_di_casa&end_time=x",
+  );
+});
+
+test("una casella non mappata resta com'è", () => {
+  /* La risposta vuota, li', è la verità: quella lettura non ha un'entità, e
+   * metterci quella di un'altra sarebbe peggio del non rispondere. */
+  assert.equal(
+    conLEntitaVera("/api/history/period/x?filter_entity_id=dm.mai_configurata", risolvi),
+    null,
+  );
+});
+
+test("un indirizzo che non chiede uno storico non si tocca", () => {
+  assert.equal(conLEntitaVera("/api/states", risolvi), null);
+  assert.equal(conLEntitaVera("/api/history/period/x", risolvi), null);
+  /* Un'entità vera nominata per nome non ha niente da tradurre. */
+  assert.equal(
+    conLEntitaVera("/api/history/period/x?filter_entity_id=binary_sensor.vera", risolvi),
+    null,
+  );
+});
+
+test("più caselle insieme, e basta che una sia da tradurre", () => {
+  assert.equal(
+    conLEntitaVera(
+      "/api/history/period/x?filter_entity_id=dm.energy_stato_rete,binary_sensor.vera,dm.mai_vista",
+      risolvi,
+    ),
+    "/api/history/period/x?filter_entity_id=binary_sensor.inverter_in_rete,binary_sensor.vera,dm.mai_vista",
+  );
+});
+
+test("una mappatura che non c'è, o che si arrabbia, non ferma la richiesta", () => {
+  const indirizzo = "/api/history/period/x?filter_entity_id=dm.server_raggiungibilita_google";
+  assert.equal(conLEntitaVera(indirizzo, undefined), null);
+  assert.equal(
+    conLEntitaVera(indirizzo, () => {
+      throw new Error("la configurazione non è ancora arrivata");
+    }),
+    null,
+  );
+  /* Una mappatura che risponde con un'altra casella virtuale non ha risposto. */
+  assert.equal(conLEntitaVera(indirizzo, () => "dm.qualcos_altro"), null);
+});

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -665,8 +665,18 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   //   importa non viene mai caricato, ed e' esattamente il difetto del
   //   cruscotto della beta.10 — nelle fotografie c'era, in una casa vera non
   //   e' mai comparso.
+  // 226 con l'indirizzo di casa (`core/indirizzo-di-casa.js`,
+  // `sections/indirizzo-di-casa-section.js`): «storico internet da' errore».
+  // «Failed to fetch» non e' una risposta, e' una richiesta mai partita: la
+  // plancia ospitata vive in una cornice `srcdoc`, il cui `location.host` e'
+  // vuoto, e l'indirizzo che il guscio si costruisce da li' e' `http://`. Il
+  // nucleo e' l'aritmetica della riparazione — data una stringa e una base,
+  // qual e' l'indirizzo giusto — e si prova senza rete; la sezione e' il
+  // gradino su `fetch` dove quella riparazione si applica, perche' la riga
+  // sbagliata sta dentro una funzione del guscio e avvolgerla per nome
+  // arriverebbe troppo tardi.
   assert.ok(
-    relative.length <= 224,
+    relative.length <= 226,
     `production graph unexpectedly grew to ${relative.length} modules`,
   );
   assertAcyclic(edges);

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -722,6 +722,16 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
    * page is the one on screen AND something is actually playing — either of
    * those stops being true and the timer dies.
    *
+   * The ninth is the chat di assistenza. The centralino is a letterbox, not a
+   * push channel: nothing in Home Assistant fires when the person at the other
+   * end writes back, and the backend's five-minute round only rings the bell —
+   * it redraws nothing. Without a beat the open window shows whatever was
+   * there when it opened, and the answer arrives only by closing and reopening
+   * it, which is what happened. Fifteen seconds, and the same discipline as
+   * the rest: only while the chat window is open, it redraws only when
+   * something actually changed, and the timer stops itself the moment it finds
+   * that window shut.
+   *
    * These are the intervals production is allowed, and they are named here so
    * another one cannot arrive unnoticed. */
   const intervals = [...graph.entries()].filter(([, source]) =>
@@ -730,6 +740,7 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   assert.deepEqual(
     intervals.map(([file]) => path.relative(frontendRoot, file).replaceAll("\\", "/")).sort(),
     [
+      "src/sections/assistenza-section.js",
       "src/sections/english-runtime-strings-section.js",
       "src/sections/home-widgets-section.js",
       "src/sections/live-ui-section.js",

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -667,14 +667,18 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   //   e' mai comparso.
   // 226 con l'indirizzo di casa (`core/indirizzo-di-casa.js`,
   // `sections/indirizzo-di-casa-section.js`): «storico internet da' errore».
-  // «Failed to fetch» non e' una risposta, e' una richiesta mai partita: la
-  // plancia ospitata vive in una cornice `srcdoc`, il cui `location.host` e'
-  // vuoto, e l'indirizzo che il guscio si costruisce da li' e' `http://`. Il
-  // nucleo e' l'aritmetica della riparazione — data una stringa e una base,
-  // qual e' l'indirizzo giusto — e si prova senza rete; la sezione e' il
-  // gradino su `fetch` dove quella riparazione si applica, perche' la riga
-  // sbagliata sta dentro una funzione del guscio e avvolgerla per nome
-  // arriverebbe troppo tardi.
+  // «Failed to fetch» non e' una risposta, e' una richiesta che non e' mai
+  // arrivata da nessuna parte: la plancia ospitata vive in una cornice
+  // `srcdoc`, il cui `location.host` e' vuoto, e il guscio — non sapendo dove
+  // sta — costruisce l'indirizzo indovinando `LOCAL_IP`. Misurato dentro la
+  // cornice con la plancia vera: `http://homeassistant.local:8123`, che e' un
+  // host che quasi nessuno ha e che comunque parla in chiaro a una pagina in
+  // https. Il nucleo e' l'aritmetica della riparazione — dato un indirizzo, la
+  // base del documento e l'host che il documento ha o non ha, qual e'
+  // l'indirizzo giusto — e si prova senza rete; la sezione e' il gradino su
+  // `fetch` dove quella riparazione si applica, perche' la riga sbagliata sta
+  // dentro una funzione del guscio e avvolgerla per nome arriverebbe troppo
+  // tardi.
   assert.ok(
     relative.length <= 226,
     `production graph unexpectedly grew to ${relative.length} modules`,

--- a/custom_components/dashboardmodern/frontend/tests/una-sezione-vuota-non-sta-nella-barra.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/una-sezione-vuota-non-sta-nella-barra.test.js
@@ -271,3 +271,31 @@ test("la semina non ridecide una voce già scritta", () =>
     seedModernSectionVisibility();
     assert.equal(leggi().piscina, true);
   }));
+
+test("un'entita' aggiunta a mano riempie la sua sezione", () => {
+  /* «Le entita' che uno si aggiunge dove vuole» stanno in una chiave sola,
+   * con dentro la sezione. Senza guardarla, una sezione che vive solo di
+   * quelle risultava vuota: al salvataggio dell'entita' appena aggiunta la
+   * scheda spariva dalla barra — proprio quella dove la si era messa. */
+  const { piene, vuote } = contenutoDelleSezioni(
+    magazzino({ cd_entita_mie: [{ entity: "sensor.nas_temp", sezione: "server" }] }),
+  );
+  assert.ok(piene.has("server"));
+  assert.ok(!vuote.has("server"));
+  /* Una sezione che questa regola non governa non si inventa. */
+  const altra = contenutoDelleSezioni(
+    magazzino({ cd_entita_mie: [{ entity: "sensor.x", sezione: "agenda" }] }),
+  );
+  assert.ok(!altra.piene.has("agenda"));
+});
+
+test("le porte non tengono in barra la scheda Sicurezza", () => {
+  /* Dalla 1.4.5 le porte si disegnano nella loro pagina, che si accende e si
+   * spegne da sola: contarle ancora come contenuto di Sicurezza teneva in
+   * barra una scheda vuota a chi ha solo le porte. */
+  assert.ok(!MAGAZZINO_DELLE_SEZIONI.security.chiavi.includes("cd_security_doors"));
+  const { piene } = contenutoDelleSezioni(
+    magazzino({ cd_security_doors: [{ name: "Porta", entity: "binary_sensor.porta" }] }),
+  );
+  assert.ok(!piene.has("security"));
+});

--- a/custom_components/dashboardmodern/github_client.py
+++ b/custom_components/dashboardmodern/github_client.py
@@ -537,6 +537,55 @@ def _state_from_issue(issue: Mapping[str, Any], risposta: str) -> str:
     return STATE_TRIAGED if risposta else STATE_SENT
 
 
+async def _ultimi_commenti(
+    hass: HomeAssistant, number: int, quanti: int, *, token: str = ""
+) -> list[dict[str, Any]]:
+    """Gli ultimi commenti di una issue, dal piu' vecchio al piu' nuovo.
+
+    GitHub li da' dal primo in poi, trenta per pagina. Chiedere la prima
+    pagina e basta — com'era — voleva dire che dal trentunesimo commento in
+    poi la risposta piu' recente non si vedeva mai: il campanello suonava per
+    un messaggio che il filo non mostrava, e lo stato dedotto dal commento del
+    manutentore restava fermo a settimane prima. Si chiede l'ultima pagina, e
+    se da sola non arriva a trenta anche quella prima: due richieste al
+    massimo, e sono le ultime trenta davvero.
+    """
+    if quanti <= 0:
+        return []
+    ultima = max(1, -(-int(quanti) // MAX_COMMENTS))
+    raccolti: list[dict[str, Any]] = []
+    for pagina in (ultima, ultima - 1):
+        if pagina < 1:
+            break
+        grezzi = await _request(
+            hass,
+            "GET",
+            f"{GITHUB_API}/repos/{REPOSITORY}/issues/{int(number)}"
+            f"/comments?per_page={MAX_COMMENTS}&page={pagina}",
+            token=token,
+        )
+        letti = (
+            [commento for commento in grezzi if isinstance(commento, dict)]
+            if isinstance(grezzi, list)
+            else []
+        )
+        raccolti = letti + raccolti
+        if len(raccolti) >= MAX_COMMENTS:
+            break
+    return raccolti[-MAX_COMMENTS:]
+
+
+async def async_comment_count(hass: HomeAssistant, token: str, number: int) -> int:
+    """Quanti commenti ha una issue adesso. Una richiesta, e solo il numero."""
+    issue = await _request(
+        hass,
+        "GET",
+        f"{GITHUB_API}/repos/{REPOSITORY}/issues/{int(number)}",
+        token=token,
+    )
+    return int(issue.get("comments") or 0) if isinstance(issue, dict) else 0
+
+
 async def async_read_issue(
     hass: HomeAssistant, number: int, *, token: str = ""
 ) -> dict[str, Any]:
@@ -553,21 +602,13 @@ async def async_read_issue(
         token=token,
     )
     risposta = ""
-    if int(issue.get("comments") or 0) > 0:
-        commenti = await _request(
-            hass,
-            "GET",
-            f"{GITHUB_API}/repos/{REPOSITORY}/issues/{int(number)}"
-            f"/comments?per_page={MAX_COMMENTS}",
-            token=token,
-        )
-        if isinstance(commenti, list):
-            for commento in reversed(commenti[-MAX_COMMENTS:]):
-                if not isinstance(commento, dict):
-                    continue
-                if str(commento.get("author_association")) in MAINTAINER_ASSOCIATIONS:
-                    risposta = str(commento.get("body") or "")
-                    break
+    commenti = await _ultimi_commenti(
+        hass, int(number), int(issue.get("comments") or 0), token=token
+    )
+    for commento in reversed(commenti):
+        if str(commento.get("author_association")) in MAINTAINER_ASSOCIATIONS:
+            risposta = str(commento.get("body") or "")
+            break
     return {
         "number": int(issue.get("number") or number),
         "state": _state_from_issue(issue, risposta),
@@ -596,31 +637,21 @@ async def async_issue_thread(
         token=token,
     )
     corpo = str(issue.get("body") or "").replace(TICKET_MARKER, "")
+    quanti = int(issue.get("comments") or 0)
     commenti: list[dict[str, Any]] = []
-    if int(issue.get("comments") or 0) > 0:
-        grezzi = await _request(
-            hass,
-            "GET",
-            f"{GITHUB_API}/repos/{REPOSITORY}/issues/{int(number)}"
-            f"/comments?per_page={MAX_COMMENTS}",
-            token=token,
+    for commento in await _ultimi_commenti(hass, int(number), quanti, token=token):
+        testo = str(commento.get("body") or "")
+        commenti.append(
+            {
+                "id": str(commento.get("id") or ""),
+                "author": str((commento.get("user") or {}).get("login") or ""),
+                "maintainer": str(commento.get("author_association"))
+                in MAINTAINER_ASSOCIATIONS,
+                "at": str(commento.get("created_at") or ""),
+                "body": _senza_allegati(testo),
+                "attachments": attachments_in(testo),
+            }
         )
-        if isinstance(grezzi, list):
-            for commento in grezzi[-MAX_COMMENTS:]:
-                if not isinstance(commento, dict):
-                    continue
-                testo = str(commento.get("body") or "")
-                commenti.append(
-                    {
-                        "id": str(commento.get("id") or ""),
-                        "author": str((commento.get("user") or {}).get("login") or ""),
-                        "maintainer": str(commento.get("author_association"))
-                        in MAINTAINER_ASSOCIATIONS,
-                        "at": str(commento.get("created_at") or ""),
-                        "body": _senza_allegati(testo),
-                        "attachments": attachments_in(testo),
-                    }
-                )
     testo, diagnostica = diagnostica_in(_senza_allegati(corpo))
     return {
         "number": int(issue.get("number") or number),
@@ -628,6 +659,9 @@ async def async_issue_thread(
         "diagnostics": diagnostica,
         "attachments": attachments_in(corpo),
         "comments": commenti,
+        # Quanti ne ha davvero, non quanti se ne mostrano: serve al campanello
+        # per prendere nota di dove sta questa segnalazione.
+        "comment_count": quanti,
         "issue_url": str(issue.get("html_url") or ""),
         "state": _state_from_issue(
             issue,

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.4.5-beta.12"
+  "version": "1.4.5-beta.13"
 }

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.4.5-beta.13"
+  "version": "1.4.5"
 }

--- a/custom_components/dashboardmodern/ticket_watch.py
+++ b/custom_components/dashboardmodern/ticket_watch.py
@@ -300,6 +300,32 @@ class TicketWatch:
         self._sfoltisci()
         await self._async_save()
 
+    def conosce(self, number: int) -> bool:
+        """Se il taccuino ha un segno per questa segnalazione.
+
+        Serve a chi sta per scrivere: alzare il segno di uno ha senso solo
+        partendo da un conto vero. Partire da zero per una issue che ne ha
+        cinque avrebbe detto «uno», e al giro dopo gli altri quattro sarebbero
+        suonati come messaggi nuovi — per la propria risposta.
+        """
+        return str(int(number)) in self._seen()
+
+    async def async_vista(self, number: int, quanti: int) -> None:
+        """Prendi nota di dove sta una segnalazione, senza suonare.
+
+        E' il gesto di chi sa gia' cosa c'e' sotto: chi l'ha appena aperta da
+        qui (zero commenti, e sono i suoi), chi ha appena letto il filo
+        intero, chi ha appena risposto e ha chiesto il conto. Da questo
+        segno in poi suona solo quello che arriva dopo.
+        """
+        numero = str(int(number))
+        seen = self._seen()
+        if seen.get(numero) == int(quanti):
+            return
+        seen[numero] = int(quanti)
+        self._sfoltisci()
+        await self._async_save()
+
     def _sfoltisci(self) -> None:
         """Tieni il taccuino sotto il tetto: restano i numeri piu' alti."""
         seen = self._seen()

--- a/custom_components/dashboardmodern/tickets.py
+++ b/custom_components/dashboardmodern/tickets.py
@@ -43,6 +43,8 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 DATA_TICKET_UNSUB = "ticket_sync_unsub"
+#: Da quale segnalazione riparte il prossimo giro di sync.
+DATA_SYNC_CURSOR = "ticket_sync_cursor"
 DATA_WATCH_UNSUB = "ticket_watch_unsub"
 
 
@@ -135,6 +137,11 @@ async def async_deliver_pending(hass: HomeAssistant, *, user_id: str = "") -> in
         await tickets.async_mark_sent(
             ticket["id"], str(aperta["number"]), issue_url=aperta["url"]
         )
+        # Il campanello la conosce da subito, e senza suonare: e' partita da
+        # qui, con zero commenti sotto. Senza questa riga al giro dopo
+        # risultava «mai vista», e chi l'aveva appena scritta si sentiva
+        # notificare «Nuova segnalazione» — la propria.
+        await (await async_get_watch(hass)).async_vista(int(aperta["number"]), 0)
         partiti += 1
     return partiti
 
@@ -144,9 +151,17 @@ async def async_sync_states(hass: HomeAssistant) -> int:
     if not enabled(hass):
         return 0
     tickets = await async_get_ticket_store(hass)
-    numeri = tickets.remote_ids()[:TICKET_SYNC_BATCH]
-    if not numeri:
+    tutti = tickets.remote_ids()
+    if not tutti:
         return 0
+    # Un giro parte da dove si era fermato quello prima. Prendere sempre le
+    # prime venti voleva dire che con ventuno segnalazioni aperte la
+    # ventunesima non veniva riletta mai — ne' il suo stato ne' la risposta —
+    # finche' una delle altre non si chiudeva.
+    domain_data: dict[str, Any] = hass.data.setdefault(DOMAIN, {})
+    da = int(domain_data.get(DATA_SYNC_CURSOR) or 0) % len(tutti)
+    numeri = (tutti[da:] + tutti[:da])[:TICKET_SYNC_BATCH]
+    domain_data[DATA_SYNC_CURSOR] = (da + len(numeri)) % len(tutti)
     gettoni = await async_get_token_store(hass)
     token = gettoni.any_token()
     aggiornamenti: list[dict[str, Any]] = []
@@ -205,11 +220,18 @@ async def async_thread(
     filo = await github_client.async_issue_thread(
         hass, gettoni.token(user_id), int(number)
     )
+    watch = await async_get_watch(hass)
+    # Chi ha letto il filo intero sa dove sta: se il campanello questa
+    # segnalazione non la conosceva — non era fra le cinquanta piu' recenti, o
+    # il taccuino l'aveva lasciata cadere — da adesso suona solo per quello
+    # che arriva dopo, invece di contare come nuovo tutto quello che c'era.
+    if not watch.conosce(int(number)):
+        await watch.async_vista(int(number), int(filo.get("comment_count") or 0))
     # Aprirlo e' averlo letto, e il segno si toglie qui invece che nel browser
     # perche' le plance sono piu' di una: chi legge la risposta dal telefono e
     # poi passa davanti al tablet in cucina non deve ritrovare lo stesso
     # pallino ad aspettarlo.
-    await (await async_get_watch(hass)).async_letta(int(number))
+    await watch.async_letta(int(number))
     return filo
 
 
@@ -233,7 +255,7 @@ async def async_answer(
         await github_client.async_comment(hass, token, number, reply.strip())
         fatto["commented"] = True
         # Il campanello non suona per quello che si e' appena scritto.
-        await (await async_get_watch(hass)).async_ho_scritto(int(number))
+        await _ho_scritto(hass, token, int(number))
     if close in {"risolto", "chiuso"}:
         await github_client.async_close_issue(
             hass, token, number, planned=close == "risolto"
@@ -307,8 +329,26 @@ async def async_reply(
         if not tickets.owns_remote(user_id, str(int(number))):
             raise GitHubError("not_yours", "Questa segnalazione non e' tua.")
     await github_client.async_comment(hass, token, int(number), testo[:MAX_REPLY])
-    await (await async_get_watch(hass)).async_ho_scritto(int(number))
+    await _ho_scritto(hass, token, int(number))
     return {"sent": True}
+
+
+async def _ho_scritto(hass: HomeAssistant, token: str, number: int) -> None:
+    """Il messaggio l'ho scritto io: il campanello non deve suonarlo.
+
+    Se il campanello quella segnalazione la conosce basta alzare il segno di
+    uno. Se non la conosce — non era fra le cinquanta piu' recenti, o il
+    taccuino l'aveva lasciata cadere — alzare da zero avrebbe detto «uno» per
+    una issue che ne ha cinque, e al giro dopo gli altri quattro sarebbero
+    suonati come messaggi nuovi, per la propria risposta. Li' si chiede il
+    conto vero: una richiesta in piu', ma solo in quel caso.
+    """
+    watch = await async_get_watch(hass)
+    if watch.conosce(number):
+        await watch.async_ho_scritto(number)
+        return
+    quanti = await github_client.async_comment_count(hass, token, number)
+    await watch.async_vista(number, quanti)
 
 
 async def async_unread(hass: HomeAssistant) -> list[dict[str, Any]]:

--- a/custom_components/dashboardmodern/update.py
+++ b/custom_components/dashboardmodern/update.py
@@ -193,12 +193,23 @@ def installa_da_zip(cartella: Path, dati: bytes, versione: str) -> None:
             if scarto.exists():
                 shutil.rmtree(scarto)
         nuova.mkdir()
-        archivio.extractall(nuova)
+        try:
+            archivio.extractall(nuova)
+        except Exception:
+            # Un'estrazione a meta' — disco pieno, archivio guasto — non deve
+            # lasciare dentro `custom_components` una cartella col manifest di
+            # questo stesso dominio: il caricatore di Home Assistant la
+            # vedrebbe come una seconda integrazione, e al riavvio potrebbe
+            # preferirla a quella vera, che e' sana. Via subito, e poi
+            # l'errore.
+            shutil.rmtree(nuova, ignore_errors=True)
+            raise
     cartella.rename(vecchia)
     try:
         nuova.rename(cartella)
     except OSError:
         vecchia.rename(cartella)
+        shutil.rmtree(nuova, ignore_errors=True)
         raise
     # A scambio riuscito la vecchia e' solo spazzatura: se il disco non la
     # lascia togliere adesso, l'installazione e' comunque fatta — annunciarla

--- a/custom_components/dashboardmodern/websocket_api.py
+++ b/custom_components/dashboardmodern/websocket_api.py
@@ -103,6 +103,7 @@ TYPE_CHAT_FORGET = f"{DOMAIN}/chat/forget"
 TYPE_CHAT_QUEUE = f"{DOMAIN}/chat/queue"
 TYPE_CHAT_OPEN = f"{DOMAIN}/chat/open"
 TYPE_CHAT_ANSWER = f"{DOMAIN}/chat/answer"
+TYPE_CHAT_DROP = f"{DOMAIN}/chat/drop"
 
 TYPE_TICKET_AUTH_START = f"{DOMAIN}/tickets/auth/start"
 TYPE_TICKET_AUTH_POLL = f"{DOMAIN}/tickets/auth/poll"
@@ -898,6 +899,35 @@ async def async_chat_answer(
     connection.send_result(msg["id"], {"message": messaggio})
 
 
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): TYPE_CHAT_DROP,
+        vol.Required("line"): vol.All(str, vol.Length(min=1, max=64)),
+    }
+)
+@websocket_api.async_response
+async def async_chat_drop(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Butta via una conversazione dalla coda di chi risponde.
+
+    Serve la chiave della console come per rispondere, e per la stessa ragione
+    piu' una: la cancellazione e' la cosa che non si rimette a posto.
+    """
+    from .chat import ChatError, async_butta
+
+    if _console_chat_denied(hass, connection, msg):
+        return
+    try:
+        connection.send_result(
+            msg["id"], {"dropped": await async_butta(hass, msg["line"])}
+        )
+    except ChatError as errore:
+        connection.send_error(msg["id"], errore.code, str(errore))
+
+
 # ─── Collegare il proprio account GitHub ─────────────────────────────────────
 #
 # Lo stesso giro che HACS fa gia' fare a chiunque installi la plancia: un
@@ -1018,6 +1048,7 @@ def async_register_websocket_api(hass: HomeAssistant) -> None:
         async_chat_queue,
         async_chat_open,
         async_chat_answer,
+        async_chat_drop,
         async_ticket_auth_start,
         async_ticket_auth_poll,
         async_ticket_auth_forget,

--- a/custom_components/dashboardmodern/websocket_api.py
+++ b/custom_components/dashboardmodern/websocket_api.py
@@ -171,6 +171,52 @@ def _deny(connection: Any, msg: dict[str, Any]) -> None:
     )
 
 
+async def _entry_for_profile(hass: HomeAssistant, profile: str) -> Any:
+    """La plancia a cui appartiene un profilo di configurazione, se c'e'.
+
+    Il profilo e' la chiave del negozio condiviso e non porta l'entry_id: si
+    risale alla plancia con la stessa mappa che assegna i profili al pannello,
+    piu' la memoria del negozio per chi ha cambiato nome nel frattempo.
+    """
+    from .frontend import _config_profile
+
+    store = await async_get_config_store(hass)
+    ricordi = store.entry_profiles()
+    for entry in _entries(hass):
+        if profile in (_config_profile(hass, entry), ricordi.get(entry.entry_id)):
+            return entry
+    return None
+
+
+async def _config_authorized(
+    hass: HomeAssistant, connection: Any, msg: dict[str, Any]
+) -> bool:
+    """Se chi chiama puo' toccare la configurazione che sta chiedendo.
+
+    Il profilo e' un campo libero, e senza entry_id `_authorized` chiedeva solo
+    «puo' usare una plancia qualsiasi?». Con due plance e due liste di utenti
+    diverse, chi era in lista sulla seconda poteva leggere — e azzerare, con
+    `reset` — la configurazione della prima chiamando questi comandi a mano.
+    Qui la domanda e' sulla plancia che quel profilo porta davvero: chi non
+    puo' usarla non la legge e non la scrive, con o senza entry_id.
+    """
+    entry_id = msg.get("entry_id")
+    if entry_id and not _authorized(hass, connection, entry_id):
+        return False
+    user = getattr(connection, "user", None)
+    if user is not None and getattr(user, "is_admin", False):
+        return True
+    entries = _entries(hass)
+    if not entries:
+        return True
+    padrona = await _entry_for_profile(hass, str(msg.get("profile") or PRIMARY_PROFILE))
+    if padrona is None:
+        # Un profilo che nessuna plancia porta non e' di nessuno: lo tocca
+        # solo l'amministratore, che e' gia' passato qui sopra.
+        return False
+    return _may_use(padrona, user)
+
+
 @websocket_api.websocket_command(
     {
         vol.Required("type"): TYPE_GET,
@@ -185,7 +231,7 @@ async def async_get_config(
     msg: dict[str, Any],
 ) -> None:
     """Return the shared snapshot of one plancia."""
-    if not _authorized(hass, connection, msg.get("entry_id")):
+    if not await _config_authorized(hass, connection, msg):
         _deny(connection, msg)
         return
     store = await async_get_config_store(hass)
@@ -221,7 +267,7 @@ async def async_set_config(
     msg: dict[str, Any],
 ) -> None:
     """Store a snapshot for one plancia."""
-    if not _authorized(hass, connection, msg.get("entry_id")):
+    if not await _config_authorized(hass, connection, msg):
         _deny(connection, msg)
         return
     store = await async_get_config_store(hass)
@@ -258,7 +304,7 @@ async def async_restore_config(
     msg: dict[str, Any],
 ) -> None:
     """Promote a kept revision of one plancia back to current."""
-    if not _authorized(hass, connection, msg.get("entry_id")):
+    if not await _config_authorized(hass, connection, msg):
         _deny(connection, msg)
         return
     store = await async_get_config_store(hass)
@@ -595,9 +641,14 @@ async def async_ticket_thread(
     Non e' riservato alla console. Lo apre anche chi ha segnalato, sulla sua,
     per leggere la risposta restando qui: mandarlo su github.com per leggerla
     sarebbe farlo uscire proprio dal posto che questa finestra esiste per non
-    fargli lasciare. Non c'e' niente da proteggere — la issue e' una pagina
-    pubblica, e chiunque puo' aprirla in un browser.
+    fargli lasciare. La issue e' una pagina pubblica, ma questo comando non e'
+    solo una lettura: aprire il filo toglie il segno di non letto a tutta la
+    casa. Quindi la stessa domanda degli altri comandi — chi puo' usare la
+    plancia — vale anche qui, e chi non puo' non spegne i pallini degli altri.
     """
+    if not _authorized(hass, connection, None):
+        _deny(connection, msg)
+        return
     try:
         filo = await async_thread(hass, _caller_id(connection), msg["number"])
     except GitHubError as errore:

--- a/custom_components/dashboardmodern/www_files.py
+++ b/custom_components/dashboardmodern/www_files.py
@@ -21,6 +21,14 @@ IMAGE_SUFFIXES = frozenset(
     {".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif", ".bmp", ".svg"}
 )
 
+# Quelle che si possono anche CARICARE da qui. L'SVG no: e' un documento, non
+# una bitmap, e Home Assistant lo serve da `/local/` sulla propria origine —
+# uno `<script>` dentro un SVG aperto dal browser gira con i gettoni di chi
+# lo apre. Chi ne ha uno lo copia in `www` a mano, come prima; il selettore lo
+# elenca lo stesso. Da questo sportello passano solo formati che il browser
+# disegna e non esegue.
+UPLOAD_SUFFIXES = frozenset(IMAGE_SUFFIXES - {".svg"})
+
 # Una cartella con migliaia di file non deve diventare un messaggio enorme.
 MAX_ENTRIES = 500
 
@@ -49,15 +57,18 @@ def list_www_folder(root: str, relative: str = "") -> dict[str, Any] | None:
     """
     try:
         base = Path(root).resolve(strict=True)
-    except OSError:
+    except (OSError, ValueError):
         return _vuota(False)
     if not base.is_dir():
         return _vuota(False)
 
     chiesto = relative.strip("/")
+    # `ValueError` e' un byte nullo nel percorso: non e' un guasto del disco,
+    # e' una richiesta che non porta da nessuna parte — e non deve diventare
+    # un traceback nel registro di casa.
     try:
         target = (base / chiesto).resolve(strict=True) if chiesto else base
-    except OSError:
+    except (OSError, ValueError):
         return None
     if target != base and base not in target.parents:
         return None
@@ -156,10 +167,7 @@ _FIRME_IMMAGINE = (
 def _sembra_immagine(payload: bytes) -> bool:
     if any(payload.startswith(firma) for firma in _FIRME_IMMAGINE):
         return payload[8:12] == b"WEBP" if payload.startswith(b"RIFF") else True
-    if payload[4:12] in (b"ftypavif", b"ftypavis"):  # AVIF
-        return True
-    testa = payload[:256].lstrip()
-    return testa.startswith((b"<?xml", b"<svg"))  # SVG
+    return payload[4:12] in (b"ftypavif", b"ftypavis")  # AVIF
 
 
 def save_www_upload(root: str, filename: str, payload: bytes) -> dict[str, Any] | None:
@@ -171,7 +179,7 @@ def save_www_upload(root: str, filename: str, payload: bytes) -> dict[str, Any] 
     sparire sotto quella di oggi.
     """
     nome = _sanitize_name(filename)
-    if Path(nome).suffix not in IMAGE_SUFFIXES:
+    if Path(nome).suffix not in UPLOAD_SUFFIXES:
         return None
     if not payload or len(payload) > MAX_UPLOAD_BYTES:
         return None

--- a/docs/CHAT.md
+++ b/docs/CHAT.md
@@ -120,6 +120,26 @@ vede l'elenco delle conversazioni e si risponde; senza, non si vede niente.
 Non e' un ruolo, e' una chiave: se un giorno i manutentori sono due, sono due
 chiavi.
 
+**La coda si tiene pulita.** Ogni conversazione dell'elenco ha un cestino, e ce
+n'e' uno anche sopra il filo aperto. Cancella davvero e per tutti e due: la
+linea sparisce dal centralino e con lei quello che si erano detti, quindi
+sparisce anche dalla plancia di quella casa. Serve perche' una coda dove non si
+butta via niente si riempie di prove, di domande gia' risolte e di righe aperte
+per sbaglio, finche' quella vera non si trova piu' — ed e' il verso giusto
+della promessa fatta prima della prima riga: quello che si scrive li' non resta
+in giro per sempre.
+
+Due tocchi e non uno: il primo arma il cestino e chiede conferma sul tasto
+stesso, il secondo cancella. Una conversazione cancellata non si rimette a
+posto, e in un elenco dove si scorre col dito un cestino che cancella al primo
+tocco butta via prima o poi quella sbagliata.
+
+**La finestra aperta si aggiorna da sola**, ogni quindici secondi, e ridisegna
+solo quando e' arrivato davvero qualcosa. Il giro dei cinque minuti del backend
+resta quello che era — serve al campanello, non allo schermo — e chiusa la
+finestra non chiede piu' niente: una plancia accesa tutto il giorno in cucina
+non deve bussare al centralino per una conversazione che nessuno sta guardando.
+
 ## Cosa viaggia, e cosa non viaggia
 
 Viaggia **solo quello che la persona ha scritto**, piu' tre cose che servono a
@@ -153,7 +173,8 @@ Chi apre la chat per la prima volta legge, prima di scrivere:
 > la lingua. Puoi cancellare la conversazione quando vuoi.
 
 E il tasto per cancellarla c'e' davvero: cancella la casa dal centralino, non
-solo dallo schermo.
+solo dallo schermo. Lo stesso vale dall'altro capo — chi risponde puo' buttare
+via una conversazione, e quello che butta via sparisce da tutti e due i lati.
 
 ## Quello che questa chat non e'
 

--- a/docs/CHAT.md
+++ b/docs/CHAT.md
@@ -134,6 +134,26 @@ stesso, il secondo cancella. Una conversazione cancellata non si rimette a
 posto, e in un elenco dove si scorre col dito un cestino che cancella al primo
 tocco butta via prima o poi quella sbagliata.
 
+**Come fa la casa ad accorgersene.** Il centralino, a chi chiede una linea che
+non c'e' piu', risponde `aperta: false`, e quel dato non si butta via: la casa
+lo riceve e manda via la propria copia — al primo giro dei cinque minuti, o
+appena qualcuno riapre la finestra. Vale anche per le linee che se ne vanno da
+sole dopo sei mesi di silenzio, ed e' la stessa promessa detta dall'altro capo:
+quello che si scrive li' non resta in giro per sempre.
+
+Chi scrive prima di aver riletto riapre la linea senza accorgersi di niente, e
+allora e' il centralino a dire che e' **nata adesso**: se una copia c'era gia',
+vuol dire che qualcuno l'aveva cancellata, e le frasi vecchie se ne vanno prima
+che le nuove si mettano in fila. Senza, questa casa si sarebbe vista una
+conversazione che chi risponde non ha — con dentro proprio le righe cancellate.
+
+**E un messaggio non sopravvive alla linea che l'ha ospitato.** Fra il
+controllo «la linea esiste?» e la scrittura ci sta una cancellazione: il
+messaggio finirebbe in archivio legato a niente, e li' resterebbe per sempre,
+perche' la potatura notturna cerca i messaggi passando dalle linee. La
+scrittura e' un'istruzione sola che il controllo se lo porta dentro — o la
+linea c'e' nel momento in cui si scrive, o non si scrive niente.
+
 **La finestra aperta si aggiorna da sola**, ogni quindici secondi, e ridisegna
 solo quando e' arrivato davvero qualcosa. Il giro dei cinque minuti del backend
 resta quello che era — serve al campanello, non allo schermo — e chiusa la

--- a/tests/test_campanello.py
+++ b/tests/test_campanello.py
@@ -380,8 +380,9 @@ async def test_chi_ha_segnalato_risponde_col_proprio_gettone(
     assert await tickets.async_reply(
         hass, user_id="anna", number=12, message="  Ho provato, niente.  "
     ) == {"sent": True}
-    scritta = github.calls[-1]
-    assert scritta["method"] == "POST"
+    # Dopo il commento il campanello chiede il conto — la 12 non la conosceva
+    # — quindi l'ultima chiamata e' una lettura: quella che scrive e' la POST.
+    scritta = next(c for c in reversed(github.calls) if c["method"] == "POST")
     assert scritta["url"].endswith("/issues/12/comments")
     assert scritta["token"] == "gho_anna"
     assert scritta["payload"] == {"body": "Ho provato, niente."}
@@ -568,3 +569,101 @@ async def test_l_elenco_non_cresce_senza_fine(hass: HomeAssistant) -> None:
     numeri = [voce["number"] for voce in watch.non_lette()]
     assert len(numeri) == MAX_NON_LETTE
     assert min(numeri) == 21
+
+
+# ─── Le cose proprie non suonano ─────────────────────────────────────────────
+
+
+async def test_la_propria_segnalazione_appena_partita_non_suona(
+    hass: HomeAssistant, github: FakeGitHub
+) -> None:
+    """Chi apre una segnalazione da qui non deve sentirsela annunciare.
+
+    La consegna non diceva niente al campanello: al giro dopo la issue nuova
+    risultava «mai vista», e a chi l'aveva appena scritta arrivava «Nuova
+    segnalazione» — la sua — con tanto di pallino fra le non lette.
+    """
+    _entry(hass)
+    await _collega(hass, "anna")
+    await _mia(hass, 1)
+    github.answer("/issues?", [_riga(1, commenti=0)])
+    await tickets.async_watch_messages(hass)
+
+    github.answer(
+        "/issues", {"number": 2, "html_url": "https://github.com/x/y/issues/2"}
+    )
+    store = await async_get_ticket_store(hass)
+    await store.async_create(
+        ticket_type=TYPE_BUG, title="la seconda", body="Non va.", opened_by="anna"
+    )
+    assert await tickets.async_deliver_pending(hass) == 1
+
+    suonate = _ascolta(hass)
+    github.answer(
+        "/issues?",
+        [_riga(1, commenti=0), _riga(2, commenti=0, quando="2026-09-09T09:00:00Z")],
+    )
+    assert await tickets.async_watch_messages(hass) == []
+    await hass.async_block_till_done()
+    assert suonate == []
+    assert (await async_get_watch(hass)).non_lette() == []
+
+
+async def test_rispondere_a_una_segnalazione_che_il_campanello_non_conosce(
+    hass: HomeAssistant, github: FakeGitHub
+) -> None:
+    """Il segno si alza da un conto vero, non da zero.
+
+    Una issue fuori dalle cinquanta piu' recenti non sta nel taccuino: dopo
+    la risposta il segno diceva «uno» per una issue che ne aveva cinque, e al
+    giro dopo gli altri quattro suonavano come nuovi — per la propria risposta.
+    """
+    _entry(hass)
+    await _collega(hass, "dani", maintainer=True)
+    github.answer("/issues?", [_riga(4, commenti=1)])
+    await tickets.async_watch_messages(hass)
+
+    github.answer("/issues/12/comments", {})
+    github.answer("/issues/12", {"number": 12, "comments": 5})
+    await tickets.async_answer(hass, user_id="dani", number=12, reply="Guardo.")
+    # Il conto lo si chiede a GitHub una volta, dopo aver scritto — e solo
+    # perche' il taccuino non aveva questa issue.
+    assert [
+        chiamata["method"]
+        for chiamata in github.calls
+        if "/issues/12" in chiamata["url"]
+    ] == ["POST", "GET"]
+
+    github.answer(
+        "/issues?",
+        [_riga(4, commenti=1), _riga(12, commenti=5, quando="2026-09-09T09:00:00Z")],
+    )
+    assert await tickets.async_watch_messages(hass) == []
+
+
+async def test_aprire_il_filo_prende_nota_di_dove_sta(
+    hass: HomeAssistant, github: FakeGitHub
+) -> None:
+    """Letto il filo intero, da li' in poi suona solo quello che arriva dopo."""
+    _entry(hass)
+    await _collega(hass, "dani", maintainer=True)
+    github.answer("/issues?", [_riga(4, commenti=1)])
+    await tickets.async_watch_messages(hass)
+
+    github.answer(
+        "/issues/12/comments",
+        [{"id": 1, "body": "uno", "user": {"login": "anna-hub"}}],
+    )
+    github.answer(
+        "/issues/12", {"number": 12, "comments": 5, "state": "open", "body": "x"}
+    )
+    await tickets.async_thread(hass, "dani", 12)
+
+    github.answer(
+        "/issues?",
+        [_riga(4, commenti=1), _riga(12, commenti=6, quando="2026-09-09T09:00:00Z")],
+    )
+    nuovi = await tickets.async_watch_messages(hass)
+    assert [(voce["number"], voce["messages"], voce["opened"]) for voce in nuovi] == [
+        (12, 1, False)
+    ]

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -11,8 +11,8 @@ solo in casa d'altri.
   deve far suonare niente: e' il modo sicuro di farlo spegnere a tutti.
 * **Cancellare cancella davvero**, anche dal centralino: e' scritto nella
   plancia prima che qualcuno scriva la prima riga.
-* **Chi non ha la chiave non risponde a nessuno.** La console della chat non si
-  deduce, si ha o non si ha.
+* **Chi non ha la chiave non risponde a nessuno**, e non butta via niente. La
+  console della chat non si deduce, si ha o non si ha.
 
 Il centralino non viene mai chiamato davvero: al suo posto c'e' `_chiama`.
 """
@@ -125,6 +125,10 @@ class FintoCentralino:
                 ]
             }
         linea = pezzi[2]
+        if metodo == "DELETE":
+            self.linee.pop(linea, None)
+            self.segreti.pop(linea, None)
+            return {"cancellata": True}
         if metodo == "POST":
             messaggio = {
                 "id": self.prossimo,
@@ -541,6 +545,40 @@ async def test_con_la_chiave_si_vede_la_coda_e_si_risponde(
     assert [riga["testo"] for riga in filo] == ["una domanda", "una risposta"]
 
 
+async def test_chi_risponde_puo_buttare_via_una_conversazione(
+    hass: HomeAssistant, centralino: FintoCentralino
+) -> None:
+    """Una coda dove non si butta via niente si riempie e non serve piu'.
+
+    Prove, domande gia' risolte, righe aperte per sbaglio: senza un cestino
+    restano li' per sempre, e quella vera non si trova piu'.
+    """
+    _entry(hass, **{OPTION_CHAT_CONSOLE_KEY: "chiave-vera"})
+    await chat.async_scrivi(hass, "era solo una prova")
+    coda = await chat.async_coda(hass)
+    assert len(coda) == 1
+
+    assert await chat.async_butta(hass, coda[0]["id"]) is True
+    assert await chat.async_coda(hass) == []
+    assert ("DELETE", f"/console/conversazioni/{coda[0]['id']}") in centralino.chiamate
+
+
+async def test_senza_chiave_non_si_butta_via_niente(
+    hass: HomeAssistant, centralino: FintoCentralino
+) -> None:
+    """La cancellazione e' la cosa che non si rimette a posto.
+
+    Se passasse senza chiave, chiunque amministri casa propria potrebbe
+    svuotare la coda di tutti — e i comandi della console si chiamano anche
+    senza finestra aperta.
+    """
+    _entry(hass)
+    await chat.async_scrivi(hass, "una domanda che deve restare")
+    with pytest.raises(ChatError):
+        await chat.async_butta(hass, "casa_x")
+    assert ("DELETE", "/console/conversazioni/casa_x") not in centralino.chiamate
+
+
 # ─── Spegnerla ───────────────────────────────────────────────────────────────
 
 
@@ -589,6 +627,8 @@ async def test_con_la_chat_spenta_non_si_risponde_nemmeno(
         await chat.async_apri(hass, "casa_x")
     with pytest.raises(ChatError):
         await chat.async_replica(hass, "casa_x", "ciao")
+    with pytest.raises(ChatError):
+        await chat.async_butta(hass, "casa_x")
     assert centralino.chiamate == []
 
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -86,7 +86,8 @@ class FintoCentralino:
         if casa in self.segreti and self.segreti[casa] != segreto:
             raise ChatError("forbidden", "Il centralino ha rifiutato.")
         if metodo == "POST":
-            if casa not in self.segreti:
+            nuova = casa not in self.segreti
+            if nuova:
                 self.segreti[casa] = segreto
                 self.linee[casa] = []
             self.note[casa] = {k: v for k, v in testate.items() if k.startswith("X-")}
@@ -98,7 +99,7 @@ class FintoCentralino:
             }
             self.prossimo += 1
             self.linee[casa].append(messaggio)
-            return {"messaggio": messaggio}
+            return {"messaggio": messaggio, "nuova": nuova}
         if metodo == "DELETE":
             self.linee.pop(casa, None)
             self.segreti.pop(casa, None)
@@ -577,6 +578,74 @@ async def test_senza_chiave_non_si_butta_via_niente(
     with pytest.raises(ChatError):
         await chat.async_butta(hass, "casa_x")
     assert ("DELETE", "/console/conversazioni/casa_x") not in centralino.chiamate
+
+
+async def test_cancellata_dalla_console_sparisce_anche_dalla_casa(
+    hass: HomeAssistant, centralino: FintoCentralino
+) -> None:
+    """Cancellare da una parte deve cancellare da tutte e due.
+
+    Il centralino, a chi chiede una linea che non c'e' piu', risponde
+    «aperta: false». Buttare via quel dato lasciava la copia in casa intatta per
+    sempre: una conversazione cancellata e ancora li', leggibile, dopo che alla
+    persona era stato promesso il contrario.
+    """
+    _entry(hass, **{OPTION_CHAT_CONSOLE_KEY: "chiave-vera"})
+    await chat.async_scrivi(hass, "una domanda")
+    store = await async_get_chat_store(hass)
+    linea = (await store.async_identita())["casa"]
+    centralino.risponde(linea, "una risposta")
+    await chat.async_conversazione(hass)
+    assert len(store.messaggi()) == 2
+
+    await chat.async_butta(hass, linea)
+    filo = await chat.async_conversazione(hass)
+    assert filo["messages"] == []
+    assert store.messaggi() == []
+    # E non e' un guasto: e' quello che doveva succedere.
+    assert not filo["error"]
+
+
+async def test_anche_il_giro_dei_cinque_minuti_se_ne_accorge(
+    hass: HomeAssistant, centralino: FintoCentralino
+) -> None:
+    """Senza, la copia resterebbe li' finche' qualcuno non apre la finestra."""
+    _entry(hass, **{OPTION_CHAT_CONSOLE_KEY: "chiave-vera"})
+    await chat.async_scrivi(hass, "una domanda")
+    store = await async_get_chat_store(hass)
+    linea = (await store.async_identita())["casa"]
+    await chat.async_butta(hass, linea)
+
+    suonate = _ascolta(hass)
+    assert await chat.async_guarda(hass) == []
+    await hass.async_block_till_done()
+    assert store.messaggi() == []
+    # Non e' arrivato niente da leggere: non suona niente.
+    assert suonate == []
+    assert _campanelle(hass) == []
+
+
+async def test_scrivere_dopo_una_cancellazione_non_incolla_il_vecchio(
+    hass: HomeAssistant, centralino: FintoCentralino
+) -> None:
+    """La linea rinasce col messaggio nuovo, e la copia di prima se ne va.
+
+    Chi scrive prima di aver riletto riapre la linea senza accorgersi di
+    niente. Se la copia restasse, questa casa si vedrebbe una conversazione che
+    chi risponde non ha — con dentro proprio le righe che erano state
+    cancellate.
+    """
+    _entry(hass, **{OPTION_CHAT_CONSOLE_KEY: "chiave-vera"})
+    await chat.async_scrivi(hass, "la prima domanda")
+    store = await async_get_chat_store(hass)
+    linea = (await store.async_identita())["casa"]
+    centralino.risponde(linea, "la prima risposta")
+    await chat.async_conversazione(hass)
+    assert len(store.messaggi()) == 2
+
+    await chat.async_butta(hass, linea)
+    await chat.async_scrivi(hass, "una domanda nuova")
+    assert [riga["testo"] for riga in store.messaggi()] == ["una domanda nuova"]
 
 
 # ─── Spegnerla ───────────────────────────────────────────────────────────────

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -721,3 +721,32 @@ async def test_senza_centralino_la_porta_non_si_disegna(
     assert chat.accesa(hass) is False
     stato = await chat.async_stato(hass)
     assert stato["enabled"] is False
+
+
+async def test_un_giro_senza_novita_non_scrive_su_disco(
+    hass: HomeAssistant, centralino: FintoCentralino
+) -> None:
+    """La finestra aperta rilegge ogni quindici secondi, e quasi sempre non
+    e' arrivato niente: salvare lo stesso voleva dire una scrittura su disco
+    a ogni battito per dire quello che c'era gia' scritto.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    _entry(hass, **{OPTION_CHAT_CONSOLE_KEY: "chiave-vera"})
+    await chat.async_scrivi(hass, "una domanda")
+    store = await async_get_chat_store(hass)
+    with patch.object(store._store, "async_save", new=AsyncMock()) as salva:
+        for _ in range(4):
+            await chat.async_conversazione(hass)
+        assert salva.call_count == 0
+
+        # La conversazione sparisce dal centralino: la prima rilettura se ne
+        # accorge e butta la copia — una scrittura, e poi basta.
+        linea = (await store.async_identita())["casa"]
+        await chat.async_butta(hass, linea)
+        await chat.async_conversazione(hass)
+        assert salva.call_count == 1
+        for _ in range(3):
+            await chat.async_conversazione(hass)
+            await chat.async_guarda(hass)
+        assert salva.call_count == 1

--- a/tests/test_setup_unload.py
+++ b/tests/test_setup_unload.py
@@ -97,6 +97,7 @@ async def test_admin_only_option_hides_the_panel(
         update: bool,
         asset_version: str,
         static_url_path: str,
+        variants: list[str] | None = None,
     ) -> None:
         captured["admin_only"] = bool(entry.options.get(OPTION_ADMIN_ONLY, False))
 
@@ -153,3 +154,60 @@ async def test_multiple_plance_have_own_paths(hass: HomeAssistant) -> None:
     assert cfg["entry_ids"] == ["entry-b"]
     assert cfg["instance_id"] == "entry-b"
     assert cfg["primary"] is False
+
+
+@pytest.mark.asyncio
+async def test_unload_scarica_la_piattaforma_solo_da_chi_l_ha_montata(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """L'erede della primaria non ha mai montato l'avviso di aggiornamento.
+
+    Quando la primaria veniva tolta, l'erede ripartiva scoprendosi primaria e
+    allo scarico chiedeva di smontare una piattaforma mai montata: Home
+    Assistant rispondeva «Config entry was never loaded!» nel registro.
+    """
+    import custom_components.dashboardmodern.frontend as frontend_module
+    from custom_components.dashboardmodern import DATA_UPDATE_ENTRY
+
+    async def fake_unregister(_hass: HomeAssistant, _entry_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(
+        frontend_module, "async_unregister_frontend_entry", fake_unregister
+    )
+    scaricate: list[str] = []
+
+    async def fake_unload(entry: MockConfigEntry, _platforms: list[str]) -> bool:
+        scaricate.append(entry.entry_id)
+        return True
+
+    monkeypatch.setattr(hass.config_entries, "async_unload_platforms", fake_unload)
+
+    entry = MockConfigEntry(domain=DOMAIN, entry_id="entry-1")
+    entry.add_to_hass(hass)
+    # Primaria per identificativo, ma la piattaforma non l'ha montata nessuno.
+    assert await async_unload_entry(hass, entry) is True
+    assert scaricate == []
+
+    # Chi l'ha montata la scarica, e il segno se ne va con lei.
+    hass.data.setdefault(DOMAIN, {})[DATA_UPDATE_ENTRY] = "entry-1"
+    assert await async_unload_entry(hass, entry) is True
+    assert scaricate == ["entry-1"]
+    assert DATA_UPDATE_ENTRY not in hass.data[DOMAIN]
+
+
+@pytest.mark.asyncio
+async def test_le_plance_legacy_si_leggono_fuori_dal_loop(hass: HomeAssistant) -> None:
+    """`is_dir` e `glob` sono disco: si leggono nell'executor e si passano giu'."""
+    import inspect
+
+    from custom_components.dashboardmodern import frontend as frontend_module
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, entry_id="entry-a", title="Casa", data={"primary": True}
+    )
+    entry.add_to_hass(hass)
+    cfg = frontend_module._panel_config(hass, entry, variants=["dashboard.html"])
+    assert cfg["legacy_variants"] == ["dashboard.html"]
+    sorgente = inspect.getsource(frontend_module)
+    assert "variants = await hass.async_add_executor_job(legacy_variants)" in sorgente

--- a/tests/test_tickets_github.py
+++ b/tests/test_tickets_github.py
@@ -1238,3 +1238,92 @@ def test_un_corpo_senza_diagnostica_resta_intero() -> None:
     testo, voci = github_client.diagnostica_in("si richiede di separare le aperture")
     assert testo == "si richiede di separare le aperture"
     assert voci == {}
+
+
+async def test_il_filo_legge_gli_ultimi_commenti_non_i_primi(
+    hass: HomeAssistant, github: FakeGitHub
+) -> None:
+    """GitHub li da' dal primo in poi, trenta per pagina.
+
+    Chiedere la prima pagina e basta voleva dire che dal trentunesimo commento
+    in poi la risposta piu' recente non si vedeva mai: il campanello suonava
+    per un messaggio che il filo non mostrava, e lo stato dedotto dal commento
+    del manutentore restava fermo a settimane prima.
+    """
+    _entry(hass)
+    await _collega(hass, "dani", maintainer=True)
+    vecchi = [
+        {
+            "id": numero,
+            "body": f"commento {numero}",
+            "user": {"login": "anna-g"},
+            "author_association": "NONE",
+            "created_at": "2026-09-01T10:00:00Z",
+        }
+        for numero in range(1, 31)
+    ]
+    ultimo = {
+        "id": 31,
+        "body": "L'ultima risposta.",
+        "user": {"login": "danigio15"},
+        "author_association": "OWNER",
+        "created_at": "2026-09-02T10:00:00Z",
+    }
+    github.answer("page=2", [ultimo])
+    github.answer("page=1", vecchi)
+    github.answer(
+        "/issues/42",
+        {
+            "number": 42,
+            "state": "open",
+            "comments": 31,
+            "body": "Il corpo.",
+            "html_url": "https://github.com/x/y/issues/42",
+        },
+    )
+    filo = await tickets.async_thread(hass, "dani", 42)
+    assert filo["comment_count"] == 31
+    assert len(filo["comments"]) == 30
+    assert filo["comments"][-1]["body"] == "L'ultima risposta."
+    assert filo["comments"][0]["body"] == "commento 2"
+    pagine = [
+        chiamata["url"].rsplit("page=", 1)[-1]
+        for chiamata in github.calls
+        if "/comments" in chiamata["url"]
+    ]
+    assert pagine == ["2", "1"]
+
+    # E la sincronia vede quella risposta, non una di trenta commenti fa.
+    letta = await github_client.async_read_issue(hass, 42, token="gho_dani")
+    assert letta["reply"] == "L'ultima risposta."
+
+
+async def test_la_sincronia_gira_su_tutte_le_segnalazioni(
+    hass: HomeAssistant, github: FakeGitHub, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Venti per giro, ma il giro dopo riparte da dove si era fermato.
+
+    Prendere sempre le prime venti voleva dire che con ventuno aperte la
+    ventunesima non veniva riletta mai, finche' una delle altre non si
+    chiudeva.
+    """
+    _entry(hass)
+    await _collega(hass, "anna")
+    store = await async_get_ticket_store(hass)
+    # Venticinque in fila: il freno sulle segnalazioni troppo frequenti qui
+    # non c'entra, e si toglie.
+    monkeypatch.setattr(type(store), "_too_frequent", lambda _self, _now: False)
+    for numero in range(1, 26):
+        bozza = await _bozza(hass, title=f"la {numero}")
+        await store.async_mark_sent(bozza["id"], str(numero))
+    github.answer("/issues/", {"state": "open", "comments": 0})
+
+    await tickets.async_sync_states(hass)
+    primi = [chiamata["url"].rsplit("/", 1)[-1] for chiamata in github.calls]
+    github.calls.clear()
+    await tickets.async_sync_states(hass)
+    secondi = [chiamata["url"].rsplit("/", 1)[-1] for chiamata in github.calls]
+
+    assert len(primi) == 20 and len(secondi) == 20
+    assert secondi[:5] == ["21", "22", "23", "24", "25"]
+    assert set(primi) | set(secondi) == {str(numero) for numero in range(1, 26)}

--- a/tests/test_update_entity.py
+++ b/tests/test_update_entity.py
@@ -29,6 +29,8 @@ import zipfile
 from collections.abc import Callable
 from pathlib import Path, PurePosixPath
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPONENT = ROOT / "custom_components/dashboardmodern"
 UPDATE = COMPONENT / "update.py"
@@ -321,3 +323,32 @@ def test_il_riavvio_si_chiede_dal_posto_standard() -> None:
         passo = voce["fix_flow"]["step"]["confirm"]
         assert voce["title"], percorso.name
         assert "{version}" in passo["description"], percorso.name
+
+
+def test_un_estrazione_fallita_non_lascia_una_seconda_integrazione(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Disco pieno a meta' estrazione: la cartella d'appoggio se ne va.
+
+    Restava `.dashboardmodern-nuovo` dentro `custom_components`, col manifest
+    di questo stesso dominio: il caricatore di Home Assistant la vedeva come
+    una seconda integrazione e al riavvio poteva preferirla a quella vera.
+    """
+    cartella = _cartella_installata(tmp_path)
+    dati = _zip_di_release("1.3.9")
+
+    def esplode(
+        self: zipfile.ZipFile, path: str = "", *_a: object, **_k: object
+    ) -> None:
+        (Path(path) / "manifest.json").write_text("{}")
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(zipfile.ZipFile, "extractall", esplode)
+    try:
+        installa_da_zip(cartella, dati, "1.3.9")
+    except OSError:
+        pass
+    else:  # pragma: no cover - il fallimento atteso e' l'eccezione
+        raise AssertionError("l'estrazione doveva fallire")
+    assert sorted(p.name for p in cartella.parent.iterdir()) == ["dashboardmodern"]
+    assert (cartella / "vecchio.py").exists()

--- a/tests/test_websocket_config.py
+++ b/tests/test_websocket_config.py
@@ -370,3 +370,64 @@ async def test_una_plancia_aperta_resta_aperta(hass: HomeAssistant) -> None:
     chiunque = StubConnection(hass, is_admin=False)
     letto = await _command(hass, chiunque, {"type": TYPE_GET}, 1)
     assert letto["snapshot"]["values"] == VALUES
+
+
+async def test_chi_e_in_lista_su_una_plancia_non_tocca_l_altra(
+    hass: HomeAssistant,
+) -> None:
+    """Il profilo e' un campo libero, e il permesso vale sulla plancia giusta.
+
+    Con due plance e due liste diverse, chi era in lista sulla seconda poteva
+    chiamare questi comandi a mano col profilo della prima — leggerla, e
+    azzerarla con `reset` — perche' bastava poter usare una plancia qualsiasi.
+    """
+    from custom_components.dashboardmodern import frontend as frontend_module
+
+    _plancia(hass, allowed_users=["user-2"])
+    mare = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry-2",
+        title="Mare",
+        data={"name": "Mare", "primary": False},
+        options={"allowed_users": ["user-1"]},
+    )
+    mare.add_to_hass(hass)
+    store = await async_get_config_store(hass)
+    await store.async_set(PRIMARY_PROFILE, VALUES, keys_revision=2)
+    profilo_mare = frontend_module._config_profile(hass, mare)
+    assert profilo_mare != PRIMARY_PROFILE
+
+    # `SimpleUser` e' "user-1": in lista solo sul Mare.
+    ospite = StubConnection(hass, is_admin=False)
+    codice, _ = await _errore(hass, ospite, {"type": TYPE_GET}, 1)
+    assert codice == websocket_api.const.ERR_UNAUTHORIZED
+    codice, _ = await _errore(
+        hass,
+        ospite,
+        {
+            "type": TYPE_SET,
+            "reset": True,
+            "snapshot": {"values": {}, "keys_revision": 2},
+        },
+        2,
+    )
+    assert codice == websocket_api.const.ERR_UNAUTHORIZED
+    codice, _ = await _errore(hass, ospite, {"type": TYPE_RESTORE, "revision": 1}, 3)
+    assert codice == websocket_api.const.ERR_UNAUTHORIZED
+    # Nemmeno passando dall'identificativo della propria plancia col profilo
+    # dell'altra.
+    codice, _ = await _errore(
+        hass, ospite, {"type": TYPE_GET, "entry_id": "entry-2"}, 4
+    )
+    assert codice == websocket_api.const.ERR_UNAUTHORIZED
+    stored = await store.async_get(PRIMARY_PROFILE)
+    assert stored["snapshot"]["values"] == VALUES
+
+    # La propria invece si legge, come e' sempre stato.
+    letto = await _command(
+        hass,
+        ospite,
+        {"type": TYPE_GET, "profile": profilo_mare, "entry_id": "entry-2"},
+        5,
+    )
+    assert letto["profile"] == profilo_mare

--- a/tests/test_websocket_tickets.py
+++ b/tests/test_websocket_tickets.py
@@ -39,6 +39,7 @@ from custom_components.dashboardmodern.websocket_api import (
     TYPE_TICKET_DELETE,
     TYPE_TICKET_LIST,
     TYPE_TICKET_QUEUE,
+    TYPE_TICKET_THREAD,
     async_register_websocket_api,
 )
 
@@ -373,5 +374,19 @@ async def test_chi_non_puo_usare_la_plancia_non_collega_niente(
         StubConnection(hass, is_admin=False, user_id="ospite"),
         {"type": TYPE_TICKET_AUTH_START},
         1,
+    )
+    assert code == websocket_api.const.ERR_UNAUTHORIZED
+
+
+async def test_chi_non_puo_usare_la_plancia_non_apre_il_filo(
+    hass: HomeAssistant,
+) -> None:
+    """Aprire il filo spegne il pallino di tutta la casa: non e' una lettura
+    qualsiasi, e chiede lo stesso permesso degli altri comandi.
+    """
+    _entry(hass, admin_only=True)
+    estraneo = StubConnection(hass, is_admin=False, user_id="ospite")
+    code, _ = await _refused(
+        hass, estraneo, {"type": TYPE_TICKET_THREAD, "number": 7}, 1
     )
     assert code == websocket_api.const.ERR_UNAUTHORIZED

--- a/tests/test_www_files.py
+++ b/tests/test_www_files.py
@@ -166,10 +166,33 @@ def test_upload_un_nome_fuori_alfabeto_tiene_la_sua_estensione(tmp_path: Path) -
     assert esito == {"path": "/local/dashboardmodern/foto.jpg"}
 
 
-def test_upload_riconosce_svg_e_webp(tmp_path: Path) -> None:
-    from custom_components.dashboardmodern.www_files import save_www_upload
+def test_upload_rifiuta_svg_e_riconosce_webp(tmp_path: Path) -> None:
+    """Un SVG non e' una bitmap: e' un documento, e puo' portare uno script.
 
-    svg = b'<svg xmlns="http://www.w3.org/2000/svg"></svg>'
-    assert save_www_upload(str(tmp_path), "auto.svg", svg) is not None
+    Home Assistant lo servirebbe da `/local/` sulla propria origine, dove
+    stanno i gettoni di chi lo apre. Chi ne vuole uno lo copia in `www` a
+    mano; da qui passano solo formati che il browser disegna e non esegue.
+    """
+    from custom_components.dashboardmodern.www_files import (
+        IMAGE_SUFFIXES,
+        save_www_upload,
+    )
+
+    svg = b'<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+    assert save_www_upload(str(tmp_path), "auto.svg", svg) is None
+    assert not (tmp_path / "dashboardmodern").exists()
+    # Nel selettore pero' si elenca ancora: quello che c'e' gia' non sparisce.
+    assert ".svg" in IMAGE_SUFFIXES
     webp = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 8
     assert save_www_upload(str(tmp_path), "auto.webp", webp) is not None
+
+
+def test_un_byte_nullo_nel_percorso_non_e_un_traceback(tmp_path: Path) -> None:
+    """Non e' un guasto del disco: e' una richiesta che non porta da nessuna
+    parte, e si risponde come a ogni altro percorso fuori posto.
+    """
+    from custom_components.dashboardmodern.www_files import list_www_folder
+
+    (tmp_path / "www").mkdir()
+    assert list_www_folder(str(tmp_path / "www"), "x\x00y") is None
+    assert list_www_folder(str(tmp_path / "www\x00"), "")["available"] is False


### PR DESCRIPTION
> «si ma mi devi dare la possibilità di eliminare anche la conversazione»
>
> «la risposta non si refresh devo uscire e rientrare»
>
> «passiamo alla versione 1.4.5 ed elimina tutte le beta, lascia solo ultima»

## La versione

Il manifest dice **`1.4.5`**, senza suffisso: la release che ne esce sarà **stabile**, non una pre-release — `release.yml` lo decide guardando se il tag ha il trattino.

**Il CHANGELOG si unisce.** Le tredici sezioni da `1.4.5-beta.1` a `1.4.5-beta.13` diventano una sola, `## 1.4.5`, coi blocchi rimessi in fila per argomento invece che per data: Aggiunto, Cambiato, Rimosso, Corretto, Da sapere.

Non è cosmesi. Le note della release le estrae `release.yml` dalla sezione che porta il numero della versione: lasciando tredici sezioni, la pagina della 1.4.5 avrebbe raccontato **un tredicesimo di sé**, e le altre dodici — cancellate insieme alle loro pre-release — non sarebbero state più da nessuna parte. Nessun punto è stato riscritto: cambiano solo i capitoli sopra di loro. Le tredici introduzioni lasciano il posto a una sola, che riepiloga la versione.

**La pulizia delle release sa fare il suo mestiere.** `cleanup-releases.yml` cancellava soltanto la numerazione pre-1.0 e le beta/rc della 1.0.0: le `1.4.5-beta.*` non le riconosceva, quindi lo strumento che esiste apposta per questo non sarebbe servito proprio adesso. Adesso è cancellabile **ogni pre-release di qualunque versione**, e nient'altro.

La garanzia resta intatta: una versione stabile non ha il trattino, non corrisponde a nessuno dei pattern, e questo workflow **non sa cancellarla nemmeno per errore di battitura**. Resta anche il controllo che impedisce di restare senza nessuna release stabile.

## Il cestino

Ogni riga della scheda «Conversazioni» ne ha uno, e ce n'è uno anche sopra il filo aperto. Cancella per davvero e per tutti e due: `DELETE /console/conversazioni/:linea` toglie la linea e i suoi messaggi dal centralino, e la casa se ne accorge e manda via la propria copia (vedi sotto).

Serve perché una coda dove non si butta via niente si riempie di prove, di domande già risolte e di righe aperte per sbaglio, finché quella vera non si trova più. Ed è il verso giusto della promessa fatta prima della prima riga: quello che si scrive lì non resta in giro per sempre.

**Due tocchi e non uno.** Il primo arma il cestino e chiede conferma sul tasto stesso, il secondo cancella. Una conversazione cancellata non si rimette a posto, e in un elenco dove si scorre col dito un cestino che cancella al primo tocco butta via prima o poi quella sbagliata.

Sul centralino la chiave della console è obbligatoria come per rispondere, e una linea già andata risponde di sì lo stesso — chi cancella vuole che non ci sia, e se non c'è già il risultato è quello: un 404 lì direbbe che qualcosa non ha funzionato mentre era a posto.

## La finestra che non si aggiornava

Leggeva una volta all'apertura e poi restava ferma: la risposta arrivava solo chiudendo e riaprendo. Il giro dei cinque minuti del backend c'era già, ma quello serve al campanello — suona e basta, non ridisegna niente.

Adesso guarda ogni quindici secondi e **ridisegna soltanto quando è arrivato davvero qualcosa**: rifare la casella quattro volte al minuto sotto le dita di chi scrive è il modo di rendere la finestra inusabile. E se ridisegna, il cursore torna dov'era.

Chiusa la finestra — o con la pagina nascosta — non chiede più niente. L'intervallo è dichiarato in `runtime-import-graph.test.js` accanto agli altri otto, con la sua ragione scritta.

## Le bolle stavano dalla parte sbagliata

Nella coda le domande della casa comparivano a destra e in verde — come se se le fosse scritte da solo chi stava leggendo — e le proprie risposte a sinistra e in grigio: una conversazione letta al contrario. «Mio» dipende da chi guarda, e questa finestra la guardano in due.

## I quattro rilievi di Codex, tutti veri

Due dicevano che questa PR **prometteva il falso**, e avevano ragione.

1. **La cancellazione non arrivava alla casa.** «Cancella davvero e per tutti e due» era scritto qui sopra e il codice non lo faceva: sparivano le righe dal centralino, e la casa si teneva la trascrizione intera per sempre. Il centralino risponde già `aperta: false` a chi chiede una linea che non c'è più, e `async_leggi` quel dato lo buttava via. Adesso diventa un `ChatError("gone")` e chi lo riceve manda via la copia. In più lo sportello della casa dice se la linea è **nata con questo messaggio**: chi scrive prima di aver riletto la riapre senza accorgersi di niente, e senza quel segnale la copia vecchia si sarebbe incollata sotto le frasi nuove.

2. **La scheda in fondo si mangiava le campanelle.** Con la finestra dimenticata aperta in una scheda nascosta, il giro dei quindici secondi leggeva — e leggere è aver letto: la risposta finiva in copia e segnata come vista, e il giro dei cinque minuti che deve suonare non trovava niente di nuovo. A pagina nascosta il giro adesso sta fermo.

3. **Un messaggio poteva sopravvivere alla linea.** Fra «la linea esiste?» e «scrivi» ci sta una cancellazione, e `messaggi.linea` non ha un vincolo verso `linee`: la riga restava orfana e la potatura notturna non la raggiungeva più. La scrittura è diventata un'istruzione sola col controllo dentro (`INSERT … SELECT … WHERE EXISTS`), e la potatura raccoglie anche gli orfani nati prima.

4. **Il filo di una casa poteva finire sotto il nome di un'altra.** Il giro assegnava le frasi di A mentre la finestra mostrava B. Adesso si appunta da dove è partito, e un giro per volta.

## Cosa cambia

| Dove | Cosa |
| --- | --- |
| `manifest.json` | `1.4.5` |
| `CHANGELOG.md` | tredici sezioni beta unite in `## 1.4.5` |
| `.github/workflows/cleanup-releases.yml` | sa cancellare ogni pre-release, mai una stabile |
| `centralino/src/index.js` | `DELETE /console/conversazioni/:linea`, scrittura con controllo dentro, `nuova`, potatura degli orfani |
| `chat_client.py` | `async_cestina`, il segnale `gone`, `nuova` |
| `chat.py` | `async_butta`, e la copia che se ne va quando la linea non c'è più |
| `websocket_api.py` | `dashboardmodern/chat/drop`, dietro la chiave della console |
| `bridge-socket.js` | il tipo nell'allowlist del ponte |
| `assistenza-section.js` | cestino, giro dei quindici secondi, verso delle bolle, cursore |
| `docs/CHAT.md`, `centralino/README.md` | il perché, e il cron che va aggiunto a mano |

## Prove

- **centralino** 31/31 — sette nuove
- **Python** 261/261 — sei nuove
- **frontend** 2116/2116 — otto nuove
- `ruff check` e `ruff format --check` puliti, `check:i18n`, `check:moduli`, `format:check` verdi

La chiave nuova `Confirm?` è nei tredici cataloghi.

## Due passaggi fuori da qui

1. **Il Worker su Cloudflare va ridistribuito** con questo `centralino/src/index.js` (che porta anche il tetto sulle linee nuove della beta.12). Il database non si tocca. Senza, il cestino nella plancia non ha nessuno dall'altra parte. E il **Cron Trigger** `0 4 * * *` va aggiunto a mano dalla pagina di Cloudflare: `[triggers]` in `wrangler.toml` vale solo per chi distribuisce con `wrangler`.
2. **La pulizia delle release** si lancia da Actions → «Pulizia release» → Run workflow, prima in anteprima e poi con la spunta. Va fatta **dopo** che la 1.4.5 è pubblicata: cancellare le beta prima lascerebbe la 1.4.4 come cosa più recente installabile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvRdWRQ9rj1LRuq56iPdpz