### PR TITLE
Due tetti di tempo sbagliati: quello del gate del rilascio, e quello di una prova su WebKit

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,9 +41,14 @@ jobs:
           - { project: desktop, shard: 2, shards: 2 }
           - { project: mobile, shard: 1, shards: 2 }
           - { project: mobile, shard: 2, shards: 2 }
-          - { project: webkit-ipad, shard: 1, shards: 3 }
-          - { project: webkit-ipad, shard: 2, shards: 3 }
-          - { project: webkit-ipad, shard: 3, shards: 3 }
+          # Quattro pezzi e non tre: WebKit e' il piu' lento, a tre sfiorava il
+          # tetto dei trenta minuti, e la suite cresce a ogni rilascio. Il tetto
+          # e' lo stesso del gate del rilascio (release.yml): se cambia uno,
+          # cambia l'altro, sennò una PR verde non basta a far uscire nulla.
+          - { project: webkit-ipad, shard: 1, shards: 4 }
+          - { project: webkit-ipad, shard: 2, shards: 4 }
+          - { project: webkit-ipad, shard: 3, shards: 4 }
+          - { project: webkit-ipad, shard: 4, shards: 4 }
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,14 +76,26 @@ jobs:
   # Same shape as the Browser E2E workflow, which is green on every commit that
   # reaches main: the browsers come with the image, so there is nothing to
   # install, and the three projects run in parallel instead of end to end.
+  # WebKit e' diviso in quattro e non in tre perche' e' il piu' lento dei tre
+  # browser: a tre pezzi ogni shard sfiorava il tetto, e la suite cresce a ogni
+  # rilascio. Sono le stesse prove, spartite piu' larghe — non una in meno.
   # Stessa divisione del giro normale: l'attesa e' quella del pezzo piu' lento,
   # non la somma. WebKit da solo teneva fermo il rilascio dodici minuti.
+  #
+  # Il tetto di tempo e' lo STESSO del giro normale (e2e.yml), e non per
+  # simmetria: qui era 25 minuti dove la' sono 30, e gli shard di WebKit ci
+  # stavano dentro per un pelo. Cresciuta la suite, la PR restava verde a
+  # ventisei minuti e qui i tre shard venivano troncati a venticinque — quindi
+  # «Publish release» si saltava e la 1.4.16 non usciva, senza che niente
+  # risultasse rosso. Un cancello piu' severo del controllo che autorizza il
+  # merge non protegge: rende solo impossibile rilasciare quello che e' stato
+  # approvato. Se uno dei due cambia, cambia l'altro.
   gate:
     name: Browser E2E release gate / ${{ matrix.project }} ${{ matrix.shard }}/${{ matrix.shards }}
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.54.1-noble
-    timeout-minutes: 25
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       max-parallel: 7
@@ -93,9 +105,10 @@ jobs:
           - { project: desktop, shard: 2, shards: 2 }
           - { project: mobile, shard: 1, shards: 2 }
           - { project: mobile, shard: 2, shards: 2 }
