### PR TITLE
Il gate del rilascio: la lente dell'avviso si ritira anche quando il guscio disegna dopo di noi

### DIFF
--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
 import "../src/sections/segnalazioni-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.15","dashboardVersion":"1.4.15","moduleVersion":14,"schemaVersion":4,"date":"2026-09-09T04:57:12+00:00","commit":"5a9d4af688a05eaae8a10b254f5653e26a9fc70a","assetHash":"04c891c5dd685807"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.15","dashboardVersion":"1.4.15","moduleVersion":14,"schemaVersion":4,"date":"2026-09-09T05:08:23+00:00","commit":"240c0147810a07482fdb689be2e43b0849432fe9","assetHash":"e4477357d17d8659"});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
 import "../src/sections/segnalazioni-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.15","dashboardVersion":"1.4.15","moduleVersion":14,"schemaVersion":4,"date":"2026-09-09T03:53:58+00:00","commit":"987b663e48a0b932c0916b437d51be3fc06f731b","assetHash":"e9508d37504fa4fc"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.15","dashboardVersion":"1.4.15","moduleVersion":14,"schemaVersion":4,"date":"2026-09-09T04:57:12+00:00","commit":"5a9d4af688a05eaae8a10b254f5653e26a9fc70a","assetHash":"04c891c5dd685807"});

