### PR TITLE
Versione 1.4.22: le icone tornano di casa, le telecamere in tempo, la predefinita anche dall'app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,81 @@
 Il formato segue [Keep a Changelog](https://keepachangelog.com/it/1.1.0/) e le
 versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
 
+## 1.4.22
+
+### Corretto
+
+- **Le icone delle stanze in Home: il disegno, mai il nome dell'icona**
+
+  «Icone stanze in home non si vedono.» Nella scheda della Home, sotto «Stanze
+  in plancia», sopra il nome di ogni stanza c'era scritto `mdi:sofa`,
+  `mdi:stove`, `mdi:shower`: il **nome** dell'icona, stampato come parola.
+  Quella riga il disegno non lo chiedeva a nessuno. La regola c'era già — sta
+  scritta da sempre sopra `writeIconGlyph`, «il token grezzo non si stampa mai
+  come testo» — ma valeva solo per chi disegna scrivendo dentro un nodo, e
+  mezza plancia disegna costruendo markup. Adesso la regola ha due facce e una
+  stanza sola, e i due posti delle stanze — la scheda e la card in Home, dove
+  il ripiego era la stessa parola — la usano tutt'e due.
+
+- **La barra sotto il meteo è tutta del catalogo di casa**
+
+  «Icone barra sotto al menu non sono del nostro catalogo, se non esistono
+  creale, e ovviamente vanno cambiate ovunque.» Quattro delle quattordici voci
+  un disegno non ce l'avevano — la posta, l'umidità, la pioggia di adesso e
+  quella di oggi — e cadevano sempre sull'emoji di ripiego, in fila accanto a
+  dieci oggetti disegnati. Adesso ci sono: la cassetta con la bandierina
+  alzata, il quadrante dell'igrometro, la nuvola con le gocce, il pluviometro.
+  E l'elenco nella configurazione, che le emoji le aveva scritte a mano tutte
+  quante, chiede il disegno allo stesso catalogo da cui lo chiedono le
+  pastiglie: una barra sola, una faccia sola. Stessa cosa per l'elenco dei
+  blocchi della Home, a cui mancava il sole dietro la nuvola dell'intestazione.
+
+- **La barra in basso rimette il disegno anche quando il guscio arriva tardi**
+
+  Le voci che aggiungono i moduli — Stanze, Luci, Prese, Robot, le telecamere,
+  le porte — nascono col simbolo scritto a mano da chi le crea, e a
+  rimpiazzarlo col disegno era un solo aggancio a una funzione del guscio. Se
+  al momento dell'installazione quella funzione non c'era ancora, l'aggancio
+  non si faceva e non si riprovava mai più: la barra restava con le emoji del
+  telefono. Adesso il disegno si rimette dove la barra si rifà — insieme al
+  filtro, che è la cosa che già succedeva al momento giusto — e gli agganci al
+  guscio si riprovano quando il guscio dichiara di esserci.
+
+- **Telecamere: il popup rispetta il tempo della strada, non uno suo**
+
+  «E ancora telecamere non funzionanti», col velo «Connessione WebRTC…» sopra
+  un fotogramma fermo. Il tempo del WebRTC nativo era scritto in due posti che
+  non si parlavano: il guscio lo chiede alla strategia — dieci secondi a una
+  telecamera di casa, venticinque a una in cloud che deve svegliarsi — e il
+  nostro negoziato ne teneva quindici, sempre, per chiunque. E contano tutt'e
+  due, perché il guscio aspetta che il negoziato torni prima di guardare il
+  proprio cronometro: a una telecamera di casa erano cinque secondi di velo in
+  più prima che la fila passasse alla strada dopo; a un'Arlo o a una Ring era
+  la trattativa interrotta dieci secondi prima della fine del tempo che le era
+  stato dato, cioè la strada buona tolta proprio a chi ne aveva bisogno.
+
+- **Plancia predefinita: l'errore sul telefono**
+
+  «Se imposto plancia predefinita da utente, da smartphone continua a dare
+  errore; da pc no.» Il pezzo che mancava era da quale apparecchio. La card
+  veniva pubblicata solo con `add_extra_js_url`, che la scrive nell'**avvio**
+  della pagina: l'app companion quell'avvio se lo tiene in cache a lungo, e un
+  avvio messo in cache prima che l'integrazione ci fosse non nomina il nostro
+  modulo — l'elemento non viene mai definito, e al suo posto Home Assistant
+  disegna «Errore di configurazione». Dal browser di un computer l'avvio si
+  richiede e basta, e lì il modulo c'è sempre. Adesso la card si pubblica
+  **anche** fra le risorse di Lovelace, che il frontend si fa dire dal socket a
+  ogni apertura della dashboard: una pagina in cache le chiede lo stesso.
+  (#372, #154, #499)
+
+### Difeso
+
+- Il modo chiosco dentro la card della plancia predefinita — che non è il
+  pannello: due ombre in mezzo, e la card che si ritaglia l'altezza sotto
+  l'intestazione. L'interruttore in ⚙️ Impostazioni la porta a tutto schermo
+  sopra l'intestazione di Lovelace, e la scelta regge il ricaricamento, che su
+  un computer è tutto quello che la tiene in piedi.
+
 ## 1.4.21
 
 ### Aggiunto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,10 @@ versioni seguono [Semantic Versioning](https://semver.org/lang/it/).
   richiede e basta, e lì il modulo c'è sempre. Adesso la card si pubblica
   **anche** fra le risorse di Lovelace, che il frontend si fa dire dal socket a
   ogni apertura della dashboard: una pagina in cache le chiede lo stesso.
-  (#372, #154, #499)
+  E quando a essere tolta è l'ultima plancia, la card si toglie da Lovelace:
+  quella riga sta sul disco, e senza toglierla chi disinstalla l'integrazione
+  si ritroverebbe ogni dashboard di casa a chiedere, a ogni apertura, un
+  modulo che non c'è più. (#372, #154, #499)
 
 ### Difeso
 

--- a/custom_components/dashboardmodern/__init__.py
+++ b/custom_components/dashboardmodern/__init__.py
@@ -152,15 +152,23 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     salvataggio delle opzioni, per dirne una — scarica e riavvia la stessa
     plancia, che si riprende l'avviso da se': svegliare anche le altre sarebbe
     lavoro per niente.
+
+    E quando a essere tolta e' l'ULTIMA, la card si toglie da Lovelace. La sua
+    riga fra le risorse sta sul disco: chi disinstalla l'integrazione, senza
+    questo, si ritroverebbe ogni dashboard di casa a chiedere a ogni apertura
+    un modulo che non c'e' piu'.
     """
-    if not _primary_entry(hass, entry):
-        return
     restanti = [
         candidata
         for candidata in hass.config_entries.async_entries(entry.domain)
         if candidata.entry_id != entry.entry_id
     ]
     if not restanti:
+        from .frontend import async_dimentica_la_card
+
+        await async_dimentica_la_card(hass)
+        return
+    if not _primary_entry(hass, entry):
         return
     erede = min(restanti, key=lambda candidata: candidata.entry_id)
     hass.config_entries.async_schedule_reload(erede.entry_id)

--- a/custom_components/dashboardmodern/frontend.py
+++ b/custom_components/dashboardmodern/frontend.py
@@ -369,6 +369,12 @@ async def _ensure_static_registered(
     domain_data[DATA_STATIC_REGISTERED] = static_url_path
 
 
+# Il percorso della card, senza la firma: e' quello che resta uguale fra un
+# aggiornamento e l'altro, ed e' con quello che la si riconosce fra le risorse
+# di Lovelace — dove la firma della riga scritta ieri non e' quella di oggi.
+PERCORSO_DELLA_CARD = f"{STATIC_URL_PATH}/dashboard-card.js"
+
+
 def _dashboard_card_module_url(asset_version: str) -> str:
     """L'indirizzo con cui il frontend carica la card, e perche' non e' versionato.
 
@@ -387,7 +393,7 @@ def _dashboard_card_module_url(asset_version: str) -> str:
     firma nuova e non riusa quella in cache. La card ricava da se' la sua base
     per il resto degli asset, quindi non le cambia niente.
     """
-    return f"{STATIC_URL_PATH}/dashboard-card.js?v={asset_version}"
+    return f"{PERCORSO_DELLA_CARD}?v={asset_version}"
 
 
 def _ensure_dashboard_card_registered(
@@ -472,6 +478,19 @@ def _risorse_di_lovelace(hass: HomeAssistant) -> Any:
     return risorse
 
 
+def _la_nostra_risorsa(voci: Any) -> dict[str, Any] | None:
+    """La riga della card fra le risorse di Lovelace, qualunque firma porti."""
+    return next(
+        (
+            voce
+            for voce in (voci or [])
+            if isinstance(voce, dict)
+            and str(voce.get("url") or "").split("?", 1)[0] == PERCORSO_DELLA_CARD
+        ),
+        None,
+    )
+
+
 async def _ensure_card_resource_registered(
     hass: HomeAssistant, module_url: str
 ) -> bool:
@@ -528,16 +547,7 @@ async def _ensure_card_resource_registered(
         if not getattr(risorse, "loaded", False):
             await risorse.async_load()
             risorse.loaded = True
-        senza_firma = module_url.split("?", 1)[0]
-        nostra = next(
-            (
-                voce
-                for voce in (elenca() or [])
-                if isinstance(voce, dict)
-                and str(voce.get("url") or "").split("?", 1)[0] == senza_firma
-            ),
-            None,
-        )
+        nostra = _la_nostra_risorsa(elenca())
         if nostra is None:
             await crea({"res_type": "module", "url": module_url})
             _LOGGER.info(
@@ -1073,6 +1083,61 @@ async def async_ripara_dashboard_compagna(hass: HomeAssistant, entry_id: str) ->
             exc_info=True,
         )
         return False
+
+
+async def async_dimentica_la_card(hass: HomeAssistant) -> bool:
+    """Toglie la card da Lovelace quando l'ultima plancia se ne va.
+
+    La risorsa di Lovelace sta sul DISCO, e non se ne va spegnendo
+    l'integrazione: chi toglie DashboardModern si ritroverebbe OGNI dashboard
+    di casa a chiedere, a ogni apertura, un modulo che non c'e' piu' — un 404
+    per volta — e una riga di troppo nell'elenco delle risorse, da cancellare a
+    mano sapendo che esiste. Il modulo scritto nell'avvio della pagina invece
+    vive in memoria e sparisce al riavvio; si toglie lo stesso, cosi' non resta
+    nemmeno fino a li'.
+
+    Si chiama quando la voce viene tolta DAVVERO e non ne resta nessun'altra.
+    Scaricare una plancia non e' toglierla: un riavvio di Home Assistant scarica
+    tutto, e una pulizia allo scarico vorrebbe dire ripubblicare la card a ogni
+    avvio come se fosse nuova.
+    """
+    tolta = False
+    domain_data: dict[str, Any] = hass.data.setdefault(DOMAIN, {})
+    module_url = domain_data.pop(DATA_DASHBOARD_CARD_REGISTERED, None)
+    if module_url:
+        try:
+            from homeassistant.components import frontend
+
+            frontend.remove_extra_js_url(hass, module_url)
+            tolta = True
+        except Exception:  # noqa: BLE001 - un modulo di troppo se ne va al riavvio
+            _LOGGER.debug("Non ho potuto togliere %s dai moduli extra", module_url)
+
+    risorse = _risorse_di_lovelace(hass)
+    elenca = getattr(risorse, "async_items", None)
+    cancella = getattr(risorse, "async_delete_item", None)
+    if risorse is None or elenca is None or cancella is None:
+        return tolta
+    try:
+        if not getattr(risorse, "loaded", False):
+            await risorse.async_load()
+            risorse.loaded = True
+        nostra = _la_nostra_risorsa(elenca())
+        if nostra is None:
+            return tolta
+        await cancella(nostra["id"])
+        _LOGGER.info(
+            "Ho tolto la card %s dalle risorse di Lovelace: non resta nessuna plancia",
+            nostra.get("url"),
+        )
+        return True
+    except Exception:  # noqa: BLE001 - una riga di troppo non rompe niente
+        _LOGGER.warning(
+            "Non sono riuscito a togliere la card dalle risorse di Lovelace: "
+            "la riga resta nell'elenco e va cancellata a mano",
+            exc_info=True,
+        )
+        return tolta
 
 
 async def async_unregister_frontend_entry(hass: HomeAssistant, entry_id: str) -> None:

--- a/custom_components/dashboardmodern/frontend.py
+++ b/custom_components/dashboardmodern/frontend.py
@@ -463,6 +463,107 @@ def _ensure_dashboard_card_registered(
     async_when_setup(hass, "frontend", _quando_frontend)
 
 
+def _risorse_di_lovelace(hass: HomeAssistant) -> Any:
+    """La collezione delle risorse di Lovelace, comunque Home Assistant la tenga."""
+    dati = hass.data.get("lovelace")
+    risorse = getattr(dati, "resources", None)
+    if risorse is None and isinstance(dati, dict):
+        risorse = dati.get("resources")
+    return risorse
+
+
+async def _ensure_card_resource_registered(
+    hass: HomeAssistant, module_url: str
+) -> bool:
+    """Pubblica la card ANCHE come risorsa di Lovelace, e non e' un doppione.
+
+    «Se imposto plancia predefinita da utente, da smartphone continua a dare
+    errore; da pc no.» E' la stessa segnalazione di sempre — «Errore di
+    configurazione» sulla plancia predefinita — con dentro la cosa che finora
+    mancava: da quale apparecchio.
+
+    Le due strade con cui un modulo del frontend arriva al browser non sono la
+    stessa cosa.
+
+    `add_extra_js_url` lo scrive nell'AVVIO della pagina: Home Assistant lo
+    stampa dentro l'index che serve al primo caricamento. L'app companion
+    quell'index se lo tiene in cache a lungo — e' il pezzo che le fa aprire la
+    plancia senza rete — quindi un index messo in cache PRIMA che questa
+    integrazione ci fosse non nomina il nostro modulo, e continuera' a non
+    nominarlo finche' la cache dura. Il browser del computer l'index lo richiede
+    e basta: li' il modulo c'e' sempre. E' esattamente la differenza fra «da
+    smartphone da' errore» e «da pc funziona», ed e' la ragione per cui la
+    stessa segnalazione torna da un anno pur essendo stata «corretta» piu'
+    volte: le correzioni di prima riguardavano la vista, il filtro e
+    l'indirizzo del modulo, cioe' tre cose vere che pero' non toccavano la
+    cache di quell'indice.
+    (#372, #154, #499)
+
+    Le RISORSE di Lovelace invece non stanno nell'index: il frontend se le fa
+    dire dal socket a ogni apertura della dashboard, e le importa allora. Una
+    pagina in cache le chiede lo stesso, perche' chiederle fa parte
+    dell'apertura della dashboard, non del caricamento della pagina.
+
+    Quindi si pubblica in tutt'e due i modi. Il modulo si definisce una volta
+    sola comunque — `dashboard-card.js` non ridichiara l'elemento se c'e'
+    gia' — percio' due strade non fanno due card: fanno due occasioni perche'
+    la card ci sia.
+
+    In modo YAML le risorse le scrive chi ha la casa, e la collezione non sa
+    creare: li' non si insiste, come per la dashboard di appoggio.
+    """
+    risorse = _risorse_di_lovelace(hass)
+    elenca = getattr(risorse, "async_items", None)
+    crea = getattr(risorse, "async_create_item", None)
+    if risorse is None or elenca is None or crea is None:
+        _LOGGER.debug(
+            "Le risorse di Lovelace non si possono scrivere (modo YAML?): la card "
+            "resta pubblicata solo nell'avvio della pagina"
+        )
+        return False
+    try:
+        # La collezione legge dal disco alla prima domanda, non alla nascita:
+        # guardare prima vorrebbe dire non trovare mai la nostra e riscriverla
+        # a ogni avvio.
+        if not getattr(risorse, "loaded", False):
+            await risorse.async_load()
+            risorse.loaded = True
+        senza_firma = module_url.split("?", 1)[0]
+        nostra = next(
+            (
+                voce
+                for voce in (elenca() or [])
+                if isinstance(voce, dict)
+                and str(voce.get("url") or "").split("?", 1)[0] == senza_firma
+            ),
+            None,
+        )
+        if nostra is None:
+            await crea({"res_type": "module", "url": module_url})
+            _LOGGER.info(
+                "Ho pubblicato la card %s fra le risorse di Lovelace", module_url
+            )
+            return True
+        if str(nostra.get("url") or "") == module_url:
+            return True
+        aggiorna = getattr(risorse, "async_update_item", None)
+        if aggiorna is None:
+            return False
+        # La firma cambia a ogni aggiornamento: si rimette in pari quella che
+        # c'e', invece di aggiungerne una seconda allo stesso percorso.
+        await aggiorna(nostra["id"], {"res_type": "module", "url": module_url})
+        return True
+    except Exception:  # noqa: BLE001 - una risorsa in meno non ferma la plancia
+        _LOGGER.warning(
+            "Non sono riuscito a pubblicare la card %s fra le risorse di Lovelace: "
+            "chi apre la plancia predefinita dall'app potrebbe vedere «Errore di "
+            "configurazione»",
+            module_url,
+            exc_info=True,
+        )
+        return False
+
+
 def _companion_view(entry: Any, config_profile: str, primary: bool) -> dict[str, Any]:
     """La vista della dashboard di appoggio: una sola card, la plancia intera.
 
@@ -926,7 +1027,13 @@ async def async_register_frontend(hass: HomeAssistant, entry_id: str) -> None:
     # finito, e subito se aveva gia' finito.
     from homeassistant.setup import async_when_setup
 
+    module_url = _dashboard_card_module_url(asset_version)
+
     async def _quando_lovelace(hass: HomeAssistant, _componente: str) -> None:
+        # Prima la card fra le risorse, poi la dashboard che la contiene: chi
+        # apre subito dopo trova tutt'e due, e in quest'ordine non c'e' un
+        # istante in cui la dashboard esiste e il suo elemento no.
+        await _ensure_card_resource_registered(hass, module_url)
         await _ensure_companion_dashboard(hass, entry_id)
 
     async_when_setup(hass, "lovelace", _quando_lovelace)

--- a/custom_components/dashboardmodern/frontend/e2e/il-chiosco-vale-anche-sulla-plancia-predefinita.spec.js
+++ b/custom_components/dashboardmodern/frontend/e2e/il-chiosco-vale-anche-sulla-plancia-predefinita.spec.js
@@ -1,0 +1,279 @@
+/* Il chiosco sulla plancia PREDEFINITA, che non è il pannello.
+ *
+ * «Se imposto plancia predefinita da utente, da smartphone continua a dare
+ *  errore; invece da pc non si apre in modalità kiosk.»
+ *
+ * Le due strade con cui si apre questa plancia hanno la stessa faccia e una
+ * topologia diversa. Dalla barra laterale si apre il PANNELLO: la cornice sta
+ * dentro l'ombra dell'elemento del pannello, che è figlio della vista di Home
+ * Assistant. Come dashboard predefinita si apre una dashboard Lovelace, e lì
+ * in mezzo c'è una CARD: l'ombra della card dentro l'ombra del contenitore
+ * della card, e la card si ritaglia da sé l'altezza sotto l'intestazione
+ * (`height: calc(100dvh - var(--header-height))`).
+ *
+ * Il chiosco scrive addosso all'elemento che ospita la cornice — quello che
+ * sta dall'altra parte della radice d'ombra — e libera gli antenati che
+ * inchioderebbero un `position: fixed`. Nel pannello quella catena è corta;
+ * nella card è più lunga e passa per due ombre, ed è l'unico posto dove
+ * questa plancia ci passa in mezzo.
+ *
+ * Questa prova rifà quella catena: intestazione, contenitore della card,
+ * card con la sua altezza ritagliata, cornice dentro. Il chiosco deve
+ * portarla a tutto schermo come fa col pannello — e sopra l'intestazione, che
+ * è la cosa che il chiosco viene a fare.
+ */
+import { expect, test } from "@playwright/test";
+
+const HOST_URL = "http://127.0.0.1:4173/dm-card-kiosk-host.html";
+const HEADER_HEIGHT = 56;
+
+const HOST_PAGE = `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  body{margin:0;background:#eef2f7}
+  /* L'intestazione di Lovelace: fissa, e con la sua sovrapposizione. */
+  .header{position:fixed;top:0;left:0;right:0;height:${HEADER_HEIGHT}px;z-index:4;background:#1976d2;color:#fff}
+  /* La vista: dove Lovelace mette la card, sotto l'intestazione. */
+  #view{position:relative;margin-top:${HEADER_HEIGHT}px;padding:4px}
+</style></head><body>
+<div class="header" id="ha-header">Home Assistant</div>
+<div id="view"><hui-card-mock id="carta"></hui-card-mock></div>
+<script type="module">
+/* Il contenitore della card: un'ombra in piu' fra la vista e la nostra card. */
+class HuiCardMock extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    const style = document.createElement("style");
+    style.textContent = ":host{display:block;height:100%;overflow:hidden}";
+    this.carta = document.createElement("dm-card");
+    shadow.append(style, this.carta);
+  }
+}
+customElements.define("hui-card-mock", HuiCardMock);
+
+/* La nostra card, con lo stesso foglio che scrive \`dashboard-card.js\`:
+   si ritaglia l'altezza sotto l'intestazione, e dentro tiene la cornice. */
+class DmCard extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    const style = document.createElement("style");
+    style.textContent =
+      ":host{display:block;width:100%;height:calc(100dvh - ${HEADER_HEIGHT}px);min-height:420px;overflow:hidden;background:#f8fafc}" +
+      ".surface{width:100%;height:100%;min-width:0;min-height:0}" +
+      "iframe{width:100%;height:100%;border:0;display:block}";
+    const surface = document.createElement("div");
+    surface.className = "surface";
+    this.frame = document.createElement("iframe");
+    surface.append(this.frame);
+    shadow.append(style, surface);
+  }
+}
+customElements.define("dm-card", DmCard);
+
+const carta = document.getElementById("carta").carta;
+const html = await (await fetch("/legacy/dashboard.html")).text();
+carta.frame.srcdoc = html.replace(/<head(?:\\s[^>]*)?>/i, (head) => head + '<base href="/legacy/">');
+window.__DM_CARD_HOST_READY__ = true;
+</script></body></html>`;
+
+async function bootCardPlancia(page, { search = "" } = {}) {
+  await page.addInitScript(() => {
+    class MockBridgeSocket extends EventTarget {
+      static OPEN = 1;
+      readyState = 1;
+      constructor() {
+        super();
+        setTimeout(() => this.dispatchEvent(new Event("open")), 0);
+      }
+      send() {}
+      close() {}
+    }
+    window.WebSocket = MockBridgeSocket;
+    /* Si riparte puliti solo alla prima apertura: una prova che RICARICA la
+     * pagina deve ritrovare quello che ha appena scelto, e uno svuotamento a
+     * ogni navigazione glielo toglierebbe di mano. */
+    try {
+      /* Solo dalla pagina che ospita, e solo alla prima apertura: lo script
+       * gira anche DENTRO la cornice, dove l'indirizzo non porta la domanda —
+       * e li' svuoterebbe proprio quello che la prova ha appena scelto. */
+      if (window.top === window && !/[?&]tieni=1/.test(location.search)) localStorage.clear();
+    } catch (_error) {}
+  });
+  await page.route(`${HOST_URL}*`, (route) =>
+    route.fulfill({ status: 200, contentType: "text/html", body: HOST_PAGE }),
+  );
+  await page.goto(`/dm-card-kiosk-host.html${search}`);
+  await page.waitForFunction(() => window.__DM_CARD_HOST_READY__ === true);
+  await page.frameLocator("iframe").locator("body").waitFor();
+}
+
+/* La procedura guidata copre la plancia finché nessuno ha configurato niente,
+ * e qui non c'è una casa da configurare: si toglie di mezzo. Si ASPETTA che
+ * nasca prima di toglierla — nasce dopo l'avvio, e toglierla prima vuol dire
+ * non toglierla affatto e ritrovarsela davanti al primo tocco. */
+async function togliLaProcedura(plancia) {
+  const mago = plancia.locator("#setup-wizard");
+  await mago.waitFor({ state: "attached", timeout: 15_000 }).catch(() => {});
+  await mago.evaluateAll((nodi) => nodi.forEach((nodo) => nodo.remove()));
+  await expect(mago).toHaveCount(0);
+}
+
+/* Due di queste prove riguardano il computer, e sul computer il chiosco non si
+ * accende mai da solo: schermo largo, nessun dito, barra degli indirizzi al suo
+ * posto. Su un telefono si accende eccome — è il suo contratto — e lì non c'è
+ * niente da accendere a mano. */
+async function soloDoveNonSiAccendeDaSolo(page) {
+  /* La stessa domanda che si fa il chiosco: uno schermo stretto con un dito è
+   * un telefono, e su un telefono si accende da sé. La si fa alla pagina che
+   * ospita, che è quella che vede lo schermo vero. */
+  const telefono = await page.evaluate(
+    () =>
+      window.matchMedia("(max-width: 870px)").matches &&
+      (Number(navigator.maxTouchPoints || 0) > 0 ||
+        "ontouchstart" in window ||
+        window.matchMedia("(pointer: coarse)").matches),
+  );
+  test.skip(telefono, "qui il chiosco si accende da solo: questa prova è quella del computer");
+}
+
+async function apriLeImpostazioni(plancia) {
+  await togliLaProcedura(plancia);
+  await plancia.locator("body").evaluate(() => {
+    if (!document.getElementById("editor-modal")?.classList.contains("show")) apriConfigEntita();
+  });
+  await plancia.locator('.ed-tab[data-tab="visib"]').first().click();
+}
+
+function cardGeometry(page) {
+  return page.evaluate(() => {
+    const carta = document.getElementById("carta").shadowRoot.querySelector("dm-card");
+    const box = carta.getBoundingClientRect();
+    return {
+      top: Math.round(box.top),
+      left: Math.round(box.left),
+      height: Math.round(box.height),
+      width: Math.round(box.width),
+      position: getComputedStyle(carta).position,
+      /* Chi dipinge nell'angolo dove sta l'intestazione: al livello del
+       * documento un'ombra si annuncia col suo ospite, quindi «carta» vuol
+       * dire la plancia e «ha-header» la barra di Home Assistant. */
+      paintedOnTop: document.elementFromPoint(10, 10)?.id || "",
+      innerHeight: window.innerHeight,
+      innerWidth: window.innerWidth,
+    };
+  });
+}
+
+test("dentro la card della plancia predefinita il chiosco va a tutto schermo", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
+  await bootCardPlancia(page, { search: "?kiosk=1" });
+
+  const html = page.frameLocator("iframe").locator("html");
+  await expect(html).toHaveAttribute("data-dm-ios-kiosk", "true");
+
+  const geometria = await cardGeometry(page);
+  expect(geometria).toMatchObject({ top: 0, left: 0, position: "fixed" });
+  expect(geometria.height).toBe(geometria.innerHeight);
+  expect(geometria.width).toBe(geometria.innerWidth);
+  /* L'intestazione di Lovelace sta a 0,0 e porta `z-index:4`: se in
+   * quell'angolo si vede ancora lei, il chiosco è sotto e non è servito a
+   * niente — che è esattamente «non si apre in modalità kiosk». */
+  expect(geometria.paintedOnTop).toBe("carta");
+});
+
+test("e spegnendolo la card restituisce alla vista l'altezza che aveva", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
+  await bootCardPlancia(page, { search: "?kiosk=1" });
+
+  const html = page.frameLocator("iframe").locator("html");
+  await expect(html).toHaveAttribute("data-dm-ios-kiosk", "true");
+
+  await page.evaluate(() => {
+    const url = new URL(location.href);
+    url.searchParams.set("kiosk", "0");
+    history.replaceState({}, "", url);
+  });
+  await page
+    .frameLocator("iframe")
+    .locator("html")
+    .evaluate(() => {
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+  await expect(html).not.toHaveAttribute("data-dm-ios-kiosk", "true");
+  const dopo = await cardGeometry(page);
+  expect(dopo.position, "il velo è rimasto addosso alla card").not.toBe("fixed");
+  expect(dopo.top, "la card copre ancora l'intestazione").toBeGreaterThan(0);
+  expect(dopo.paintedOnTop).toBe("ha-header");
+});
+
+/* E l'interruttore in ⚙️ Impostazioni, che su un computer è l'unica strada.
+ *
+ * Su un telefono il chiosco si accende da solo, e il dito tenuto premuto
+ * sull'hamburger lo commuta. Su un computer no: lo schermo è largo, la barra
+ * degli indirizzi c'è, e il chiosco resta spento finché qualcuno non lo
+ * chiede. Quel «qualcuno lo chiede» è l'interruttore della scheda
+ * Impostazioni, ed è per questo che è nato (#480).
+ *
+ * Quindi su un computer quell'interruttore non è un comodo in più: è la sola
+ * cosa che possa rispondere a «da pc non si apre in modalità kiosk». */
+test("l'interruttore delle Impostazioni porta la card a tutto schermo", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
+  await bootCardPlancia(page);
+
+  const plancia = page.frameLocator("iframe");
+  const html = plancia.locator("html");
+  await soloDoveNonSiAccendeDaSolo(page);
+  await apriLeImpostazioni(plancia);
+
+  const interruttore = plancia.locator("[data-dm-chiosco-int]");
+  await expect(interruttore).toBeVisible({ timeout: 15_000 });
+  await expect(interruttore).toHaveAttribute("aria-checked", "false");
+
+  await interruttore.click();
+
+  await expect(interruttore).toHaveAttribute("aria-checked", "true");
+  await expect(html).toHaveAttribute("data-dm-ios-kiosk", "true");
+  const geometria = await cardGeometry(page);
+  expect(geometria).toMatchObject({ top: 0, left: 0, position: "fixed" });
+  expect(geometria.height).toBe(geometria.innerHeight);
+  expect(geometria.paintedOnTop).toBe("carta");
+});
+
+/* E la scelta resta: ricaricando, la plancia predefinita si riapre com'era.
+ *
+ * Su un computer il chiosco non si accende mai da solo — schermo largo, barra
+ * degli indirizzi al suo posto — quindi tutto quello che tiene in piedi la
+ * scelta di chi l'ha fatta è che venga ricordata. Se si perdesse al primo
+ * ricaricamento, da un computer la plancia predefinita non si aprirebbe mai a
+ * tutto schermo pur avendo l'interruttore acceso. */
+test("e la scelta regge il ricaricamento, che su un computer è tutto", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(testInfo.project.name === "webkit-ipad" ? 120_000 : 75_000);
+  await bootCardPlancia(page);
+
+  const plancia = page.frameLocator("iframe");
+  await soloDoveNonSiAccendeDaSolo(page);
+  await apriLeImpostazioni(plancia);
+  await plancia.locator("[data-dm-chiosco-int]").click();
+  await expect(plancia.locator("html")).toHaveAttribute("data-dm-ios-kiosk", "true");
+
+  await bootCardPlancia(page, { search: "?tieni=1" });
+
+  await expect(page.frameLocator("iframe").locator("html")).toHaveAttribute(
+    "data-dm-ios-kiosk",
+    "true",
+  );
+  const geometria = await cardGeometry(page);
+  expect(geometria).toMatchObject({ top: 0, left: 0, position: "fixed" });
+  expect(geometria.paintedOnTop).toBe("carta");
+});

--- a/custom_components/dashboardmodern/frontend/legacy/build-info.js
+++ b/custom_components/dashboardmodern/frontend/legacy/build-info.js
@@ -12,4 +12,4 @@ import "../src/sections/beta25-real-device-fixes-section.js";
 import "../src/sections/beta25-compatibility-section.js";
 import "../src/sections/beta26-real-device-stability-section.js";
 import "../src/sections/segnalazioni-section.js";
-export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.21","dashboardVersion":"1.4.21","moduleVersion":14,"schemaVersion":4,"date":"2026-09-11T20:45:23+00:00","commit":"724a3daa20c9392a0d9e1c5bd0f2ff16017e8cad","assetHash":"9f26d45e144cf928"});
+export const BUILD_INFO = Object.freeze({"generated":true,"integrationVersion":"1.4.22","dashboardVersion":"1.4.22","moduleVersion":14,"schemaVersion":4,"date":"2026-09-12T02:49:21+00:00","commit":"7c012f48b15b3a98345438b4160a4b97707b2d88","assetHash":"fa6b2eaa03159e9d"});

--- a/custom_components/dashboardmodern/frontend/src/core/oggetti-widget.js
+++ b/custom_components/dashboardmodern/frontend/src/core/oggetti-widget.js
@@ -814,6 +814,110 @@ const OGGETTI = Object.freeze({
     <path d="M16 8.2l5.8 6.4h-3.2v6.6h-5.2v-6.6h-3.2Z" fill="#fff" fill-opacity=".95"/>
     <path d="M9.2 10.2a8.8 8.8 0 0 1 4.6-3.6" stroke="#fff" stroke-opacity=".7" stroke-width="1.6"
       fill="none" stroke-linecap="round"/>`,
+
+  /* ── la barra sotto il meteo: i quattro che le mancavano ─────────────────
+   *
+   * «Icone barra sotto al menu non sono del nostro catalogo, se non esistono
+   * creale.» La barra chiede il disegno di casa e ripiega sull'emoji quando il
+   * catalogo non ce l'ha: quattro delle sue pastiglie — la posta, l'umidita' e
+   * le due della pioggia — cadevano sempre nel ripiego, e stavano in fila
+   * accanto a dieci disegni. Il ripiego adesso non serve piu' a nessuna. */
+
+  /* La cassetta della posta (#357): lo sportello, la lettera che spunta e la
+   * bandierina alzata — che e' esattamente la notizia che la pastiglia porta. */
+  posta: `<defs>
+      <linearGradient id="dmoPostaC" x1="0" y1="0" x2=".35" y2="1">
+        <stop offset="0" stop-color="#60a5fa"/><stop offset=".55" stop-color="#2563eb"/>
+        <stop offset="1" stop-color="#1e3a8a"/></linearGradient>
+      <linearGradient id="dmoPostaL" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#dbeafe"/></linearGradient>
+      <linearGradient id="dmoPostaB" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stop-color="#fca5a5"/><stop offset=".5" stop-color="#ef4444"/>
+        <stop offset="1" stop-color="#b91c1c"/></linearGradient></defs>
+    ${OMBRA(16, 28.6, 8.6)}
+    <path d="M5.6 24.4v-9.8a6.6 6.6 0 0 1 6.6-6.6h6.6a6.6 6.6 0 0 1 6.6 6.6v9.8Z" fill="url(#dmoPostaC)"/>
+    <path d="M12.2 8a6.6 6.6 0 0 0-6.6 6.6v9.8h4.4v-9.8A6.6 6.6 0 0 1 16.6 8Z" fill="#0b1220" fill-opacity=".2"/>
+    <rect x="13.2" y="13.2" width="11.4" height="7.8" rx="1.4" fill="url(#dmoPostaL)"/>
+    <path d="m13.6 14.2 5.3 3.4 5.3-3.4" stroke="#93c5fd" stroke-width="1.3" fill="none"
+      stroke-linecap="round" stroke-linejoin="round"/>
+    <rect x="4.4" y="24.4" width="23.2" height="2.8" rx="1.4" fill="#334155"/>
+    <rect x="25.4" y="8.6" width="1.7" height="9.4" rx=".85" fill="#94a3b8"/>
+    <path d="M27.1 9h4l-1.2 1.9 1.2 1.9h-4Z" fill="url(#dmoPostaB)"/>
+    <path d="M8.2 14.8a4.4 4.4 0 0 1 3.4-4.4" stroke="#fff" stroke-opacity=".55" stroke-width="1.4"
+      fill="none" stroke-linecap="round"/>`,
+
+  /* L'umidita': il quadrante dell'igrometro con la goccia dentro. Non e' la
+   * goccia degli allagamenti — quella e' l'acqua dov'e' finita, questa e'
+   * l'acqua che si misura — e sta accanto al termometro, con cui divide la
+   * ghiera e il vetro. */
+  umidita: `<defs>
+      <radialGradient id="dmoUmiG" cx=".35" cy=".3" r=".85">
+        <stop offset="0" stop-color="#ffffff"/><stop offset=".6" stop-color="#e2e8f0"/>
+        <stop offset="1" stop-color="#94a3b8"/></radialGradient>
+      <linearGradient id="dmoUmiA" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stop-color="#bae6fd"/><stop offset=".5" stop-color="#0ea5e9"/>
+        <stop offset="1" stop-color="#0369a1"/></linearGradient></defs>
+    ${OMBRA(16, 28.8, 8.6)}
+    <circle cx="16" cy="15.4" r="11.2" fill="url(#dmoUmiG)"/>
+    <circle cx="16" cy="15.4" r="9.2" fill="#f8fafc"/>
+    <g stroke="#94a3b8" stroke-width="1.3" stroke-linecap="round">
+      <path d="M16 7.4v1.8M23.9 15.4h-1.8M16 23.4v-1.8M8.1 15.4h1.8"/></g>
+    <path d="M16 9.4c2.7 3.2 4.9 5.7 4.9 8.3a4.9 4.9 0 1 1-9.8 0c0-2.6 2.2-5.1 4.9-8.3Z" fill="url(#dmoUmiA)"/>
+    <path d="M13.7 15.6a4.6 4.6 0 0 0-1.1 2.9" stroke="#fff" stroke-opacity=".75" stroke-width="1.3"
+      fill="none" stroke-linecap="round"/>
+    <path d="M8.6 9.2a10.2 10.2 0 0 1 4.6-3.4" stroke="#fff" stroke-opacity=".8" stroke-width="1.6"
+      fill="none" stroke-linecap="round"/>`,
+
+  /* La pioggia di adesso: la nuvola e le gocce che stanno cadendo. */
+  pioggia: `<defs>
+      <linearGradient id="dmoPiogN" x1="0" y1="0" x2=".3" y2="1">
+        <stop offset="0" stop-color="#f8fafc"/><stop offset=".5" stop-color="#cbd5e1"/>
+        <stop offset="1" stop-color="#64748b"/></linearGradient>
+      <linearGradient id="dmoPiogA" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0" stop-color="#7dd3fc"/><stop offset="1" stop-color="#1d4ed8"/></linearGradient></defs>
+    <path d="M10.6 18.4a5.4 5.4 0 0 1-.6-10.7 7.2 7.2 0 0 1 13.6 1.6 4.6 4.6 0 0 1-.8 9.1Z" fill="url(#dmoPiogN)"/>
+    <path d="M11.6 8.6a5.8 5.8 0 0 1 5.2-3.4" stroke="#fff" stroke-opacity=".85" stroke-width="1.7"
+      fill="none" stroke-linecap="round"/>
+    <g fill="url(#dmoPiogA)">
+      <path d="M11.4 20.4c1.4 1.8 2.1 2.9 2.1 3.8a2.1 2.1 0 1 1-4.2 0c0-.9.7-2 2.1-3.8Z"/>
+      <path d="M16 22.4c1.4 1.8 2.1 2.9 2.1 3.8a2.1 2.1 0 1 1-4.2 0c0-.9.7-2 2.1-3.8Z"/>
+      <path d="M20.6 20.4c1.4 1.8 2.1 2.9 2.1 3.8a2.1 2.1 0 1 1-4.2 0c0-.9.7-2 2.1-3.8Z"/></g>`,
+
+  /* La pioggia di oggi: il pluviometro. Sono due domande diverse — quanta ne
+   * sta venendo giu' adesso, quanta ne e' caduta da stamattina — e due domande
+   * diverse accanto non possono portare lo stesso oggetto. */
+  pioggiaOggi: `<defs>
+      <linearGradient id="dmoPlvV" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0" stop-color="#ffffff"/><stop offset=".5" stop-color="#e2e8f0"/>
+        <stop offset="1" stop-color="#b6c2d2"/></linearGradient>
+      <linearGradient id="dmoPlvA" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0" stop-color="#38bdf8"/><stop offset="1" stop-color="#1d4ed8"/></linearGradient></defs>
+    ${OMBRA(16, 29, 6.6)}
+    <path d="M7.2 4.6h17.6l-5.4 6.8h-6.8Z" fill="#94a3b8"/>
+    <path d="M7.2 4.6h17.6l-1.3 1.6H8.5Z" fill="#e2e8f0"/>
+    <rect x="12.4" y="10.4" width="7.2" height="16.6" rx="3.6" fill="url(#dmoPlvV)"/>
+    <path d="M13.6 17.2h4.8v6.2a2.4 2.4 0 0 1-4.8 0Z" fill="url(#dmoPlvA)"/>
+    <g stroke="#64748b" stroke-width="1.1" stroke-linecap="round">
+      <path d="M17.4 13.4h1.5M17.4 16.4h1M17.4 19.4h1.5M17.4 22.4h1"/></g>
+    <path d="M14 12.2v12.4" stroke="#fff" stroke-opacity=".75" stroke-width="1.3"
+      stroke-linecap="round" fill="none"/>`,
+
+  /* Il meteo: il sole dietro la nuvola. E' l'intestazione della Home nell'elenco
+   * dei blocchi, l'unica riga di quell'elenco che non aveva il suo oggetto. */
+  meteo: `<defs>
+      <radialGradient id="dmoMeteoS" cx=".38" cy=".32" r=".8">
+        <stop offset="0" stop-color="#fef3c7"/><stop offset=".55" stop-color="#fbbf24"/>
+        <stop offset="1" stop-color="#d97706"/></radialGradient>
+      <linearGradient id="dmoMeteoN" x1="0" y1="0" x2=".3" y2="1">
+        <stop offset="0" stop-color="#ffffff"/><stop offset=".55" stop-color="#e2e8f0"/>
+        <stop offset="1" stop-color="#94a3b8"/></linearGradient></defs>
+    <circle cx="11.6" cy="11.4" r="5.2" fill="url(#dmoMeteoS)"/>
+    <g stroke="#f59e0b" stroke-width="1.8" stroke-linecap="round">
+      <path d="M11.6 2.8v2.2M11.6 17.8v2.2M2.8 11.4H5M18.2 11.4H20.4M5.4 5.2l1.6 1.6M16.2 16l1.6 1.6M5.4 17.6l1.6-1.6M16.2 6.8l1.6-1.6"/></g>
+    <circle cx="9.8" cy="9.6" r="1.5" fill="#fff" fill-opacity=".6"/>
+    <path d="M13.4 26.2a5.6 5.6 0 0 1-.6-11.1 7.4 7.4 0 0 1 14 1.7 4.7 4.7 0 0 1-.8 9.4Z" fill="url(#dmoMeteoN)"/>
+    <path d="M14.4 16.2a6 6 0 0 1 5.4-3.5" stroke="#fff" stroke-opacity=".85" stroke-width="1.7"
+      fill="none" stroke-linecap="round"/>`,
 });
 
 /* Due nomi per lo stesso disegno.

--- a/custom_components/dashboardmodern/frontend/src/core/strategie-telecamera.js
+++ b/custom_components/dashboardmodern/frontend/src/core/strategie-telecamera.js
@@ -153,6 +153,26 @@ export function siSveglia(stato = {}) {
 }
 
 /**
+ * Quanto tempo ha la strada del flusso per questa telecamera.
+ *
+ * Vale per l'HLS e per il WebRTC che negozia Home Assistant: sono le due
+ * strade che devono prima SVEGLIARE l'apparecchio, e chi sta in cloud ci mette
+ * secondi mentre chi sta in casa risponde subito.
+ *
+ * Sta qui, e non dentro `strategieDellaTelecamera`, perche' quel numero non lo
+ * guarda soltanto chi mette in fila le strade: lo deve rispettare anche chi la
+ * strada la percorre. Il negoziato del popup se n'era scritto uno suo —
+ * quindici secondi fissi — e i due numeri non erano lo stesso: a una
+ * telecamera di casa toglieva cinque secondi buttati prima di passare alla
+ * strada dopo, e a una in cloud, che di secondi ne ha venticinque, la
+ * interrompeva dieci secondi prima della fine. «E ancora telecamere non
+ * funzionanti.» Un tempo solo, scritto una volta.
+ */
+export function attesaDelFlusso(stato = {}) {
+  return siSveglia(stato) ? ATTESE.HLS_SVEGLIA : ATTESE.HLS_LOCALE;
+}
+
+/**
  * Le strade da provare, in ordine, con quanto aspettare ciascuna.
  *
  * Ogni voce che si salta porta il suo `salta`: un codice, non una frase, cosi'
@@ -166,6 +186,7 @@ export function siSveglia(stato = {}) {
 export function strategieDellaTelecamera(cam = {}, stato = {}, opzioni = {}) {
   const nomeDelFlusso = pulito(cam.stream);
   const dorme = siSveglia(stato);
+  const attesaDelSuoFlusso = attesaDelFlusso(stato);
   const webrtcNelBrowser = opzioni.webrtcNelBrowser !== false;
   const hlsNelBrowser = opzioni.hlsNelBrowser !== false;
   /* Home Assistant moderno parla WebRTC da solo: `frontend_stream_type` vale
@@ -213,7 +234,7 @@ export function strategieDellaTelecamera(cam = {}, stato = {}, opzioni = {}) {
       /* Una telecamera in cloud che negozia in nativo deve prima svegliarsi:
        * il tempo e' quello della sveglia, non quello della rete di casa. E qui
        * l'attesa non e' buttata — e' la strada scelta, non una prova. */
-      attesa: dorme ? ATTESE.HLS_SVEGLIA : ATTESE.HLS_LOCALE,
+      attesa: attesaDelSuoFlusso,
       nativa: true,
     });
   else strade.push({ nome: "WebRTC", salta: "senza-nome-di-flusso" });
@@ -243,7 +264,7 @@ export function strategieDellaTelecamera(cam = {}, stato = {}, opzioni = {}) {
   else
     strade.push({
       nome: "HLS",
-      attesa: dorme ? ATTESE.HLS_SVEGLIA : ATTESE.HLS_LOCALE,
+      attesa: attesaDelSuoFlusso,
       sveglia: dorme,
     });
 

--- a/custom_components/dashboardmodern/frontend/src/sections/come-sta-la-casa-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/come-sta-la-casa-section.js
@@ -494,22 +494,30 @@ function schedaAperta() {
 
 /* I nomi delle voci. Sono gli stessi delle tessere che le raccontano — chi
  * legge «Finestre» nella scheda ritrova «Finestre» in Home — e la posta e' la
- * sola che una tessera non ce l'ha. */
+ * sola che una tessera non ce l'ha.
+ *
+ * Qui c'erano anche le emoji, ed erano le stesse che la barra mostrava quando
+ * il catalogo non aveva il disegno: «icone barra sotto al menu non sono del
+ * nostro catalogo». Adesso il disegno ce l'hanno tutte — la posta, l'umidita'
+ * e le due della pioggia sono arrivate col catalogo — e questa tabella torna a
+ * fare la cosa che sa fare: i nomi. Il disegno lo chiede chi disegna, allo
+ * stesso catalogo da cui lo chiedono le pastiglie: due elenchi della stessa
+ * barra con due facce diverse sarebbero la stessa cosa detta due volte. */
 const NOMI_DELLE_VOCI = () => ({
-  posta: ["📬", t("Posta", "Mail")],
-  rifiuti: ["♻️", t("Rifiuti", "Waste")],
-  sicurezza: ["🛡️", t("Sicurezza", "Security")],
-  porte: ["🚪", t("Porte", "Doors")],
-  varchi: ["🚪", t("Varchi", "Openings")],
-  luci: ["💡", t("Luci", "Lights")],
-  tapparelle: ["🪟", t("Finestre", "Windows")],
-  clima: ["❄️", t("Clima", "Climate")],
-  prese: ["🔌", t("Prese", "Sockets")],
-  media: ["🔊", t("Musica", "Media")],
-  temperatura: ["🌡️", t("Temperatura", "Temperature")],
-  umidita: ["💧", t("Umidità", "Humidity")],
-  pioggia: ["🌧️", t("Pioggia adesso", "Rain now")],
-  pioggiaOggi: ["☔", t("Pioggia di oggi", "Rain today")],
+  posta: t("Posta", "Mail"),
+  rifiuti: t("Rifiuti", "Waste"),
+  sicurezza: t("Sicurezza", "Security"),
+  porte: t("Porte", "Doors"),
+  varchi: t("Varchi", "Openings"),
+  luci: t("Luci", "Lights"),
+  tapparelle: t("Finestre", "Windows"),
+  clima: t("Clima", "Climate"),
+  prese: t("Prese", "Sockets"),
+  media: t("Musica", "Media"),
+  temperatura: t("Temperatura", "Temperature"),
+  umidita: t("Umidità", "Humidity"),
+  pioggia: t("Pioggia adesso", "Rain now"),
+  pioggiaOggi: t("Pioggia di oggi", "Rain today"),
 });
 
 /* Una casella per un sensore della barra: le due misure hanno la stessa forma
@@ -528,9 +536,9 @@ function pannelloMarkup() {
   const config = configurazione();
   const nomi = NOMI_DELLE_VOCI();
   const righe = VOCI_DELLA_BARRA.map((voce) => {
-    const [icona, etichetta] = nomi[voce.chiave] || ["", voce.chiave];
+    const etichetta = nomi[voce.chiave] || voce.chiave;
     return `<label class="ed-row dm-casa-ed-riga">
-      <span class="dm-casa-ed-ic" aria-hidden="true">${icona}</span>
+      <span class="dm-casa-ed-ic" aria-hidden="true">${oggettoWidget(voce.chiave)}</span>
       <span class="ed-row-main"><strong class="ed-row-new">${esc(etichetta)}</strong></span>
       <input type="checkbox" data-dm-casa-voce="${esc(voce.chiave)}"${
         config.voci[voce.chiave] ? " checked" : ""
@@ -819,6 +827,7 @@ function stile() {
     #ed-body .dm-casa-ed-list{display:grid;gap:6px;margin-bottom:12px}
     #ed-body .dm-casa-ed-riga{display:flex!important;align-items:center;gap:10px;padding:8px 12px!important;cursor:pointer}
     #ed-body .dm-casa-ed-ic{display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;flex:0 0 24px;font-size:17px}
+    #ed-body .dm-casa-ed-ic .dm-oggetto{width:24px;height:24px;display:block}
     #ed-body .dm-casa-ed-campo{display:block;margin-bottom:12px}
   `;
 }

--- a/custom_components/dashboardmodern/frontend/src/sections/home-blocchi-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/home-blocchi-section.js
@@ -16,6 +16,7 @@
  * resto della plancia, e qui vale doppio perche' spostare nodi costa
  * impaginazione.
  */
+import { oggettoWidget } from "../core/oggetti-widget.js";
 import { spostaNellElenco } from "../core/ordine-a-mano.js";
 import {
   BLOCCHI_DELLA_HOME,
@@ -41,6 +42,7 @@ import {
   clean,
   doc,
   esc,
+  iconGlyphHtml,
   installStyle,
   onEditorRedraw,
   readJson,
@@ -179,13 +181,23 @@ const SCHEDA_HOME = "sez0";
  * scelgono e si ordinano fra loro; le persone e le azioni rapide pure. Qui si
  * mettono in fila i blocchi. */
 const NOMI_DEI_BLOCCHI = () => ({
-  meteo: ["🌤️", t("Intestazione col meteo", "Weather header")],
-  persone: ["👥", t("Persone", "People")],
-  widget: ["🧩", t("Widget", "Widgets")],
-  azioni: ["⚡", t("Azioni rapide", "Quick actions")],
-  stanze: ["🛋️", t("Stanze", "Rooms")],
-  dispositivi: ["📟", t("Dispositivi", "Devices")],
+  meteo: t("Intestazione col meteo", "Weather header"),
+  persone: t("Persone", "People"),
+  widget: t("Widget", "Widgets"),
+  azioni: t("Azioni rapide", "Quick actions"),
+  stanze: t("Stanze", "Rooms"),
+  dispositivi: t("Dispositivi", "Devices"),
 });
+
+/* Quale disegno di casa porta ogni blocco.
+ *
+ * Quasi tutti si chiamano gia' come il proprio oggetto — persone, widget,
+ * azioni, stanze — e per quelli non c'e' niente da scrivere. Gli altri due
+ * sono i soliti due nomi: il riquadro in cima si chiama «meteo» e i
+ * dispositivi sono gli elettrodomestici della griglia. */
+const OGGETTO_DEL_BLOCCO = Object.freeze({ dispositivi: "elettrodomestici" });
+
+const disegnoDelBlocco = (nome) => oggettoWidget(OGGETTO_DEL_BLOCCO[nome] || nome);
 
 function schedaAperta() {
   return clean(doc?.querySelector?.(".ed-tab.active")?.dataset?.tab);
@@ -196,9 +208,9 @@ function pannelloMarkup() {
   const fila = ordineSalvato();
   const righe = fila
     .map((nome, indice) => {
-      const [icona, etichetta] = nomi[nome] || ["", nome];
+      const etichetta = nomi[nome] || nome;
       return `<div class="ed-row dm-blocco-row" data-blocco="${esc(nome)}">
-        <span class="dm-blocco-icona" aria-hidden="true">${icona}</span>
+        <span class="dm-blocco-icona" aria-hidden="true">${disegnoDelBlocco(nome)}</span>
         <span class="ed-row-main"><strong class="ed-row-new">${esc(etichetta)}</strong></span>
         <button type="button" class="ed-del dm-blocco-move" data-blocco-su aria-label="${esc(
           t("Più in alto", "Move up"),
@@ -272,7 +284,11 @@ function stanzeMarkup() {
       if (!id) return "";
       const accesa = laStanzaSiVede(scelte, stanza);
       return `<label class="ed-row dm-blocco-stanza">
-        <span class="dm-blocco-icona" aria-hidden="true">${esc(clean(stanza.icon) || "\u{1F6CB}\uFE0F")}</span>
+        <span class="dm-blocco-icona" aria-hidden="true">${iconGlyphHtml(stanza.icon, {
+          size: 22,
+          kind: "room",
+          fallback: "\u{1F6CB}\uFE0F",
+        })}</span>
         <span class="ed-row-main"><strong class="ed-row-new">${esc(clean(stanza.name) || id)}</strong></span>
         <span class="dm-blocco-switch"><input type="checkbox" data-dm-stanza-plancia-scelta="${esc(id)}"${
           accesa ? " checked" : ""
@@ -384,6 +400,9 @@ function stile() {
     #ed-body .dm-blocco-list{display:grid;gap:6px;margin-bottom:14px}
     #ed-body .dm-blocco-row{display:flex!important;align-items:center;gap:10px;padding:8px 12px!important}
     #ed-body .dm-blocco-icona{font-size:17px;display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;flex:0 0 24px}
+    #ed-body .dm-blocco-icona .dm-oggetto{width:24px;height:24px;display:block}
+    #ed-body .dm-blocco-icona .dm-icon-engine-glyph{display:inline-flex;align-items:center;justify-content:center}
+    #ed-body .dm-blocco-icona svg{max-width:100%;max-height:100%}
     #ed-body .dm-blocco-move[disabled]{opacity:.3;pointer-events:none}
     #ed-body .dm-blocco-pastiglie,
     #ed-body .dm-blocco-stanza{display:flex!important;align-items:center;gap:12px;padding:10px 12px!important}

--- a/custom_components/dashboardmodern/frontend/src/sections/navigation-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/navigation-section.js
@@ -1007,15 +1007,30 @@ function filtraNelFotogramma() {
   chiedi.call(root, () => {
     state.filtroInCoda = false;
     applicaLaVisibilita();
+    disegniNellaBarra();
   });
 }
 
+/* Una voce appena nata si filtra subito E si disegna subito.
+ *
+ * Le due cose succedono nello stesso momento — la voce nasce — e finora solo
+ * una delle due era agganciata qui: il filtro. Il disegno stava appeso a
+ * `cdApplyNavVis`, che e' del guscio, e se al momento dell'installazione quella
+ * funzione non c'era ancora l'aggancio non si faceva piu': la voce nasceva col
+ * simbolo scritto a mano da chi l'ha creata — «🚪», «📷» — e restava cosi'
+ * finche' qualcuno non cambiava scheda. E' la stessa strada del guasto della
+ * voce delle porte, che quella volta non nasceva affatto.
+ *
+ * `disegniNellaBarra` non ridisegna quello che e' gia' a posto: si ferma sul
+ * primo confronto per ogni voce, quindi metterla qui non aggiunge lavoro a un
+ * giro in cui non c'e' niente di nuovo. */
 function filtraDopo(nome) {
   const originale = root[nome];
   if (typeof originale !== "function" || originale.__dmVisibilitaSubito) return false;
   const avvolta = function (...argomenti) {
     const esito = originale.apply(this, argomenti);
     applicaLaVisibilita();
+    disegniNellaBarra();
     filtraNelFotogramma();
     return esito;
   };
@@ -1107,8 +1122,17 @@ export function installNavigationSection() {
   accodaDopo("cdApplyNavOrder");
   accodaDopo("cdApplyNavVis");
   filtraDopo("render");
+  /* Le funzioni del guscio possono non esserci ancora quando questo modulo si
+   * installa: `accodaDopo` e `filtraDopo` in quel caso non agganciano niente e
+   * lo dicono tornando falso. Riprovarci ai due momenti in cui il guscio
+   * dichiara di esserci e' il modo di non restare senza aggancio per sempre —
+   * e tutt'e due si rifiutano di avvolgere due volte la stessa funzione. */
   for (const evento of ["dashboardmodern:legacy-ready", "dashboardmodern:runtime-ready"])
-    root.addEventListener?.(evento, () => filtraDopo("render"));
+    root.addEventListener?.(evento, () => {
+      accodaDopo("cdApplyNavOrder");
+      accodaDopo("cdApplyNavVis");
+      filtraDopo("render");
+    });
   /* La configurazione condivisa, arrivando, riscrive le chiavi: se quella
    * dell'altro dispositivo non la porta, qui resterebbe vuota e la barra
    * tornerebbe a scomparsa da sola. */

--- a/custom_components/dashboardmodern/frontend/src/sections/shared.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/shared.js
@@ -876,25 +876,40 @@ export function writeIconGlyph(target, icon, { size = 26, fallback = "🔌", kin
     if (target.textContent !== token) target.textContent = token;
     return true;
   }
+  /* Il motore, quando puo', scrive lui dentro il nodo: sa cosa c'e' gia' e non
+   * lo riscrive per niente. Quando non puo' — non e' ancora salito, o il nodo
+   * non e' il suo — resta il markup, che e' la stessa regola vista da fuori. */
   try {
     if (root.DashboardModernIconEngine?.render?.(target, kind, token, { size })) return true;
   } catch (_error) {}
+  target.innerHTML = iconGlyphHtml(token, { size, fallback, kind });
+  return true;
+}
+
+/* La stessa regola, per chi il markup se lo costruisce a stringhe.
+ *
+ * Mezza plancia disegna scrivendo markup — un pannello della configurazione si
+ * rifa' tutto in una volta — e li' `writeIconGlyph` non si puo' chiamare:
+ * serve il pezzo di testo, non il nodo. Chi ne aveva bisogno se l'e' scritto
+ * per conto suo, e chi se l'e' dimenticato ha stampato il token: «mdi:sofa»
+ * come parola sopra il nome della stanza, che e' esattamente la cosa che il
+ * commento qui sopra promette non succeda mai.
+ *
+ * La regola adesso sta in una funzione sola e le due facce la dividono: quella
+ * che scrive nel nodo chiama questa. `esc` sul ripiego perche' un simbolo
+ * scelto a mano puo' contenere qualunque cosa, e questo esce come markup. */
+export function iconGlyphHtml(icon, { size = 26, fallback = "🔌", kind = "action" } = {}) {
+  const token = clean(icon) || fallback;
+  if (!/^mdi:/i.test(token)) return esc(token);
   try {
     const markup = root.DashboardModernIconEngine?.markup?.(kind, token, { size });
-    if (markup) {
-      target.innerHTML = markup;
-      return true;
-    }
+    if (markup) return markup;
   } catch (_error) {}
   try {
     const legacy = root.cdIconMarkup?.(token, size);
-    if (legacy && legacy !== token) {
-      target.innerHTML = legacy;
-      return true;
-    }
+    if (legacy && legacy !== token) return legacy;
   } catch (_error) {}
-  target.textContent = fallback;
-  return true;
+  return esc(fallback);
 }
 
 export function afterResult(result, callback) {

--- a/custom_components/dashboardmodern/frontend/src/sections/stanze-in-plancia-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/stanze-in-plancia-section.js
@@ -24,7 +24,17 @@ import {
   idDellaStanza,
   stanzeInPlancia,
 } from "../core/stanze-in-plancia.js";
-import { allStates, clean, doc, esc, installStyle, readJson, root, t } from "./shared.js";
+import {
+  allStates,
+  clean,
+  doc,
+  esc,
+  iconGlyphHtml,
+  installStyle,
+  readJson,
+  root,
+  t,
+} from "./shared.js";
 import { apriLaStanza, roomPages } from "./rooms-page-section.js";
 
 const KEY = "__DASHBOARDMODERN_STANZE_IN_PLANCIA__";
@@ -39,14 +49,15 @@ export function stanzeScelte() {
 
 /* Il disegno della stanza, dal catalogo di casa: è lo stesso che la stanza
  * porta nella sua pagina e nel Clima, e prenderne un altro qui vorrebbe dire
- * la stessa stanza con due facce. */
+ * la stessa stanza con due facce.
+ *
+ * Il ripiego non e' il token. Qui si tornava a mani vuote quando il motore non
+ * rispondeva, e chi chiamava scriveva al suo posto `pagina.icon`: una stanza
+ * con l'icona scelta dal catalogo mdi si ritrovava «mdi:sofa» stampato come
+ * parola dentro la card. Il ripiego adesso e' un simbolo, ed e' `iconGlyphHtml`
+ * a sceglierlo — la stessa regola di tutta la plancia, scritta una volta. */
 function disegnoDellaStanza(icona) {
-  if (!clean(icona)) return "";
-  try {
-    return root.DashboardModernIconEngine?.markup?.("room", clean(icona), { size: 34 }) || "";
-  } catch (_error) {
-    return "";
-  }
+  return iconGlyphHtml(icona, { size: 34, kind: "room", fallback: "🛋️" });
 }
 
 const numero = (entity, states) => {
@@ -91,7 +102,7 @@ function cardMarkup(pagina, states) {
   const acceso = accese > 0;
   return `<button type="button" class="dm-stanza-plancia" data-dm-stanza-plancia="${esc(pagina.id)}"
       data-accesa="${acceso}" aria-label="${esc(pagina.name)}">
-    <span class="dm-stanza-plancia-ic" aria-hidden="true">${disegno || esc(pagina.icon || "🛋️")}</span>
+    <span class="dm-stanza-plancia-ic" aria-hidden="true">${disegno}</span>
     <span class="dm-stanza-plancia-testo">
       <b>${esc(pagina.name)}</b>
       <small>${esc(misure)}</small>

--- a/custom_components/dashboardmodern/frontend/src/sections/telecamera-webrtc-section.js
+++ b/custom_components/dashboardmodern/frontend/src/sections/telecamera-webrtc-section.js
@@ -19,6 +19,7 @@
  * niente e per quando il video non parte. La regola sta in
  * `core/telecamera-webrtc.js`; qui ci sono il socket e il DOM.
  */
+import { attesaDelFlusso } from "../core/strategie-telecamera.js";
 import {
   attesaDelVideo,
   candidatoDaEvento,
@@ -514,8 +515,25 @@ async function avviaPerIlPopup(entityId, videoEl) {
    * apre sopra di lei, quindi nessuno la sta guardando — e per una telecamera
    * che regge un flusso solo, due sono uno di troppo. */
   spegniSessione(entity, { pausa: false });
+  /* Il tempo e' quello che la strategia ha dato a QUESTA strada, non un numero
+   * scritto qui.
+   *
+   * Qui c'erano quindici secondi fissi, e il guscio intanto ne concedeva
+   * dieci a una telecamera di casa e venticinque a una in cloud: il negoziato
+   * e il velo «Connessione WebRTC…» andavano ognuno per conto suo. Da una
+   * parte cinque secondi di velo in piu' prima che la fila passasse alla
+   * strada dopo — il guscio aspetta che questa funzione torni PRIMA di
+   * guardare il suo cronometro, quindi quei secondi li paga chi guarda. Dall
+   * altra, peggio: a un'Arlo o a una Ring la trattativa veniva interrotta al
+   * quindicesimo secondo, dieci prima della fine del tempo che il guscio le
+   * aveva dato — cioe' proprio alle telecamere che di tempo hanno bisogno si
+   * toglieva la strada che avrebbe funzionato.
+   *
+   * `attesaDelFlusso` e' lo stesso conto che fa la strategia per la strada
+   * nativa: un tempo solo, e questa funzione lo rispetta invece di averne
+   * uno suo. */
   const sessione = await avviaWebRtcNativo(entity, videoEl, {
-    attesa: 15000,
+    attesa: attesaDelFlusso(allStates()?.[entity]),
     conAudio: true,
     quandoSiPuoChiudere: (chiudi) => {
       chiudiIlNegoziatoDelPopup = chiudi;

--- a/custom_components/dashboardmodern/frontend/tests/il-popup-della-telecamera-ha-il-tempo-della-strada.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/il-popup-della-telecamera-ha-il-tempo-della-strada.test.js
@@ -1,0 +1,74 @@
+/* «E ancora telecamere non funzionanti.» Il velo «Connessione WebRTC…» sopra un
+ * fotogramma fermo, e la fila che non passa mai alla strada dopo.
+ *
+ * Il tempo del WebRTC nativo era scritto in due posti che non si parlavano.
+ *
+ * Il guscio lo chiede alla strategia: `dmCamWebRTC(cam, strada, content,
+ * strada.attesa)`, e per la strada nativa la strategia dà dieci secondi a una
+ * telecamera di casa e venticinque a una in cloud, che deve prima svegliarsi.
+ *
+ * Il nostro negoziato — che sostituisce quello del guscio per portarci i TURN
+ * di casa — se n'era scritto uno suo: quindici secondi, sempre, per chiunque.
+ *
+ * E i due numeri contano tutt'e due, perché il guscio aspetta che la nostra
+ * funzione TORNI prima di guardare il proprio cronometro:
+ *
+ *   · a una telecamera di casa, quindici invece di dieci sono cinque secondi di
+ *     velo in più prima che la fila passi all'MJPEG o alle istantanee. Chi
+ *     guarda li paga tutti;
+ *   · a un'Arlo o a una Ring, quindici invece di venticinque vuol dire
+ *     interrompere la trattativa dieci secondi prima della fine del tempo che
+ *     il guscio le aveva dato: proprio alle telecamere che di tempo hanno
+ *     bisogno si toglieva la strada buona.
+ *
+ * Il tempo adesso è uno solo e lo dice la strategia, che è il posto dove la
+ * strada viene scelta.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+import {
+  ATTESE,
+  attesaDelFlusso,
+  strategieDellaTelecamera,
+} from "../src/core/strategie-telecamera.js";
+
+const SORGENTE = readFileSync(
+  new URL("../src/sections/telecamera-webrtc-section.js", import.meta.url),
+  "utf8",
+);
+
+const NATIVA = { frontend_stream_types: ["web_rtc"] };
+const inCasa = { entity_id: "camera.cameretta", attributes: { friendly_name: "Cam 02 Cameretta" } };
+const inCloud = { entity_id: "camera.arlo_giardino", attributes: { friendly_name: "Arlo Giardino" } };
+
+test("il tempo della strada nativa è quello della sveglia, o quello di casa", () => {
+  assert.equal(attesaDelFlusso(inCasa), ATTESE.HLS_LOCALE);
+  assert.equal(attesaDelFlusso(inCloud), ATTESE.HLS_SVEGLIA);
+});
+
+test("ed è lo stesso numero che la strategia mette sulla strada", () => {
+  for (const stato of [inCasa, inCloud]) {
+    const strade = strategieDellaTelecamera({ entity: stato.entity_id }, stato, {
+      capacita: NATIVA,
+    });
+    const webrtc = strade.find((strada) => strada.nome === "WebRTC");
+    assert.ok(webrtc && !webrtc.salta, "la strada nativa deve essere quella scelta");
+    assert.equal(webrtc.attesa, attesaDelFlusso(stato));
+  }
+});
+
+test("il negoziato del popup chiede quel tempo, non ne tiene uno suo", () => {
+  assert.match(
+    SORGENTE,
+    /const sessione = await avviaWebRtcNativo\(entity, videoEl, \{\s*\n\s*attesa: attesaDelFlusso\(allStates\(\)\?\.\[entity\]\),/,
+  );
+  /* E il numero non è scritto qui: viene dal modulo che sceglie le strade. */
+  assert.match(SORGENTE, /import \{ attesaDelFlusso \} from "\.\.\/core\/strategie-telecamera\.js";/);
+  const negoziato = SORGENTE.slice(SORGENTE.indexOf("async function avviaPerIlPopup"));
+  assert.ok(
+    !/attesa:\s*\d/.test(negoziato),
+    "nessun tempo scritto a mano dentro il negoziato del popup",
+  );
+});

--- a/custom_components/dashboardmodern/frontend/tests/la-barra-sotto-il-meteo-e-tutta-di-casa.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/la-barra-sotto-il-meteo-e-tutta-di-casa.test.js
@@ -1,0 +1,72 @@
+/* «Icone barra sotto al menu non sono del nostro catalogo: se non esistono
+ *  creale, e ovviamente vanno cambiate ovunque.»
+ *
+ * La barra sotto il meteo il disegno lo chiedeva gia': `facciaDellaPastiglia`
+ * prova prima il catalogo di casa e solo dopo ripiega sull'emoji. Il guaio e'
+ * che per quattro delle sue quattordici voci il catalogo non aveva niente —
+ * la posta, l'umidita', la pioggia di adesso e quella di oggi — e quelle
+ * quattro cadevano sempre nel ripiego: l'emoji del sistema, in fila accanto a
+ * dieci oggetti disegnati.
+ *
+ * E l'elenco nella configurazione le emoji ce le aveva TUTTE, scritte a mano
+ * riga per riga: la stessa barra con due facce diverse a seconda di dove la
+ * si guardava.
+ *
+ * Adesso il catalogo le ha tutte e quattro, e l'elenco della scheda chiede il
+ * disegno allo stesso catalogo da cui lo chiedono le pastiglie. Questa prova
+ * tiene le due cose insieme: nessuna voce senza oggetto, e nessun posto che se
+ * lo disegni per conto suo.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+import { VOCI_DELLA_BARRA } from "../src/core/come-sta-la-casa.js";
+import { haOggettoWidget, oggettoWidget } from "../src/core/oggetti-widget.js";
+
+const leggi = (nome) => readFileSync(new URL(`../src/${nome}`, import.meta.url), "utf8");
+
+test("ogni voce della barra ha il suo oggetto nel catalogo", () => {
+  const senza = VOCI_DELLA_BARRA.map((voce) => voce.chiave).filter(
+    (chiave) => !haOggettoWidget(chiave),
+  );
+  assert.deepEqual(senza, [], `voci senza disegno di casa: ${senza.join(", ")}`);
+});
+
+test("i quattro che mancavano sono disegni, non simboli", () => {
+  for (const chiave of ["posta", "umidita", "pioggia", "pioggiaOggi"]) {
+    const disegno = oggettoWidget(chiave);
+    assert.match(disegno, /^<svg class="dm-oggetto"/, `${chiave} deve essere un disegno`);
+    /* Ognuno e' il SUO oggetto: quattro copie dello stesso non sarebbero
+     * quattro pastiglie distinguibili. */
+    assert.notEqual(disegno, oggettoWidget("temperatura"));
+  }
+  /* La pioggia di adesso e quella di oggi sono due domande diverse — quanta ne
+   * viene giu' ora, quanta ne e' caduta da stamattina — e portano due oggetti
+   * diversi. */
+  assert.notEqual(oggettoWidget("pioggia"), oggettoWidget("pioggiaOggi"));
+});
+
+test("l'elenco della scheda chiede il disegno, non si scrive un'emoji", () => {
+  const sorgente = leggi("sections/come-sta-la-casa-section.js");
+  assert.match(
+    sorgente,
+    /<span class="dm-casa-ed-ic" aria-hidden="true">\$\{oggettoWidget\(voce\.chiave\)\}<\/span>/,
+  );
+  /* E la tabella dei nomi e' tornata a fare i nomi: niente piu' coppie
+   * [emoji, nome], che erano il posto da cui usciva la seconda faccia. */
+  assert.match(sorgente, /const NOMI_DELLE_VOCI = \(\) => \(\{\s*\n\s*posta: t\("Posta", "Mail"\),/);
+  const tabella = sorgente.slice(
+    sorgente.indexOf("const NOMI_DELLE_VOCI"),
+    sorgente.indexOf("/* Una casella per un sensore della barra"),
+  );
+  assert.ok(
+    !/\[\s*"[^"]*\p{Extended_Pictographic}/u.test(tabella),
+    "nessuna emoji scritta a mano nell'elenco della barra",
+  );
+});
+
+test("il disegno nella scheda ha la sua misura, o esce grande quanto il foglio", () => {
+  const sorgente = leggi("sections/come-sta-la-casa-section.js");
+  assert.match(sorgente, /#ed-body \.dm-casa-ed-ic \.dm-oggetto\{width:24px;height:24px/);
+});

--- a/custom_components/dashboardmodern/frontend/tests/lintestazione-col-meteo-si-sposta.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/lintestazione-col-meteo-si-sposta.test.js
@@ -35,6 +35,7 @@ import {
   ilMeteoStaInTestata,
 } from "../src/core/ordine-dei-blocchi.js";
 import { CONFIG_KEYS } from "../src/core/chiavi-di-configurazione.js";
+import { haOggettoWidget } from "../src/core/oggetti-widget.js";
 
 const leggi = (nome) => readFileSync(new URL(`../src/${nome}`, import.meta.url), "utf8");
 
@@ -100,8 +101,13 @@ test("chi mette in fila i blocchi sa che il meteo e' uno di loro", () => {
     sorgente,
     /if \(nome === BLOCCO_DEL_METEO\)\s*\n\s*return \[dentro\(doc\.querySelector\("\.dm-testata-riga"\)\)\]\.filter\(Boolean\);/,
   );
-  /* E ha un nome nella scheda: una riga senza etichetta non si sposta. */
-  assert.match(sorgente, /meteo: \["\u{1F324}️", t\("Intestazione col meteo", "Weather header"\)\]/u);
+  /* E ha un nome nella scheda: una riga senza etichetta non si sposta. Il
+   * simbolo accanto al nome non e' piu' un'emoji di sistema — «non voglio
+   * vedere icone che non sono nostre» — ma il sole dietro la nuvola del
+   * catalogo, che e' l'oggetto chiamato «meteo» come il blocco. */
+  assert.match(sorgente, /meteo: t\("Intestazione col meteo", "Weather header"\)/);
+  assert.match(sorgente, /const disegnoDelBlocco = \(nome\) =>\s*\n?\s*oggettoWidget\(/);
+  assert.ok(haOggettoWidget("meteo"), "il blocco del meteo deve avere il suo oggetto");
   /* Alla freccia il riquadro cambia casa PRIMA che si rimetta in fila: dopo,
    * sarebbe una fila con un blocco in meno, e lo si vedrebbe muoversi solo al
    * prossimo giro di stati. */

--- a/custom_components/dashboardmodern/frontend/tests/nessuna-icona-esce-come-parola.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/nessuna-icona-esce-come-parola.test.js
@@ -1,0 +1,92 @@
+/* «Icone stanze in home non si vedono.»
+ *
+ * Nella scheda della Home, sotto «Stanze in plancia», sopra il nome di ogni
+ * stanza c'era scritto `mdi:sofa`, `mdi:stove`, `mdi:shower`: il NOME
+ * dell'icona, stampato come parola. Non era un disegno mancante — era il
+ * disegno mai chiesto. Quella riga scriveva il token dentro il markup e via.
+ *
+ * La regola c'era gia', e sta scritta sopra `writeIconGlyph`: «il token grezzo
+ * non si stampa mai come testo». Solo che `writeIconGlyph` scrive dentro un
+ * nodo, e mezza plancia disegna costruendo markup a stringhe — un pannello
+ * della configurazione si rifa' tutto in una volta. Chi ne aveva bisogno se
+ * l'e' riscritta per conto suo; chi se l'e' dimenticata ha stampato il nome.
+ *
+ * Adesso la regola ha due facce e una sola stanza: `iconGlyphHtml` torna il
+ * markup, `writeIconGlyph` lo scrive nel nodo. Questa prova guarda la faccia
+ * nuova e i due posti delle stanze che ci cascavano.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+import { iconGlyphHtml } from "../src/sections/shared.js";
+
+const leggi = (nome) => readFileSync(new URL(`../src/${nome}`, import.meta.url), "utf8");
+
+/* Il motore vero sta in una sezione che vuole un documento: qui basta che
+ * risponda come lui — un nome mdi entra, del markup esce. */
+function conIlMotore(markup, corpo) {
+  const prima = globalThis.DashboardModernIconEngine;
+  globalThis.DashboardModernIconEngine = markup ? { markup } : undefined;
+  try {
+    return corpo();
+  } finally {
+    if (prima === undefined) delete globalThis.DashboardModernIconEngine;
+    else globalThis.DashboardModernIconEngine = prima;
+  }
+}
+
+test("un nome mdi esce come disegno, mai come parola", () => {
+  const uscita = conIlMotore(
+    (kind, token, opzioni) => `<svg data-genere="${kind}" data-token="${token}" data-lato="${opzioni.size}"></svg>`,
+    () => iconGlyphHtml("mdi:sofa", { kind: "room", size: 34 }),
+  );
+  assert.equal(uscita, '<svg data-genere="room" data-token="mdi:sofa" data-lato="34"></svg>');
+});
+
+test("senza motore esce il ripiego, e comunque non il nome dell'icona", () => {
+  const uscita = conIlMotore(null, () => iconGlyphHtml("mdi:sofa", { kind: "room", fallback: "🛋️" }));
+  assert.equal(uscita, "🛋️");
+  assert.ok(!uscita.includes("mdi:"), "il nome dell'icona non esce mai come testo");
+});
+
+test("un simbolo scelto a mano resta quello che è, al riparo dal markup", () => {
+  assert.equal(iconGlyphHtml("🛋️", { kind: "room" }), "🛋️");
+  /* Chi sceglie l'icona scrive quello che vuole nella casella: esce come
+   * markup, quindi esce protetto. */
+  assert.equal(iconGlyphHtml("<b>x</b>", { kind: "room" }), "&lt;b>x&lt;/b>");
+});
+
+test("niente icona vuol dire il ripiego, non una casella vuota", () => {
+  assert.equal(iconGlyphHtml("", { kind: "room", fallback: "🛋️" }), "🛋️");
+  assert.equal(iconGlyphHtml(null, { kind: "room", fallback: "🛋️" }), "🛋️");
+});
+
+test("la regola sta in un posto solo: chi scrive nel nodo chiama chi torna il markup", () => {
+  const sorgente = leggi("sections/shared.js");
+  assert.match(
+    sorgente,
+    /export function writeIconGlyph\([\s\S]{0,900}?target\.innerHTML = iconGlyphHtml\(token, \{ size, fallback, kind \}\);/,
+  );
+});
+
+test("i due posti delle stanze chiedono il disegno, non scrivono il nome", () => {
+  /* La scheda della Home: la riga di ogni stanza sotto «Stanze in plancia». */
+  const scheda = leggi("sections/home-blocchi-section.js");
+  assert.match(
+    scheda,
+    /<span class="dm-blocco-icona" aria-hidden="true">\$\{iconGlyphHtml\(stanza\.icon, \{\s*\n\s*size: 22,\s*\n\s*kind: "room",/,
+  );
+  /* E la card in Home: qui il ripiego ERA il token — `disegno || esc(pagina.icon)` —
+   * cioe' la stessa parola, per la stessa stanza, nell'altro posto. */
+  const blocco = leggi("sections/stanze-in-plancia-section.js");
+  assert.match(
+    blocco,
+    /function disegnoDellaStanza\(icona\) \{\s*\n\s*return iconGlyphHtml\(icona, \{ size: 34, kind: "room", fallback: "🛋️" \}\);\s*\n\}/,
+  );
+  assert.match(blocco, /class="dm-stanza-plancia-ic" aria-hidden="true">\$\{disegno\}</);
+  assert.ok(
+    !/esc\(pagina\.icon/.test(blocco),
+    "il nome dell'icona non torna come ripiego della card",
+  );
+});

--- a/custom_components/dashboardmodern/frontend/tests/ogni-sezione-porta-il-suo-disegno.test.js
+++ b/custom_components/dashboardmodern/frontend/tests/ogni-sezione-porta-il-suo-disegno.test.js
@@ -92,3 +92,30 @@ test("quello che le due tabelle promettono, il catalogo lo sa disegnare", () => 
     for (const [voce, disegno] of Object.entries(tavola))
       assert.ok(haOggettoWidget(disegno), `${nome}[${voce}] promette «${disegno}», che non esiste`);
 });
+
+/* Avere il disegno non basta: bisogna anche METTERLO, e metterlo quando la voce
+ * nasce.
+ *
+ * Le voci che aggiungono i moduli — Stanze, Luci, Prese, Robot, le telecamere,
+ * le porte — nascono nel fotogramma dopo `render`, e col simbolo scritto a mano
+ * da chi le ha create. A rimpiazzarlo col disegno era solo l'aggancio su
+ * `cdApplyNavVis`: una funzione del guscio, che al momento in cui questo modulo
+ * si installa puo' non esserci ancora. Quando non c'era, l'aggancio non si
+ * faceva — e non si riprovava mai piu': la barra restava col simbolo del
+ * telefono, e chi guarda vede «icone che non sono nostre» su una plancia il cui
+ * catalogo li aveva tutti.
+ */
+test("il disegno si rimette dove la barra si rifà, non solo se il guscio è già pronto", () => {
+  const barra = sorgente("../src/sections/navigation-section.js");
+  /* Insieme al filtro, che e' la cosa che gia' succedeva al momento giusto:
+   * subito dopo `render` e in fondo allo stesso fotogramma. */
+  assert.match(barra, /applicaLaVisibilita\(\);\s*\n\s*disegniNellaBarra\(\);\s*\n\s*filtraNelFotogramma\(\);/);
+  assert.match(barra, /state\.filtroInCoda = false;\s*\n\s*applicaLaVisibilita\(\);\s*\n\s*disegniNellaBarra\(\);/);
+  /* E gli agganci al guscio si riprovano quando il guscio dichiara di esserci:
+   * tutt'e due si rifiutano di avvolgere due volte la stessa funzione, quindi
+   * riprovare non costa niente. */
+  assert.match(
+    barra,
+    /for \(const evento of \["dashboardmodern:legacy-ready", "dashboardmodern:runtime-ready"\]\)\s*\n\s*root\.addEventListener\?\.\(evento, \(\) => \{\s*\n\s*accodaDopo\("cdApplyNavOrder"\);\s*\n\s*accodaDopo\("cdApplyNavVis"\);\s*\n\s*filtraDopo\("render"\);/,
+  );
+});

--- a/custom_components/dashboardmodern/manifest.json
+++ b/custom_components/dashboardmodern/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/danigio15/dashboardmodern-v2/issues",
   "requirements": [],
-  "version": "1.4.21"
+  "version": "1.4.22"
 }

--- a/tests/test_la_card_e_anche_una_risorsa_lovelace.py
+++ b/tests/test_la_card_e_anche_una_risorsa_lovelace.py
@@ -131,3 +131,51 @@ async def test_senza_lovelace_non_si_rompe_niente(hass: HomeAssistant) -> None:
 
     pannelli = hass.data.get(ha_frontend.DATA_PANELS, {})
     assert "dashboardmodern" in pannelli
+
+
+@pytest.mark.asyncio
+async def test_l_ultima_plancia_tolta_si_porta_via_la_card(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+) -> None:
+    """Una risorsa che punta a un 404 non deve restare in casa di nessuno.
+
+    La riga fra le risorse sta sul DISCO, e non se ne va spegnendo
+    l'integrazione: chi disinstalla DashboardModern si ritroverebbe ogni
+    dashboard a chiedere, a ogni apertura, un modulo che non c'è più.
+    """
+    assert await async_setup_component(hass, "lovelace", {})
+    entry = _voce(hass)
+
+    await fe.async_register_frontend(hass, entry.entry_id)
+    await hass.async_block_till_done()
+    assert len(_risorse(hass)) == 1
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert _risorse(hass) == []
+
+
+@pytest.mark.asyncio
+async def test_togliere_una_plancia_su_due_lascia_la_card(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+) -> None:
+    """Chi resta la card la usa ancora: si toglie solo quando non resta nessuno."""
+    assert await async_setup_component(hass, "lovelace", {})
+    prima = _voce(hass)
+    seconda = MockConfigEntry(
+        domain=DOMAIN, entry_id="1234567890abcdef", title="Taverna"
+    )
+    seconda.add_to_hass(hass)
+
+    await fe.async_register_frontend(hass, prima.entry_id)
+    await fe.async_register_frontend(hass, seconda.entry_id)
+    await hass.async_block_till_done()
+    assert len(_risorse(hass)) == 1
+
+    await hass.config_entries.async_remove(prima.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(_risorse(hass)) == 1

--- a/tests/test_la_card_e_anche_una_risorsa_lovelace.py
+++ b/tests/test_la_card_e_anche_una_risorsa_lovelace.py
@@ -1,0 +1,133 @@
+"""La card della plancia predefinita arriva anche a una pagina rimasta in cache.
+
+«Se imposto plancia predefinita da utente, da smartphone continua a dare
+errore; da pc no.»
+
+È la stessa segnalazione di sempre — «Errore di configurazione» sulla plancia
+predefinita — con dentro il pezzo che mancava: da QUALE apparecchio. E quel
+pezzo cambia la diagnosi.
+
+Le due strade con cui un modulo del frontend arriva al browser non sono la
+stessa cosa. `add_extra_js_url` lo scrive nell'AVVIO della pagina: Home
+Assistant lo stampa dentro l'index che serve al primo caricamento. L'app
+companion quell'index se lo tiene in cache a lungo — è il pezzo che le fa aprire
+la plancia anche senza rete — quindi un index messo in cache prima che
+l'integrazione ci fosse non nomina il nostro modulo, e continuerà a non
+nominarlo finché la cache dura: `dashboardmodern-card` non viene mai definito, e
+al suo posto Home Assistant disegna la schermata rossa. Il browser del computer
+l'index lo richiede e basta, e lì il modulo c'è sempre.
+
+Le RISORSE di Lovelace, invece, non stanno nell'index: il frontend se le fa dire
+dal socket a ogni apertura della dashboard, e le importa allora. Anche una
+pagina in cache le chiede, perché chiederle fa parte dell'apertura della
+dashboard.
+
+Queste prove tengono ferma la seconda strada: che la card ci sia fra le risorse,
+che un aggiornamento rimetta in pari quella che c'è invece di aggiungerne una
+seconda, e che un secondo avvio non ne fabbrichi un doppione.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip(
+    "homeassistant", reason="Home Assistant test dependency is not installed"
+)
+
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.dashboardmodern import frontend as fe
+from custom_components.dashboardmodern.const import DOMAIN
+
+
+def _voce(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN, entry_id="abcdef1234567890", title="Casa 3.0"
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _risorse(hass: HomeAssistant) -> list[dict]:
+    collezione = fe._risorse_di_lovelace(hass)
+    assert collezione is not None, "Lovelace non espone le risorse"
+    return [
+        voce
+        for voce in (collezione.async_items() or [])
+        if "dashboard-card.js" in str(voce.get("url") or "")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_la_card_finisce_fra_le_risorse_di_lovelace(hass: HomeAssistant) -> None:
+    """Chi apre la dashboard se la fa dire dal socket, non dalla pagina in cache."""
+    assert await async_setup_component(hass, "lovelace", {})
+    entry = _voce(hass)
+
+    await fe.async_register_frontend(hass, entry.entry_id)
+    await hass.async_block_till_done()
+
+    trovate = _risorse(hass)
+    assert len(trovate) == 1, trovate
+    (risorsa,) = trovate
+    assert risorsa["type"] == "module"
+    # Lo stesso indirizzo stabile con la firma nella domanda che va nell'avvio
+    # della pagina: due strade per lo stesso modulo, non due moduli.
+    assert risorsa["url"].startswith("/dashboardmodern_static/dashboard-card.js?v=")
+
+
+@pytest.mark.asyncio
+async def test_un_secondo_avvio_non_fa_un_doppione(hass: HomeAssistant) -> None:
+    """Riavviare non deve riempire l'elenco delle risorse della stessa riga."""
+    assert await async_setup_component(hass, "lovelace", {})
+    entry = _voce(hass)
+
+    await fe.async_register_frontend(hass, entry.entry_id)
+    await hass.async_block_till_done()
+    await fe.async_register_frontend(hass, entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(_risorse(hass)) == 1
+
+
+@pytest.mark.asyncio
+async def test_una_firma_vecchia_si_rimette_in_pari(hass: HomeAssistant) -> None:
+    """Dopo un aggiornamento la firma cambia: si corregge la riga, non se ne aggiunge
+    una."""
+    assert await async_setup_component(hass, "lovelace", {})
+    collezione = fe._risorse_di_lovelace(hass)
+    await collezione.async_load()
+    collezione.loaded = True
+    await collezione.async_create_item(
+        {
+            "res_type": "module",
+            "url": "/dashboardmodern_static/dashboard-card.js?v=firmavecchia",
+        }
+    )
+    entry = _voce(hass)
+
+    await fe.async_register_frontend(hass, entry.entry_id)
+    await hass.async_block_till_done()
+
+    trovate = _risorse(hass)
+    assert len(trovate) == 1, trovate
+    assert (
+        trovate[0]["url"] != "/dashboardmodern_static/dashboard-card.js?v=firmavecchia"
+    )
+
+
+@pytest.mark.asyncio
+async def test_senza_lovelace_non_si_rompe_niente(hass: HomeAssistant) -> None:
+    """Lovelace in modo YAML o non ancora in piedi: la plancia si registra lo stesso."""
+    entry = _voce(hass)
+
+    await fe.async_register_frontend(hass, entry.entry_id)
+    await hass.async_block_till_done()
+
+    from homeassistant.components import frontend as ha_frontend
+
+    pannelli = hass.data.get(ha_frontend.DATA_PANELS, {})
+    assert "dashboardmodern" in pannelli


### PR DESCRIPTION
Quattro segnalazioni, una per volta.

## «Icone stanze in home non si vedono»

Nella scheda della Home, sotto «Stanze in plancia», sopra il nome di ogni stanza c'era scritto `mdi:sofa`, `mdi:stove`, `mdi:shower`: il **nome** dell'icona, stampato come parola. Non era un disegno mancante — era il disegno mai chiesto.

La regola contro questo c'era già, e sta scritta da sempre sopra `writeIconGlyph`: «il token grezzo non si stampa mai come testo». Solo che `writeIconGlyph` scrive dentro un nodo, e metà plancia disegna costruendo markup a stringhe: chi ne aveva bisogno se l'era riscritta per conto suo, chi se l'è dimenticata ha stampato il nome. Adesso la regola ha due facce e una stanza sola — `iconGlyphHtml` torna il markup, `writeIconGlyph` lo scrive nel nodo chiamando lei — e i due posti delle stanze la usano tutt'e due: la scheda, e la card in Home dove il ripiego era la stessa parola (`disegno || esc(pagina.icon)`).

## «Icone barra sotto al menu non sono del nostro catalogo, se non esistono creale»

Quattro voci su quattordici un disegno non ce l'avevano — la posta, l'umidità, la pioggia di adesso e quella di oggi — e cadevano sempre sull'emoji di ripiego, in fila accanto a dieci oggetti disegnati. Adesso ci sono: la cassetta con la bandierina alzata, il quadrante dell'igrometro con la goccia, la nuvola con le gocce, il pluviometro. Più il sole dietro la nuvola, che mancava all'intestazione nell'elenco dei blocchi della Home.

E gli elenchi nella configurazione — che le emoji le avevano scritte a mano riga per riga — chiedono il disegno allo stesso catalogo da cui lo chiedono le pastiglie: una barra sola, una faccia sola.

Nella barra in basso il difetto era un altro e della stessa famiglia: le voci che aggiungono i moduli nascono col simbolo scritto a mano da chi le crea, e a rimpiazzarlo col disegno era un solo aggancio a una funzione del guscio, fatto una volta all'installazione. Se in quel momento la funzione non c'era ancora, l'aggancio non si faceva e non si riprovava mai più. Adesso il disegno si rimette dove la barra si rifà — insieme al filtro, che è la cosa che già succedeva al momento giusto — e gli agganci si riprovano quando il guscio dichiara di esserci.

## «E ancora telecamere non funzionanti»

Il tempo del WebRTC nativo era scritto in due posti che non si parlavano. Il guscio lo chiede alla strategia: dieci secondi a una telecamera di casa, venticinque a una in cloud che deve prima svegliarsi. Il nostro negoziato — quello che sostituisce il suo per portarci i TURN di casa — ne teneva quindici, sempre, per chiunque.

E contano tutt'e due, perché il guscio aspetta che la nostra funzione **torni** prima di guardare il proprio cronometro:

- a una telecamera di casa, quindici invece di dieci sono cinque secondi di velo «Connessione WebRTC…» in più prima che la fila passi alla strada dopo;
- a un'Arlo o a una Ring, quindici invece di venticinque vuol dire interrompere la trattativa dieci secondi prima della fine del tempo che il guscio le aveva dato — cioè togliere la strada buona proprio a chi ne ha bisogno.

Il tempo adesso è uno solo, e lo dice `attesaDelFlusso` nel modulo dove la strada viene scelta.

## «Se imposto plancia predefinita da utente, da smartphone continua a dare errore; da pc no»

Il pezzo che mancava era da quale apparecchio, e cambia la diagnosi.

`add_extra_js_url` scrive il modulo nell'**avvio** della pagina: Home Assistant lo stampa dentro l'index che serve al primo caricamento. L'app companion quell'index se lo tiene in cache a lungo — è il pezzo che le fa aprire la plancia anche senza rete — quindi un index messo in cache prima che l'integrazione ci fosse non nomina il nostro modulo: `dashboardmodern-card` non viene mai definito, e al suo posto Home Assistant disegna «Errore di configurazione». Il browser di un computer l'index lo richiede e basta, e lì il modulo c'è sempre.

Le **risorse** di Lovelace invece non stanno nell'index: il frontend se le fa dire dal socket a ogni apertura della dashboard, e le importa allora. Anche una pagina in cache le chiede. Adesso la card si pubblica in tutt'e due i modi — il modulo si definisce una volta sola comunque, quindi due strade non fanno due card: fanno due occasioni perché la card ci sia. In modo YAML, dove le risorse le scrive chi ha la casa, non si insiste. (#372, #154, #499)

## Il chiosco sulla plancia predefinita

Non è un difetto corretto: è una cosa che non era mai stata provata. La card della plancia predefinita non è il pannello — due ombre in mezzo e la card che si ritaglia l'altezza sotto l'intestazione — ed è l'unico posto dove il chiosco ci passa attraverso. Adesso quella topologia ha le sue prove col browser: l'interruttore in ⚙️ Impostazioni la porta a tutto schermo sopra l'intestazione di Lovelace, spegnendolo la vista riprende la sua altezza, e la scelta regge il ricaricamento — che su un computer, dove il chiosco non si accende mai da solo, è tutto quello che la tiene in piedi.

## Le prove

Ogni correzione è stata provata rossa sul codice di prima:

| prova | cosa difende |
| --- | --- |
| `tests/nessuna-icona-esce-come-parola.test.js` | il nome dell'icona non esce mai come testo, e la regola sta in un posto solo |
| `tests/la-barra-sotto-il-meteo-e-tutta-di-casa.test.js` | ogni voce della barra ha il suo oggetto, e la scheda lo chiede al catalogo |
| `tests/ogni-sezione-porta-il-suo-disegno.test.js` | il disegno si rimette dove la barra si rifà, non solo se il guscio è già pronto |
| `tests/il-popup-della-telecamera-ha-il-tempo-della-strada.test.js` | il negoziato non tiene un tempo suo |
| `tests/test_la_card_e_anche_una_risorsa_lovelace.py` | la card fra le risorse, senza doppioni e con la firma in pari |
| `e2e/il-chiosco-vale-anche-sulla-plancia-predefinita.spec.js` | il chiosco dentro la card della predefinita |

Verde: 3699 prove del frontend, 371 pytest, `check:i18n`, `check:guscio`, `check:moduli`, `check:inline-syntax`, `format:check`, ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZHecyyyQUEKZ1bZKho4Xv

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZHecyyyQUEKZ1bZKho4Xv)_