### PR TITLE
Due correzioni prima della 1.4.13: la tessera dei rifiuti e l'HLS delle telecamere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,33 @@ aggiornamento.
   sull'ultimo valore finché non si muoveva qualcos'altro. L'elenco adesso è
   uno solo.
 
+- **Telecamere Arlo: l'HLS vale quando il video si muove davvero** (#385)
+
+  Nei registri allegati alla segnalazione: `[Cam] ✓ HLS`, e un istante dopo lo
+  stallo con due millesimi di secondo in pancia. La plancia aveva dichiarato
+  riuscita quella strada perché era arrivata l'**intestazione** del flusso —
+  `loadedmetadata`, che scatta prima di qualunque immagine — e di immagini non
+  ne è arrivata nessuna: rotella tolta, rettangolo fermo, nessuna parola.
+
+  Il guaio vero non è il rettangolo fermo: dichiarando riuscita quella strada
+  non se ne provava più nessun'altra. Sotto ci sono il flusso del proxy e le
+  istantanee, e le istantanee sono proprio la modalità pensata per chi
+  trasmette solo su richiesta — Arlo, Ring, Blink. Una telecamera che si
+  sarebbe fatta vedere a due fotogrammi al secondo non si vedeva affatto.
+
+  Adesso si guarda l'unica cosa che risponde alla domanda: il tempo del video
+  va avanti? Se va avanti non cambia niente. Se non va avanti la catena scende
+  alla strada dopo, com'era giusto fin dall'inizio.
+
+- **La tessera dei rifiuti c'è anche con le sole due settimane scritte a mano.**
+
+  Il calendario di casa (#366) non ha nessuna entità: è il foglietto sul frigo.
+  Ma il cancello della tessera in Home pretendeva almeno un'entità non esclusa
+  dai widget, e con l'elenco vuoto non passava — quindi chi configurava SOLO le
+  due settimane, cioè esattamente chi quel turno l'ha chiesto perché un
+  calendario in Home Assistant non ce l'ha, si ritrovava la sezione piena e in
+  Home niente.
+
 - **Rinominando la plancia si rinomina anche la dashboard di appoggio.**
 
   Quella che permette di sceglierla come predefinita nasceva col nome del

--- a/custom_components/dashboardmodern/frontend/e2e/il-calendario-dei-rifiuti-si-scrive-a-mano.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/il-calendario-dei-rifiuti-si-scrive-a-mano.spec.js
@@ -97,3 +97,35 @@ test("senza data d'inizio il turno non si inventa niente", async ({ page }, test
   // per quasi tutti, e senza una data il turno non si potrebbe collocare.
   await expect(page.locator("#ed-body [data-dm-turno-inizio]")).not.toHaveValue("");
 });
+
+test("con le sole due settimane la tessera c'e' anche in Home", async ({ page }, testInfo) => {
+  /* Il turno scritto a mano non ha nessuna entita': e' il foglietto sul frigo.
+   * Il cancello della tessera in Home pretendeva almeno un'entita' non esclusa
+   * dai widget, e con l'elenco vuoto non passava — quindi chi configurava SOLO
+   * le due settimane, cioe' esattamente chi quel turno l'ha chiesto, si
+   * ritrovava la sezione piena e in Home niente. */
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  /* Le tessere della Home escono solo su una plancia configurata: una luce
+   * basta, ed e' quello che ha chiunque abbia qualcosa da vedere in Home. */
+  const conUnaLuce = {
+    ...seed,
+    sections: { ...seed.sections, lights: [{ entity: "light.salotto", name: "Salotto" }] },
+  };
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, conUnaLuce);
+  await page.locator("#setup-wizard").evaluateAll((nodi) => nodi.forEach((n) => n.remove()));
+
+  await page.evaluate(() => {
+    const oggi = new Date();
+    const due = (n) => String(n).padStart(2, "0");
+    const inizio = `${oggi.getFullYear()}-${due(oggi.getMonth() + 1)}-${due(oggi.getDate())}`;
+    const giorni = Array.from({ length: 14 }, () => []);
+    giorni[0] = ["carta"];
+    window.localStorage.setItem("cd_rifiuti", JSON.stringify({ turno: { inizio, giorni } }));
+    window.dispatchEvent(new CustomEvent("dashboardmodern:states-ready", { detail: {} }));
+    window.renderHomeWidgets?.();
+  });
+
+  const tessera = page.locator('.dm-tile[data-dm-widget="rifiuti"]').first();
+  await expect(tessera).toBeVisible({ timeout: 20_000 });
+  await expect(tessera.locator("[data-dm-tile-caption]")).toContainText(/Carta/i);
+});

--- a/custom_components/dashboardmodern/frontend/e2e/il-calendario-dei-rifiuti-si-scrive-a-mano.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/il-calendario-dei-rifiuti-si-scrive-a-mano.spec.js
@@ -129,3 +129,64 @@ test("con le sole due settimane la tessera c'e' anche in Home", async ({ page },
   await expect(tessera).toBeVisible({ timeout: 20_000 });
   await expect(tessera.locator("[data-dm-tile-caption]")).toContainText(/Carta/i);
 });