--- a/custom_components/dashboardmodern/frontend/src/sections/beta11-real-device-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta11-real-device-polish-section.js
@@ -211,12 +211,18 @@ function vestiIlCampoAvviso(input) {
    * il campo mostrava la scritta «mdi:door-closed» a caratteri cubitali al
    * posto di una porta. L'emoji resta emoji. */
   const valore = clean(input.value) || "🔔";
-  const disegnata = /^mdi:/i.test(valore)
-    ? root.DashboardModernIconEngine?.markup?.("action", valore, { size: 34 }) || ""
-    : "";
-  if (disegnata) preview.innerHTML = disegnata;
-  else preview.textContent = valore;
-  preview.dataset.alertIcon = valore;
+  /* Si riscrive solo quando cambia. Riscriverla ogni volta vorrebbe dire
+   * cambiare il documento a ogni passata, e chi guarda il corpo dell'editor
+   * (vedi in fondo) rimetterebbe in coda la passata successiva: un giro che
+   * non finisce mai, sul fotogramma, cioe' la ventola accesa per niente. */
+  if (preview.dataset.alertIcon !== valore) {
+    const disegnata = /^mdi:/i.test(valore)
+      ? root.DashboardModernIconEngine?.markup?.("action", valore, { size: 34 }) || ""
+      : "";
+    if (disegnata) preview.innerHTML = disegnata;
+    else preview.textContent = valore;
+    preview.dataset.alertIcon = valore;
+  }
   if (input.dataset.dmBeta11Bound !== "true") {
     input.dataset.dmBeta11Bound = "true";
     input.addEventListener("input", decorateAlertIconField);
@@ -227,11 +233,20 @@ function vestiIlCampoAvviso(input) {
    * il proprio selettore: due menu per la stessa icona. L'anteprima e' il
    * menu; il tasto di prima si ritira, ma resta marcato cosi' un click
    * arrivato prima di questa vestizione finisce comunque sul catalogo. */
-  row.querySelectorAll(".dm-beta5-alert-icon-trigger").forEach((button) => {
-    button.dataset.dmBeta11AlertPicker = "true";
-    button.hidden = true;
-  });
+  ritiraLeLenti();
   return true;
+}
+
+/* Le lenti si ritirano tutte, ovunque stiano nel corpo dell'editor.
+ *
+ * Guardarle solo dentro la riga della casella voleva dire fidarsi di dove
+ * l'editor storico le mette, che non e' una cosa su cui questo modulo abbia
+ * voce. Sono un pugno di nodi: si guardano tutti. */
+function ritiraLeLenti() {
+  for (const button of doc?.querySelectorAll?.("#ed-body .dm-beta5-alert-icon-trigger") || []) {
+    if (button.dataset.dmBeta11AlertPicker !== "true") button.dataset.dmBeta11AlertPicker = "true";
+    if (!button.hidden) button.hidden = true;
+  }
 }
 
 /* Gli avvisi vivono in fondo alla scheda dei widget: quello che conta e' che
@@ -344,8 +359,29 @@ function install() {
       true,
     );
     root.addEventListener?.("dashboardmodern:legacy-ready", schedule);
+    guardaIlCorpoDellEditor();
   }
   schedule();
+}
+
+/* Il corpo dell'editor si riscrive anche quando non lo dice a nessuno.
+ *
+ * Il click e il cambio arrivano PRIMA che il guscio disegni: si vestiva quello
+ * che c'era in quel fotogramma, e la lente comparsa subito dopo restava com'era
+ * — nascosta dal foglio, perche' la riga la classe ce l'aveva gia', ma non
+ * ritirata. Su un iPad sotto carico e' successo davvero, e a intermittenza:
+ * dipende da chi arriva prima fra il nostro fotogramma e il disegno del guscio.
+ *
+ * Non e' un sorvegliante che gira a vuoto: dorme finche' l'editor non cambia,
+ * e quando cambia rimette in coda la stessa vestizione di sempre, che e'
+ * idempotente. Si guarda solo la struttura, non gli attributi, cosi' quello che
+ * scriviamo noi non ci risveglia. */
+function guardaIlCorpoDellEditor() {
+  const Osservatore = root.MutationObserver;
+  const modale = doc?.getElementById?.("editor-modal");
+  if (typeof Osservatore !== "function" || !modale) return false;
+  new Osservatore(schedule).observe(modale, { childList: true, subtree: true });
+  return true;
 }
 
 if (doc?.readyState === "loading") {

--- a/custom_components/dashboardmodern/frontend/src/sections/beta11-real-device-polish-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/beta11-real-device-polish-section.js
@@ -233,17 +233,28 @@ function vestiIlCampoAvviso(input) {
    * il proprio selettore: due menu per la stessa icona. L'anteprima e' il
    * menu; il tasto di prima si ritira, ma resta marcato cosi' un click
    * arrivato prima di questa vestizione finisce comunque sul catalogo. */
-  ritiraLeLenti();
+  ritiraLeLenti(row, preview);
   return true;
 }
 
-/* Le lenti si ritirano tutte, ovunque stiano nel corpo dell'editor.
+/* Si ritira ogni tasto della riga che non sia la nostra anteprima.
  *
- * Guardarle solo dentro la riga della casella voleva dire fidarsi di dove
- * l'editor storico le mette, che non e' una cosa su cui questo modulo abbia
- * voce. Sono un pugno di nodi: si guardano tutti. */
-function ritiraLeLenti() {
-  for (const button of doc?.querySelectorAll?.("#ed-body .dm-beta5-alert-icon-trigger") || []) {
+ * Prima si cercava la classe `dm-beta5-alert-icon-trigger`, e quella non e'
+ * nostra: gliela mette la rifinitura da telefono, con un classList.add in una
+ * sua passata. Quale delle due passate arrivi prima dipende dal carico — su un
+ * iPad con sette prove in parallelo arrivava prima la nostra — e allora qui non
+ * c'era ancora nessuna classe da riconoscere: la lente restava nascosta dal
+ * foglio ma non ritirata. E' lo stato a intermittenza che ha fermato il
+ * rilascio due volte.
+ *
+ * Aspettare l'altro modulo vorrebbe dire un orecchio o un secondo giro, e
+ * questo modulo non ne vuole — e' scritto nella sua prova. Ma non serve: quale
+ * sia la lente si sa senza chiedere niente a nessuno. Nella riga della casella
+ * i tasti sono due, l'anteprima e lei, e l'anteprima e' la nostra: tutto quello
+ * che non e' nostro, li' dentro, e' la lente di prima. */
+function ritiraLeLenti(row, preview) {
+  for (const button of row.querySelectorAll(":scope > button")) {
+    if (button === preview) continue;
     if (button.dataset.dmBeta11AlertPicker !== "true") button.dataset.dmBeta11AlertPicker = "true";
     if (!button.hidden) button.hidden = true;
   }
@@ -311,7 +322,8 @@ function installStyles() {
     #ed-body .dm-beta11-alert-icon-row>#ed-avv-icon{min-width:0!important;width:100%!important;grid-column:2!important}
     #ed-body .dm-beta11-alert-preview{overflow:hidden!important;word-break:break-all!important}
     #ed-body .dm-beta11-alert-preview svg{width:34px!important;height:34px!important;display:block!important}
-    #ed-body .dm-beta11-alert-icon-row>.dm-beta5-alert-icon-trigger{display:none!important}
+    #ed-body .dm-beta11-alert-icon-row>.dm-beta5-alert-icon-trigger,
+    #ed-body .dm-beta11-alert-icon-row>[data-dm-beta11-alert-picker="true"]{display:none!important}
     .dm-beta11-alert-dialog{width:min(720px,calc(100vw - 24px))!important;max-height:min(82vh,760px)!important;overflow:hidden!important}.dm-beta11-alert-search{padding:14px 16px 8px!important}.dm-beta11-alert-grid{display:grid!important;grid-template-columns:repeat(4,minmax(0,1fr))!important;gap:10px!important;padding:8px 16px 18px!important;max-height:60vh!important;overflow:auto!important}.dm-beta11-alert-option{display:grid!important;grid-template-rows:48px auto!important;place-items:center!important;gap:7px!important;min-height:94px!important;padding:10px 7px!important;border:1px solid var(--divider-color,#dbe4ee)!important;border-radius:16px!important;background:var(--card-background-color,#fff)!important;cursor:pointer!important}.dm-beta11-alert-option[hidden]{display:none!important}.dm-beta11-alert-glyph{font-size:31px!important}.dm-beta11-alert-option b{font-size:11px!important;text-align:center!important}
     @media(max-width:560px){html body #editor-modal #ed-body [data-ev-appearance] .dm-brand-preview[data-dm-beta11-ev-preview="true"]{grid-template-columns:92px minmax(0,1fr)!important;gap:9px!important;padding:10px!important}html body #editor-modal #ed-body [data-ev-appearance] .dm-brand-preview .dm-car-brand,html body #editor-modal #ed-body [data-ev-appearance] .dm-brand-preview .dm-leapmotor-mark{width:88px!important;max-width:88px!important;height:44px!important;max-height:44px!important}#ed-body .ed-row.dm-room-config-row.dm-beta11-room-row{grid-template-columns:56px minmax(0,1fr) 46px 46px!important;gap:8px!important;padding:11px 10px!important}.dm-beta11-alert-grid{grid-template-columns:repeat(3,minmax(0,1fr))!important}}
   `,
@@ -333,7 +345,9 @@ function install() {
          * la vestizione c'e' passata, non il permesso: se una lente e' li' e
          * qualcuno la preme, il menu da aprire e' uno solo comunque — quello
          * del catalogo — anche se la vestizione non l'ha ancora raggiunta. */
-        const trigger = event.target?.closest?.(".dm-beta5-alert-icon-trigger");
+        const trigger = event.target?.closest?.(
+          '.dm-beta5-alert-icon-trigger,[data-dm-beta11-alert-picker="true"]',
+        );
         if (trigger) {
           const input = trigger.closest(".dm-beta11-alert-icon-row")?.querySelector("#ed-avv-icon");
           if (input) {
@@ -359,29 +373,8 @@ function install() {
       true,
     );
     root.addEventListener?.("dashboardmodern:legacy-ready", schedule);
-    guardaIlCorpoDellEditor();
   }
   schedule();
-}
-
-/* Il corpo dell'editor si riscrive anche quando non lo dice a nessuno.
- *
- * Il click e il cambio arrivano PRIMA che il guscio disegni: si vestiva quello
- * che c'era in quel fotogramma, e la lente comparsa subito dopo restava com'era
- * — nascosta dal foglio, perche' la riga la classe ce l'aveva gia', ma non
- * ritirata. Su un iPad sotto carico e' successo davvero, e a intermittenza:
- * dipende da chi arriva prima fra il nostro fotogramma e il disegno del guscio.
- *
- * Non e' un sorvegliante che gira a vuoto: dorme finche' l'editor non cambia,
- * e quando cambia rimette in coda la stessa vestizione di sempre, che e'
- * idempotente. Si guarda solo la struttura, non gli attributi, cosi' quello che
- * scriviamo noi non ci risveglia. */
-function guardaIlCorpoDellEditor() {
-  const Osservatore = root.MutationObserver;
-  const modale = doc?.getElementById?.("editor-modal");
-  if (typeof Osservatore !== "function" || !modale) return false;
-  new Osservatore(schedule).observe(modale, { childList: true, subtree: true });
-  return true;
 }
 
 if (doc?.readyState === "loading") {

--- a/custom_components/dashboardmodern/frontend/tests/beta11-real-device-polish.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta11-real-device-polish.test.js
@@ -81,9 +81,12 @@ test("l'icona degli avvisi ha un menu solo: l'anteprima", async () => {
   const source = await readFile(polishUrl, "utf8");
   assert.match(source, /button\.hidden = true/);
   assert.doesNotMatch(source, /button\.textContent = "🎨"/);
+  /* Nascosta per la classe dell'altro modulo quando c'è, e per il nostro segno
+   * quando quella classe non è ancora arrivata. */
+  assert.match(source, /\.dm-beta11-alert-icon-row>\.dm-beta5-alert-icon-trigger,/);
   assert.match(
     source,
-    /\.dm-beta11-alert-icon-row>\.dm-beta5-alert-icon-trigger\{display:none!important\}/,
+    /\.dm-beta11-alert-icon-row>\[data-dm-beta11-alert-picker="true"\]\{display:none!important\}/,
   );
   assert.match(
     source,
@@ -158,33 +161,35 @@ test("di caselle avviso ce ne può essere più d'una, e si vestono tutte", async
   /* E il click si prende ogni lente, marcata o no: la marcatura dice che la
    * vestizione c'è passata, non se quel tasto può aprire il catalogo. Un menu
    * solo vale anche per la lente che la vestizione non ha ancora raggiunto. */
-  assert.match(source, /closest\?\.\("\.dm-beta5-alert-icon-trigger"\)/);
+  assert.match(source, /\.dm-beta5-alert-icon-trigger,\[data-dm-beta11-alert-picker="true"\]/);
 });
 
-/* Il corpo dell'editor si riscrive anche quando non lo dice a nessuno.
- *
- * Il click e il cambio arrivano PRIMA che il guscio disegni: si vestiva quello
- * che c'era in quel fotogramma, e la lente comparsa subito dopo restava com'era
- * — nascosta dal foglio, perché la riga la classe ce l'aveva già, ma non
- * ritirata. È il difetto che su iPad si è visto a intermittenza: dipende da chi
- * arriva prima fra il nostro fotogramma e il disegno del guscio, e per due
- * volte su tre arrivavamo prima noi.
- *
- * Adesso c'è un orecchio sul corpo dell'editor. E siccome la vestizione mette
- * mano al documento, l'orecchio potrebbe risvegliarla all'infinito: guarda solo
- * la struttura e non gli attributi, e l'anteprima si riscrive solo quando
- * cambia davvero. Un giro che si richiama da solo sul fotogramma è la ventola
- * accesa per niente — questo repository ne ha già inseguito uno.
- */
-test("un orecchio sul corpo dell'editor, e niente giri che si richiamano", async () => {
+test("la lente si riconosce da sola, senza aspettare un altro modulo", async () => {
+  /* La classe `dm-beta5-alert-icon-trigger` non è di questo modulo: gliela mette
+   * la rifinitura da telefono, con un classList.add in una sua passata.
+   * Cercarla voleva dire dipendere da quale delle due passate arriva prima —
+   * che dipende dal carico — e su un iPad con sette prove in parallelo
+   * arrivava prima la nostra: qui non c'era ancora nessuna classe da
+   * riconoscere, e la lente restava nascosta dal foglio ma non ritirata. È lo
+   * stato a intermittenza che ha fermato il rilascio della 1.4.15 due volte.
+   *
+   * Aspettare l'altro modulo vorrebbe dire un orecchio o un secondo giro, e
+   * questo modulo non ne vuole: è la prova qui sopra a dirlo. Ma non serve —
+   * nella riga della casella i tasti sono due, l'anteprima e la lente, e
+   * l'anteprima è la nostra.
+   */
   const source = await readFile(polishUrl, "utf8");
-  assert.match(source, /function guardaIlCorpoDellEditor\(\)/);
-  assert.match(source, /guardaIlCorpoDellEditor\(\);/);
-  /* Solo la struttura: gli attributi li scriviamo noi, e non devono risvegliarci. */
-  assert.match(source, /\.observe\(modale, \{ childList: true, subtree: true \}\)/);
-  assert.doesNotMatch(source, /observe\([^)]*attributes: true/);
-  /* E l'anteprima si riscrive solo quando cambia. */
+  assert.match(source, /function ritiraLeLenti\(row, preview\)/);
+  assert.match(source, /row\.querySelectorAll\(":scope > button"\)/);
+  assert.match(source, /if \(button === preview\) continue;/);
+  /* E niente sorveglianti: questo modulo non ne ha, e la prova di sopra lo
+   * verifica — qui si guarda che non siano rientrati da una porta di servizio,
+   * cioè con un altro nome. */
+  assert.doesNotMatch(source, /MutationObserver/);
+  /* Il foglio nasconde per il NOSTRO segno, non per la classe di un altro. */
+  assert.match(source, /\[data-dm-beta11-alert-picker="true"\]\{display:none!important\}/);
+  /* E il click si prende la lente anche prima che l'altro modulo la battezzi. */
+  assert.match(source, /\.dm-beta5-alert-icon-trigger,\[data-dm-beta11-alert-picker="true"\]/);
+  /* L'anteprima si riscrive solo quando cambia: meno lavoro a ogni passata. */
   assert.match(source, /if \(preview\.dataset\.alertIcon !== valore\) \{/);
-  /* Le lenti si ritirano tutte, ovunque stiano nel corpo dell'editor. */
-  assert.match(source, /"#ed-body \.dm-beta5-alert-icon-trigger"/);
 });

--- a/custom_components/dashboardmodern/frontend/tests/beta11-real-device-polish.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/beta11-real-device-polish.test.js
@@ -160,3 +160,31 @@ test("di caselle avviso ce ne può essere più d'una, e si vestono tutte", async
    * solo vale anche per la lente che la vestizione non ha ancora raggiunto. */
   assert.match(source, /closest\?\.\("\.dm-beta5-alert-icon-trigger"\)/);
 });
+
+/* Il corpo dell'editor si riscrive anche quando non lo dice a nessuno.
+ *
+ * Il click e il cambio arrivano PRIMA che il guscio disegni: si vestiva quello
+ * che c'era in quel fotogramma, e la lente comparsa subito dopo restava com'era
+ * — nascosta dal foglio, perché la riga la classe ce l'aveva già, ma non
+ * ritirata. È il difetto che su iPad si è visto a intermittenza: dipende da chi
+ * arriva prima fra il nostro fotogramma e il disegno del guscio, e per due
+ * volte su tre arrivavamo prima noi.
+ *
+ * Adesso c'è un orecchio sul corpo dell'editor. E siccome la vestizione mette
+ * mano al documento, l'orecchio potrebbe risvegliarla all'infinito: guarda solo
+ * la struttura e non gli attributi, e l'anteprima si riscrive solo quando
+ * cambia davvero. Un giro che si richiama da solo sul fotogramma è la ventola
+ * accesa per niente — questo repository ne ha già inseguito uno.
+ */
+test("un orecchio sul corpo dell'editor, e niente giri che si richiamano", async () => {
+  const source = await readFile(polishUrl, "utf8");
+  assert.match(source, /function guardaIlCorpoDellEditor\(\)/);
+  assert.match(source, /guardaIlCorpoDellEditor\(\);/);
+  /* Solo la struttura: gli attributi li scriviamo noi, e non devono risvegliarci. */
+  assert.match(source, /\.observe\(modale, \{ childList: true, subtree: true \}\)/);
+  assert.doesNotMatch(source, /observe\([^)]*attributes: true/);
+  /* E l'anteprima si riscrive solo quando cambia. */
+  assert.match(source, /if \(preview\.dataset\.alertIcon !== valore\) \{/);
+  /* Le lenti si ritirano tutte, ovunque stiano nel corpo dell'editor. */
+  assert.match(source, /"#ed-body \.dm-beta5-alert-icon-trigger"/);
+});


### PR DESCRIPTION
Il gate del rilascio della 1.4.15 è caduto su **webkit-ipad 1/3**, e «Publish release» è stato saltato: la release non è uscita. Il punto è sempre lo stesso — `beta11-real-device-polish.spec.js:174`, l'ultima lente dell'avviso nascosta ma non marcata.

## Il difetto

Il modulo cercava la lente per la classe `dm-beta5-alert-icon-trigger`. Quella classe non è nostra: gliela mette la rifinitura da telefono, con un `classList.add` in una sua passata. Cercarla voleva dire dipendere da quale delle due passate arriva prima — e quello dipende dal carico. Su un iPad con sette shard in parallelo arrivava prima la nostra: qui non c'era ancora nessuna classe da riconoscere, e la lente restava nascosta dal foglio ma non ritirata.

È esattamente quello che dice il log: `toBeHidden()` passa, `toHaveAttribute` no. Ed è lo stato a intermittenza che ha fermato il rilascio due volte — verde sul ramo `04e2f26`, rossa sul merge `5a9d4af`, stesso albero.

## La correzione

Niente attese e niente sorveglianti: **quale sia la lente si sa senza chiedere niente a nessuno**. Nella riga della casella i tasti sono due, l'anteprima e lei, e l'anteprima è la nostra. Si ritira tutto quello che non è nostro.

- `ritiraLeLenti(row, preview)` scorre i tasti figli della riga e ritira ogni tasto che non sia l'anteprima — marcandolo e nascondendolo. Non chiede più di che classe sia.
- Il foglio nasconde per il **nostro** segno (`[data-dm-beta11-alert-picker="true"]`), non solo per la classe dell'altro modulo, e l'intercettatore del click si prende la lente anche prima che l'altro modulo la battezzi: un click arrivato prima della vestizione finisce comunque sul catalogo.
- Le caselle `#ed-avv-icon` si vestono **tutte** (`querySelectorAll`), non la prima: dopo un ridisegno parziale l'editor storico può lasciarne in piedi due.
- L'anteprima si riscrive solo quando il valore cambia davvero.

## Prove

3069 del frontend (due nuove, che guardano anche che non rientri nessun sorvegliante da una porta di servizio), 342 di pytest, ruff, `format:check`, `check:i18n`, `check:guscio`, `check:moduli`, `check:inline-syntax`. In locale ho rigirato anche le e2e di `beta11`, `beta4` e `beta5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZHecyyyQUEKZ1bZKho4Xv