-          - { project: webkit-ipad, shard: 1, shards: 3 }
-          - { project: webkit-ipad, shard: 2, shards: 3 }
-          - { project: webkit-ipad, shard: 3, shards: 3 }
+          - { project: webkit-ipad, shard: 1, shards: 4 }
+          - { project: webkit-ipad, shard: 2, shards: 4 }
+          - { project: webkit-ipad, shard: 3, shards: 4 }
+          - { project: webkit-ipad, shard: 4, shards: 4 }
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/custom_components/dashboardmodern/frontend/tests/i-due-giri-hanno-lo-stesso-tetto.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/i-due-giri-hanno-lo-stesso-tetto.test.js
@@ -1,0 +1,100 @@
+/* Le stesse prove, girate due volte, devono avere lo stesso tetto di tempo.
+ *
+ * La 1.4.16 non e' uscita, e niente era rosso. Il cancello del rilascio
+ * (`release.yml`) dava venticinque minuti per shard dove il giro che autorizza
+ * il merge (`e2e.yml`) ne dava trenta: gli stessi test, due budget diversi.
+ * Cresciuta la suite, gli shard di WebKit stavano dentro i trenta e venivano
+ * troncati ai venticinque — «cancelled» e non «failure», quindi «Publish
+ * release» si saltava in silenzio. Un cancello piu' severo del controllo che
+ * autorizza il merge non protegge niente: rende impossibile rilasciare quello
+ * che e' gia' stato approvato, e lo fa senza dirlo.
+ *
+ * Il perche' stava scritto in un commento accanto a tutti e due i numeri, e un
+ * commento non ferma nessuno. Qui i due numeri si guardano in faccia.
+ *
+ * E la stessa cosa vale per il tetto della singola prova: quello di serie e'
+ * trenta secondi per tutti e tre i browser, ma WebKit su iPad ci mette una
+ * volta e mezza gli altri. Chi se n'e' ricordato l'ha scritto a mano nel
+ * proprio file — novantacinque volte, in cinquantacinque file — e le prove che
+ * cadono sono esattamente quelle a cui nessuno l'ha scritto. Il pavimento sta
+ * dove il browser e' dichiarato, e qui si controlla che ci sia per ognuno.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const RADICE = join(dirname(fileURLToPath(import.meta.url)), "../../../..");
+
+const leggi = (percorso) => readFileSync(join(RADICE, percorso), "utf8");
+
+/* Il lavoro che gira le prove nel browser: e' quello nel contenitore di
+ * Playwright, in tutti e due i file. Gli altri lavori dello stesso file — la
+ * verifica, la pubblicazione — hanno un tetto loro e non c'entrano. */
+function lavoroDelBrowser(yaml) {
+  const pezzi = yaml.split(/\n(?= {2}[a-z][a-z0-9-]*:\n)/);
+  const trovato = pezzi.find((pezzo) => pezzo.includes("mcr.microsoft.com/playwright"));
+  assert.ok(trovato, "nessun lavoro gira le prove nel contenitore di Playwright");
+  return trovato;
+}
+
+const tetto = (pezzo) => Number(pezzo.match(/^\s*timeout-minutes:\s*(\d+)\s*$/m)?.[1]);
+
+const spartizione = (pezzo) =>
+  [...pezzo.matchAll(/-\s*\{\s*project:\s*([\w-]+),\s*shard:\s*(\d+),\s*shards:\s*(\d+)\s*\}/g)]
+    .map(([, progetto, pezzoNumero, quanti]) => `${progetto} ${pezzoNumero}/${quanti}`)
+    .sort();
+
+const GIRO = lavoroDelBrowser(leggi(".github/workflows/e2e.yml"));
+const CANCELLO = lavoroDelBrowser(leggi(".github/workflows/release.yml"));
+
+test("il cancello del rilascio da' lo stesso tempo del giro che autorizza il merge", () => {
+  assert.ok(Number.isInteger(tetto(GIRO)), "il giro normale non dichiara un tetto");
+  assert.equal(
+    tetto(CANCELLO),
+    tetto(GIRO),
+    "un tetto piu' stretto qui non protegge: tronca gli shard senza farli diventare rossi, " +
+      "e la release si salta in silenzio",
+  );
+});
+
+test("le prove si spartiscono allo stesso modo nei due giri", () => {
+  /* Se il rilascio spartisse WebKit in tre dove il giro normale lo spartisce in
+   * quattro, ogni pezzo del rilascio sarebbe piu' lungo di un terzo: lo stesso
+   * tetto tornerebbe a non bastare, e per la stessa ragione di prima. */
+  assert.deepEqual(spartizione(CANCELLO), spartizione(GIRO));
+});
+
+test("ogni browser dichiara il proprio tetto per prova, senza fidarsi di quello di serie", () => {
+  const config = leggi("playwright.config.js");
+  const dentroProgetti = config.slice(config.indexOf("projects: ["));
+  const nomi = [...dentroProgetti.matchAll(/name:\s*"([\w-]+)"/g)].map(([, nome]) => nome);
+  assert.deepEqual(nomi, ["desktop", "mobile", "webkit-ipad"]);
+
+  for (const nome of nomi) {
+    const inizio = dentroProgetti.indexOf(`name: "${nome}"`);
+    const fine = dentroProgetti.indexOf('name: "', inizio + 1);
+    const pezzo = dentroProgetti.slice(inizio, fine === -1 ? undefined : fine);
+    assert.match(
+      pezzo,
+      /timeout:\s*[\d_]+/,
+      `«${nome}» si affida ai trenta secondi di serie: e' il tranello in cui sono cadute ` +
+        "le prove lunghe che nessuno si e' ricordato di allungare a mano",
+    );
+  }
+
+  /* WebKit e' il piu' lento dei tre, e il suo tetto lo dice. */
+  const tempo = (nome) =>
+    Number(
+      dentroProgetti
+        .slice(dentroProgetti.indexOf(`name: "${nome}"`))
+        .match(/timeout:\s*([\d_]+)/)?.[1]
+        .replaceAll("_", ""),
+    );
+  assert.ok(
+    tempo("webkit-ipad") > tempo("desktop"),
+    "WebKit ci mette di piu' degli altri due: dargli lo stesso tempo vuol dire " +
+      "farlo cadere per primo",
+  );
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -23,10 +23,32 @@ export default defineConfig({
     port: 4173,
     reuseExistingServer: true,
   },
+  // Il tetto di tempo di una prova e' un fatto del browser, non della prova.
+  //
+  // Il valore di serie e' trenta secondi, e vale lo stesso per tutti e tre i
+  // progetti — ma WebKit su iPad, dentro un contenitore, ci mette circa una
+  // volta e mezza quello che ci mette Chromium. `phase6-functional` gira in
+  // diciotto secondi sul desktop: su WebKit sotto carico passa i trenta, e
+  // cade. Non resta appesa da nessuna parte — il tempo finisce mentre fa
+  // l'ultima cosa, e infatti cade in un punto diverso a ogni giro.
+  //
+  // Che il tetto di serie fosse stretto lo diceva gia' la suite da sola: in
+  // cinquantacinque file c'e' scritto a mano
+  // `setTimeout(project === "webkit-ipad" ? 120_000 : 75_000)`, novantacinque
+  // volte. E le prove che cadono sono esattamente quelle a cui nessuno si e'
+  // ricordato di scriverlo — `phase6-functional` sulla PR, `beta32-real-device-
+  // uniformity` su main. Una regola da ricordare a mano in ogni file nuovo non
+  // e' una regola: e' un tranello.
+  //
+  // Quindi il pavimento sta qui, dove il browser e' dichiarato. Quello scritto
+  // nelle singole prove resta, ed e' un'altra cosa: un permesso in piu' per i
+  // giri lunghi, sopra il pavimento, non il pavimento stesso. Nessuna prova
+  // perde tempo, perche' ogni valore scritto a mano e' gia' maggiore o uguale.
   projects: [
-    { name: "desktop", use: { viewport: { width: 1440, height: 900 } } },
+    { name: "desktop", timeout: 75_000, use: { viewport: { width: 1440, height: 900 } } },
     {
       name: "mobile",
+      timeout: 75_000,
       use: {
         browserName: "chromium",
         viewport: { width: 390, height: 844 },
@@ -35,6 +57,10 @@ export default defineConfig({
         deviceScaleFactor: 2,
       },
     },
-    { name: "webkit-ipad", use: { ...devices["iPad Pro 11"], browserName: "webkit" } },
+    {
+      name: "webkit-ipad",
+      timeout: 120_000,
+      use: { ...devices["iPad Pro 11"], browserName: "webkit" },
+    },
   ],
 });


### PR DESCRIPTION
La **1.4.16 non è uscita**, e non c'era niente di rosso. Cercando il perché è saltato fuori un secondo tetto sbagliato, della stessa famiglia.

## 1. Il cancello del rilascio era più severo del controllo che autorizza il merge

Il workflow Release è partito regolare col merge della #446, ha passato `Verify before releasing`, ha passato desktop e mobile del gate — e i **tre shard webkit-ipad sono stati troncati a 25 minuti**. `cancelled`, non `failure`. Con il gate incompleto, il job **`Publish release` è stato saltato**: nessun errore da nessuna parte, e nessuna release.

| | budget per shard | webkit sulla #446 |
|---|---|---|
| `e2e.yml` (il controllo che autorizza il merge) | **30 min** | 24,5 · 26,7 · 25,3 → verdi |
| `release.yml` (il gate del rilascio) | **25 min** | troncati |

Gli stessi test con due budget diversi. WebKit ci stava dentro per un pelo; cresciuta la suite con questo rilascio, ha passato il limite **solo dove il limite era più basso**.

Un cancello più severo del controllo che autorizza il merge non protegge niente: rende impossibile rilasciare quello che è già stato approvato, e lo fa in silenzio.

- **WebKit passa da tre pezzi a quattro**, in entrambi i giri. Sono le stesse prove spartite più larghe: ogni shard scende sotto i venti minuti, e resta margine per la suite che cresce a ogni rilascio.
- **Il tetto del gate va a 30**, uguale a quello del giro normale.

## 2. Il tetto di una prova è del browser, non della prova

Col quarto shard è caduta `phase6-functional` su `dashboard-en.html`: «Test timeout of 30000ms exceeded», tre tentativi su tre. Non restava appesa da nessuna parte — cadeva in un punto **diverso** a ogni giro, e nell'ultimo tentativo era già arrivata in fondo al giro lungo dell'editor. È il tempo che finisce, non qualcosa che si blocca.

Cronometrata: **18,0s** e **15,7s** su desktop, **19,5s** e **16,6s** su mobile, a macchina scarica. WebKit su iPad dentro un contenitore ci mette circa una volta e mezza tanto — nello stesso shard `weekly-analysis` ha impiegato 20,0s — e sotto carico i trenta secondi di serie non bastano più.

Che quel tetto fosse stretto lo diceva già la suite da sola: in **55 file** c'è scritto a mano `setTimeout(project === "webkit-ipad" ? 120_000 : 75_000)`, **95 volte**. E le prove che cadono sono esattamente quelle a cui nessuno si è ricordato di scriverlo — questa qui, e `beta32-real-device-uniformity`, che per la stessa ragione è rossa **anche su main**. Una regola da ricordare a mano in ogni file nuovo non è una regola: è un tranello.

Quindi il pavimento va dove il browser è dichiarato — `playwright.config.js`: 75s per desktop e mobile, 120s per WebKit, cioè i valori che la suite si era già scelta. Quello scritto nelle singole prove resta ed è un'altra cosa: un permesso in più per i giri lunghi, sopra il pavimento. **Nessuna prova perde tempo**, perché ogni valore scritto a mano è già maggiore o uguale.

## 3. E i numeri adesso si guardano in faccia

Il «se cambia uno, cambia l'altro» era solo un commento, e un commento non ferma nessuno. Una prova nuova controlla che il cancello del rilascio dia lo stesso tempo del giro che autorizza il merge, che WebKit sia spartito allo stesso modo nei due file, e che nessun browser si affidi ai trenta secondi di serie. Verificata contro tutti e tre i guasti che deve fermare, uno per volta.

## Cosa NON cambia

Nessuna prova viene toccata, spenta, saltata o resa più permissiva nel merito: cambiano solo i tempi concessi, e nessuno di questi tempi era una scelta — erano il valore di serie e una svista.

## Dopo il merge

Questo diff non tocca `manifest.json`, quindi il `push` su main **non** farà ripartire il Release da sé (il trigger guarda quel file). Il workflow ha `workflow_dispatch`: va lanciato a mano su main, che porta già `1.4.16` nel manifest, così `verify` risolve il tag `v1.4.16` e pubblica. Nessun tag forzato a mano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZHecyyyQUEKZ1bZKho4Xv