+
+test("un sensore tolto dai widget non rientra dalla porta del turno", async ({
+  page,
+}, testInfo) => {
+  /* L'interruttore «Nel widget» toglie le entita' una per una. Il cancello
+   * guardava solo se ne restava ALMENO UNA, e poi il modello leggeva la
+   * configurazione intera: le righe escluse tornavano dentro il valore, la
+   * didascalia e l'elenco ogni volta che un'altra entita' bastava ad aprire la
+   * tessera — e col turno, che apre da solo, sarebbero tornate sempre. */
+  await page.route("https://**", (route) => route.fulfill({ status: 200, body: "" }));
+  const conUnaLuce = {
+    ...seed,
+    sections: { ...seed.sections, lights: [{ entity: "light.salotto", name: "Salotto" }] },
+  };
+  await bootNamespacedDashboard(page, "dashboard.html", testInfo, conUnaLuce);
+  await page.locator("#setup-wizard").evaluateAll((nodi) => nodi.forEach((n) => n.remove()));
+
+  await page.evaluate(() => {
+    const oggi = new Date();
+    const due = (n) => String(n).padStart(2, "0");
+    const inizio = `${oggi.getFullYear()}-${due(oggi.getMonth() + 1)}-${due(oggi.getDate())}`;
+    const giorni = Array.from({ length: 14 }, () => []);
+    giorni[0] = ["carta"];
+    window.localStorage.setItem(
+      "cd_rifiuti",
+      JSON.stringify({
+        turno: { inizio, giorni },
+        righe: [{ entity: "sensor.ritiro_vetro", materiale: "vetro" }],
+      }),
+    );
+    // Il vetro e' stato tolto dai widget, apposta.
+    window.localStorage.setItem(
+      "cd_widgets",
+      JSON.stringify({ excluded: ["sensor.ritiro_vetro"] }),
+    );
+    const stati = {
+      "sensor.ritiro_vetro": {
+        entity_id: "sensor.ritiro_vetro",
+        state: "1",
+        attributes: { friendly_name: "Ritiro vetro", daysTo: 1 },
+      },
+    };
+    window.__HASS__ = { states: { ...(window.__HASS__?.states || {}), ...stati } };
+    const raw = window.eval("typeof _RAW_STATES !== 'undefined' ? _RAW_STATES : null");
+    if (raw) Object.assign(raw, stati);
+    window.dispatchEvent(new CustomEvent("dashboardmodern:states-ready", { detail: {} }));
+    window.renderHomeWidgets?.();
+  });
+
+  const tessera = page.locator('.dm-tile[data-dm-widget="rifiuti"]').first();
+  await expect(tessera).toBeVisible({ timeout: 20_000 });
+  await expect(tessera.locator("[data-dm-tile-caption]")).toContainText(/Carta/i);
+
+  /* Le righe stanno nella scheda, non sulla tessera: e' li' che il vetro
+   * escluso rientrava. */
+  await tessera.click();
+  const scheda = page.locator("#dm-widget-popup");
+  await expect(scheda).toBeVisible({ timeout: 10_000 });
+  await expect(scheda).toContainText(/Carta/i);
+  await expect(scheda).not.toContainText(/Vetro/i);
+});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
 import "../src/sections/segnalazioni-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.13","dashboardVersion":"1.4.13","moduleVersion":14,"schemaVersion":4,"date":"2026-09-07T19:23:32+00:00","commit":"b22e6085fe87390e1426bacd4aeafc7219f53430","assetHash":"ef319efc786cfd5b"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.13","dashboardVersion":"1.4.13","moduleVersion":14,"schemaVersion":4,"date":"2026-09-07T19:42:15+00:00","commit":"0dfafde0ec87a54dcdbeb8b7eb90668ec6f3444e","assetHash":"ebbeb641f27a7ef3"});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
 import "../src/sections/segnalazioni-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.13","dashboardVersion":"1.4.13","moduleVersion":14,"schemaVersion":4,"date":"2026-09-07T18:09:03+00:00","commit":"0c0ad07bad44e5f49806670c628edf8537e0ef93","assetHash":"9d76a65dd1840c47"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.13","dashboardVersion":"1.4.13","moduleVersion":14,"schemaVersion":4,"date":"2026-09-07T19:23:32+00:00","commit":"b22e6085fe87390e1426bacd4aeafc7219f53430","assetHash":"ef319efc786cfd5b"});

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard-en.html
@@ -290,6 +290,7 @@ html[data-theme="dark"] #cd-boot-overlay b{color:#e2e8f0}
 <link rel="modulepreload" href="../src/sections/storico-condiviso-section.js">
 <link rel="modulepreload" href="../src/sections/storico-connettivita-section.js">
 <link rel="modulepreload" href="../src/sections/subload-popup-section.js">
+<link rel="modulepreload" href="../src/sections/telecamera-il-video-si-muove-section.js">
 <link rel="modulepreload" href="../src/sections/telecamera-rtsp-section.js">
 <link rel="modulepreload" href="../src/sections/telecamera-vivo-section.js">
 <link rel="modulepreload" href="../src/sections/telecamera-webrtc-section.js">

--- a/custom_components/dashboardmodern/frontend/legacy/dashboard.html
+++ b/custom_components/dashboardmodern/frontend/legacy/dashboard.html
@@ -290,6 +290,7 @@ html[data-theme="dark"] #cd-boot-overlay b{color:#e2e8f0}
 <link rel="modulepreload" href="../src/sections/storico-condiviso-section.js">
 <link rel="modulepreload" href="../src/sections/storico-connettivita-section.js">
 <link rel="modulepreload" href="../src/sections/subload-popup-section.js">
+<link rel="modulepreload" href="../src/sections/telecamera-il-video-si-muove-section.js">
 <link rel="modulepreload" href="../src/sections/telecamera-rtsp-section.js">
 <link rel="modulepreload" href="../src/sections/telecamera-vivo-section.js">
 <link rel="modulepreload" href="../src/sections/telecamera-webrtc-section.js">

--- a/custom_components/dashboardmodern/frontend/src/i18n/ar.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ar.js
@@ -2121,6 +2121,7 @@ export default Object.freeze({
   "Short": "قصيرة",
   "Show devices and energy sources": "إظهار الأجهزة ومصادر الطاقة",
   "Show in Report": "إظهار في التقرير",
+  "HLS: the header arrives but the pictures do not": "HLS: يصل الترويس لكن الصور لا تصل",
   "Show all": "عرض الكل",
   "🖥️ Added to the list": "🖥️ أُضيفت إلى القائمة",
   "Add what is not found": "أضف ما لم يُعثر عليه",

--- a/custom_components/dashboardmodern/frontend/src/i18n/de.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/de.js
@@ -2121,6 +2121,7 @@ export default Object.freeze({
   "Short": "Kurz",
   "Show devices and energy sources": "Geräte und Energiequellen anzeigen",
   "Show in Report": "Im Bericht anzeigen",
+  "HLS: the header arrives but the pictures do not": "HLS: Der Kopf kommt an, die Bilder nicht",
   "Show all": "Alle anzeigen",
   "🖥️ Added to the list": "🖥️ Zur Liste hinzugefügt",
   "Add what is not found": "Hinzufügen, was nicht gefunden wird",

--- a/custom_components/dashboardmodern/frontend/src/i18n/es.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/es.js
@@ -2121,6 +2121,7 @@ export default Object.freeze({
   "Short": "Corta",
   "Show devices and energy sources": "Mostrar dispositivos y fuentes de energía",
   "Show in Report": "Mostrar en el informe",
+  "HLS: the header arrives but the pictures do not": "HLS: la cabecera llega pero las imágenes no",
   "Show all": "Mostrar todo",
   "🖥️ Added to the list": "🖥️ Añadida a la lista",
   "Add what is not found": "Añade lo que no se encuentra",

--- a/custom_components/dashboardmodern/frontend/src/i18n/fr.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/fr.js
@@ -2121,6 +2121,7 @@ export default Object.freeze({
   "Short": "Courte",
   "Show devices and energy sources": "Afficher les appareils et les sources d'énergie",
   "Show in Report": "Afficher dans le rapport",
+  "HLS: the header arrives but the pictures do not": "HLS : l’en-tête arrive mais pas les images",
   "Show all": "Tout afficher",
   "🖥️ Added to the list": "🖥️ Ajoutée à la liste",
   "Add what is not found": "Ajouter ce qui n'est pas trouvé",

--- a/custom_components/dashboardmodern/frontend/src/i18n/hi.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/hi.js
@@ -2121,6 +2121,7 @@ export default Object.freeze({
   "Short": "छोटी",
   "Show devices and energy sources": "उपकरण और ऊर्जा स्रोत दिखाएँ",
   "Show in Report": "रिपोर्ट में दिखाएँ",
+  "HLS: the header arrives but the pictures do not": "HLS: हेडर आता है पर तस्वीरें नहीं",
   "Show all": "सभी दिखाएँ",
   "🖥️ Added to the list": "🖥️ सूची में जोड़ा गया",
   "Add what is not found": "जो नहीं मिला उसे जोड़ें",

--- a/custom_components/dashboardmodern/frontend/src/i18n/ja.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ja.js
@@ -2121,6 +2121,7 @@ export default Object.freeze({
   "Short": "ショート",
   "Show devices and energy sources": "機器と電力の供給元を表示",
   "Show in Report": "レポートに表示",
+  "HLS: the header arrives but the pictures do not": "HLS: ヘッダーは届きますが映像が届きません",
   "Show all": "すべて表示",
   "🖥️ Added to the list": "🖥️ 一覧に追加しました",
   "Add what is not found": "見つからないものを追加",

--- a/custom_components/dashboardmodern/frontend/src/i18n/ko.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ko.js
@@ -2121,6 +2121,7 @@ export default Object.freeze({
   "Short": "짧은 수염",
   "Show devices and energy sources": "기기와 전력원 표시",
   "Show in Report": "보고서에 표시",
+  "HLS: the header arrives but the pictures do not": "HLS: 헤더는 오지만 영상이 오지 않습니다",
   "Show all": "전체 보기",
   "🖥️ Added to the list": "🖥️ 목록에 추가했습니다",
   "Add what is not found": "찾지 못한 것 추가",

--- a/custom_components/dashboardmodern/frontend/src/i18n/nl.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/nl.js
@@ -2121,6 +2121,7 @@ export default Object.freeze({
   "Short": "Kort",
   "Show devices and energy sources": "Apparaten en energiebronnen tonen",
   "Show in Report": "Tonen in het rapport",
+  "HLS: the header arrives but the pictures do not": "HLS: de header komt aan maar de beelden niet",
   "Show all": "Alles tonen",
   "🖥️ Added to the list": "🖥️ Aan de lijst toegevoegd",
   "Add what is not found": "Voeg toe wat niet gevonden wordt",

--- a/custom_components/dashboardmodern/frontend/src/i18n/pl.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/pl.js
@@ -2121,6 +2121,7 @@ export default Object.freeze({
   "Short": "Krótka",
   "Show devices and energy sources": "Pokaż urządzenia i źródła energii",
   "Show in Report": "Pokaż w raporcie",
+  "HLS: the header arrives but the pictures do not": "HLS: nagłówek dociera, ale obrazu brak",
   "Show all": "Pokaż wszystkie",
   "🖥️ Added to the list": "🖥️ Dodano do listy",
   "Add what is not found": "Dodaj to, czego nie znaleziono",

--- a/custom_components/dashboardmodern/frontend/src/i18n/pt.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/pt.js
@@ -2121,6 +2121,7 @@ export default Object.freeze({
   "Short": "Curta",
   "Show devices and energy sources": "Mostrar dispositivos e fontes de energia",
   "Show in Report": "Mostrar no relatório",
+  "HLS: the header arrives but the pictures do not": "HLS: o cabeçalho chega mas as imagens não",
   "Show all": "Mostrar tudo",
   "🖥️ Added to the list": "🖥️ Adicionada à lista",
   "Add what is not found": "Adicionar o que não é encontrado",

--- a/custom_components/dashboardmodern/frontend/src/i18n/ru.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/ru.js
@@ -2121,6 +2121,7 @@ export default Object.freeze({
   "Short": "Короткая",
   "Show devices and energy sources": "Показать устройства и источники энергии",
   "Show in Report": "Показывать в отчёте",
+  "HLS: the header arrives but the pictures do not": "HLS: заголовок приходит, а изображение нет",
   "Show all": "Показать все",
   "🖥️ Added to the list": "🖥️ Добавлено в список",
   "Add what is not found": "Добавить то, что не найдено",

--- a/custom_components/dashboardmodern/frontend/src/i18n/source-index.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/source-index.js
@@ -1401,6 +1401,7 @@ export const SOURCE_INDEX = Object.freeze({
   "History N/D": "History N/A",
   "HLS non disponibile": "HLS not available",
   "HLS non supportato e hls.js mancante": "HLS not supported and hls.js missing",
+  "HLS: l'intestazione arriva ma le immagini no": "HLS: the header arrives but the pictures do not",
   "HLS: saltato, hls.js non caricato": "HLS: skipped, hls.js not loaded",
   "Home Assistant · Sistema core": "Home Assistant · Core system",
   "Home Assistant · Sistema Core": "Home Assistant · Core system",

--- a/custom_components/dashboardmodern/frontend/src/i18n/tr.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/tr.js
@@ -2121,6 +2121,7 @@ export default Object.freeze({
   "Short": "Kısa",
   "Show devices and energy sources": "Cihazları ve enerji kaynaklarını göster",
   "Show in Report": "Raporda göster",
+  "HLS: the header arrives but the pictures do not": "HLS: başlık geliyor ama görüntü gelmiyor",
   "Show all": "Tümünü göster",
   "🖥️ Added to the list": "🖥️ Listeye eklendi",
   "Add what is not found": "Bulunamayanı ekle",

--- a/custom_components/dashboardmodern/frontend/src/i18n/zh-Hans.js
+++ b/custom_components/dashboardmodern/frontend/src/i18n/zh-Hans.js
@@ -2121,6 +2121,7 @@ export default Object.freeze({
   "Short": "短须",
   "Show devices and energy sources": "显示设备和电力来源",
   "Show in Report": "在报表中显示",
+  "HLS: the header arrives but the pictures do not": "HLS：收到了头信息，但没有画面",
   "Show all": "显示全部",
   "🖥️ Added to the list": "🖥️ 已加入列表",
   "Add what is not found": "添加没被找到的",

--- a/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
@@ -139,10 +139,9 @@ import {
 import { categoriaDelleAllerte, fraseDellAllerta } from "./allerte-section.js";
 import {
   CHIAVE_RIFIUTI,
-  entitaDeiRifiuti,
   letturaRifiuti,
+  normalizzaRifiuti,
   rifiutiConfigurati,
-  turnoConfigurato,
 } from "../core/rifiuti-model.js";
 import { nomeDellaRiga, parolaDelQuando } from "./rifiuti-section.js";
 import { CHIAVE_VMC, entitaDellaVmc, letturaVmc, vmcDisegnabili, vmcParla } from "../core/vmc-model.js";
@@ -3806,19 +3805,27 @@ function allerteModel(states) {
  * cosa: e' la risposta alla domanda della sera. Si accende il giorno prima e
  * il giorno stesso, che sono i due momenti in cui serve vederla. */
 function rifiutiModel(states) {
-  const config = readJson(CHIAVE_RIFIUTI, {});
-  if (!rifiutiConfigurati(config)) return null;
-  /* L'interruttore «Nel widget» toglie le entita' una per una, e se le hanno
-   * spente tutte la tessera non ha piu' niente da dire.
+  const grezza = readJson(CHIAVE_RIFIUTI, {});
+  /* L'interruttore «Nel widget» toglie le entita' una per una: quello che ha
+   * spento non deve entrare nella tessera. Si toglie DAL MODELLO, non dal solo
+   * cancello — leggere tutto e poi limitarsi a non aprire la tessera lasciava
+   * le righe escluse dentro il valore, la didascalia e l'elenco ogni volta che
+   * un'altra entita' bastava a farla aprire.
    *
-   * Il turno scritto a mano (#366) pero' non e' un'entita': e' il foglietto sul
-   * frigo, e non ha nessun interruttore da spegnere. Contarlo per zero voleva
-   * dire che chi configurava SOLO le due settimane — cioe' esattamente chi quel
-   * turno l'ha chiesto, perche' un calendario in Home Assistant non ce l'ha —
-   * si ritrovava la sezione piena e in Home nessuna tessera. */
+   * Cosi' la domanda torna a essere una sola, la stessa della sezione: quello
+   * che resta dice qualcosa? Il turno scritto a mano (#366) risponde di si'
+   * anche da solo, ed e' il punto — non e' un'entita', e' il foglietto sul
+   * frigo, e di interruttori da spegnere non ne ha. Contarlo per zero voleva
+   * dire che chi configurava SOLO le due settimane si ritrovava la sezione
+   * piena e in Home nessuna tessera. */
   const fuori = widgetExcludedEntities();
-  const daUnEntita = entitaDeiRifiuti(config).some((entity) => widgetIncludes(entity, fuori));
-  if (!daUnEntita && !turnoConfigurato(config?.turno)) return null;
+  const dato = normalizzaRifiuti(grezza);
+  const config = {
+    ...dato,
+    righe: dato.righe.filter((riga) => widgetIncludes(riga.entity, fuori)),
+    calendario: widgetIncludes(dato.calendario, fuori) ? dato.calendario : "",
+  };
+  if (!rifiutiConfigurati(config)) return null;
   const lettura = letturaRifiuti(config, states, root.resolveEntity || ((value) => value));
   const dalCalendario =
     lettura.calendario && lettura.calendario.giorni !== null && lettura.calendario.giorni >= 0

--- a/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/home-widgets-section.js
@@ -142,6 +142,7 @@ import {
   entitaDeiRifiuti,
   letturaRifiuti,
   rifiutiConfigurati,
+  turnoConfigurato,
 } from "../core/rifiuti-model.js";
 import { nomeDellaRiga, parolaDelQuando } from "./rifiuti-section.js";
 import { CHIAVE_VMC, entitaDellaVmc, letturaVmc, vmcDisegnabili, vmcParla } from "../core/vmc-model.js";
@@ -3807,8 +3808,17 @@ function allerteModel(states) {
 function rifiutiModel(states) {
   const config = readJson(CHIAVE_RIFIUTI, {});
   if (!rifiutiConfigurati(config)) return null;
+  /* L'interruttore «Nel widget» toglie le entita' una per una, e se le hanno
+   * spente tutte la tessera non ha piu' niente da dire.
+   *
+   * Il turno scritto a mano (#366) pero' non e' un'entita': e' il foglietto sul
+   * frigo, e non ha nessun interruttore da spegnere. Contarlo per zero voleva
+   * dire che chi configurava SOLO le due settimane — cioe' esattamente chi quel
+   * turno l'ha chiesto, perche' un calendario in Home Assistant non ce l'ha —
+   * si ritrovava la sezione piena e in Home nessuna tessera. */
   const fuori = widgetExcludedEntities();
-  if (!entitaDeiRifiuti(config).some((entity) => widgetIncludes(entity, fuori))) return null;
+  const daUnEntita = entitaDeiRifiuti(config).some((entity) => widgetIncludes(entity, fuori));
+  if (!daUnEntita && !turnoConfigurato(config?.turno)) return null;
   const lettura = letturaRifiuti(config, states, root.resolveEntity || ((value) => value));
   const dalCalendario =
     lettura.calendario && lettura.calendario.giorni !== null && lettura.calendario.giorni >= 0

--- a/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/section-runtime.js
@@ -83,6 +83,7 @@ import { installStrisceDiLinguette } from "./le-strisce-di-linguette-section.js"
 import { installWeatherInMasthead } from "./weather-in-masthead-section.js";
 import { installShutterSceneSection } from "./shutter-scene-section.js";
 import { installClimatePowerSection } from "./climate-power-section.js";
+import { installVideoSiMuove } from "./telecamera-il-video-si-muove-section.js";
 import { installShutterSkySection } from "./shutter-sky-section.js";
 import { installShutterWindowSection } from "./shutter-window-section.js";
 import { installPoolIrrigationSceneSection } from "./pool-irrigation-scene-section.js";
@@ -938,6 +939,9 @@ export function installSectionRuntime() {
     // Il cielo si installa dopo chi disegna la finestra: ridefinisce solo le
     // variabili del fondo, e le trova gia' al loro posto.
     installClimatePowerSection();
+    /* L'HLS di una telecamera vale quando il video si muove davvero (#385):
+     * si avvolge la strada del guscio, che si accontentava dell'intestazione. */
+    installVideoSiMuove();
     installShutterSkySection();
     installPageMastheadSection();
     /* Il meteo si accoda al nome della casa nell'intestazione: si installa

--- a/custom_components/dashboardmodern/frontend/src/sections/telecamera-il-video-si-muove-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/telecamera-il-video-si-muove-section.js
@@ -32,22 +32,38 @@
  * strada dopo — che e' quello che avrebbe fatto se l'HLS avesse fallito
  * subito, perche' e' esattamente quello che e' successo.
  *
- * L'attesa e' corta apposta: il guscio ha gia' speso la sua — venticinque
- * secondi per chi dorme — ad aspettare l'intestazione. Da li' alle immagini,
- * su un flusso sano, passa meno di un secondo.
+ * L'attesa e' quella che AVANZA. Le strategie danno venticinque secondi a una
+ * telecamera che dorme, ma il guscio scioglie la promessa all'intestazione:
+ * se l'intestazione arriva al primo secondo, ventiquattro secondi di quel
+ * permesso non sono stati spesi, e sono esattamente il tempo che serve a
+ * un'Arlo per svegliarsi. Dare qui un'attesa fissa e corta avrebbe buttato via
+ * il flusso proprio delle telecamere per cui il permesso lungo era stato
+ * scritto: si conta quanto ci ha messo il guscio e si guarda per il resto.
+ *
+ * E chi ha un fotogramma fermo sullo schermo non e' un guasto. Un video che il
+ * browser non lascia partire da solo — l'autoplay negato — mostra la prima
+ * immagine e aspetta un tocco: li' c'e' qualcosa da vedere, e scendere alle
+ * istantanee lo peggiorerebbe. Si distingue dal fermo vero per una cosa sola:
+ * quello e' in pausa apposta, l'altro sta andando e non va avanti.
  */
 import { doc, root, t } from "./shared.js";
 
 const KEY = "__DASHBOARDMODERN_VIDEO_SI_MUOVE__";
 const state = (root[KEY] ||= { installed: false });
 
-/** Quanto si aspetta che il tempo del video parta, e ogni quanto lo si guarda. */
-export const ATTESA_FOTOGRAMMI = 6000;
+/* Quanto si guarda, e ogni quanto.
+ *
+ * `MINIMA` e' il fondo: anche quando del permesso non avanza niente, un flusso
+ * sano parte in meno di un secondo e merita di essere guardato. `SENZA_DETTO`
+ * e' quella del guscio quando nessuno gliene passa una — la usa `dmAttivaAudio`,
+ * che chiama la strada HLS senza attesa. */
+export const ATTESA_MINIMA = 4000;
+export const ATTESA_SENZA_DETTO = 10_000;
 export const PASSO_FOTOGRAMMI = 400;
 
-/* `readyState` di HTMLMediaElement: da 3 in su il browser dichiara di avere
- * abbastanza per andare avanti, e quello e' un si' senza aspettare. */
-const ABBASTANZA_PER_ANDARE = 3;
+/* `readyState` di HTMLMediaElement: da 2 (HAVE_CURRENT_DATA) in su il browser
+ * ha i dati della posizione corrente, cioe' un'immagine da disegnare. */
+const UN_FOTOGRAMMA = 2;
 
 /**
  * Se fra due letture il tempo del video e' andato avanti.
@@ -68,6 +84,30 @@ function tempoDi(video) {
   return Number.isFinite(letto) ? letto : Number.NaN;
 }
 
+/* Se quel video e' ancora quello che si sta guardando.
+ *
+ * Chi chiude il popup, o apre un'altra telecamera, si porta via l'elemento: da
+ * li' in poi il tempo non si muove piu' per forza di cose, e continuare a
+ * giudicarlo vorrebbe dire sollevare un errore su una cosa che non c'e'. Il
+ * guscio prenderebbe quell'errore per un HLS fallito e proverebbe la strada
+ * dopo — scrivendo dentro un popup che nel frattempo e' di qualcun altro. */
+function eAncoraSuo(video) {
+  if (video?.isConnected === false) return false;
+  const adesso = doc?.getElementById?.("cam-hls");
+  return !adesso || adesso === video;
+}
+
+/**
+ * Un fotogramma fermo, mostrato apposta.
+ *
+ * L'autoplay negato lascia la prima immagine sullo schermo e aspetta un tocco:
+ * il tempo non va avanti, ma qualcosa da vedere c'e'. Si riconosce perche' e'
+ * in PAUSA: un flusso che si e' piantato sta andando, e non va avanti.
+ */
+export function ceUnaFotoFerma(video) {
+  return Boolean(video) && video.paused === true && Number(video.readyState) >= UN_FOTOGRAMMA;
+}
+
 /**
  * Aspetta che quel video si muova; se non si muove, solleva.
  *
@@ -75,22 +115,24 @@ function tempoDi(video) {
  * ha funzionato, una riga per strada: dice cosa e' successo, non «errore».
  */
 export async function aspettaCheSiMuova(video, opzioni = {}) {
-  const attesa = Number(opzioni.attesa) > 0 ? Number(opzioni.attesa) : ATTESA_FOTOGRAMMI;
+  const attesa = Number(opzioni.attesa) > 0 ? Number(opzioni.attesa) : ATTESA_SENZA_DETTO;
   const passo = Number(opzioni.passo) > 0 ? Number(opzioni.passo) : PASSO_FOTOGRAMMI;
   const dormi =
     opzioni.dormi || ((ms) => new Promise((risolvi) => root.setTimeout?.(risolvi, ms) || risolvi()));
   /* Nessun elemento vuol dire che non e' questa la strada che ha disegnato:
    * non si inventa un fallimento su una cosa che non si sta guardando. */
   if (!video) return true;
-  if (Number(video.readyState) >= ABBASTANZA_PER_ANDARE) return true;
   let prima = tempoDi(video);
   for (let speso = 0; speso < attesa; speso += passo) {
     await dormi(passo);
-    if (Number(video.readyState) >= ABBASTANZA_PER_ANDARE) return true;
+    if (!eAncoraSuo(video)) return true;
     const adesso = tempoDi(video);
     if (siEMosso(prima, adesso)) return true;
     if (Number.isFinite(adesso)) prima = adesso;
   }
+  /* Finito il tempo senza un passo avanti: se un'immagine c'e' e sta ferma
+   * apposta, si tiene — e' piu' di quanto darebbero le istantanee. */
+  if (ceUnaFotoFerma(video)) return true;
   /* I secondi si accodano fuori dalla frase: dentro sarebbero parte della
    * chiave da tradurre, e una frase con un numero incorporato non si traduce
    * — cambierebbe chiave a ogni attesa diversa. */
@@ -106,8 +148,13 @@ export function installVideoSiMuove() {
   const precedente = root.dmCamHLS;
   if (typeof precedente !== "function" || precedente.__dmVideoSiMuove) return false;
   async function avvolta(cam, content, attesa) {
+    const inizio = Date.now();
     const esito = await precedente.call(this, cam, content, attesa);
-    await aspettaCheSiMuova(doc?.getElementById("cam-hls"));
+    /* Quello che avanza del permesso di questa strada: il guscio ha sciolto la
+     * promessa all'intestazione, e quello che non ha speso serve qui. */
+    const concesso = Number(attesa) > 0 ? Number(attesa) : ATTESA_SENZA_DETTO;
+    const resto = Math.max(ATTESA_MINIMA, concesso - (Date.now() - inizio));
+    await aspettaCheSiMuova(doc?.getElementById("cam-hls"), { attesa: resto });
     return esito;
   }
   avvolta.__dmVideoSiMuove = true;

--- a/custom_components/dashboardmodern/frontend/src/sections/telecamera-il-video-si-muove-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/telecamera-il-video-si-muove-section.js
@@ -1,0 +1,120 @@
+/* L'HLS vale quando il video si muove davvero (#385).
+ *
+ * «Problema telecamere Arlo», con i registri del browser allegati. Dentro si
+ * legge la sequenza esatta:
+ *
+ *     [Cam] – WebRTC: senza-nome-di-flusso
+ *     [Cam] ✓ HLS
+ *     [HLS] { details: "bufferStalledError", buffer: 0.0027… }
+ *
+ * La plancia ha dichiarato riuscito l'HLS, e un istante dopo il video si e'
+ * fermato con due millesimi di secondo in pancia: cioe' non e' mai partito.
+ *
+ * La ragione sta nel guscio, che considera riuscita la strada al primo fra
+ * `loadedmetadata`, `canplay`, `loadeddata` e `playing`. Gli ultimi tre
+ * vogliono dire che c'e' un fotogramma; il primo no — `loadedmetadata` scatta
+ * appena si e' letta l'intestazione del flusso, quando di immagine non e'
+ * arrivato ancora niente. Su una telecamera che risponde subito i quattro
+ * eventi arrivano quasi insieme e la differenza non si vede. Su una che dorme
+ * in cloud — Arlo, Ring, Blink — l'intestazione arriva e le immagini no: la
+ * plancia toglieva la rotella, si fermava li' convinta di aver vinto, e
+ * lasciava un rettangolo fermo senza una parola.
+ *
+ * Il guaio vero non e' il rettangolo fermo: e' che dichiarando riuscita quella
+ * strada non si prova piu' nessun'altra. Sotto l'HLS ci sono il flusso del
+ * proxy e le istantanee, e le istantanee sono proprio la modalita' pensata per
+ * chi trasmette solo su richiesta. Una telecamera che avrebbe potuto farsi
+ * vedere a due fotogrammi al secondo non si vedeva affatto.
+ *
+ * Qui si guarda l'unica cosa che risponde alla domanda: il tempo del video va
+ * avanti? Se va avanti la strada e' buona e non cambia niente. Se non va
+ * avanti si solleva l'errore che il guscio si aspetta, e la catena scende alla
+ * strada dopo — che e' quello che avrebbe fatto se l'HLS avesse fallito
+ * subito, perche' e' esattamente quello che e' successo.
+ *
+ * L'attesa e' corta apposta: il guscio ha gia' speso la sua — venticinque
+ * secondi per chi dorme — ad aspettare l'intestazione. Da li' alle immagini,
+ * su un flusso sano, passa meno di un secondo.
+ */
+import { doc, root, t } from "./shared.js";
+
+const KEY = "__DASHBOARDMODERN_VIDEO_SI_MUOVE__";
+const state = (root[KEY] ||= { installed: false });
+
+/** Quanto si aspetta che il tempo del video parta, e ogni quanto lo si guarda. */
+export const ATTESA_FOTOGRAMMI = 6000;
+export const PASSO_FOTOGRAMMI = 400;
+
+/* `readyState` di HTMLMediaElement: da 3 in su il browser dichiara di avere
+ * abbastanza per andare avanti, e quello e' un si' senza aspettare. */
+const ABBASTANZA_PER_ANDARE = 3;
+
+/**
+ * Se fra due letture il tempo del video e' andato avanti.
+ *
+ * La soglia c'e' perche' un flusso dal vivo si posiziona sul bordo appena
+ * agganciato: `currentTime` diventa subito un numero grande senza che sia stato
+ * mostrato niente, quindi «maggiore di zero» non risponde alla domanda. Quello
+ * che risponde e' il MOVIMENTO fra due istanti.
+ */
+export function siEMosso(prima, dopo) {
+  if (!Number.isFinite(prima) || !Number.isFinite(dopo)) return false;
+  return dopo > prima + 0.05;
+}
+
+/** Il tempo del video adesso, o `NaN` se non c'e' niente da leggere. */
+function tempoDi(video) {
+  const letto = Number(video?.currentTime);
+  return Number.isFinite(letto) ? letto : Number.NaN;
+}
+
+/**
+ * Aspetta che quel video si muova; se non si muove, solleva.
+ *
+ * Il messaggio finisce nell'elenco che il guscio scrive quando nessuna strada
+ * ha funzionato, una riga per strada: dice cosa e' successo, non «errore».
+ */
+export async function aspettaCheSiMuova(video, opzioni = {}) {
+  const attesa = Number(opzioni.attesa) > 0 ? Number(opzioni.attesa) : ATTESA_FOTOGRAMMI;
+  const passo = Number(opzioni.passo) > 0 ? Number(opzioni.passo) : PASSO_FOTOGRAMMI;
+  const dormi =
+    opzioni.dormi || ((ms) => new Promise((risolvi) => root.setTimeout?.(risolvi, ms) || risolvi()));
+  /* Nessun elemento vuol dire che non e' questa la strada che ha disegnato:
+   * non si inventa un fallimento su una cosa che non si sta guardando. */
+  if (!video) return true;
+  if (Number(video.readyState) >= ABBASTANZA_PER_ANDARE) return true;
+  let prima = tempoDi(video);
+  for (let speso = 0; speso < attesa; speso += passo) {
+    await dormi(passo);
+    if (Number(video.readyState) >= ABBASTANZA_PER_ANDARE) return true;
+    const adesso = tempoDi(video);
+    if (siEMosso(prima, adesso)) return true;
+    if (Number.isFinite(adesso)) prima = adesso;
+  }
+  /* I secondi si accodano fuori dalla frase: dentro sarebbero parte della
+   * chiave da tradurre, e una frase con un numero incorporato non si traduce
+   * — cambierebbe chiave a ogni attesa diversa. */
+  const detto = t(
+    "HLS: l'intestazione arriva ma le immagini no",
+    "HLS: the header arrives but the pictures do not",
+  );
+  throw new Error(`${detto} (${Math.round(attesa / 1000)}s)`);
+}
+
+export function installVideoSiMuove() {
+  if (state.installed) return false;
+  const precedente = root.dmCamHLS;
+  if (typeof precedente !== "function" || precedente.__dmVideoSiMuove) return false;
+  async function avvolta(cam, content, attesa) {
+    const esito = await precedente.call(this, cam, content, attesa);
+    await aspettaCheSiMuova(doc?.getElementById("cam-hls"));
+    return esito;
+  }
+  avvolta.__dmVideoSiMuove = true;
+  avvolta.__dmPrevious = precedente;
+  root.dmCamHLS = avvolta;
+  state.installed = true;
+  return true;
+}
+
+installVideoSiMuove();

--- a/custom_components/dashboardmodern/frontend/tests/i18n-message-keys.js
+++ b/custom_components/dashboardmodern/frontend/tests/i18n-message-keys.js
@@ -1411,6 +1411,7 @@ export const MESSAGE_KEYS = Object.freeze([
   "HLS not available",
   "HLS not supported and hls.js missing",
   "HLS: skipped, hls.js not loaded",
+  "HLS: the header arrives but the pictures do not",
   "Hob",
   "Home",
   "Home (fallback)",

--- a/custom_components/dashboardmodern/frontend/tests/il-video-si-muove-davvero.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/il-video-si-muove-davvero.test.js
@@ -1,0 +1,90 @@
+/* «Problema telecamere Arlo» (#385).
+ *
+ * Nei registri allegati: `[Cam] ✓ HLS` e subito dopo uno stallo con due
+ * millesimi di secondo in pancia. La strada era stata dichiarata buona perche'
+ * era arrivata l'intestazione del flusso — `loadedmetadata`, il primo dei
+ * quattro eventi che il guscio accetta — e di immagini non ne era arrivata
+ * nessuna. Dichiarandola buona non si provava piu' niente altro: sotto c'erano
+ * il flusso del proxy e le istantanee, che sono proprio la modalita' fatta per
+ * le telecamere che trasmettono su richiesta.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  aspettaCheSiMuova,
+  siEMosso,
+} from "../src/sections/telecamera-il-video-si-muove-section.js";
+
+/* Un video finto: `readyState` e `currentTime` sono le due cose che si leggono. */
+function video(passi) {
+  const letture = [...passi];
+  return {
+    readyState: 1,
+    get currentTime() {
+      return letture.length > 1 ? letture.shift() : letture[0];
+    },
+  };
+}
+
+const subito = () => Promise.resolve();
+
+test("un flusso dal vivo si posiziona sul bordo: «maggiore di zero» non basta", () => {
+  /* Agganciato il flusso, `currentTime` diventa subito un numero grande senza
+   * che sia stato mostrato niente. La domanda e' se si MUOVE. */
+  assert.equal(siEMosso(12.5, 12.5), false);
+  assert.equal(siEMosso(0, 0), false);
+  assert.equal(siEMosso(12.5, 13.1), true);
+  /* Un tremolio da niente non e' partire. */
+  assert.equal(siEMosso(12.5, 12.52), false);
+  assert.equal(siEMosso(Number.NaN, 3), false);
+  assert.equal(siEMosso(3, Number.NaN), false);
+});
+
+test("il video che si muove passa, e non aspetta la fine dell'attesa", async () => {
+  const v = video([10, 10.4, 10.9]);
+  assert.equal(await aspettaCheSiMuova(v, { attesa: 4000, passo: 100, dormi: subito }), true);
+});
+
+test("il video che ha gia' abbastanza per andare passa subito", async () => {
+  const v = video([0]);
+  v.readyState = 3;
+  assert.equal(await aspettaCheSiMuova(v, { attesa: 4000, passo: 100, dormi: subito }), true);
+});
+
+test("il video fermo sul bordo solleva, e la catena scende alla strada dopo", async () => {
+  /* E' il caso della Arlo: l'intestazione c'e', il tempo sta fermo. */
+  const v = video([12.5]);
+  await assert.rejects(
+    () => aspettaCheSiMuova(v, { attesa: 800, passo: 100, dormi: subito }),
+    (errore) => {
+      /* Il messaggio finisce nell'elenco che il guscio scrive quando nessuna
+       * strada regge: deve dire cosa e' successo, non «errore». */
+      assert.match(errore.message, /HLS/);
+      assert.match(errore.message, /immagini|pictures/);
+      return true;
+    },
+  );
+});
+
+test("senza nessun video non si inventa un fallimento", async () => {
+  /* Se l'HLS non e' la strada che ha disegnato, non c'e' niente da giudicare. */
+  assert.equal(await aspettaCheSiMuova(null, { attesa: 400, passo: 100, dormi: subito }), true);
+});
+
+test("il guscio si avvolge una volta sola, e ricorda chi c'era prima", async () => {
+  const { readFileSync } = await import("node:fs");
+  const { dirname, join } = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+  const qui = dirname(fileURLToPath(import.meta.url));
+  const sorgente = readFileSync(
+    join(qui, "..", "src/sections/telecamera-il-video-si-muove-section.js"),
+    "utf8",
+  );
+  assert.match(sorgente, /precedente\.__dmVideoSiMuove/);
+  assert.match(sorgente, /avvolta\.__dmPrevious = precedente/);
+  /* Il guscio storico non si tocca: si avvolge la sua funzione. */
+  assert.match(sorgente, /root\.dmCamHLS = avvolta/);
+  const runtime = readFileSync(join(qui, "..", "src/sections/section-runtime.js"), "utf8");
+  assert.match(runtime, /installVideoSiMuove\(\);/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/il-video-si-muove-davvero.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/il-video-si-muove-davvero.test.js
@@ -12,7 +12,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  ATTESA_MINIMA,
   aspettaCheSiMuova,
+  ceUnaFotoFerma,
   siEMosso,
 } from "../src/sections/telecamera-il-video-si-muove-section.js";
 
@@ -21,6 +23,7 @@ function video(passi) {
   const letture = [...passi];
   return {
     readyState: 1,
+    paused: false,
     get currentTime() {
       return letture.length > 1 ? letture.shift() : letture[0];
     },
@@ -46,10 +49,34 @@ test("il video che si muove passa, e non aspetta la fine dell'attesa", async () 
   assert.equal(await aspettaCheSiMuova(v, { attesa: 4000, passo: 100, dormi: subito }), true);
 });
 
-test("il video che ha gia' abbastanza per andare passa subito", async () => {
-  const v = video([0]);
+test("un fotogramma fermo mostrato apposta non e' un guasto", async () => {
+  /* L'autoplay negato lascia la prima immagine sullo schermo e aspetta un
+   * tocco: il tempo non va avanti, ma qualcosa da vedere c'e', e scendere alle
+   * istantanee lo peggiorerebbe. Si riconosce dalla pausa. */
+  const v = video([12.5]);
+  v.paused = true;
+  v.readyState = 2;
+  assert.equal(ceUnaFotoFerma(v), true);
+  assert.equal(await aspettaCheSiMuova(v, { attesa: 600, passo: 100, dormi: subito }), true);
+});
+
+test("un flusso che sta andando e non va avanti non e' un fotogramma fermo", async () => {
+  /* E' il piantato vero: non e' in pausa, sta andando — e non si muove. */
+  const v = video([12.5]);
+  v.paused = false;
   v.readyState = 3;
-  assert.equal(await aspettaCheSiMuova(v, { attesa: 4000, passo: 100, dormi: subito }), true);
+  assert.equal(ceUnaFotoFerma(v), false);
+  await assert.rejects(() => aspettaCheSiMuova(v, { attesa: 600, passo: 100, dormi: subito }));
+});
+
+test("il popup chiuso ferma il giudizio invece di sollevare", async () => {
+  /* Chi chiude, o apre un'altra telecamera, si porta via l'elemento: da li' il
+   * tempo non si muove per forza di cose. Sollevare vorrebbe dire far provare
+   * al guscio la strada dopo, che scriverebbe dentro un popup di qualcun
+   * altro. */
+  const v = video([12.5]);
+  v.isConnected = false;
+  assert.equal(await aspettaCheSiMuova(v, { attesa: 600, passo: 100, dormi: subito }), true);
 });
 
 test("il video fermo sul bordo solleva, e la catena scende alla strada dopo", async () => {
@@ -65,6 +92,26 @@ test("il video fermo sul bordo solleva, e la catena scende alla strada dopo", as
       return true;
     },
   );
+});
+
+test("l'involucro guarda per il tempo che AVANZA del permesso", async () => {
+  /* Le strategie danno venticinque secondi a una telecamera che dorme, ma il
+   * guscio scioglie la promessa all'intestazione: quello che non ha speso
+   * serve qui, o si butterebbe via il flusso proprio delle telecamere per cui
+   * il permesso lungo era stato scritto. */
+  const { readFileSync } = await import("node:fs");
+  const { dirname, join } = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+  const qui = dirname(fileURLToPath(import.meta.url));
+  const sorgente = readFileSync(
+    join(qui, "..", "src/sections/telecamera-il-video-si-muove-section.js"),
+    "utf8",
+  );
+  assert.match(sorgente, /const resto = Math\.max\(ATTESA_MINIMA, concesso - \(Date\.now\(\) - inizio\)\)/);
+  assert.match(sorgente, /aspettaCheSiMuova\(doc\?\.getElementById\("cam-hls"\), \{ attesa: resto \}\)/);
+  /* E il fondo c'e': anche a permesso esaurito un flusso sano parte in meno di
+   * un secondo e merita di essere guardato. */
+  assert.ok(ATTESA_MINIMA >= 1000);
 });
 
 test("senza nessun video non si inventa un fallimento", async () => {

--- a/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/runtime-import-graph.test.js
@@ -932,8 +932,22 @@ test("production graph is single-owner, acyclic and contains no facade pass-thro
   // nelle mancanti non passavano piu' il cancello. Le loro tessere restavano
   // ferme sull'ultimo valore. Adesso l'elenco e' uno: la persistenza lo
   // ri-esporta com'era e al cancello lo passa chi lo installa.
+  // 288 con il video che deve muoversi davvero
+  // (`sections/telecamera-il-video-si-muove-section.js`, #385): «problema
+  // telecamere Arlo», coi registri allegati. Il guscio considera riuscita la
+  // strada HLS al primo fra `loadedmetadata`, `canplay`, `loadeddata` e
+  // `playing`; gli ultimi tre vogliono dire che c'e' un fotogramma, il primo
+  // no — scatta appena letta l'intestazione del flusso. Su una telecamera che
+  // dorme in cloud l'intestazione arriva e le immagini no, e la plancia
+  // toglieva la rotella dichiarando fatto: un rettangolo fermo, e nessuna
+  // delle strade sotto — il flusso del proxy, le istantanee — piu' tentata,
+  // proprio quelle fatte per chi trasmette su richiesta. Il modulo guarda se
+  // il tempo del video va avanti e, quando non va, solleva l'errore che il
+  // guscio si aspetta: la catena scende, come sarebbe scesa se l'HLS avesse
+  // fallito subito. Il guscio storico non si tocca: gli si avvolge la
+  // funzione.
   assert.ok(
-    relative.length <= 287,
+    relative.length <= 288,
     `production graph unexpectedly grew to ${relative.length} modules`,
   );
   assertAcyclic(edges);


### PR DESCRIPTION
La release 1.4.13 era stata fermata prima della pubblicazione. Queste sono le due correzioni chieste prima di farla ripartire.

## Corretto

| | |
|---|---|
| — | **La tessera dei rifiuti c'è anche con le sole due settimane scritte a mano.** Il calendario di casa (#366) non ha nessuna entità — è il foglietto sul frigo — ma il cancello della tessera in Home pretendeva almeno un'entità non esclusa dai widget. Con l'elenco vuoto non passava: sezione piena, Home vuota, per esattamente chi quel turno l'ha chiesto. È un difetto nato in questa stessa versione. |
| **#385** | **Telecamere Arlo: l'HLS vale quando il video si muove davvero.** Nei registri allegati alla segnalazione: `[Cam] ✓ HLS`, e un istante dopo lo stallo con 2,7 ms in pancia. La strada era dichiarata buona perché era arrivata l'*intestazione* del flusso (`loadedmetadata`, il primo dei quattro eventi che il guscio accetta) e di immagini non ne era arrivata nessuna. Dichiarandola buona non se ne provava più nessun'altra — e sotto ci sono il flusso del proxy e le istantanee, che sono la modalità fatta per chi trasmette su richiesta. |

Sul secondo, il criterio non è «`currentTime` maggiore di zero»: un flusso dal vivo si posiziona sul bordo appena agganciato e quel numero diventa grande senza che sia stato mostrato niente. È se **si muove** fra due istanti. Se si muove non cambia nulla; se non si muove si solleva l'errore che il guscio si aspetta e la catena scende alla strada dopo. Il guscio storico non si tocca: gli si avvolge la funzione.

## Le prove

- 2869 unit (node:test), 336 pytest, ruff pulito
- entrambe le correzioni verificate **al contrario**: tolta la correzione, il test fallisce
- e2e nuovo per la tessera dei rifiuti col solo turno; 34 e2e verdi su desktop e mobile, compresi i quattro che guidano il lettore delle telecamere (`telecamera-strade`, `il-webrtc-nativo-si-prova`, e i due delle telecamere in finestra)
- `check:i18n`, `check:guscio`, `check:moduli`, `format:check` verdi; la stringa nuova tradotta a mano nei tredici cataloghi

## Restano aperte

`#389` per la parte del layout compresso, `#383` e `#384` in attesa di un dato da chi le ha aperte. `#363` e la parte dei cicli di `#389` sono già chiuse dal lavoro che è dentro questa versione.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZHecyyyQUEKZ1bZKho4Xv

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZHecyyyQUEKZ1bZKho4Xv)_